### PR TITLE
feat: org-scoped Skills + Promote action for shared resources (#155)

### DIFF
--- a/apps/backend/drizzle/0041_org_scoped_skills.sql
+++ b/apps/backend/drizzle/0041_org_scoped_skills.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "skill" ALTER COLUMN "workspace_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "skill" ADD COLUMN "organization_id" text;--> statement-breakpoint
+ALTER TABLE "skill" ADD CONSTRAINT "skill_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_skill_organization_id" ON "skill" USING btree ("organization_id");--> statement-breakpoint
+ALTER TABLE "skill" ADD CONSTRAINT "unique_skill_name_org" UNIQUE("organization_id","name");

--- a/apps/backend/drizzle/meta/0041_snapshot.json
+++ b/apps/backend/drizzle/meta/0041_snapshot.json
@@ -1,0 +1,3872 @@
+{
+  "id": "a1004c13-a4a5-4363-bc40-0caab0fdf8ad",
+  "prevId": "c1ec3c53-23cf-455d-936f-47d517c91ebe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_set_ids": {
+          "name": "tool_set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "skill_ids": {
+          "name": "skill_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "sub_agent_ids": {
+          "name": "sub_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "input_placeholder": {
+          "name": "input_placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_workspace_id": {
+          "name": "idx_agent_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_provider_id": {
+          "name": "idx_agent_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_id_workspace_id_fk": {
+          "name": "agent_workspace_id_workspace_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_provider_id_provider_id_fk": {
+          "name": "agent_provider_id_provider_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment": {
+      "name": "attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_attachment_workspace": {
+          "name": "idx_attachment_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attachment_resource": {
+          "name": "idx_attachment_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_workspace_id_workspace_id_fk": {
+          "name": "attachment_workspace_id_workspace_id_fk",
+          "tableFrom": "attachment",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_attachment": {
+          "name": "unique_attachment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "resource_type",
+            "resource_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_memory_processed_at": {
+          "name": "last_memory_processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_status": {
+          "name": "memory_extraction_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_workspace_id": {
+          "name": "idx_chat_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_tags": {
+          "name": "idx_chat_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_chat_memory_processing": {
+          "name": "idx_chat_memory_processing",
+          "columns": [
+            {
+              "expression": "memory_extraction_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_memory_processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_workspace_id_workspace_id_fk": {
+          "name": "chat_workspace_id_workspace_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context": {
+      "name": "context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_context_user_id": {
+          "name": "idx_context_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_workspace_id": {
+          "name": "idx_context_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "context_user_id_user_id_fk": {
+          "name": "context_user_id_user_id_fk",
+          "tableFrom": "context",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "context_workspace_id_workspace_id_fk": {
+          "name": "context_workspace_id_workspace_id_fk",
+          "tableFrom": "context",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_context_user_workspace": {
+          "name": "unique_context_user_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard": {
+      "name": "dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desktop_layout": {
+          "name": "desktop_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mobile_layout": {
+          "name": "mobile_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_dashboard_workspace_id": {
+          "name": "idx_dashboard_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_dashboard_workspace_name": {
+          "name": "uq_dashboard_workspace_name",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_workspace_id_workspace_id_fk": {
+          "name": "dashboard_workspace_id_workspace_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitation_email": {
+          "name": "idx_invitation_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitation_org_id": {
+          "name": "idx_invitation_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_invited_by_user_id_fk": {
+          "name": "invitation_invited_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_invitation_org_email": {
+          "name": "unique_invitation_org_email",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_board": {
+      "name": "kanban_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_board_workspace_id": {
+          "name": "idx_kanban_board_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_board_workspace_id_workspace_id_fk": {
+          "name": "kanban_board_workspace_id_workspace_id_fk",
+          "tableFrom": "kanban_board",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_kanban_board_name_workspace": {
+          "name": "unique_kanban_board_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card": {
+      "name": "kanban_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_ids": {
+          "name": "label_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "assignees": {
+          "name": "assignees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_user_id": {
+          "name": "last_edited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_agent_id": {
+          "name": "last_edited_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_column_id": {
+          "name": "idx_kanban_card_column_id",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_label_ids": {
+          "name": "idx_kanban_card_label_ids",
+          "columns": [
+            {
+              "expression": "label_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_kanban_card_assignees": {
+          "name": "idx_kanban_card_assignees",
+          "columns": [
+            {
+              "expression": "assignees",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_kanban_card_due_date": {
+          "name": "idx_kanban_card_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_priority": {
+          "name": "idx_kanban_card_priority",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_column_position": {
+          "name": "idx_kanban_card_column_position",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_column_id_kanban_column_id_fk": {
+          "name": "kanban_card_column_id_kanban_column_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "kanban_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kanban_card_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_last_edited_by_user_id_user_id_fk": {
+          "name": "kanban_card_last_edited_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "last_edited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_last_edited_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_last_edited_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "last_edited_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card_comment": {
+      "name": "kanban_card_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_comment_card_id": {
+          "name": "idx_kanban_card_comment_card_id",
+          "columns": [
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_comment_card_id_kanban_card_id_fk": {
+          "name": "kanban_card_comment_card_id_kanban_card_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "kanban_card",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kanban_card_comment_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_comment_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_comment_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_comment_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_column": {
+      "name": "kanban_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_column_board_id": {
+          "name": "idx_kanban_column_board_id",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_column_board_id_kanban_board_id_fk": {
+          "name": "kanban_column_board_id_kanban_board_id_fk",
+          "tableFrom": "kanban_column",
+          "tableTo": "kanban_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp": {
+      "name": "mcp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_access_token": {
+          "name": "oauth_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_refresh_token": {
+          "name": "oauth_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_expires_at": {
+          "name": "oauth_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_requested_scope": {
+          "name": "oauth_requested_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_workspace_id": {
+          "name": "idx_mcp_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_organization_id": {
+          "name": "idx_mcp_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_organization_id_organization_id_fk": {
+          "name": "mcp_organization_id_organization_id_fk",
+          "tableFrom": "mcp",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_workspace_id_workspace_id_fk": {
+          "name": "mcp_workspace_id_workspace_id_fk",
+          "tableFrom": "mcp",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_mcp_name_org": {
+          "name": "unique_mcp_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        },
+        "unique_mcp_name_workspace": {
+          "name": "unique_mcp_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_state": {
+      "name": "mcp_oauth_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_oauth_state_mcp_id": {
+          "name": "idx_mcp_oauth_state_mcp_id",
+          "columns": [
+            {
+              "expression": "mcp_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_state_mcp_id_mcp_id_fk": {
+          "name": "mcp_oauth_state_mcp_id_mcp_id_fk",
+          "tableFrom": "mcp_oauth_state",
+          "tableTo": "mcp",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_daily_summary": {
+      "name": "memory_daily_summary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_date": {
+          "name": "summary_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_summary_user_workspace": {
+          "name": "idx_daily_summary_user_workspace",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_summary_date": {
+          "name": "idx_daily_summary_date",
+          "columns": [
+            {
+              "expression": "summary_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_daily_summary_user_id_user_id_fk": {
+          "name": "memory_daily_summary_user_id_user_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_daily_summary_workspace_id_workspace_id_fk": {
+          "name": "memory_daily_summary_workspace_id_workspace_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_daily_summary_user_workspace_date": {
+          "name": "unique_daily_summary_user_workspace_date",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workspace_id",
+            "summary_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_workspace_id": {
+          "name": "idx_notification_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_agent_id": {
+          "name": "idx_notification_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_created_at": {
+          "name": "idx_notification_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_workspace_id_workspace_id_fk": {
+          "name": "notification_workspace_id_workspace_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_agent_id_agent_id_fk": {
+          "name": "notification_agent_id_agent_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_read": {
+      "name": "notification_read",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_read_user_id": {
+          "name": "idx_notification_read_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_read_notification_id": {
+          "name": "idx_notification_read_notification_id",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_read_notification_id_notification_id_fk": {
+          "name": "notification_read_notification_id_notification_id_fk",
+          "tableFrom": "notification_read",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_read_user_id_user_id_fk": {
+          "name": "notification_read_user_id_user_id_fk",
+          "tableFrom": "notification_read",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_notification_read": {
+          "name": "unique_notification_read",
+          "nullsNotDistinct": false,
+          "columns": [
+            "notification_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_member": {
+      "name": "organization_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_member_org_id": {
+          "name": "idx_org_member_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_member_user_id": {
+          "name": "idx_org_member_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_member_organization_id_organization_id_fk": {
+          "name": "organization_member_organization_id_organization_id_fk",
+          "tableFrom": "organization_member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_member_user_id_user_id_fk": {
+          "name": "organization_member_user_id_user_id_fk",
+          "tableFrom": "organization_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraBody": {
+          "name": "extraBody",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_mode": {
+          "name": "api_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'responses'"
+        },
+        "modelIds": {
+          "name": "modelIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_model_id": {
+          "name": "task_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_extraction_model_id": {
+          "name": "memory_extraction_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_workspace_id": {
+          "name": "idx_provider_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_organization_id": {
+          "name": "idx_provider_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_organization_id_organization_id_fk": {
+          "name": "provider_organization_id_organization_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_provider_name_org": {
+          "name": "unique_provider_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        },
+        "unique_provider_name_workspace": {
+          "name": "unique_provider_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox": {
+      "name": "sandbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "admin_env": {
+          "name": "admin_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_env": {
+          "name": "user_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_sandbox_workspace_id": {
+          "name": "unique_sandbox_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_workspace_id_workspace_id_fk": {
+          "name": "sandbox_workspace_id_workspace_id_fk",
+          "tableFrom": "sandbox",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_teardown_failure": {
+      "name": "sandbox_teardown_failure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_teardown_failure_workspace_id": {
+          "name": "idx_sandbox_teardown_failure_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill": {
+      "name": "skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_workspace_id": {
+          "name": "idx_skill_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skill_organization_id": {
+          "name": "idx_skill_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_organization_id_organization_id_fk": {
+          "name": "skill_organization_id_organization_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_workspace_id_workspace_id_fk": {
+          "name": "skill_workspace_id_workspace_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_skill_name_workspace": {
+          "name": "unique_skill_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "unique_skill_name_org": {
+          "name": "unique_skill_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger": {
+      "name": "trigger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_runs_to_keep": {
+          "name": "max_runs_to_keep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "search": {
+          "name": "search",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_workspace_id": {
+          "name": "idx_trigger_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_next_run_at": {
+          "name": "idx_trigger_next_run_at",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_type": {
+          "name": "idx_trigger_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_workspace_id_workspace_id_fk": {
+          "name": "trigger_workspace_id_workspace_id_fk",
+          "tableFrom": "trigger",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_agent_id_agent_id_fk": {
+          "name": "trigger_agent_id_agent_id_fk",
+          "tableFrom": "trigger",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_run": {
+      "name": "trigger_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_run_trigger_id": {
+          "name": "idx_trigger_run_trigger_id",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_run_started_at": {
+          "name": "idx_trigger_run_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_run_trigger_id_trigger_id_fk": {
+          "name": "trigger_run_trigger_id_trigger_id_fk",
+          "tableFrom": "trigger_run",
+          "tableTo": "trigger",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Webhook'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_secret": {
+          "name": "signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhook_workspace_id": {
+          "name": "idx_webhook_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_workspace_id_workspace_id_fk": {
+          "name": "webhook_workspace_id_workspace_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget": {
+      "name": "widget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_widget_dashboard_id": {
+          "name": "idx_widget_dashboard_id",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_widget_dashboard_title": {
+          "name": "uq_widget_dashboard_title",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "widget_dashboard_id_dashboard_id_fk": {
+          "name": "widget_dashboard_id_dashboard_id_fk",
+          "tableFrom": "widget",
+          "tableTo": "dashboard",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace": {
+      "name": "workspace",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_model_provider_id": {
+          "name": "task_model_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_provider_id": {
+          "name": "memory_extraction_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_embedding_provider_id": {
+          "name": "memory_embedding_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_daily_summaries": {
+          "name": "max_daily_summaries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 90
+        },
+        "provider_self_management": {
+          "name": "provider_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mcp_self_management": {
+          "name": "mcp_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_organization_id": {
+          "name": "idx_workspace_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_owner_id": {
+          "name": "idx_workspace_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_organization_id_organization_id_fk": {
+          "name": "workspace_organization_id_organization_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_owner_id_user_id_fk": {
+          "name": "workspace_owner_id_user_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_task_model_provider_id_provider_id_fk": {
+          "name": "workspace_task_model_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "task_model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_memory_extraction_provider_id_provider_id_fk": {
+          "name": "workspace_memory_extraction_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_extraction_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_memory_embedding_provider_id_provider_id_fk": {
+          "name": "workspace_memory_embedding_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_embedding_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1780215237579,
       "tag": "0040_backfill_org_attachments",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1780220802520,
+      "tag": "0041_org_scoped_skills",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -291,7 +291,10 @@ export const attachment = pgTable(
       .text("workspace_id")
       .notNull()
       .references(() => workspace.id, { onDelete: "cascade" }),
-    resourceType: t.text("resource_type").$type<"mcp" | "provider">().notNull(),
+    resourceType: t
+      .text("resource_type")
+      .$type<"mcp" | "provider" | "skill">()
+      .notNull(),
     resourceId: t.text("resource_id").notNull(),
     createdAt: t.timestamp("created_at").notNull().defaultNow(),
   }),
@@ -416,12 +419,18 @@ export const skill = pgTable(
   "skill",
   (t) => ({
     id: t.text("id").primaryKey(),
-    workspaceId: t
-      .text("workspace_id")
-      .notNull()
-      .references(() => workspace.id, {
+    // A Skill is scoped to either an Organization or a Workspace (mutually
+    // exclusive), mirroring the dual-scope shape of `provider`/`mcp`. Org-scoped
+    // Skills are Shared resources managed by Org Admins (ADR-0007); the XOR is
+    // enforced in the Zod schema and by the create routes.
+    organizationId: t
+      .text("organization_id")
+      .references(() => organization.id, {
         onDelete: "cascade",
       }),
+    workspaceId: t.text("workspace_id").references(() => workspace.id, {
+      onDelete: "cascade",
+    }),
     name: t.text("name").notNull(),
     description: t.text("description").notNull(),
     body: t.text("body").notNull(),
@@ -430,7 +439,9 @@ export const skill = pgTable(
   }),
   (t) => [
     index("idx_skill_workspace_id").on(t.workspaceId),
+    index("idx_skill_organization_id").on(t.organizationId),
     unique("unique_skill_name_workspace").on(t.workspaceId, t.name),
+    unique("unique_skill_name_org").on(t.organizationId, t.name),
   ],
 );
 

--- a/apps/backend/src/routes/attachment.test.ts
+++ b/apps/backend/src/routes/attachment.test.ts
@@ -48,6 +48,27 @@ describe("Attachment Routes", () => {
       expect(await res.json()).toEqual(record);
     });
 
+    it("attaches an org-scoped skill for an admin", async () => {
+      mockAdminAccess();
+      mockDb.limit.mockResolvedValueOnce([{ id: "skill-1" }]); // org-scope lookup
+      const record = {
+        id: "att-2",
+        workspaceId,
+        resourceType: "skill",
+        resourceId: "skill-1",
+      };
+      mockDb.returning.mockResolvedValueOnce([record]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({ resourceType: "skill", resourceId: "skill-1" }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(201);
+      expect(await res.json()).toEqual(record);
+    });
+
     it("returns 403 for a non-admin", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess

--- a/apps/backend/src/routes/attachment.ts
+++ b/apps/backend/src/routes/attachment.ts
@@ -6,6 +6,7 @@ import {
   attachment as attachmentTable,
   mcp as mcpTable,
   provider as providerTable,
+  skill as skillTable,
 } from "../db/schema.ts";
 import { attachmentCreateSchema } from "@platypus/schemas";
 import { eq, and } from "drizzle-orm";
@@ -59,7 +60,12 @@ attachment.post(
 
     // The resource must be org-scoped and belong to this organization — you can
     // only attach a Shared resource, never a workspace-scoped one.
-    const table = resourceType === "mcp" ? mcpTable : providerTable;
+    const table =
+      resourceType === "mcp"
+        ? mcpTable
+        : resourceType === "skill"
+          ? skillTable
+          : providerTable;
     const resource = await db
       .select({ id: table.id })
       .from(table)
@@ -106,7 +112,10 @@ attachment.delete(
       .where(
         and(
           eq(attachmentTable.workspaceId, workspaceId),
-          eq(attachmentTable.resourceType, resourceType as "mcp" | "provider"),
+          eq(
+            attachmentTable.resourceType,
+            resourceType as "mcp" | "provider" | "skill",
+          ),
           eq(attachmentTable.resourceId, resourceId),
         ),
       )

--- a/apps/backend/src/routes/org-skill.test.ts
+++ b/apps/backend/src/routes/org-skill.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
+import app from "../server.ts";
+
+describe("Organization Skill Routes", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+  });
+
+  const orgId = "org-1";
+  const baseUrl = `/organizations/${orgId}/skills`;
+
+  const createBody = {
+    name: "org-skill",
+    description: "This is a long enough description for the skill.",
+    body: "This is a long enough body for the skill to pass the validation requirements.",
+    organizationId: orgId,
+  };
+
+  describe("POST /", () => {
+    it("creates an org skill if org admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+
+      const mockSkill = {
+        id: "skill-1",
+        name: "org-skill",
+        organizationId: orgId,
+        workspaceId: null,
+      };
+      mockDb.returning.mockResolvedValueOnce([mockSkill]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify(createBody),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(201);
+      expect(await res.json()).toEqual(mockSkill);
+    });
+
+    it("returns 403 if not org admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify(createBody),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 409 if a skill name already exists in the org", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+
+      const err = new Error("DrizzleQueryError");
+      (err as any).cause = {
+        code: "23505",
+        message:
+          'duplicate key value violates unique constraint "unique_skill_name_org"',
+      };
+      mockDb.returning.mockRejectedValueOnce(err);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify(createBody),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe("GET /", () => {
+    it("lists org skills for any member", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      const skills = [{ id: "skill-1", name: "org-skill" }];
+      mockDb.where.mockReturnValueOnce(mockDb).mockResolvedValueOnce(skills);
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ results: skills });
+    });
+  });
+
+  describe("GET /:skillId", () => {
+    it("returns an org skill", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      const skill = { id: "skill-1", name: "org-skill", organizationId: orgId };
+      mockDb.limit.mockResolvedValueOnce([skill]);
+
+      const res = await app.request(`${baseUrl}/skill-1`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(skill);
+    });
+
+    it("returns 404 if not found", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const res = await app.request(`${baseUrl}/missing`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PUT /:skillId", () => {
+    it("updates an org skill if org admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      const updated = {
+        id: "skill-1",
+        name: "org-skill",
+        organizationId: orgId,
+      };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const res = await app.request(`${baseUrl}/skill-1`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "org-skill",
+          description: "This is a long enough description for the skill.",
+          body: "This is a long enough body for the skill to pass the validation requirements.",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(updated);
+    });
+
+    it("returns 403 for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+
+      const res = await app.request(`${baseUrl}/skill-1`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "org-skill",
+          description: "This is a long enough description for the skill.",
+          body: "This is a long enough body for the skill to pass the validation requirements.",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("DELETE /:skillId", () => {
+    it("deletes an org skill if org admin and not attached", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]); // attachment guard: none
+      mockDb.returning.mockResolvedValueOnce([{ id: "skill-1" }]);
+
+      const res = await app.request(`${baseUrl}/skill-1`, { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ message: "Skill deleted" });
+    });
+
+    it("returns 409 when the skill is attached to a workspace", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attachment guard: attached
+
+      const res = await app.request(`${baseUrl}/skill-1`, { method: "DELETE" });
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 403 for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+
+      const res = await app.request(`${baseUrl}/skill-1`, { method: "DELETE" });
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/apps/backend/src/routes/org-skill.ts
+++ b/apps/backend/src/routes/org-skill.ts
@@ -1,0 +1,173 @@
+import { Hono } from "hono";
+import { sValidator } from "@hono/standard-validator";
+import { nanoid } from "nanoid";
+import { db } from "../index.ts";
+import {
+  skill as skillTable,
+  attachment as attachmentTable,
+} from "../db/schema.ts";
+import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
+import { eq, and } from "drizzle-orm";
+import { requireAuth } from "../middleware/authentication.ts";
+import { requireOrgAccess } from "../middleware/authorization.ts";
+import type { Variables } from "../server.ts";
+
+// Org-scoped Skills are Shared resources (ADR-0007): a single source of truth
+// defined once at Organization scope and referenced by Workspaces through an
+// Attachment. They are managed only by Org Admins on the Organization surface,
+// so all mutations are org-admin-only; any member may read them.
+const orgSkill = new Hono<{ Variables: Variables }>();
+
+/** Detects a Postgres unique-constraint violation across driver shapes. */
+const isUniqueViolation = (error: any): boolean =>
+  error.code === "23505" ||
+  error.cause?.code === "23505" ||
+  error.message?.includes("unique constraint") ||
+  error.cause?.message?.includes("unique constraint");
+
+const NAME_CONFLICT = {
+  error: "A skill with this name already exists in this organization",
+} as const;
+
+/** Create an org-scoped Skill (admin only) */
+orgSkill.post(
+  "/",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  sValidator("json", skillCreateSchema),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    // Agent associations are a workspace concern; org-scoped Skills carry none.
+    const { agentIds: _agentIds, ...data } = c.req.valid("json");
+
+    try {
+      const record = await db
+        .insert(skillTable)
+        .values({
+          id: nanoid(),
+          name: data.name,
+          description: data.description,
+          body: data.body,
+          organizationId: orgId,
+          workspaceId: null,
+        })
+        .returning();
+      return c.json(record[0], 201);
+    } catch (error: any) {
+      if (isUniqueViolation(error)) {
+        return c.json(NAME_CONFLICT, 409);
+      }
+      throw error;
+    }
+  },
+);
+
+/** List org-scoped Skills */
+orgSkill.get("/", requireAuth, requireOrgAccess(), async (c) => {
+  const orgId = c.req.param("orgId")!;
+  const results = await db
+    .select()
+    .from(skillTable)
+    .where(eq(skillTable.organizationId, orgId));
+  return c.json({ results });
+});
+
+/** Get an org-scoped Skill by ID */
+orgSkill.get("/:skillId", requireAuth, requireOrgAccess(), async (c) => {
+  const orgId = c.req.param("orgId")!;
+  const skillId = c.req.param("skillId");
+  const record = await db
+    .select()
+    .from(skillTable)
+    .where(
+      and(eq(skillTable.id, skillId), eq(skillTable.organizationId, orgId)),
+    )
+    .limit(1);
+  if (record.length === 0) {
+    return c.json({ error: "Skill not found" }, 404);
+  }
+  return c.json(record[0]);
+});
+
+/** Update an org-scoped Skill by ID (admin only) */
+orgSkill.put(
+  "/:skillId",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  sValidator("json", skillUpdateSchema),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const skillId = c.req.param("skillId");
+    const { agentIds: _agentIds, ...data } = c.req.valid("json");
+
+    try {
+      const record = await db
+        .update(skillTable)
+        .set({
+          name: data.name,
+          description: data.description,
+          body: data.body,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(eq(skillTable.id, skillId), eq(skillTable.organizationId, orgId)),
+        )
+        .returning();
+      if (record.length === 0) {
+        return c.json({ error: "Skill not found" }, 404);
+      }
+      return c.json(record[0], 200);
+    } catch (error: any) {
+      if (isUniqueViolation(error)) {
+        return c.json(NAME_CONFLICT, 409);
+      }
+      throw error;
+    }
+  },
+);
+
+/** Delete an org-scoped Skill by ID (admin only) */
+orgSkill.delete(
+  "/:skillId",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const skillId = c.req.param("skillId");
+
+    // A Shared resource cannot be deleted while any Attachment references it
+    // (ADR-0007) — detach it from every Workspace first.
+    const [attached] = await db
+      .select()
+      .from(attachmentTable)
+      .where(
+        and(
+          eq(attachmentTable.resourceType, "skill"),
+          eq(attachmentTable.resourceId, skillId),
+        ),
+      )
+      .limit(1);
+    if (attached) {
+      return c.json(
+        {
+          error:
+            "Cannot delete: this skill is attached to one or more workspaces. Detach it first.",
+        },
+        409,
+      );
+    }
+
+    const result = await db
+      .delete(skillTable)
+      .where(
+        and(eq(skillTable.id, skillId), eq(skillTable.organizationId, orgId)),
+      )
+      .returning();
+    if (result.length === 0) {
+      return c.json({ error: "Skill not found" }, 404);
+    }
+    return c.json({ message: "Skill deleted" });
+  },
+);
+
+export { orgSkill };

--- a/apps/backend/src/routes/skill.test.ts
+++ b/apps/backend/src/routes/skill.test.ts
@@ -108,22 +108,96 @@ describe("Skill Routes", () => {
   });
 
   describe("GET /", () => {
-    it("should list all skills in workspace", async () => {
+    it("should list workspace and attached org skills tagged with scope", async () => {
       mockSession();
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
 
-      const mockSkills = [{ id: "skill-1", name: "skill-1" }];
+      const workspaceSkills = [{ id: "skill-1", name: "skill-1" }];
+      // The attached org-scoped Skills come back from an inner join, shaped
+      // { skill: {...} }.
+      const attachedOrgRows = [
+        { skill: { id: "org-skill-1", name: "org-skill-1" } },
+      ];
       mockDb.where
-        .mockReturnValueOnce(mockDb)
-        .mockReturnValueOnce(mockDb)
-        .mockResolvedValueOnce(mockSkills);
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // requireWorkspaceAccess
+        .mockResolvedValueOnce(workspaceSkills) // workspace-scoped query
+        .mockResolvedValueOnce(attachedOrgRows); // attached org-scoped query
 
       const res = await app.request(baseUrl);
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ results: mockSkills });
+      expect(await res.json()).toEqual({
+        results: [
+          { id: "org-skill-1", name: "org-skill-1", scope: "organization" },
+          { id: "skill-1", name: "skill-1", scope: "workspace" },
+        ],
+      });
+    });
+  });
+
+  describe("POST /:skillId/promote", () => {
+    const promoteUrl = `${baseUrl}/skill-1/promote`;
+
+    it("returns 403 if not org admin", async () => {
+      mockSession();
+      // requireOrgAccess(["admin"]) → member rejected
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+
+      const res = await app.request(promoteUrl, { method: "POST" });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 404 if the workspace skill does not exist", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([]); // skill lookup → not found
+
+      const res = await app.request(promoteUrl, { method: "POST" });
+      expect(res.status).toBe(404);
+    });
+
+    it("re-scopes the skill to org and auto-attaches the origin workspace", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "skill-1", workspaceId, name: "my-skill" },
+      ]); // skill lookup
+      // transaction: update ... returning, then insert attachment
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "skill-1", organizationId: orgId, workspaceId: null },
+      ]);
+
+      const res = await app.request(promoteUrl, { method: "POST" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        id: "skill-1",
+        organizationId: orgId,
+        workspaceId: null,
+        scope: "organization",
+      });
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(mockDb.onConflictDoNothing).toHaveBeenCalled();
+    });
+
+    it("returns 404 (no orphan attachment) when a concurrent promote already re-scoped the skill", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "skill-1", workspaceId, name: "my-skill" },
+      ]); // skill lookup (pre-transaction)
+      // Transaction update matches no row (skill already re-scoped) → rollback
+      mockDb.returning.mockResolvedValueOnce([]);
+
+      const res = await app.request(promoteUrl, { method: "POST" });
+      expect(res.status).toBe(404);
+      // The auto-attach insert must never run when the update found nothing.
+      expect(mockDb.onConflictDoNothing).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/routes/skill.ts
+++ b/apps/backend/src/routes/skill.ts
@@ -2,9 +2,13 @@ import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import { skill as skillTable, agent as agentTable } from "../db/schema.ts";
+import {
+  skill as skillTable,
+  agent as agentTable,
+  attachment as attachmentTable,
+} from "../db/schema.ts";
 import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
-import { eq, and, sql, inArray, notInArray } from "drizzle-orm";
+import { eq, and, or, sql, inArray, notInArray } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
@@ -14,18 +18,43 @@ import type { Variables } from "../server.ts";
 
 const skill = new Hono<{ Variables: Variables }>();
 
-/** List all skills in workspace */
+/** List skills visible in this workspace (workspace-scoped + attached org-scoped) */
 skill.get(
   "/",
   requireAuth,
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
-    const results = await db
+
+    // Workspace-scoped Skills
+    const workspaceSkills = await db
       .select()
       .from(skillTable)
       .where(eq(skillTable.workspaceId, workspaceId));
+
+    // Org-scoped (Shared) Skills appear in a Workspace only where attached
+    // (ADR-0007 / #154) — gate by an inner join on the Attachment table.
+    const attachedOrgRows = await db
+      .select()
+      .from(skillTable)
+      .innerJoin(
+        attachmentTable,
+        and(
+          eq(attachmentTable.resourceId, skillTable.id),
+          eq(attachmentTable.resourceType, "skill"),
+          eq(attachmentTable.workspaceId, workspaceId),
+        ),
+      )
+      .where(eq(skillTable.organizationId, orgId));
+    const orgSkills = attachedOrgRows.map((r) => r.skill);
+
+    // Tag each Skill with its scope for the frontend (locked cards for org).
+    const results = [
+      ...orgSkills.map((s) => ({ ...s, scope: "organization" as const })),
+      ...workspaceSkills.map((s) => ({ ...s, scope: "workspace" as const })),
+    ];
 
     return c.json({ results });
   },
@@ -38,16 +67,22 @@ skill.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
     const skillId = c.req.param("skillId");
 
+    // Resolve a Skill at either scope: the invoking workspace, or the
+    // organization (a Shared Skill — ADR-0007).
     const record = await db
       .select()
       .from(skillTable)
       .where(
         and(
           eq(skillTable.id, skillId),
-          eq(skillTable.workspaceId, workspaceId),
+          or(
+            eq(skillTable.workspaceId, workspaceId),
+            eq(skillTable.organizationId, orgId),
+          ),
         ),
       )
       .limit(1);
@@ -56,7 +91,26 @@ skill.get(
       return c.json({ error: "Skill not found" }, 404);
     }
 
-    // Find agents that have this skill assigned
+    // An org-scoped (Shared) Skill is only visible here where attached.
+    const isOrgScoped = !!record[0].organizationId && !record[0].workspaceId;
+    if (isOrgScoped) {
+      const [attached] = await db
+        .select({ id: attachmentTable.id })
+        .from(attachmentTable)
+        .where(
+          and(
+            eq(attachmentTable.workspaceId, workspaceId),
+            eq(attachmentTable.resourceType, "skill"),
+            eq(attachmentTable.resourceId, skillId),
+          ),
+        )
+        .limit(1);
+      if (!attached) {
+        return c.json({ error: "Skill not found" }, 404);
+      }
+    }
+
+    // Find workspace agents that have this skill assigned
     const agentsWithSkill = await db
       .select({ id: agentTable.id })
       .from(agentTable)
@@ -69,6 +123,7 @@ skill.get(
 
     return c.json({
       ...record[0],
+      scope: isOrgScoped ? "organization" : "workspace",
       agentIds: agentsWithSkill.map((a) => a.id),
     });
   },
@@ -82,20 +137,27 @@ skill.post(
   requireWorkspaceAccess,
   sValidator("json", skillCreateSchema),
   async (c) => {
+    const workspaceId = c.req.param("workspaceId")!;
     const { agentIds, ...data } = c.req.valid("json");
     try {
       const newId = nanoid();
+      // The workspace route only ever creates workspace-scoped Skills; the
+      // scope is taken from the route, never the body (org-scoped Skills are
+      // created via the Organization surface or by Promote).
       const record = await db
         .insert(skillTable)
         .values({
           id: newId,
-          ...data,
+          name: data.name,
+          description: data.description,
+          body: data.body,
+          workspaceId,
+          organizationId: null,
         })
         .returning();
 
       // Add skill to specified agents
       if (agentIds && agentIds.length > 0) {
-        const workspaceId = c.req.param("workspaceId")!;
         const newIdJson = JSON.stringify([newId]);
         await db
           .update(agentTable)
@@ -271,6 +333,106 @@ skill.delete(
     }
 
     return c.json({ message: "Skill deleted" });
+  },
+);
+
+/**
+ * Promote a workspace-scoped Skill to Organization scope (admin only — ADR-0007).
+ *
+ * Re-scopes the Skill from this Workspace to the Organization, turning it into a
+ * Shared resource, and auto-attaches the origin Workspace so the author keeps
+ * using/editing it in place. A Skill is leaf text (it references no other
+ * resource), so there is no "references must already be Shared" prerequisite —
+ * Skills establish the Promote pattern that Agents build on. Workspace Agents
+ * that already reference the Skill keep their references intact (the id is
+ * unchanged) and resolve it at Chat-turn time via the Attachment.
+ */
+skill.post(
+  "/:skillId/promote",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  requireWorkspaceAccess,
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const workspaceId = c.req.param("workspaceId")!;
+    const skillId = c.req.param("skillId");
+
+    // Only a workspace-scoped Skill in this workspace can be promoted.
+    const [existing] = await db
+      .select()
+      .from(skillTable)
+      .where(
+        and(
+          eq(skillTable.id, skillId),
+          eq(skillTable.workspaceId, workspaceId),
+        ),
+      )
+      .limit(1);
+    if (!existing) {
+      return c.json({ error: "Skill not found" }, 404);
+    }
+
+    // Sentinel for a lost TOCTOU race: the Skill was re-scoped or deleted
+    // between the lookup above and the in-transaction update. Throwing rolls
+    // back the auto-attach so we never leave a dangling Attachment.
+    const PROMOTE_RACE = "skill_no_longer_workspace_scoped";
+
+    try {
+      const promoted = await db.transaction(async (tx) => {
+        const [record] = await tx
+          .update(skillTable)
+          .set({
+            organizationId: orgId,
+            workspaceId: null,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(skillTable.id, skillId),
+              eq(skillTable.workspaceId, workspaceId),
+            ),
+          )
+          .returning();
+
+        if (!record) {
+          throw new Error(PROMOTE_RACE);
+        }
+
+        // Auto-attach the origin Workspace so it keeps seeing the Skill.
+        await tx
+          .insert(attachmentTable)
+          .values({
+            id: nanoid(),
+            workspaceId,
+            resourceType: "skill",
+            resourceId: skillId,
+          })
+          .onConflictDoNothing();
+
+        return record;
+      });
+
+      return c.json({ ...promoted, scope: "organization" }, 200);
+    } catch (error: any) {
+      if (error?.message === PROMOTE_RACE) {
+        return c.json({ error: "Skill not found" }, 404);
+      }
+      const isUniqueViolation =
+        error.code === "23505" ||
+        error.cause?.code === "23505" ||
+        error.message?.includes("unique constraint") ||
+        error.cause?.message?.includes("unique constraint");
+
+      if (isUniqueViolation) {
+        return c.json(
+          {
+            error: "A skill with this name already exists in this organization",
+          },
+          409,
+        );
+      }
+      throw error;
+    }
   },
 );
 

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -15,6 +15,7 @@ import "./sandbox/backends/index.ts";
 import { provider } from "./routes/provider.ts";
 import { orgProvider } from "./routes/org-provider.ts";
 import { orgMcp } from "./routes/org-mcp.ts";
+import { orgSkill } from "./routes/org-skill.ts";
 import { attachment } from "./routes/attachment.ts";
 import { invitation } from "./routes/invitation.ts";
 import { userInvitation } from "./routes/user-invitation.ts";
@@ -146,6 +147,7 @@ app.route("/organizations/:orgId/workspaces/:workspaceId/skills", skill);
 app.route("/organizations/:orgId/workspaces/:workspaceId/providers", provider);
 app.route("/organizations/:orgId/providers", orgProvider);
 app.route("/organizations/:orgId/mcps", orgMcp);
+app.route("/organizations/:orgId/skills", orgSkill);
 app.route(
   "/organizations/:orgId/workspaces/:workspaceId/attachments",
   attachment,

--- a/apps/backend/src/services/chat-execution.test-fixtures.ts
+++ b/apps/backend/src/services/chat-execution.test-fixtures.ts
@@ -17,16 +17,17 @@ export type ChatTurnQueriesFixtures = {
   providers?: Provider[];
   skills?: Array<{
     id: string;
-    workspaceId: string;
+    workspaceId?: string | null;
+    organizationId?: string | null;
     name: string;
     description: string;
   }>;
   mcps?: McpRow[];
   // Attachments of org-scoped Shared resources to workspaces (ADR-0007). An
-  // org-scoped Provider/MCP resolves at Chat-turn time only where attached.
+  // org-scoped Provider/MCP/Skill resolves at Chat-turn time only where attached.
   attachments?: Array<{
     workspaceId: string;
-    resourceType: "mcp" | "provider";
+    resourceType: "mcp" | "provider" | "skill";
     resourceId: string;
   }>;
   userContexts?: Array<{
@@ -46,7 +47,7 @@ export const createInMemoryChatTurnQueries = (
   fx: ChatTurnQueriesFixtures = {},
 ): ChatTurnQueries => {
   const isAttached = (
-    resourceType: "mcp" | "provider",
+    resourceType: "mcp" | "provider" | "skill",
     resourceId: string,
     workspaceId: string,
   ) =>
@@ -87,10 +88,20 @@ export const createInMemoryChatTurnQueries = (
       return p;
     },
 
-    async getSkillsByIds(ids, workspaceId) {
+    async getSkillsByIds(ids, orgId, workspaceId) {
       if (ids.length === 0) return [];
       return (fx.skills ?? [])
-        .filter((s) => s.workspaceId === workspaceId && ids.includes(s.id))
+        .filter((s) => {
+          if (!ids.includes(s.id)) return false;
+          // Workspace-scoped Skill in this workspace.
+          if (s.workspaceId === workspaceId) return true;
+          // Org-scoped (Shared) Skill resolves only where attached (ADR-0007).
+          return (
+            s.organizationId === orgId &&
+            !s.workspaceId &&
+            isAttached("skill", s.id, workspaceId)
+          );
+        })
         .map((s) => ({ name: s.name, description: s.description }));
     },
 

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -174,6 +174,60 @@ describe("chat-execution", () => {
       await expect(turn.dispose()).resolves.toBeUndefined();
     });
 
+    it("resolves an org-scoped (Shared) Skill referenced by the Agent only where attached", async () => {
+      const agentWithSkill = { ...baseAgent, skillIds: ["org-skill-1"] };
+      const orgSkill = {
+        id: "org-skill-1",
+        organizationId: "org-1",
+        workspaceId: null,
+        name: "shared-skill",
+        description: "An organization-shared skill",
+      };
+
+      // Attached → the Skill surfaces in the system prompt.
+      const attached = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        agents: [agentWithSkill as any],
+        providers: [baseProvider as any],
+        skills: [orgSkill],
+        attachments: [
+          {
+            workspaceId: "ws-1",
+            resourceType: "skill",
+            resourceId: "org-skill-1",
+          },
+        ],
+      });
+
+      const attachedTurn = await prepareChatTurn(
+        {
+          ...baseInput,
+          request: { id: "chat-os", agentId: agentWithSkill.id },
+        },
+        attached,
+      );
+      expect(attachedTurn.stream.system).toContain("shared-skill");
+      expect(attachedTurn.stream.tools).toHaveProperty("loadSkill");
+
+      // Not attached → the Skill is invisible to this workspace.
+      const detached = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        agents: [agentWithSkill as any],
+        providers: [baseProvider as any],
+        skills: [orgSkill],
+      });
+
+      const detachedTurn = await prepareChatTurn(
+        {
+          ...baseInput,
+          request: { id: "chat-os2", agentId: agentWithSkill.id },
+        },
+        detached,
+      );
+      expect(detachedTurn.stream.system).not.toContain("shared-skill");
+      expect(detachedTurn.stream.tools).not.toHaveProperty("loadSkill");
+    });
+
     it("Direct Provider+Model selection populates resolved.systemPrompt and merges request overrides", async () => {
       const queries = createInMemoryChatTurnQueries({
         workspaces: [baseWorkspace],

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -186,6 +186,7 @@ export type ChatTurnQueries = {
   ): Promise<Provider | null>;
   getSkillsByIds(
     ids: string[],
+    orgId: string,
     workspaceId: string,
   ): Promise<Array<Pick<Skill, "name" | "description">>>;
   getMcp(
@@ -214,7 +215,7 @@ export type ChatTurnQueries = {
  * (ADR-0007). Org-scoped resources resolve at Chat-turn time only where attached.
  */
 const isAttached = async (
-  resourceType: "mcp" | "provider",
+  resourceType: "mcp" | "provider" | "skill",
   resourceId: string,
   workspaceId: string,
 ): Promise<boolean> => {
@@ -280,9 +281,10 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
     return row as Provider;
   },
 
-  async getSkillsByIds(ids, workspaceId) {
+  async getSkillsByIds(ids, orgId, workspaceId) {
     if (ids.length === 0) return [];
-    return db
+    // Workspace-scoped Skills referenced by the Agent.
+    const workspaceSkills = await db
       .select({ name: skillTable.name, description: skillTable.description })
       .from(skillTable)
       .where(
@@ -291,6 +293,30 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
           inArray(skillTable.id, ids),
         ),
       );
+
+    // Org-scoped (Shared) Skills resolve only where attached (ADR-0007) — gate
+    // by an inner join on the Attachment table for the invoking workspace.
+    const orgSkills = await db
+      .select({ name: skillTable.name, description: skillTable.description })
+      .from(skillTable)
+      .innerJoin(
+        attachmentTable,
+        and(
+          eq(attachmentTable.resourceId, skillTable.id),
+          eq(attachmentTable.resourceType, "skill"),
+          eq(attachmentTable.workspaceId, workspaceId),
+        ),
+      )
+      .where(
+        and(eq(skillTable.organizationId, orgId), inArray(skillTable.id, ids)),
+      );
+
+    // A workspace-scoped Skill wins a name collision with an attached org-scoped
+    // one, matching loadSkill's workspace-first resolution — so the advertised
+    // list and the tool agree on which body the model loads, with no duplicate
+    // entry in the system prompt.
+    const seen = new Set(workspaceSkills.map((s) => s.name));
+    return [...workspaceSkills, ...orgSkills.filter((s) => !seen.has(s.name))];
   },
 
   async getMcp(id, orgId, workspaceId) {
@@ -419,7 +445,7 @@ export const prepareChatTurn = async (
     sandboxEnvKeys,
   ] = await Promise.all([
     loadTools(queries, agent, workspaceId, orgId, frontendUrl, user.id),
-    loadSkills(queries, agent, workspaceId),
+    loadSkills(queries, agent, orgId, workspaceId),
     loadSubAgents(queries, agent, orgId, workspaceId, frontendUrl, onActivity),
     queries.getUserContexts(user.id, workspaceId),
     queries.getRecentMemories(user.id, workspaceId),
@@ -458,7 +484,7 @@ export const prepareChatTurn = async (
   );
 
   if (skills.length > 0) {
-    tools.loadSkill = createLoadSkillTool(workspaceId);
+    tools.loadSkill = createLoadSkillTool(orgId, workspaceId);
   }
 
   const heartbeat = onActivity ? createToolHeartbeat(onActivity) : null;
@@ -812,10 +838,11 @@ const resolveGenerationConfig = (
 const loadSkills = async (
   queries: ChatTurnQueries,
   agent: AgentRow | undefined,
+  orgId: string,
   workspaceId: string,
 ): Promise<Array<Pick<Skill, "name" | "description">>> => {
   if (!agent?.skillIds || agent.skillIds.length === 0) return [];
-  return queries.getSkillsByIds(agent.skillIds, workspaceId);
+  return queries.getSkillsByIds(agent.skillIds, orgId, workspaceId);
 };
 
 const loadSubAgents = async (

--- a/apps/backend/src/test-utils.ts
+++ b/apps/backend/src/test-utils.ts
@@ -28,6 +28,8 @@ const { mockDb, mockAuth } = vi.hoisted(() => {
     "execute",
     "inArray",
     "groupBy",
+    "onConflictDoNothing",
+    "onConflictDoUpdate",
   ];
 
   methods.forEach((method) => {
@@ -75,6 +77,8 @@ export const resetMockDb = () => {
     "execute",
     "inArray",
     "groupBy",
+    "onConflictDoNothing",
+    "onConflictDoUpdate",
   ];
 
   methods.forEach((method) => {

--- a/apps/backend/src/tools/skill.test.ts
+++ b/apps/backend/src/tools/skill.test.ts
@@ -6,6 +6,7 @@ const { mockDb, dbMethods } = vi.hoisted(() => {
     "select",
     "from",
     "where",
+    "innerJoin",
     "limit",
     "orderBy",
     "insert",
@@ -30,6 +31,7 @@ import { createLoadSkillTool } from "./skill.ts";
 const ctx = { toolCallId: "test", messages: [] };
 
 describe("createLoadSkillTool", () => {
+  const orgId = "org-1";
   const workspaceId = "ws-1";
   let loadSkill: ReturnType<typeof createLoadSkillTool>;
 
@@ -38,16 +40,17 @@ describe("createLoadSkillTool", () => {
     dbMethods.forEach((method) => {
       mockDb[method] = vi.fn().mockReturnValue(mockDb);
     });
-    loadSkill = createLoadSkillTool(workspaceId);
+    loadSkill = createLoadSkillTool(orgId, workspaceId);
   });
 
   it("returns a tool with the correct description", () => {
     expect(loadSkill.description).toContain("skill");
   });
 
-  it("returns skill data when found", async () => {
+  it("returns workspace skill data when found", async () => {
     const skillData = { name: "my-skill", body: "Skill instructions here" };
-    mockDb.limit.mockResolvedValue([skillData]);
+    // First query (workspace-scoped) resolves with the skill.
+    mockDb.limit.mockResolvedValueOnce([skillData]);
 
     const result = await loadSkill.execute({ name: "my-skill" }, ctx);
     expect(result).toEqual({
@@ -56,7 +59,16 @@ describe("createLoadSkillTool", () => {
     });
   });
 
-  it("returns error when skill not found", async () => {
+  it("falls back to an attached org-scoped skill", async () => {
+    const orgSkill = { name: "shared-skill", body: "Shared instructions" };
+    // Workspace query empty, then the attached org-scoped query resolves.
+    mockDb.limit.mockResolvedValueOnce([]).mockResolvedValueOnce([orgSkill]);
+
+    const result = await loadSkill.execute({ name: "shared-skill" }, ctx);
+    expect(result).toEqual(orgSkill);
+  });
+
+  it("returns error when skill not found at either scope", async () => {
     mockDb.limit.mockResolvedValue([]);
 
     const result = await loadSkill.execute({ name: "nonexistent" }, ctx);

--- a/apps/backend/src/tools/skill.ts
+++ b/apps/backend/src/tools/skill.ts
@@ -1,10 +1,13 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { db } from "../index.ts";
-import { skill as skillTable } from "../db/schema.ts";
+import {
+  skill as skillTable,
+  attachment as attachmentTable,
+} from "../db/schema.ts";
 import { and, eq } from "drizzle-orm";
 
-export const createLoadSkillTool = (workspaceId: string) =>
+export const createLoadSkillTool = (orgId: string, workspaceId: string) =>
   tool({
     description:
       "Load the full content of a skill by name. Use this when a user request relates to one of the available skills.",
@@ -12,7 +15,8 @@ export const createLoadSkillTool = (workspaceId: string) =>
       name: z.string().describe("The kebab-case name of the skill to load"),
     }),
     execute: async ({ name }: { name: string }) => {
-      const [result] = await db
+      // A workspace-scoped Skill in this workspace.
+      const [workspaceSkill] = await db
         .select()
         .from(skillTable)
         .where(
@@ -23,10 +27,32 @@ export const createLoadSkillTool = (workspaceId: string) =>
         )
         .limit(1);
 
-      if (!result) {
+      if (workspaceSkill) {
+        return { name: workspaceSkill.name, body: workspaceSkill.body };
+      }
+
+      // Otherwise an org-scoped (Shared) Skill, resolved only where attached
+      // to the invoking workspace (ADR-0007).
+      const [orgSkill] = await db
+        .select({ name: skillTable.name, body: skillTable.body })
+        .from(skillTable)
+        .innerJoin(
+          attachmentTable,
+          and(
+            eq(attachmentTable.resourceId, skillTable.id),
+            eq(attachmentTable.resourceType, "skill"),
+            eq(attachmentTable.workspaceId, workspaceId),
+          ),
+        )
+        .where(
+          and(eq(skillTable.organizationId, orgId), eq(skillTable.name, name)),
+        )
+        .limit(1);
+
+      if (!orgSkill) {
         return { error: `Skill '${name}' not found` };
       }
 
-      return { name: result.name, body: result.body };
+      return { name: orgSkill.name, body: orgSkill.body };
     },
   });

--- a/apps/frontend/app/[orgId]/settings/skills/[skillId]/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/skills/[skillId]/page.tsx
@@ -1,0 +1,20 @@
+import { SkillForm } from "@/components/skill-form";
+import { BackButton } from "@/components/back-button";
+
+const EditOrgSkillPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string; skillId: string }>;
+}) => {
+  const { orgId, skillId } = await params;
+
+  return (
+    <div>
+      <BackButton fallbackHref={`/${orgId}/settings/skills`} />
+      <h1 className="text-2xl font-bold mb-4">Edit Organization Skill</h1>
+      <SkillForm orgId={orgId} skillId={skillId} />
+    </div>
+  );
+};
+
+export default EditOrgSkillPage;

--- a/apps/frontend/app/[orgId]/settings/skills/create/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/skills/create/page.tsx
@@ -1,0 +1,20 @@
+import { SkillForm } from "@/components/skill-form";
+import { BackButton } from "@/components/back-button";
+
+const CreateOrgSkillPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) => {
+  const { orgId } = await params;
+
+  return (
+    <div>
+      <BackButton fallbackHref={`/${orgId}/settings/skills`} />
+      <h1 className="text-2xl font-bold mb-4">Create Organization Skill</h1>
+      <SkillForm orgId={orgId} />
+    </div>
+  );
+};
+
+export default CreateOrgSkillPage;

--- a/apps/frontend/app/[orgId]/settings/skills/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/skills/page.tsx
@@ -1,0 +1,22 @@
+import { SkillsList } from "@/components/skills-list";
+
+const OrgSkillsPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) => {
+  const { orgId } = await params;
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Organization Skills</h1>
+      <p className="text-muted-foreground mb-6">
+        Skills defined here are shared resources. They appear in a workspace
+        only where an admin attaches them, and are edited only here.
+      </p>
+      <SkillsList orgId={orgId} />
+    </div>
+  );
+};
+
+export default OrgSkillsPage;

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/page.tsx
@@ -413,11 +413,6 @@ const Workspace = () => {
             storageKey="section:skills:open"
           >
             <SkillsList orgId={orgId} workspaceId={workspaceId} />
-            <Button variant="outline" asChild>
-              <Link href={`/${orgId}/workspace/${workspaceId}/skills/create`}>
-                <Plus /> Create Skill
-              </Link>
-            </Button>
           </CollapsibleSection>
 
           <Separator />

--- a/apps/frontend/components/attach-shared-resource-dialog.tsx
+++ b/apps/frontend/components/attach-shared-resource-dialog.tsx
@@ -15,7 +15,19 @@ import {
 import { Item, ItemActions, ItemContent, ItemTitle } from "./ui/item";
 import { useState } from "react";
 
-type ResourceType = "mcp" | "provider";
+type ResourceType = "mcp" | "provider" | "skill";
+
+const COLLECTION: Record<ResourceType, string> = {
+  mcp: "mcps",
+  provider: "providers",
+  skill: "skills",
+};
+
+const LABEL: Record<ResourceType, string> = {
+  mcp: "MCP server",
+  provider: "provider",
+  skill: "skill",
+};
 
 /**
  * Admin-only picker for attaching an org-scoped Shared resource to a Workspace
@@ -40,8 +52,8 @@ const AttachSharedResourceDialog = ({
   onAttached: () => void;
 }) => {
   const backendUrl = useBackendUrl();
-  const collection = resourceType === "mcp" ? "mcps" : "providers";
-  const label = resourceType === "mcp" ? "MCP server" : "provider";
+  const collection = COLLECTION[resourceType];
+  const label = LABEL[resourceType];
 
   const { data } = useSWR<{ results: { id: string; name: string }[] }>(
     open && backendUrl

--- a/apps/frontend/components/org-settings-menu.tsx
+++ b/apps/frontend/components/org-settings-menu.tsx
@@ -8,7 +8,7 @@ import {
   SidebarMenuItem,
   SidebarMenu,
 } from "@/components/ui/sidebar";
-import { Mail, Plug, Settings, Unplug, Users } from "lucide-react";
+import { Mail, Plug, Settings, Sparkles, Unplug, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -23,6 +23,7 @@ export function OrgSettingsMenu({ orgId }: OrgSettingsMenuProps) {
   const invitationsHref = `/${orgId}/settings/invitations`;
   const providersHref = `/${orgId}/settings/providers`;
   const mcpHref = `/${orgId}/settings/mcp`;
+  const skillsHref = `/${orgId}/settings/skills`;
 
   return (
     <SidebarContent>
@@ -73,6 +74,16 @@ export function OrgSettingsMenu({ orgId }: OrgSettingsMenuProps) {
               >
                 <Link href={mcpHref}>
                   <Plug /> MCP
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                asChild
+                isActive={pathname.startsWith(skillsHref)}
+              >
+                <Link href={skillsHref}>
+                  <Sparkles /> Skills
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -32,7 +32,9 @@ const SkillForm = ({
 }: {
   classNames?: string;
   orgId: string;
-  workspaceId: string;
+  // Absent on the Organization settings surface, where the form manages an
+  // org-scoped Shared Skill (ADR-0007).
+  workspaceId?: string;
   skillId?: string;
 }) => {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -42,22 +44,25 @@ const SkillForm = ({
   const { user } = useAuth();
   const backendUrl = useBackendUrl();
 
-  // Fetch existing skill data if editing (includes agentIds)
+  // The scope determines the backend collection and where we return after save.
+  const collectionUrl = workspaceId
+    ? `/organizations/${orgId}/workspaces/${workspaceId}/skills`
+    : `/organizations/${orgId}/skills`;
+  const returnPath = workspaceId
+    ? `/${orgId}/workspace/${workspaceId}`
+    : `/${orgId}/settings/skills`;
+
+  // Fetch existing skill data if editing (includes agentIds in workspace mode)
   const { data: skill, isLoading: skillLoading } = useSWR<
     Skill & { agentIds?: string[] }
   >(
-    skillId && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/skills/${skillId}`,
-        )
-      : null,
+    skillId && user ? joinUrl(backendUrl, `${collectionUrl}/${skillId}`) : null,
     fetcher,
   );
 
-  // Fetch agents for association
+  // Agent associations are a workspace concern; only fetched on that surface.
   const { data: agentsData } = useSWR<{ results: Agent[] }>(
-    backendUrl && user
+    backendUrl && user && workspaceId
       ? joinUrl(
           backendUrl,
           `/organizations/${orgId}/workspaces/${workspaceId}/agents`,
@@ -130,22 +135,18 @@ const SkillForm = ({
     setValidationErrors({});
     try {
       const payload = {
-        workspaceId,
         name: formData.name,
         description: formData.description,
         body: formData.body,
-        agentIds: selectedAgentIds,
+        // Scope and agent associations only apply to the workspace surface.
+        ...(workspaceId
+          ? { workspaceId, agentIds: selectedAgentIds }
+          : { organizationId: orgId }),
       };
 
       const url = skillId
-        ? joinUrl(
-            backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}/skills/${skillId}`,
-          )
-        : joinUrl(
-            backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}/skills`,
-          );
+        ? joinUrl(backendUrl, `${collectionUrl}/${skillId}`)
+        : joinUrl(backendUrl, collectionUrl);
 
       const method = skillId ? "PUT" : "POST";
 
@@ -159,11 +160,13 @@ const SkillForm = ({
       });
 
       if (response.ok) {
-        router.push(`/${orgId}/workspace/${workspaceId}`);
+        router.push(returnPath);
       } else {
         const errorData = await response.json();
         if (response.status === 409) {
-          setValidationErrors({ name: errorData.message });
+          setValidationErrors({
+            name: errorData.error || errorData.message,
+          });
         } else {
           setValidationErrors(parseValidationErrors(errorData));
         }
@@ -183,10 +186,7 @@ const SkillForm = ({
     setDeleteError(null);
     try {
       const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/skills/${skillId}`,
-        ),
+        joinUrl(backendUrl, `${collectionUrl}/${skillId}`),
         {
           method: "DELETE",
           credentials: "include",
@@ -194,10 +194,12 @@ const SkillForm = ({
       );
 
       if (response.ok) {
-        router.push(`/${orgId}/workspace/${workspaceId}`);
+        router.push(returnPath);
       } else {
         const errorData = await response.json();
-        setDeleteError(errorData.message || "Failed to delete skill");
+        setDeleteError(
+          errorData.error || errorData.message || "Failed to delete skill",
+        );
         setIsDeleting(false);
       }
     } catch (error) {

--- a/apps/frontend/components/skills-list.tsx
+++ b/apps/frontend/components/skills-list.tsx
@@ -11,6 +11,14 @@ import {
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -23,11 +31,17 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
+  ArrowUpFromLine,
   Bot,
+  Building,
   EllipsisVertical,
+  ExternalLink,
+  Link2,
   Pencil,
+  Plus,
   Trash2,
   TriangleAlert,
+  Unlink,
 } from "lucide-react";
 import { type Skill, type Agent } from "@platypus/schemas";
 import useSWR from "swr";
@@ -35,39 +49,59 @@ import { fetcher, joinUrl } from "@/lib/utils";
 import Link from "next/link";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
+import { AttachSharedResourceDialog } from "@/components/attach-shared-resource-dialog";
+
+// The list serves two surfaces: a Workspace (workspaceId provided) where it
+// shows workspace-scoped Skills plus attached org-scoped Shared Skills as
+// locked cards, and the Organization settings surface (no workspaceId) where it
+// manages org-scoped Skills directly (ADR-0007).
+type SkillWithScope = Skill & { scope?: "organization" | "workspace" };
 
 export const SkillsList = ({
   orgId,
   workspaceId,
 }: {
   orgId: string;
-  workspaceId: string;
+  workspaceId?: string;
 }) => {
-  const { user } = useAuth();
+  const { user, isOrgAdmin } = useAuth();
   const backendUrl = useBackendUrl();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const [skillToDelete, setSkillToDelete] = useState<Skill | null>(null);
+  const [skillToDelete, setSkillToDelete] = useState<SkillWithScope | null>(
+    null,
+  );
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [selectedOrgSkill, setSelectedOrgSkill] =
+    useState<SkillWithScope | null>(null);
+  const [detaching, setDetaching] = useState(false);
+  const [attachOpen, setAttachOpen] = useState(false);
+  const [skillToPromote, setSkillToPromote] = useState<SkillWithScope | null>(
+    null,
+  );
+  const [promoting, setPromoting] = useState(false);
+  const [promoteError, setPromoteError] = useState<string | null>(null);
+
+  const listUrl = workspaceId
+    ? `/organizations/${orgId}/workspaces/${workspaceId}/skills`
+    : `/organizations/${orgId}/skills`;
+  const editBasePath = workspaceId
+    ? `/${orgId}/workspace/${workspaceId}/skills`
+    : `/${orgId}/settings/skills`;
 
   const {
     data: skillsData,
     isLoading,
     mutate,
   } = useSWR<{
-    results: Skill[];
-  }>(
-    backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/skills`,
-        )
-      : null,
-    fetcher,
-  );
+    results: SkillWithScope[];
+  }>(backendUrl && user ? joinUrl(backendUrl, listUrl) : null, fetcher);
 
+  // Agent associations are a workspace concern; only fetched on that surface.
   const { data: agentsData } = useSWR<{
     results: Agent[];
   }>(
-    backendUrl && user
+    backendUrl && user && workspaceId
       ? joinUrl(
           backendUrl,
           `/organizations/${orgId}/workspaces/${workspaceId}/agents`,
@@ -82,36 +116,92 @@ export const SkillsList = ({
     a.name.localeCompare(b.name),
   );
 
+  // Attaching/detaching org-scoped Shared resources is an Org Admin action,
+  // available only inside a workspace (ADR-0007 / #154).
+  const canAttach = Boolean(workspaceId) && isOrgAdmin;
+  // Promote is an Org Admin action on a workspace-scoped Skill (ADR-0007).
+  const canPromote = canAttach;
+
+  const attachedOrgIds = skills
+    .filter((s) => s.scope === "organization")
+    .map((s) => s.id);
+
   const getAgentsForSkill = (skillId: string) =>
     agents.filter((agent) => agent.skillIds?.includes(skillId));
 
-  const handleDeleteClick = (skill: Skill) => {
+  const handleDeleteClick = (skill: SkillWithScope) => {
     setSkillToDelete(skill);
+    setDeleteError(null);
     setDeleteDialogOpen(true);
   };
 
   const handleDeleteConfirm = async () => {
     if (!skillToDelete || !backendUrl) return;
+    // Org-scoped Skills are deleted from the Organization surface; workspace
+    // Skills from the workspace route.
+    const deleteUrl =
+      skillToDelete.scope === "organization" && !workspaceId
+        ? `/organizations/${orgId}/skills/${skillToDelete.id}`
+        : `${listUrl}/${skillToDelete.id}`;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const response = await fetch(joinUrl(backendUrl, deleteUrl), {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (response.ok) {
+        await mutate();
+        setDeleteDialogOpen(false);
+        setSkillToDelete(null);
+      } else {
+        const info = await response.json().catch(() => ({}));
+        setDeleteError(info.error || "Failed to delete skill.");
+      }
+    } finally {
+      setDeleting(false);
+    }
+  };
 
+  const detachOrgSkill = async (skillId: string) => {
+    if (!backendUrl || !workspaceId) return;
+    setDetaching(true);
+    try {
+      await fetch(
+        joinUrl(
+          backendUrl,
+          `/organizations/${orgId}/workspaces/${workspaceId}/attachments/skill/${skillId}`,
+        ),
+        { method: "DELETE", credentials: "include" },
+      );
+      setSelectedOrgSkill(null);
+      await mutate();
+    } finally {
+      setDetaching(false);
+    }
+  };
+
+  const handlePromoteConfirm = async () => {
+    if (!skillToPromote || !backendUrl || !workspaceId) return;
+    setPromoting(true);
+    setPromoteError(null);
     try {
       const response = await fetch(
         joinUrl(
           backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/skills/${skillToDelete.id}`,
+          `/organizations/${orgId}/workspaces/${workspaceId}/skills/${skillToPromote.id}/promote`,
         ),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
+        { method: "POST", credentials: "include" },
       );
-
       if (response.ok) {
-        mutate();
-        setDeleteDialogOpen(false);
-        setSkillToDelete(null);
+        await mutate();
+        setSkillToPromote(null);
+      } else {
+        const info = await response.json().catch(() => ({}));
+        setPromoteError(info.error || "Failed to promote skill.");
       }
-    } catch (error) {
-      console.error("Failed to delete skill:", error);
+    } finally {
+      setPromoting(false);
     }
   };
 
@@ -119,14 +209,43 @@ export const SkillsList = ({
     return <div>Loading...</div>;
   }
 
-  if (!skills.length) {
-    return null;
-  }
-
   return (
     <>
       <ul className="grid grid-cols-1 lg:grid-cols-2 grid-rows-1 gap-2 lg:gap-4">
         {skills.map((skill) => {
+          // Org-scoped (Shared) Skills are locked inside a workspace: they can
+          // only be edited from the organization settings surface.
+          const isOrgScopedInWorkspace =
+            Boolean(workspaceId) && skill.scope === "organization";
+
+          if (isOrgScopedInWorkspace) {
+            return (
+              <li key={skill.id}>
+                <Item
+                  variant="outline"
+                  className="h-full cursor-pointer"
+                  onClick={() => setSelectedOrgSkill(skill)}
+                >
+                  <ItemContent>
+                    <div className="flex items-center gap-2">
+                      <ItemTitle>{skill.name}</ItemTitle>
+                      <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-secondary text-[10px] font-medium text-secondary-foreground uppercase tracking-wider">
+                        <Building className="size-3" />
+                        Organization
+                      </div>
+                    </div>
+                    <ItemDescription className="text-xs line-clamp-2">
+                      {skill.description}
+                    </ItemDescription>
+                  </ItemContent>
+                  <ItemActions>
+                    <Pencil className="size-4" />
+                  </ItemActions>
+                </Item>
+              </li>
+            );
+          }
+
           const skillAgents = getAgentsForSkill(skill.id);
           const agentCount = skillAgents.length;
 
@@ -134,43 +253,45 @@ export const SkillsList = ({
             <li key={skill.id}>
               <Item
                 variant="outline"
-                className={`h-full cursor-pointer ${agentCount === 0 ? "border-warning" : ""}`}
+                className={`h-full cursor-pointer ${
+                  workspaceId && agentCount === 0 ? "border-warning" : ""
+                }`}
                 asChild
               >
-                <Link
-                  href={`/${orgId}/workspace/${workspaceId}/skills/${skill.id}`}
-                >
+                <Link href={`${editBasePath}/${skill.id}`}>
                   <ItemContent>
                     <ItemTitle>{skill.name}</ItemTitle>
                     <ItemDescription className="text-xs line-clamp-2">
                       {skill.description}
                     </ItemDescription>
-                    <div className="mt-1 text-xs text-muted-foreground">
-                      {agentCount > 0 ? (
-                        <Tooltip>
-                          <TooltipTrigger
-                            className="flex items-center gap-1 cursor-default"
-                            onClick={(e) => e.preventDefault()}
-                          >
-                            <Bot className="h-3 w-3" />
-                            {agentCount} agent{agentCount !== 1 && "s"}
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <ul className="text-left">
-                              {skillAgents.map((agent) => (
-                                <li key={agent.id}>{agent.name}</li>
-                              ))}
-                            </ul>
-                          </TooltipContent>
-                        </Tooltip>
-                      ) : (
-                        <span className="flex items-center gap-1 cursor-default text-warning-foreground">
-                          <TriangleAlert className="h-3 w-3" />
-                          <strong>WARNING:</strong> Skill not associated with
-                          any agents.
-                        </span>
-                      )}
-                    </div>
+                    {workspaceId && (
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        {agentCount > 0 ? (
+                          <Tooltip>
+                            <TooltipTrigger
+                              className="flex items-center gap-1 cursor-default"
+                              onClick={(e) => e.preventDefault()}
+                            >
+                              <Bot className="h-3 w-3" />
+                              {agentCount} agent{agentCount !== 1 && "s"}
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <ul className="text-left">
+                                {skillAgents.map((agent) => (
+                                  <li key={agent.id}>{agent.name}</li>
+                                ))}
+                              </ul>
+                            </TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <span className="flex items-center gap-1 cursor-default text-warning-foreground">
+                            <TriangleAlert className="h-3 w-3" />
+                            <strong>WARNING:</strong> Skill not associated with
+                            any agents.
+                          </span>
+                        )}
+                      </div>
+                    )}
                   </ItemContent>
                   <ItemActions>
                     <DropdownMenu>
@@ -188,11 +309,22 @@ export const SkillsList = ({
                         <DropdownMenuItem asChild>
                           <Link
                             className="cursor-pointer"
-                            href={`/${orgId}/workspace/${workspaceId}/skills/${skill.id}`}
+                            href={`${editBasePath}/${skill.id}`}
                           >
                             <Pencil /> Edit
                           </Link>
                         </DropdownMenuItem>
+                        {canPromote && (
+                          <DropdownMenuItem
+                            className="cursor-pointer"
+                            onSelect={() => {
+                              setPromoteError(null);
+                              setSkillToPromote(skill);
+                            }}
+                          >
+                            <ArrowUpFromLine /> Promote to organization
+                          </DropdownMenuItem>
+                        )}
                         <DropdownMenuSeparator />
                         <DropdownMenuItem
                           className="cursor-pointer text-destructive focus:text-destructive"
@@ -210,14 +342,105 @@ export const SkillsList = ({
         })}
       </ul>
 
+      <div className="mt-4 flex gap-2">
+        <Button variant="outline" asChild>
+          <Link href={`${editBasePath}/create`}>
+            <Plus /> Create Skill
+          </Link>
+        </Button>
+        {canAttach && (
+          <Button variant="outline" onClick={() => setAttachOpen(true)}>
+            <Link2 className="size-4" /> Attach shared skill
+          </Button>
+        )}
+      </div>
+
+      {canAttach && workspaceId && (
+        <AttachSharedResourceDialog
+          open={attachOpen}
+          onOpenChange={setAttachOpen}
+          orgId={orgId}
+          workspaceId={workspaceId}
+          resourceType="skill"
+          attachedIds={attachedOrgIds}
+          onAttached={() => {
+            setAttachOpen(false);
+            mutate();
+          }}
+        />
+      )}
+
+      <Dialog
+        open={!!selectedOrgSkill}
+        onOpenChange={(open) => !open && setSelectedOrgSkill(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Organization Skill</DialogTitle>
+            <DialogDescription>
+              The skill <strong>{selectedOrgSkill?.name}</strong> is managed at
+              the organization level. It can only be edited from the
+              organization settings.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setSelectedOrgSkill(null)}>
+              Close
+            </Button>
+            {canAttach && selectedOrgSkill && (
+              <Button
+                variant="destructive"
+                disabled={detaching}
+                onClick={() => detachOrgSkill(selectedOrgSkill.id)}
+              >
+                <Unlink className="size-4" />
+                Detach
+              </Button>
+            )}
+            {isOrgAdmin && selectedOrgSkill && (
+              <Button asChild>
+                <Link href={`/${orgId}/settings/skills/${selectedOrgSkill.id}`}>
+                  <ExternalLink className="size-4" />
+                  Org settings
+                </Link>
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmDialog
+        open={!!skillToPromote}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSkillToPromote(null);
+            setPromoteError(null);
+          }
+        }}
+        title="Promote to organization"
+        description={`Promote "${skillToPromote?.name}" to an organization-shared skill? It will be managed by org admins and remain attached to this workspace.`}
+        confirmLabel="Promote"
+        onConfirm={handlePromoteConfirm}
+        loading={promoting}
+        error={promoteError}
+      />
+
       <ConfirmDialog
         open={deleteDialogOpen}
-        onOpenChange={setDeleteDialogOpen}
+        onOpenChange={(open) => {
+          setDeleteDialogOpen(open);
+          if (!open) {
+            setSkillToDelete(null);
+            setDeleteError(null);
+          }
+        }}
         title="Delete Skill"
         description={`Are you sure you want to delete "${skillToDelete?.name}"? This action cannot be undone.`}
         confirmLabel="Delete"
         confirmVariant="destructive"
         onConfirm={handleDeleteConfirm}
+        loading={deleting}
+        error={deleteError}
       />
     </>
   );

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -7,6 +7,7 @@ import {
   organizationCreateSchema,
   invitationCreateSchema,
   mcpSchema,
+  skillSchema,
   attachmentSchema,
   attachmentCreateSchema,
   sandboxEnvSchema,
@@ -92,6 +93,14 @@ describe("Attachment Schema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts a skill resource type", () => {
+    const result = attachmentCreateSchema.safeParse({
+      resourceType: "skill",
+      resourceId: "skill-1",
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("create schema rejects a missing resourceId", () => {
     const result = attachmentCreateSchema.safeParse({ resourceType: "mcp" });
     expect(result.success).toBe(false);
@@ -129,6 +138,50 @@ describe("MCP Schema", () => {
 
   it("rejects an MCP scoped to neither", () => {
     const result = mcpSchema.safeParse(base);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("Skill Schema", () => {
+  const base = {
+    id: "skill-1",
+    name: "my-skill",
+    description: "A description that is at least twenty-four chars long.",
+    body: "A skill body that is comfortably longer than the forty-eight character minimum requirement.",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  it("accepts a workspace-scoped Skill", () => {
+    const result = skillSchema.safeParse({ ...base, workspaceId: "ws-1" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an org-scoped Skill", () => {
+    const result = skillSchema.safeParse({ ...base, organizationId: "org-1" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a Skill scoped to both an organization and a workspace", () => {
+    const result = skillSchema.safeParse({
+      ...base,
+      organizationId: "org-1",
+      workspaceId: "ws-1",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a Skill scoped to neither", () => {
+    const result = skillSchema.safeParse(base);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-kebab-case name", () => {
+    const result = skillSchema.safeParse({
+      ...base,
+      workspaceId: "ws-1",
+      name: "Not Kebab",
+    });
     expect(result.success).toBe(false);
   });
 });

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -246,9 +246,14 @@ export const agentUpdateSchema = agentSchema.pick({
 
 const skillNameRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
-export const skillSchema = z.object({
+// A Skill is scoped to either a Workspace or an Organization (mutually
+// exclusive), mirroring the dual-scope shape of `provider`/`mcp`. Org-scoped
+// Skills are Shared resources managed by Org Admins (ADR-0007). The XOR is
+// enforced on `skillSchema` below; the create routes inject the scope.
+const skillBaseSchema = z.object({
   id: z.string(),
-  workspaceId: z.string(),
+  organizationId: z.string().optional(),
+  workspaceId: z.string().optional(),
   name: z
     .string()
     .min(5)
@@ -260,10 +265,24 @@ export const skillSchema = z.object({
   updatedAt: z.date(),
 });
 
+export const skillSchema = skillBaseSchema.refine(
+  (data) => {
+    const hasOrg = Boolean(data.organizationId);
+    const hasWorkspace = Boolean(data.workspaceId);
+    return (hasOrg || hasWorkspace) && !(hasOrg && hasWorkspace);
+  },
+  {
+    message:
+      "Skill must have either organizationId or workspaceId, but not both",
+    path: ["organizationId"],
+  },
+);
+
 export type Skill = z.infer<typeof skillSchema>;
 
-export const skillCreateSchema = skillSchema
+export const skillCreateSchema = skillBaseSchema
   .pick({
+    organizationId: true,
     workspaceId: true,
     name: true,
     description: true,
@@ -273,7 +292,7 @@ export const skillCreateSchema = skillSchema
     agentIds: z.array(z.string()).optional(),
   });
 
-export const skillUpdateSchema = skillSchema
+export const skillUpdateSchema = skillBaseSchema
   .pick({
     name: true,
     description: true,
@@ -414,7 +433,11 @@ export const mcpTestSchema = mcpBaseSchema
 // Attachment — the explicit link that surfaces an org-scoped Shared resource
 // inside a specific Workspace (ADR-0007 / #154). Polymorphic over resource type.
 
-export const attachmentResourceTypeSchema = z.enum(["mcp", "provider"]);
+export const attachmentResourceTypeSchema = z.enum([
+  "mcp",
+  "provider",
+  "skill",
+]);
 export type AttachmentResourceType = z.infer<
   typeof attachmentResourceTypeSchema
 >;


### PR DESCRIPTION
Closes #155.

Gives **Skills** the dual-scope shape (Workspace **or** Organization) and adds the **Promote** action that re-scopes a Workspace Skill to Organization scope, turning it into a **Shared resource** (ADR-0007). Skills are the simplest Shared resource (leaf text), so they establish the Promote + locked-reference pattern that Agents will build on — faithfully mirroring the org-scoped MCP/Provider attachment spine from #154.

## What changed

**Schema & migration**
- `skill` table: `workspace_id` now nullable, added nullable `organization_id` FK + `idx_skill_organization_id` + `unique_skill_name_org` (mirrors `mcp`). Attachment `resource_type` widened to include `"skill"`.
- Migration `0041_org_scoped_skills.sql` — safe on existing data (existing rows keep `organization_id = NULL`).
- `@platypus/schemas`: `skillSchema` enforces org-XOR-workspace; `"skill"` added to `attachmentResourceTypeSchema`.

**Backend**
- New `org-skill.ts` — admin-only CRUD at `/organizations/:orgId/skills`, with the deletion-blocked-while-attached guard.
- `skill.ts` — workspace list/GET surface attached org Skills tagged `scope: "organization"`; create is pinned to workspace scope; **`POST /:skillId/promote`** (admin-only) re-scopes a workspace Skill to the org and auto-attaches the origin workspace in a transaction (guarded against a lost TOCTOU race so it can't return 200 with an orphan attachment).
- `attachment.ts` maps `"skill" → skillTable`.
- Chat-turn loading (`getSkillsByIds`, `loadSkill`) resolves org Skills only where attached, with workspace-first precedence on name collisions.

**Frontend**
- Org Skills render as **locked cards** in borrowing workspaces (detach + "Org settings" link); a **Promote** action on workspace Skills; an inline "Attach shared skill" button beside "Create Skill"; and a full Organization Skills management surface (pages + sidebar entry). `skill-form`/`skills-list` made dual-scope.

## Acceptance criteria
- [x] Skill scoped to a Workspace or an Organization (mutually exclusive)
- [x] Promote re-scopes a Workspace Skill to org scope and auto-attaches its origin Workspace
- [x] Org-scoped Skill management on the Organization surface (admin-only)
- [x] Borrowing Workspaces see org Skills as locked; Workspace Owners cannot edit/remove them
- [x] Chat-turn loads org-scoped Skills correctly
- [x] Tests cover scoping, Promote + origin auto-attach, locked state, and chat-turn loading

## Testing
- Backend **802 passed**, schemas **34 passed**, frontend **16 passed**; frontend typechecks clean.

## Follow-up (out of scope)
`requireWorkspaceAccess` does not verify the workspace belongs to the path `orgId` — a pre-existing systemic gap affecting all workspace-scoped routes. Worth a separate security ticket rather than bundling a high-blast-radius middleware change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)