### PR TITLE
fix(backend): append access_type=offline for Google OAuth authorization URLs

### DIFF
--- a/apps/backend/src/services/mcp-oauth-provider.ts
+++ b/apps/backend/src/services/mcp-oauth-provider.ts
@@ -190,7 +190,13 @@ export class DatabaseOAuthClientProvider implements OAuthClientProvider {
   }
 
   async redirectToAuthorization(authorizationUrl: URL) {
-    // Capture the URL so the endpoint can read it
+    // Google requires access_type=offline to return a refresh token.
+    // prompt=consent forces re-consent even if the user previously authorized,
+    // which is required when requesting offline access for the first time.
+    if (authorizationUrl.hostname.endsWith(".google.com") || authorizationUrl.hostname === "google.com") {
+      authorizationUrl.searchParams.set("access_type", "offline");
+      authorizationUrl.searchParams.set("prompt", "consent");
+    }
     this.pendingAuthUrl = authorizationUrl;
   }
 


### PR DESCRIPTION
## Summary

- Google only returns a refresh token when `access_type=offline` is present in the authorization URL — the `@ai-sdk/mcp` library never adds this parameter
- `prompt=consent` is added alongside it to force re-consent, which Google requires when granting offline access for the first time (even for previously-authorized accounts)
- The parameters are only injected for Google domains (`*.google.com`), so non-Google OAuth providers are unaffected

Without this fix, tokens expire after ~1 hour and the user must manually re-authorize in the MCP settings with no automatic recovery.

## Test plan

- [ ] Authorize a Google Drive or Google Calendar MCP via the OAuth flow
- [ ] Confirm `oauth_refresh_token` is stored in the `mcp` table after authorization
- [ ] Wait for the access token to expire (or manually clear it) and confirm the MCP continues working via automatic token refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)