### PR TITLE
fix(frontend): reset MCP OAuth authorize button when popup closes

### DIFF
--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -420,6 +420,15 @@ const McpForm = ({
         // If the popup was blocked, fall back to same-window redirect
         if (!popup) {
           window.location.replace(data.authorizationUrl);
+        } else {
+          // Reset Authorize button when popup closes without success
+          // (e.g. upstream provider rejects with 400 — no postMessage fires).
+          const interval = setInterval(() => {
+            if (popup.closed) {
+              clearInterval(interval);
+              setIsAuthorizing(false);
+            }
+          }, 500);
         }
       } else {
         toast.error(data.error || "Failed to start OAuth authorization");


### PR DESCRIPTION
## Summary

When the OAuth popup closes without firing a `postMessage` (e.g. the upstream provider rejects the request with a 400 error page that never reaches the callback route), the Authorize button stays in its `Redirecting...` state and cannot be clicked again. Users currently have to reload the page to retry.

## Fix

Poll `popup.closed` after opening the OAuth popup and reset `isAuthorizing` once the popup is gone, so the button becomes clickable again. The existing `postMessage`-based reset path (success/error from the callback page) still works — this is only an additional safety net for the case where the popup never reaches our callback.

## Test plan

- [x] Reproduced the stuck-button state by triggering a 400 from Google OAuth (missing scope, private-IP redirect URI, etc.) and confirmed the button stays disabled before the patch
- [x] After patch, closing the popup re-enables the Authorize button
- [x] Successful OAuth flow still works (popup auto-closes via callback, button resets via existing postMessage path)