### PR TITLE
fix(mcp): one-click Reauthorize via force flag, surface silent refresh as success

### DIFF
--- a/apps/backend/src/routes/mcp.test.ts
+++ b/apps/backend/src/routes/mcp.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
 import app from "../server.ts";
+import { auth as mcpAuth } from "@ai-sdk/mcp";
 
 vi.mock("@ai-sdk/mcp", () => ({
   experimental_createMCPClient: vi.fn().mockResolvedValue({
     tools: vi.fn().mockResolvedValue({ tool1: {} }),
     close: vi.fn().mockResolvedValue(undefined),
   }),
+  auth: vi.fn(),
 }));
 
 describe("MCP Routes", () => {
@@ -80,6 +82,80 @@ describe("MCP Routes", () => {
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ success: true, toolNames: ["tool1"] });
+    });
+  });
+
+  describe("POST /:mcpId/oauth/authorize", () => {
+    const mcpId = "mcp-1";
+    const authorizeUrl = `${baseUrl}/${mcpId}/oauth/authorize`;
+
+    const mcpRecord = {
+      id: mcpId,
+      workspaceId,
+      authType: "OAuth",
+      url: "http://mcp.example.com",
+      oauthAccessToken: "access-old",
+      oauthRefreshToken: "refresh-old",
+      oauthTokenExpiresAt: new Date(),
+      oauthScope: "read",
+      oauthClientId: "client-id",
+      oauthClientSecret: "client-secret",
+    };
+
+    it("force=true: clears the four oauth token columns in DB and returns authorizationUrl", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([{ ...mcpRecord }]); // MCP lookup
+
+      (mcpAuth as any).mockImplementationOnce(async (provider: any) => {
+        await provider.redirectToAuthorization(
+          new URL("https://provider.example.com/authorize?x=1"),
+        );
+        return "REDIRECT";
+      });
+
+      const res = await app.request(`${authorizeUrl}?force=true`, {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        authorizationUrl: "https://provider.example.com/authorize?x=1",
+      });
+
+      // Token-clear update was issued
+      expect(mockDb.update).toHaveBeenCalled();
+      expect(mockDb.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          oauthAccessToken: null,
+          oauthRefreshToken: null,
+          oauthTokenExpiresAt: null,
+          oauthScope: null,
+        }),
+      );
+
+      // DCR/static client credentials are deliberately preserved
+      const setPayload = (mockDb.set as any).mock.calls[0][0];
+      expect(setPayload).not.toHaveProperty("oauthClientId");
+      expect(setPayload).not.toHaveProperty("oauthClientSecret");
+    });
+
+    it("no force flag: leaves token columns untouched when SDK silently refreshes", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([{ ...mcpRecord }]); // MCP lookup
+
+      (mcpAuth as any).mockResolvedValueOnce("AUTHORIZED");
+
+      const res = await app.request(authorizeUrl, { method: "POST" });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ alreadyAuthorized: true });
+
+      // No update issued → token columns untouched
+      expect(mockDb.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/routes/mcp.ts
+++ b/apps/backend/src/routes/mcp.ts
@@ -309,6 +309,34 @@ mcp.post(
       return c.json({ error: "MCP URL is not configured" }, 400);
     }
 
+    // `force=true` clears stored tokens before running the OAuth flow so
+    // mcpAuth always returns REDIRECT. Lets the UI offer a single-click
+    // "Reauthorize" even when Platypus still holds a valid refresh token (the
+    // SDK would otherwise silently refresh and report AUTHORIZED, which the
+    // frontend currently shows as a failure because no authorizationUrl is
+    // returned). The DCR/static `oauthClientId`/`oauthClientSecret` are
+    // preserved so the same OAuth client is reused.
+    const force = c.req.query("force") === "true";
+    if (force) {
+      await db
+        .update(mcpTable)
+        .set({
+          oauthAccessToken: null,
+          oauthRefreshToken: null,
+          oauthTokenExpiresAt: null,
+          oauthScope: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(mcpTable.id, mcpId));
+      mcpRecord[0] = {
+        ...mcpRecord[0],
+        oauthAccessToken: null,
+        oauthRefreshToken: null,
+        oauthTokenExpiresAt: null,
+        oauthScope: null,
+      };
+    }
+
     try {
       const callbackUrl = buildOAuthCallbackUrl();
       const provider = new DatabaseOAuthClientProvider(
@@ -329,8 +357,10 @@ mcp.post(
         return c.json({ authorizationUrl: authUrl.toString() });
       }
 
-      // Already authorized
-      return c.json({ message: "Already authorized" });
+      // Already authorized — refresh token still valid, SDK rotated silently.
+      // Reported as success so the frontend can treat it as a no-op rather
+      // than an error.
+      return c.json({ alreadyAuthorized: true });
     } catch (error) {
       logger.error({ error }, "OAuth authorize error");
       const errorMessage =

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -396,18 +396,32 @@ const McpForm = ({
         }
       }
 
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/mcps/${resolvedMcpId}/oauth/authorize`,
-        ),
-        {
-          method: "POST",
-          credentials: "include",
-        },
+      // When the MCP already holds an access token, ask the backend to wipe
+      // it before running mcpAuth so the OAuth flow is always entered. Without
+      // ?force=true a valid refresh token causes mcpAuth to silently rotate
+      // and return alreadyAuthorized — which is fine on a normal page load
+      // but surprising when the user just clicked "Reauthorize".
+      const authorizeUrl = joinUrl(
+        backendUrl,
+        `/organizations/${orgId}/workspaces/${workspaceId}/mcps/${resolvedMcpId}/oauth/authorize${
+          oauthAuthorized ? "?force=true" : ""
+        }`,
       );
+      const response = await fetch(authorizeUrl, {
+        method: "POST",
+        credentials: "include",
+      });
 
       const data = await response.json();
+
+      if (response.ok && data.alreadyAuthorized) {
+        // Backend silently refreshed via stored refresh_token. Treat as
+        // success rather than an error toast.
+        toast.success("Already authorized");
+        mutateMcp();
+        setIsAuthorizing(false);
+        return;
+      }
 
       if (response.ok && data.authorizationUrl) {
         // If we just created the MCP, redirect to the edit page so the URL


### PR DESCRIPTION
## Summary

The **Reauthorize** button on an MCP row reports `Failed to start OAuth authorization` whenever Platypus still holds a valid refresh token. The OAuth callback completes silently in the background but the UI treats it as a failure.

## Root cause

`POST /mcps/:mcpId/oauth/authorize` calls `mcpAuth(provider)` from `@ai-sdk/mcp`. When the stored refresh token is still valid the SDK silently rotates and returns `AUTHORIZED`; the handler then responds `{ message: "Already authorized" }` with no `authorizationUrl`. The frontend (`apps/frontend/components/mcp-form.tsx`) checks only for `data.authorizationUrl` and falls through to `toast.error(...)`. A successful silent refresh therefore looks identical to an error.

The user has no way to force a fresh OAuth flow short of editing the database to wipe tokens — `/oauth/revoke` exists but requires a separate click and confuses the intent.

## Fix

Two complementary changes:

1. **Backend** — add an opt-in `?force=true` query parameter to `POST /mcps/:mcpId/oauth/authorize`. When present, the handler clears `oauthAccessToken`, `oauthRefreshToken`, `oauthTokenExpiresAt`, `oauthScope` before invoking `mcpAuth`, so the flow always returns `REDIRECT` and yields an `authorizationUrl`. The DCR / static `oauthClientId` and `oauthClientSecret` are deliberately preserved so the same OAuth client is reused.

2. **Backend + frontend** — rename the silent-refresh response payload from `{ message: "Already authorized" }` to `{ alreadyAuthorized: true }`, and have the frontend treat that as success (`toast.success("Already authorized")` + revalidate the MCP row) rather than an error.

The Reauthorize button now passes `force=true` whenever the row is currently authorized; the initial Authorize button (no token yet) still posts without the flag.

## Test plan

- [x] Backend tests in `apps/backend/src/services/mcp-oauth-provider.test.ts` still pass.
- [x] Manual: with a valid refresh token, click Reauthorize → popup opens at the provider's authorize endpoint (force path).
- [x] Manual: without any tokens, click Authorize → identical behaviour to before (no `?force=true`).
- [x] Manual: trigger the silent-refresh path (page load reauthorize on a freshly-refreshed token) → success toast instead of failure toast.
- [x] No effect on Bearer / None auth types — the endpoint still rejects those upfront.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
