### PR TITLE
chore(mcp): tighten oauthRequestedScope handling

### DIFF
--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -224,7 +224,9 @@ export const mcp = pgTable(
     oauthAccessToken: t.text("oauth_access_token"),
     oauthRefreshToken: t.text("oauth_refresh_token"),
     oauthTokenExpiresAt: t.timestamp("oauth_token_expires_at"),
+    // Granted scope returned by the token endpoint after authorization.
     oauthScope: t.text("oauth_scope"),
+    // Scope sent to the authorize endpoint; some providers (e.g. Google) reject /authorize without it.
     oauthRequestedScope: t.text("oauth_requested_scope"),
     oauthClientId: t.text("oauth_client_id"),
     oauthClientSecret: t.text("oauth_client_secret"),

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -210,8 +210,8 @@ const McpForm = ({
           ? formData.oauthClientSecret
           : undefined,
       oauthRequestedScope:
-        formData.authType === "OAuth" && formData.oauthRequestedScope
-          ? formData.oauthRequestedScope
+        formData.authType === "OAuth" && formData.oauthRequestedScope?.trim()
+          ? formData.oauthRequestedScope.trim()
           : undefined,
     };
     return payload;

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -311,7 +311,7 @@ const mcpBaseSchema = z.object({
   bearerToken: z.string().optional(),
   oauthClientId: z.string().optional(),
   oauthClientSecret: z.string().optional(),
-  oauthRequestedScope: z.string().optional(),
+  oauthRequestedScope: z.string().max(1024).optional(),
   oauthAuthorized: z.boolean().optional(),
   createdAt: z.date(),
   updatedAt: z.date(),


### PR DESCRIPTION
## Summary

Follow-up polish on the `oauthRequestedScope` field added in #134.

- **Schema comments** disambiguating `oauthScope` (granted at the token endpoint) from `oauthRequestedScope` (sent to `/authorize`) on `apps/backend/src/db/schema.ts`.
- **`.max(1024)`** on `oauthRequestedScope` in `packages/schemas/index.ts` as cheap defense-in-depth — real OAuth scope strings are small.
- **Whitespace trim** in `apps/frontend/components/mcp-form.tsx` so whitespace-only input is treated as empty (sent as `undefined` to the backend rather than a blank string).

No behavior change for normal OAuth flows; no migration.

## Test plan

- [x] `pnpm test` — all 674 backend tests pass
- [x] `pnpm build` — clean
- [ ] Spot-check: create an OAuth MCP with a scope; confirm the value round-trips
- [ ] Spot-check: paste `"   "` into the scope field; confirm it's saved as empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)