### PR TITLE
fix(frontend): avoid creating duplicate MCP rows on OAuth retry

### DIFF
--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -404,6 +404,15 @@ const McpForm = ({
       const data = await response.json();
 
       if (response.ok && data.authorizationUrl) {
+        // If we just created the MCP, redirect to the edit page so the URL
+        // reflects the new mcpId and any later actions (retries, save,
+        // re-authorize) update the existing record instead of creating
+        // duplicates.
+        if (!mcpId && resolvedMcpId) {
+          router.replace(
+            `/${orgId}/workspace/${workspaceId}/settings/mcp/${resolvedMcpId}`,
+          );
+        }
         // Open OAuth in a popup so the main page is never navigated away.
         // This avoids bfcache issues where the browser restores stale auth
         // state when the user clicks the Back button.


### PR DESCRIPTION
## Summary

When clicking **Authorize** on a new (unsaved) MCP form, `saveMcp()` is called to create the row before redirecting to the OAuth provider. The `router.replace()` that updates the URL to `/[mcpId]` was only invoked in the error branch, so on the happy path the URL stayed on `/new`. If the upstream OAuth attempt failed and the user retried, a brand new MCP row was created every time — leaving the workspace cluttered with unauthorized duplicates.

## Fix

Move the `router.replace()` into the success branch (right after the MCP is created and before the popup opens). Subsequent retries then update the existing record instead of creating duplicates.

## Test plan

- [x] Created a new OAuth MCP, hit Authorize, intentionally failed the upstream flow, retried — confirmed only one row exists in the database after the patch (instead of one per retry)
- [x] Confirmed the existing error-path redirect still works (when `/oauth/authorize` itself fails)
- [x] Confirmed editing an existing MCP and re-authorizing still works (no spurious redirect, since `mcpId` is already set)