### PR TITLE
fix(frontend): unbreak ESLint 10 lint + clear mechanical lint errors

### DIFF
--- a/apps/frontend/app/[orgId]/settings/invitations/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/invitations/page.tsx
@@ -69,7 +69,7 @@ const OrgInvitationsPage = () => {
       } else {
         toast.error("Failed to delete invitation");
       }
-    } catch (error) {
+    } catch {
       toast.error("Error deleting invitation");
     } finally {
       setIsDeleting(false);
@@ -161,7 +161,7 @@ const OrgInvitationsPage = () => {
                       <TableCell>{invite.email}</TableCell>
                       <TableCell className="text-muted-foreground">
                         {invite.workspaceName || (
-                          <span className="italic">Member's name</span>
+                          <span className="italic">Member&apos;s name</span>
                         )}
                       </TableCell>
                       <TableCell>{getStatusBadge(invite.status)}</TableCell>

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/page.tsx
@@ -13,7 +13,6 @@ import {
   Bot,
   MessageSquare,
   Plus,
-  BotMessageSquare,
   FolderOpen,
   Settings,
   Sparkles,

--- a/apps/frontend/app/settings/contexts/page.tsx
+++ b/apps/frontend/app/settings/contexts/page.tsx
@@ -80,14 +80,12 @@ const ContextsPage = () => {
           toast.error("Failed to create context");
         }
       }
-    } catch (error) {
+    } catch {
       toast.error("Error saving context");
     } finally {
       setIsSavingGlobal(false);
     }
   };
-
-  const globalContext = contexts?.results.find((c) => !c.workspaceId);
 
   return (
     <div>

--- a/apps/frontend/app/settings/invitations/page.tsx
+++ b/apps/frontend/app/settings/invitations/page.tsx
@@ -45,7 +45,7 @@ const UserInvitationsPage = () => {
         const errorData = await response.json();
         toast.error(errorData.message || "Failed to accept invitation");
       }
-    } catch (error) {
+    } catch {
       toast.error("Error accepting invitation");
     }
   };
@@ -69,7 +69,7 @@ const UserInvitationsPage = () => {
       } else {
         toast.error("Failed to decline invitation");
       }
-    } catch (error) {
+    } catch {
       toast.error("Error declining invitation");
     } finally {
       setIsDeclining(false);

--- a/apps/frontend/app/sign-in/page.tsx
+++ b/apps/frontend/app/sign-in/page.tsx
@@ -33,7 +33,7 @@ export default function SignInPage() {
       }
 
       router.push("/");
-    } catch (err) {
+    } catch {
       setError("An unexpected error occurred");
     } finally {
       setIsLoading(false);

--- a/apps/frontend/app/sign-up/page.tsx
+++ b/apps/frontend/app/sign-up/page.tsx
@@ -35,7 +35,7 @@ export default function SignUpPage() {
       }
 
       router.push("/");
-    } catch (err) {
+    } catch {
       setError("An unexpected error occurred");
     } finally {
       setIsLoading(false);

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -271,7 +271,7 @@ const AgentForm = ({
   const handleModelChange = (value: string) => {
     if (value.startsWith("provider:")) {
       // Provider/model selected
-      const [_, newProviderId, ...modelIdParts] = value.split(":");
+      const [, newProviderId, ...modelIdParts] = value.split(":");
       const newModelId = modelIdParts.join(":");
       setFormData((prevData) => ({
         ...prevData,

--- a/apps/frontend/components/ai-elements/prompt-input.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.tsx
@@ -730,7 +730,7 @@ export const PromptInput = ({
             controller.textInput.clear();
           }
         }
-      } catch (error) {
+      } catch {
         // Don't clear on error - user may want to retry
       }
     });
@@ -1038,13 +1038,13 @@ interface SpeechRecognition extends EventTarget {
   lang: string;
   start(): void;
   stop(): void;
-  onstart: ((this: SpeechRecognition, ev: Event) => any) | null;
-  onend: ((this: SpeechRecognition, ev: Event) => any) | null;
+  onstart: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onend: ((this: SpeechRecognition, ev: Event) => void) | null;
   onresult:
-    | ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => any)
+    | ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void)
     | null;
   onerror:
-    | ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => any)
+    | ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void)
     | null;
 }
 

--- a/apps/frontend/components/app-sidebar.tsx
+++ b/apps/frontend/components/app-sidebar.tsx
@@ -41,7 +41,6 @@ import {
 } from "@/components/ui/dialog";
 import { useState, useEffect } from "react";
 import {
-  Bot,
   FolderOpen,
   BotMessageSquare,
   EllipsisVertical,
@@ -173,10 +172,6 @@ export function AppSidebar() {
       icon: CalendarDays,
     },
   ].filter((group) => group.chats.length > 0);
-
-  const handleWorkspaceChange = (newWorkspaceId: string) => {
-    router.push(`/${orgId}/workspace/${newWorkspaceId}/chat`);
-  };
 
   const handleRenameChat = async () => {
     if (!renameChatId) return;

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -244,7 +244,9 @@ export const Chat = ({
   } = chatUI;
 
   // Use ref to store getRequestBody so the transport callback can access current values
-  const getRequestBodyRef = useRef<(() => any) | undefined>(undefined);
+  const getRequestBodyRef = useRef<(() => Record<string, unknown>) | undefined>(
+    undefined,
+  );
 
   // Create getRequestBody function that depends on extracted values
   const getRequestBody = useCallback(() => {
@@ -496,7 +498,7 @@ export const Chat = ({
           <div className="w-full xl:w-4/5 max-w-4xl">
             {isWorkspaceOwner ? (
               <PromptInput
-                onSubmit={(message, event) => {
+                onSubmit={(message) => {
                   handleSubmit(message);
                   setInputValue("");
                 }}

--- a/apps/frontend/components/collapsible-section.tsx
+++ b/apps/frontend/components/collapsible-section.tsx
@@ -7,7 +7,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { cn } from "@/lib/utils";
 
 interface CollapsibleSectionProps {
   title: React.ReactNode;

--- a/apps/frontend/components/error-dialog.tsx
+++ b/apps/frontend/components/error-dialog.tsx
@@ -14,7 +14,7 @@ import { TriangleAlert, Copy, Check } from "lucide-react";
 interface ErrorDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  error: any;
+  error: Error | undefined;
 }
 
 export const ErrorDialog = ({

--- a/apps/frontend/components/invitation-form.tsx
+++ b/apps/frontend/components/invitation-form.tsx
@@ -10,9 +10,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
-import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import { parseValidationErrors, joinUrl } from "@/lib/utils";
 import { useBackendUrl } from "@/app/client-context";
-import { useAuth } from "@/components/auth-provider";
 import { toast } from "sonner";
 
 interface InvitationFormProps {
@@ -21,7 +20,6 @@ interface InvitationFormProps {
 }
 
 export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
-  const { user } = useAuth();
   const backendUrl = useBackendUrl();
 
   const [email, setEmail] = useState("");
@@ -72,7 +70,7 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
           toast.error("Failed to send invitation");
         }
       }
-    } catch (error) {
+    } catch {
       toast.error("Error sending invitation");
     } finally {
       setIsSubmitting(false);

--- a/apps/frontend/components/kanban-board.tsx
+++ b/apps/frontend/components/kanban-board.tsx
@@ -248,13 +248,6 @@ export function KanbanBoard({
     [columnIds],
   );
 
-  const findColumnByCardId = useCallback(
-    (cardId: string): ColumnWithCards | undefined => {
-      return columns.find((col) => col.cards.some((c) => c.id === cardId));
-    },
-    [columns],
-  );
-
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {
       const { active } = event;

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -118,9 +118,8 @@ const McpForm = ({
 
   useEffect(() => {
     if (mcp) {
-      const existingHeaders = (mcp as any).headers as
-        | Record<string, string>
-        | undefined;
+      const existingHeaders = (mcp as { headers?: Record<string, string> })
+        .headers;
       const headerRows: HeaderRow[] = existingHeaders
         ? Object.entries(existingHeaders).map(([key, value]) => ({
             key,

--- a/apps/frontend/components/member-edit-dialog.tsx
+++ b/apps/frontend/components/member-edit-dialog.tsx
@@ -64,7 +64,7 @@ export function MemberEditDialog({
           data.error || data.message || "Failed to update member role",
         );
       }
-    } catch (error) {
+    } catch {
       toast.error("Error updating member role");
     } finally {
       setIsSubmitting(false);

--- a/apps/frontend/components/notifications-dropdown.tsx
+++ b/apps/frontend/components/notifications-dropdown.tsx
@@ -257,7 +257,7 @@ export function NotificationsDropdown({
                       Organization Invitation
                     </div>
                     <div className="text-xs text-muted-foreground line-clamp-2">
-                      You've been invited to join{" "}
+                      You&apos;ve been invited to join{" "}
                       <strong>{invite.organizationName}</strong>.
                     </div>
                   </Link>

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -143,7 +143,7 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
         setIsDeleting(false);
         setIsDeleteDialogOpen(false);
       }
-    } catch (error) {
+    } catch {
       toast.error("Error deleting organization");
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);

--- a/apps/frontend/components/protected-route.tsx
+++ b/apps/frontend/components/protected-route.tsx
@@ -12,7 +12,7 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { Button } from "@/components/ui/button";
-import { OctagonX, Home, Layout, Building } from "lucide-react";
+import { OctagonX, Home, Building } from "lucide-react";
 import Link from "next/link";
 
 type RequiredOrgRole = "member" | "admin";

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -660,7 +660,7 @@ const ProviderForm = ({
                       </SelectContent>
                     </Select>
                     <FieldDescription>
-                      Responses is OpenAI's default and supports hosted
+                      Responses is OpenAI&apos;s default and supports hosted
                       web_search, reasoning summaries, and previous_response_id.
                       Switch to Chat Completions when pointing at an
                       OpenAI-compatible server that does not implement

--- a/apps/frontend/components/remove-member-dialog.tsx
+++ b/apps/frontend/components/remove-member-dialog.tsx
@@ -52,7 +52,7 @@ export function RemoveMemberDialog({
         const data = await response.json();
         toast.error(data.error || data.message || "Failed to remove member");
       }
-    } catch (error) {
+    } catch {
       toast.error("Error removing member");
     } finally {
       setIsSubmitting(false);

--- a/apps/frontend/components/sandbox-settings.tsx
+++ b/apps/frontend/components/sandbox-settings.tsx
@@ -210,10 +210,12 @@ const SandboxSettings = ({
     const res = await fetch(url, { credentials: "include" });
     if (res.status === 404) return null;
     if (!res.ok) {
-      const error = new Error("Failed to load sandbox");
+      const error: Error & { info?: unknown; status?: number } = new Error(
+        "Failed to load sandbox",
+      );
       const info = await res.json().catch(() => ({}));
-      (error as any).info = info;
-      (error as any).status = res.status;
+      error.info = info;
+      error.status = res.status;
       throw error;
     }
     return res.json();
@@ -327,16 +329,15 @@ const SandboxSettings = ({
 
     if (response.ok) return { ok: true };
 
-    const errorData = await response.json().catch(() => ({}));
+    const errorData = (await response.json().catch(() => ({}))) as {
+      error?: string;
+    };
 
-    if (
-      response.status === 500 &&
-      isForceRetryError((errorData as any)?.error)
-    ) {
+    if (response.status === 500 && isForceRetryError(errorData?.error)) {
       return {
         ok: false,
         forceRetry: true,
-        errorMessage: (errorData as any).error,
+        errorMessage: errorData.error,
       };
     }
 
@@ -344,7 +345,7 @@ const SandboxSettings = ({
     if (Object.keys(fieldErrors).length > 0) {
       setValidationErrors(fieldErrors);
     } else {
-      toast.error((errorData as any)?.error || "Failed to save sandbox");
+      toast.error(errorData?.error || "Failed to save sandbox");
     }
     return { ok: false };
   };
@@ -394,14 +395,13 @@ const SandboxSettings = ({
 
     if (response.ok) return { ok: true };
 
-    const errorData = await response.json().catch(() => ({}));
-    if (
-      response.status === 500 &&
-      isForceRetryError((errorData as any)?.error)
-    ) {
+    const errorData = (await response.json().catch(() => ({}))) as {
+      error?: string;
+    };
+    if (response.status === 500 && isForceRetryError(errorData?.error)) {
       return { ok: false, forceRetry: true };
     }
-    toast.error((errorData as any)?.error || "Failed to delete sandbox");
+    toast.error(errorData?.error || "Failed to delete sandbox");
     return { ok: false };
   };
 

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -568,7 +568,7 @@ const TriggerForm = ({
         setValidationErrors(parseValidationErrors(errorData));
         toast.error("Failed to save trigger");
       }
-    } catch (error) {
+    } catch {
       toast.error("Error saving trigger");
     } finally {
       setIsSubmitting(false);
@@ -598,7 +598,7 @@ const TriggerForm = ({
         setIsDeleting(false);
         setIsDeleteDialogOpen(false);
       }
-    } catch (error) {
+    } catch {
       toast.error("Error deleting trigger");
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);
@@ -929,7 +929,7 @@ const TriggerForm = ({
                   />
                   <FieldDescription>
                     Format: minute hour day-of-month month day-of-week. Example:
-                    "0 9 * * *" runs daily at 9:00 AM.
+                    &quot;0 9 * * *&quot; runs daily at 9:00 AM.
                   </FieldDescription>
                   {validationErrors.cronExpression && (
                     <FieldError>{validationErrors.cronExpression}</FieldError>

--- a/apps/frontend/components/trigger-list.tsx
+++ b/apps/frontend/components/trigger-list.tsx
@@ -118,7 +118,7 @@ export const TriggerList = ({
         setDeleteDialogOpen(false);
         setTriggerToDelete(null);
       }
-    } catch (error) {
+    } catch {
       toast.error("Failed to delete trigger");
     } finally {
       setIsDeleting(false);
@@ -151,7 +151,7 @@ export const TriggerList = ({
       if (response.ok) {
         mutate();
       }
-    } catch (error) {
+    } catch {
       toast.error("Failed to toggle trigger");
     } finally {
       setIsToggling(false);

--- a/apps/frontend/components/widgets/chart-utils.tsx
+++ b/apps/frontend/components/widgets/chart-utils.tsx
@@ -14,7 +14,7 @@ export function textToSeriesValues(text: string): (number | null)[] {
 }
 
 export function yAxisLabelContent(label: string) {
-  return ({ viewBox }: { viewBox?: object }) => {
+  const YAxisLabel = ({ viewBox }: { viewBox?: object }) => {
     if (!viewBox || !("x" in viewBox)) return null;
     const { x, y, height } = viewBox as {
       x: number;
@@ -33,4 +33,5 @@ export function yAxisLabelContent(label: string) {
       </text>
     );
   };
+  return YAxisLabel;
 }

--- a/apps/frontend/components/workspace-context-form.tsx
+++ b/apps/frontend/components/workspace-context-form.tsx
@@ -174,7 +174,7 @@ export const WorkspaceContextForm = ({ contextId }: { contextId?: string }) => {
           toast.error("Failed to create context");
         }
       }
-    } catch (error) {
+    } catch {
       toast.error("Error saving context");
     } finally {
       setIsSubmitting(false);
@@ -200,7 +200,7 @@ export const WorkspaceContextForm = ({ contextId }: { contextId?: string }) => {
       } else {
         toast.error("Failed to delete context");
       }
-    } catch (error) {
+    } catch {
       toast.error("Error deleting context");
     } finally {
       setIsDeleting(false);
@@ -216,13 +216,15 @@ export const WorkspaceContextForm = ({ contextId }: { contextId?: string }) => {
               <Field>
                 <FieldLabel>Organization</FieldLabel>
                 <div className="text-sm text-muted-foreground">
-                  {(contextData as any)?.organizationName || "\u00A0"}
+                  {(contextData as { organizationName?: string })
+                    ?.organizationName || "\u00A0"}
                 </div>
               </Field>
               <Field>
                 <FieldLabel>Workspace</FieldLabel>
                 <div className="text-sm text-muted-foreground">
-                  {(contextData as any)?.workspaceName || "\u00A0"}
+                  {(contextData as { workspaceName?: string })?.workspaceName ||
+                    "\u00A0"}
                 </div>
               </Field>
             </>

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -248,7 +248,7 @@ const WorkspaceForm = ({
         setIsDeleting(false);
         setIsDeleteDialogOpen(false);
       }
-    } catch (error) {
+    } catch {
       toast.error("Error deleting workspace");
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);
@@ -427,7 +427,10 @@ const WorkspaceForm = ({
                 <SelectContent>
                   <SelectItem value="none">Disabled</SelectItem>
                   {providers
-                    .filter((p) => (p as any).embeddingModelId)
+                    .filter(
+                      (p) =>
+                        (p as { embeddingModelId?: string }).embeddingModelId,
+                    )
                     .map((provider) => (
                       <SelectItem key={provider.id} value={provider.id}>
                         {provider.name}

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -5,6 +5,25 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // eslint-config-next sets `settings.react.version = "detect"`, which makes
+  // eslint-plugin-react@7.37.5 call the `context.getFilename()` API that was
+  // removed in ESLint 10, crashing every lint run. Pin an explicit version to
+  // skip auto-detection. Remove once eslint-plugin-react ships ESLint 10 support.
+  {
+    settings: {
+      react: {
+        version: "19.2",
+      },
+    },
+    rules: {
+      // Allow the destructure-to-omit pattern (e.g. `const { id, ...rest } = obj`)
+      // where the named siblings are intentionally discarded.
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { ignoreRestSiblings: true },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/apps/frontend/hooks/use-model-selection.ts
+++ b/apps/frontend/hooks/use-model-selection.ts
@@ -30,7 +30,7 @@ export const useModelSelection = (
       setModelId("");
     } else if (value.startsWith("provider:")) {
       // Provider/model selected
-      const [_, newProviderId, ...modelIdParts] = value.split(":");
+      const [, newProviderId, ...modelIdParts] = value.split(":");
       const newModelId = modelIdParts.join(":");
       setProviderId(newProviderId);
       setModelId(newModelId);

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -21,11 +21,13 @@ export function joinUrl(base: string, path: string): string {
 export const fetcher = async (input: RequestInfo | URL, init?: RequestInit) => {
   const res = await fetch(input, { ...init, credentials: "include" });
   if (!res.ok) {
-    const error = new Error("An error occurred while fetching the data.");
+    const error: Error & { info?: unknown; status?: number } = new Error(
+      "An error occurred while fetching the data.",
+    );
     // Attach extra info to the error object.
     const info = await res.json().catch(() => ({}));
-    (error as any).info = info;
-    (error as any).status = res.status;
+    error.info = info;
+    error.status = res.status;
     throw error;
   }
   return res.json();


### PR DESCRIPTION
## Summary

Fixes the frontend lint crash from #169 and clears the mechanical lint errors it had been masking.

### The crash (#169)
`pnpm --filter @platypus/frontend lint` crashed before checking any file: `eslint-config-next` hardcodes `settings.react.version = "detect"`, which drives `eslint-plugin-react@7.37.5` into `context.getFilename()` — an API **removed in ESLint 10**.

No published `eslint-plugin-react` supports ESLint 10 yet (latest 7.37.5 and the `next` tag both cap their peer at `eslint ^9.7`), so overriding/upgrading the plugin isn't currently viable. Instead we pin an explicit React version in `eslint.config.mjs`, which skips the auto-detection code path that hits the removed API — no ESLint downgrade required. Remove the pin once `eslint-plugin-react` ships ESLint 10 support.

### Mechanical lint cleanup
With ESLint running again, the low-risk findings are fixed to zero:

| Rule | Before | After |
|---|---|---|
| `@typescript-eslint/no-unused-vars` | 38 | 0 |
| `@typescript-eslint/no-explicit-any` | 19 | 0 |
| `react/no-unescaped-entities` | 5 | 0 |
| `react/display-name` | 1 | 0 |

Unused `catch` bindings → optional catch, dead imports/vars/functions removed, `[_, ...]` → array holes, trivial `any` → concrete types, JSX entities escaped, chart label component named. Also enabled `no-unused-vars` `ignoreRestSiblings` for the destructure-to-omit pattern.

### Deferred
The remaining react-hooks v7 rules (`set-state-in-effect`, `exhaustive-deps`, `refs`, etc.) and `no-img-element` require behavioral refactors and are tracked in #172.

## Testing
- `pnpm test` — all suites pass (backend 802, frontend 16, schemas)
- `tsc --noEmit` — clean
- `pnpm --filter @platypus/frontend lint` — runs to completion; only the deferred (#172) rules remain

Closes #169
Refs #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)