### PR TITLE
fix(backend): force Chat Completions API for custom OpenAI-compatible endpoints

### DIFF
--- a/apps/backend/src/services/provider.ts
+++ b/apps/backend/src/services/provider.ts
@@ -23,7 +23,7 @@ export const openProvider = (provider: Provider): OpenedProvider => {
         project: provider.project ?? undefined,
       });
       return {
-        languageModel: (id) => sdk.chat(id),
+        languageModel: (id) => (provider.baseUrl ? sdk.chat(id) : sdk(id)),
         embeddingModel: (id) => sdk.embeddingModel(id),
         searchTools: () => ({
           web_search: sdk.tools.webSearch({

--- a/apps/backend/src/services/provider.ts
+++ b/apps/backend/src/services/provider.ts
@@ -23,7 +23,7 @@ export const openProvider = (provider: Provider): OpenedProvider => {
         project: provider.project ?? undefined,
       });
       return {
-        languageModel: (id) => sdk(id),
+        languageModel: (id) => sdk.chat(id),
         embeddingModel: (id) => sdk.embeddingModel(id),
         searchTools: () => ({
           web_search: sdk.tools.webSearch({


### PR DESCRIPTION
## Summary

- `sdk(id)` in `@ai-sdk/openai` v3+ resolves to the Responses API (`/v1/responses`), which uses a completely different request format (an `input` array containing `item_reference` and `function_call_output` objects)
- vLLM and other OpenAI-compatible servers only implement `/v1/chat/completions` and return a Python `KeyError('role')` 500 when receiving Responses API requests
- `sdk.chat(id)` explicitly targets `/v1/chat/completions`, which all providers handle correctly

## Test plan

- [x] Configure an OpenAI-compatible provider with a custom `baseUrl` (e.g. vLLM)
- [x] Send a message that triggers tool calls (e.g. an agent with MCP tools)
- [x] Confirm tool results are processed and the agent returns a final answer without a `'role'` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)