### PR TITLE
feat(backend): let sandbox containers reach host services via host-gateway

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -44,5 +44,18 @@ STORAGE_DISK_PATH=./data/files
 # Requires a reachable Docker daemon. See docs/adr/0003.
 PLATYPUS_SANDBOX_DOCKER_ENABLED=false
 
+# Sandbox host reachability — comma-separated ExtraHosts entries applied to
+# every Docker sandbox container at creation. Lets agent-written code reach
+# host-published services (e.g. local model servers, transcription, the
+# internal-resource-proxy) without hardcoded IPs. See docs/adr/0005.
+#
+#   unset           → host.docker.internal:host-gateway (default)
+#   empty string    → no ExtraHosts (opt out)
+#   "name:ip,..."   → exact list, replaces the default
+#
+# Only affects newly-created containers; existing sandbox containers keep
+# their config until destroyed and recreated.
+# PLATYPUS_SANDBOX_EXTRA_HOSTS=host.docker.internal:host-gateway
+
 # Frontend URL for generating resource links in tool responses
 FRONTEND_URL=http://localhost:3001

--- a/apps/backend/src/sandbox/backends/docker.test.ts
+++ b/apps/backend/src/sandbox/backends/docker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { PassThrough } from "node:stream";
 
 // ---------------------------------------------------------------------------
@@ -315,6 +315,59 @@ describe("DockerSandboxBackend — provisioning", () => {
     expect(opts.HostConfig.MemorySwap).toBe(opts.HostConfig.Memory);
     expect(opts.HostConfig.NanoCpus).toBe(2_000_000_000);
     expect(opts.HostConfig.SecurityOpt).toEqual(["no-new-privileges:true"]);
+    expect(opts.HostConfig.ExtraHosts).toEqual([
+      "host.docker.internal:host-gateway",
+    ]);
+  });
+
+  describe("PLATYPUS_SANDBOX_EXTRA_HOSTS", () => {
+    const originalEnv = process.env.PLATYPUS_SANDBOX_EXTRA_HOSTS;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.PLATYPUS_SANDBOX_EXTRA_HOSTS;
+      } else {
+        process.env.PLATYPUS_SANDBOX_EXTRA_HOSTS = originalEnv;
+      }
+    });
+
+    it("opts out of ExtraHosts entirely when set to empty string", async () => {
+      process.env.PLATYPUS_SANDBOX_EXTRA_HOSTS = "";
+      setupFreshProvision();
+      queueExec({ exitCode: 0 });
+
+      const backend = new DockerSandboxBackend({}, {});
+      await backend.shellExec(ctx, { command: "true" });
+
+      expect(mockState.createContainerCalls[0].HostConfig.ExtraHosts).toEqual(
+        [],
+      );
+    });
+
+    it("replaces default with a custom comma-separated list", async () => {
+      process.env.PLATYPUS_SANDBOX_EXTRA_HOSTS =
+        "host.docker.internal:host-gateway, internal.example:10.0.0.5";
+      setupFreshProvision();
+      queueExec({ exitCode: 0 });
+
+      const backend = new DockerSandboxBackend({}, {});
+      await backend.shellExec(ctx, { command: "true" });
+
+      expect(mockState.createContainerCalls[0].HostConfig.ExtraHosts).toEqual([
+        "host.docker.internal:host-gateway",
+        "internal.example:10.0.0.5",
+      ]);
+    });
+
+    it("throws on malformed entries", async () => {
+      process.env.PLATYPUS_SANDBOX_EXTRA_HOSTS = "not a valid entry";
+      setupFreshProvision();
+
+      const backend = new DockerSandboxBackend({}, {});
+      await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
+        /PLATYPUS_SANDBOX_EXTRA_HOSTS/,
+      );
+    });
   });
 
   it("reuses an existing running container without re-creating", async () => {

--- a/apps/backend/src/sandbox/backends/docker.ts
+++ b/apps/backend/src/sandbox/backends/docker.ts
@@ -38,6 +38,50 @@ const MEMORY_BYTES = 2 * 1024 * 1024 * 1024; // 2 GB
 const NANO_CPUS = 2 * 1_000_000_000; // 2 CPUs
 const SECURITY_OPT = ["no-new-privileges:true"];
 
+// Default ExtraHosts entry: gives sandbox containers a Docker-convention
+// hostname (`host.docker.internal`) that resolves to the host's gateway IP,
+// so agent-written code can reach services the operator publishes on the
+// host (local model inference, transcription, the Platypus
+// internal-resource-proxy, etc.) without hardcoded IPs. See ADR-0005.
+//
+// Configurable via PLATYPUS_SANDBOX_EXTRA_HOSTS:
+//   - unset           → DEFAULT_EXTRA_HOSTS below
+//   - empty string    → no ExtraHosts at all (opt out)
+//   - "name:ip,..."   → exact comma-separated list (replaces default)
+//
+// Reads the env per call so operators can adjust without rebuilding the
+// image; only takes effect on newly-created containers (existing
+// containers keep their old config until destroyed and recreated, per
+// ADR-0003).
+const DEFAULT_EXTRA_HOSTS = ["host.docker.internal:host-gateway"];
+
+// Validate a single ExtraHosts entry. We accept the Docker daemon's own
+// format `host:ip-or-magic` where the right side is either an IPv4
+// address, an IPv6 address, or one of Docker's documented magic tokens
+// (currently `host-gateway`). Anything else is rejected — the daemon
+// would also reject it, but failing early gives a clearer error.
+const EXTRA_HOST_PATTERN =
+  /^[A-Za-z0-9.-]+:(?:host-gateway|[0-9.]+|[0-9A-Fa-f:]+)$/;
+
+function readExtraHosts(): string[] {
+  const raw = process.env.PLATYPUS_SANDBOX_EXTRA_HOSTS;
+  if (raw === undefined) return DEFAULT_EXTRA_HOSTS;
+  const trimmed = raw.trim();
+  if (trimmed === "") return [];
+  return trimmed
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => {
+      if (!EXTRA_HOST_PATTERN.test(entry)) {
+        throw new Error(
+          `Invalid PLATYPUS_SANDBOX_EXTRA_HOSTS entry: ${JSON.stringify(entry)}`,
+        );
+      }
+      return entry;
+    });
+}
+
 export const dockerSandboxConfigSchema = z.object({}).strict();
 export const dockerSandboxCredentialsSchema = z.object({}).strict();
 
@@ -327,6 +371,7 @@ export class DockerSandboxBackend implements SandboxBackend {
         MemorySwap: MEMORY_BYTES,
         NanoCpus: NANO_CPUS,
         SecurityOpt: SECURITY_OPT,
+        ExtraHosts: readExtraHosts(),
       },
     });
     await container.start();

--- a/docs/adr/0005-sandbox-host-reachability-via-extra-hosts.md
+++ b/docs/adr/0005-sandbox-host-reachability-via-extra-hosts.md
@@ -1,0 +1,21 @@
+# Sandbox containers reach host services via host-gateway
+
+The Docker reference Sandbox adapter sets `HostConfig.ExtraHosts` on every Sandbox container at creation. The default entry, `host.docker.internal:host-gateway`, lets agent-written code resolve the host's gateway IP using the canonical Docker convention, so the sandbox can participate in a local multi-service stack (Ollama, local Whisper, the Platypus `internal-resource-proxy`, …) without hardcoded IPs or per-deployment glue. The entry list is operator-controlled via `PLATYPUS_SANDBOX_EXTRA_HOSTS`: unset uses the default, empty string opts out entirely, and a comma-separated list replaces the default with a custom set.
+
+## Considered Options
+
+- **Hardcoded, non-configurable** (ADR-0003 spirit of "minimal v1 knobs"). Rejected: operators have legitimate reasons to want this off (stricter isolation requirements) or to add aliases (additional internal hostnames). An env-only knob is the smallest possible surface that addresses both.
+- **Per-Sandbox row config column**. Rejected: keeps adapter `config` schema clean (ADR-0001) and avoids leaking what is fundamentally a host-deployment concern into per-workspace data.
+- **Join sandbox to `platypus-network`**. Rejected: explicitly violates ADR-0003's blast-radius bound by giving sandbox containers direct database reachability.
+- **`network_mode: host`**. Rejected: removes network namespace isolation entirely.
+- **Document a workaround (operator-run everything in Docker on the platypus network)**. Rejected: pushes operator complexity for what is the most common self-hosted single-node deployment shape.
+- **OS-conditional defaults (Linux needs `host-gateway`, Mac doesn't strictly)**. Rejected: `host-gateway` works on both since Docker 20.10. Conditional adds complexity for no benefit.
+
+## Consequences
+
+- Requires Docker daemon 20.10+ for `host-gateway` resolution. Documented in README and `.env.example`.
+- Sandbox can reach any service the operator publishes on the host. Sandbox cannot reach `platypus-network` services that are not published on the host (the database remains unreachable).
+- The trust model from ADR-0004 (agent is trusted to use secrets, not exfiltrate them) is unchanged; this ADR exposes additional reachable surfaces only, not new authority.
+- Existing containers built before this change continue to run without the new entries until destroyed and recreated, consistent with ADR-0003's existing-container clause.
+- Env var is read per container creation, so operators can adjust without rebuilding the image. Entries are validated at creation time; an invalid entry fails the sandbox provisioning loudly rather than silently.
+- The default entry is `host.docker.internal:host-gateway`. Operators wanting strict isolation set `PLATYPUS_SANDBOX_EXTRA_HOSTS=` (empty) to disable the alias entirely.


### PR DESCRIPTION
## Summary

- The Docker reference sandbox adapter now injects `host.docker.internal:host-gateway` into `HostConfig.ExtraHosts` for every sandbox container at creation time
- On Linux, `host.docker.internal` is not automatically resolvable inside Docker containers (unlike Mac/Windows Docker Desktop) - without this, agent-written code cannot reach host-published services such as local model servers, transcription services, or any sidecar the operator runs on the host
- Operator-controlled via `PLATYPUS_SANDBOX_EXTRA_HOSTS` env var:
  - unset → default `host.docker.internal:host-gateway`
  - empty string → no ExtraHosts (opt out entirely)
  - `"name:ip,name2:ip2"` → exact list, replaces the default
- Entries are validated against Docker's accepted formats (hostname + IPv4/IPv6/`host-gateway`); a malformed entry fails sandbox provisioning loudly rather than silently
- Only affects newly-created containers; existing sandboxes keep their network config until destroyed and recreated (consistent with ADR-0003)
- ADR-0005 added documenting the threat-model delta: sandbox can reach operator-published host services; the `platypus-network` database and other internal services remain unreachable

## Test plan

- [x] Create a new sandbox on Linux - verify `host.docker.internal` resolves inside the container (`ping host.docker.internal` or `curl http://host.docker.internal:<port>`)
- [x] Set `PLATYPUS_SANDBOX_EXTRA_HOSTS=""` - verify no ExtraHosts are added
- [x] Set `PLATYPUS_SANDBOX_EXTRA_HOSTS="myhost:1.2.3.4"` - verify only that entry is present
- [x] Set a malformed value — verify sandbox creation fails with a clear error
- [x] Run existing Docker adapter tests: `pnpm --filter backend test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)