### PR TITLE
fix(frontend): make tool call headers and config labels text-selectable

### DIFF
--- a/apps/frontend/components/ai-elements/tool.tsx
+++ b/apps/frontend/components/ai-elements/tool.tsx
@@ -223,7 +223,7 @@ export const ToolHeader = ({
     >
       <div className="flex items-center gap-2 min-w-0">
         <Icon className="size-4 shrink-0 text-muted-foreground" />
-        <span className="font-medium text-sm truncate">
+        <span className="font-medium text-sm truncate select-text">
           {title ?? humanizeToolType(type)}
           {label && (
             <span className="font-normal text-muted-foreground">

--- a/apps/frontend/components/ui/label.tsx
+++ b/apps/frontend/components/ui/label.tsx
@@ -13,7 +13,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-sm leading-none font-medium group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

Two independent text-selection bugs fixed together (both are 1-line changes):

**1. Config labels (`label.tsx`)**
Shadcn/Radix ships `Label` with `select-none` in its default className. This prevents users from selecting any label text across the entire UI - agent name fields, system prompt labels, temperature labels, MCP config fields, etc. Removing `select-none` restores normal browser text selection behaviour.

**2. Tool call headers (`tool.tsx`)**
Tool call titles ("Shell exec", "List files", "Get board state", …) are rendered inside a `CollapsibleTrigger` which renders as `<button>`. Browsers suppress `user-select` on `<button>` elements by default, so the tool name was not selectable even though it looks like plain text. Adding `select-text` to the inner `<span>` overrides this.

Both of these fixes greatly help while debugging agent tool calls and configuration changes.

## Test plan

- [x] Open a chat with any agent that has tools
- [x] Verify tool call header text (e.g. "Shell exec") is selectable/copyable
- [x] Open agent settings or any config form
- [x] Verify label text ("Model", "System prompt", "Temperature", etc.) is selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)