### PR TITLE
fix(backend): verify workspace belongs to path orgId in requireWorkspaceAccess

### DIFF
--- a/apps/backend/src/middleware/authorization.test.ts
+++ b/apps/backend/src/middleware/authorization.test.ts
@@ -79,10 +79,19 @@ describe("Authorization Middleware", () => {
   });
 
   describe("requireWorkspaceAccess", () => {
-    it("should allow super admin to bypass workspace checks", async () => {
-      // Mock workspace lookup for super admin
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "other-user" }]);
-
+    // Routes are mounted under :orgId so the cross-org guard can compare the
+    // resolved workspace's organizationId against the path orgId.
+    const buildApp = (
+      user: any,
+      orgMembership: any,
+    ): Hono<{
+      Variables: {
+        user: any;
+        orgMembership: any;
+        isWorkspaceOwner: any;
+        db: any;
+      };
+    }> => {
       const app = new Hono<{
         Variables: {
           user: any;
@@ -92,99 +101,80 @@ describe("Authorization Middleware", () => {
         };
       }>();
       app.use("*", async (c, next) => {
-        c.set("user", { id: "admin-1", role: "admin" });
-        c.set("orgMembership", { role: "admin", isSuperAdmin: true });
+        c.set("user", user);
+        c.set("orgMembership", orgMembership);
         c.set("db", mockDb);
         await next();
       });
-      app.use("/workspaces/:workspaceId/*", requireWorkspaceAccess);
-      app.get("/workspaces/:workspaceId/test", (c) =>
+      app.use(
+        "/organizations/:orgId/workspaces/:workspaceId/*",
+        requireWorkspaceAccess,
+      );
+      app.get("/organizations/:orgId/workspaces/:workspaceId/test", (c) =>
         c.json({ isWorkspaceOwner: c.get("isWorkspaceOwner") }),
       );
+      return app;
+    };
 
-      const res = await app.request("/workspaces/ws-1/test");
+    it("should allow super admin to bypass workspace checks", async () => {
+      // Mock workspace lookup for super admin
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "other-user", organizationId: "org-1" },
+      ]);
+
+      const app = buildApp(
+        { id: "admin-1", role: "admin" },
+        { role: "admin", isSuperAdmin: true },
+      );
+
+      const res = await app.request(
+        "/organizations/org-1/workspaces/ws-1/test",
+      );
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ isWorkspaceOwner: false });
     });
 
     it("should allow org admin to bypass workspace checks", async () => {
       // Workspace lookup
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "other-user" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "other-user", organizationId: "org-1" },
+      ]);
 
-      const app = new Hono<{
-        Variables: {
-          user: any;
-          orgMembership: any;
-          isWorkspaceOwner: any;
-          db: any;
-        };
-      }>();
-      app.use("*", async (c, next) => {
-        c.set("user", { id: "u1", role: "user" });
-        c.set("orgMembership", { role: "admin" });
-        c.set("db", mockDb);
-        await next();
-      });
-      app.use("/workspaces/:workspaceId/*", requireWorkspaceAccess);
-      app.get("/workspaces/:workspaceId/test", (c) =>
-        c.json({ isWorkspaceOwner: c.get("isWorkspaceOwner") }),
+      const app = buildApp({ id: "u1", role: "user" }, { role: "admin" });
+
+      const res = await app.request(
+        "/organizations/org-1/workspaces/ws-1/test",
       );
-
-      const res = await app.request("/workspaces/ws-1/test");
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ isWorkspaceOwner: false });
     });
 
     it("should allow workspace owner access", async () => {
       // Workspace lookup - user is owner
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "u1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "u1", organizationId: "org-1" },
+      ]);
 
-      const app = new Hono<{
-        Variables: {
-          user: any;
-          orgMembership: any;
-          isWorkspaceOwner: any;
-          db: any;
-        };
-      }>();
-      app.use("*", async (c, next) => {
-        c.set("user", { id: "u1", role: "user" });
-        c.set("orgMembership", { role: "member" });
-        c.set("db", mockDb);
-        await next();
-      });
-      app.use("/workspaces/:workspaceId/*", requireWorkspaceAccess);
-      app.get("/workspaces/:workspaceId/test", (c) =>
-        c.json({ isWorkspaceOwner: c.get("isWorkspaceOwner") }),
+      const app = buildApp({ id: "u1", role: "user" }, { role: "member" });
+
+      const res = await app.request(
+        "/organizations/org-1/workspaces/ws-1/test",
       );
-
-      const res = await app.request("/workspaces/ws-1/test");
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ isWorkspaceOwner: true });
     });
 
     it("should return 403 if user is not workspace owner", async () => {
       // Workspace lookup - user is not owner
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "other-user" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "other-user", organizationId: "org-1" },
+      ]);
 
-      const app = new Hono<{
-        Variables: {
-          user: any;
-          orgMembership: any;
-          isWorkspaceOwner: any;
-          db: any;
-        };
-      }>();
-      app.use("*", async (c, next) => {
-        c.set("user", { id: "u1", role: "user" });
-        c.set("orgMembership", { role: "member" });
-        c.set("db", mockDb);
-        await next();
-      });
-      app.use("/workspaces/:workspaceId/*", requireWorkspaceAccess);
-      app.get("/workspaces/:workspaceId/test", (c) => c.text("ok"));
+      const app = buildApp({ id: "u1", role: "user" }, { role: "member" });
 
-      const res = await app.request("/workspaces/ws-1/test");
+      const res = await app.request(
+        "/organizations/org-1/workspaces/ws-1/test",
+      );
       expect(res.status).toBe(403);
     });
 
@@ -192,25 +182,58 @@ describe("Authorization Middleware", () => {
       // Workspace lookup - not found
       mockDb.limit.mockResolvedValueOnce([]);
 
-      const app = new Hono<{
-        Variables: {
-          user: any;
-          orgMembership: any;
-          isWorkspaceOwner: any;
-          db: any;
-        };
-      }>();
-      app.use("*", async (c, next) => {
-        c.set("user", { id: "u1", role: "user" });
-        c.set("orgMembership", { role: "member" });
-        c.set("db", mockDb);
-        await next();
-      });
-      app.use("/workspaces/:workspaceId/*", requireWorkspaceAccess);
-      app.get("/workspaces/:workspaceId/test", (c) => c.text("ok"));
+      const app = buildApp({ id: "u1", role: "user" }, { role: "member" });
 
-      const res = await app.request("/workspaces/ws-1/test");
+      const res = await app.request(
+        "/organizations/org-1/workspaces/ws-1/test",
+      );
       expect(res.status).toBe(404);
+    });
+
+    it("should return 404 when workspace belongs to a different org (member)", async () => {
+      // Workspace exists but lives in org-2 while the path names org-1.
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "u1", organizationId: "org-2" },
+      ]);
+
+      const app = buildApp({ id: "u1", role: "user" }, { role: "member" });
+
+      const res = await app.request(
+        "/organizations/org-1/workspaces/ws-1/test",
+      );
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "Workspace not found" });
+    });
+
+    it("should return 404 when workspace belongs to a different org (org admin)", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "other-user", organizationId: "org-2" },
+      ]);
+
+      const app = buildApp({ id: "u1", role: "user" }, { role: "admin" });
+
+      const res = await app.request(
+        "/organizations/org-1/workspaces/ws-1/test",
+      );
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "Workspace not found" });
+    });
+
+    it("should return 404 when workspace belongs to a different org (super admin)", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "other-user", organizationId: "org-2" },
+      ]);
+
+      const app = buildApp(
+        { id: "admin-1", role: "admin" },
+        { role: "admin", isSuperAdmin: true },
+      );
+
+      const res = await app.request(
+        "/organizations/org-1/workspaces/ws-1/test",
+      );
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "Workspace not found" });
     });
   });
 

--- a/apps/backend/src/middleware/authorization.ts
+++ b/apps/backend/src/middleware/authorization.ts
@@ -160,34 +160,13 @@ export const requireWorkspaceAccess = createMiddleware(async (c, next) => {
   const orgMembership = c.get("orgMembership");
 
   const workspaceId = c.req.param("workspaceId");
+  const orgId = c.req.param("orgId");
 
   if (!workspaceId) {
     return c.json({ error: "Workspace ID required" }, 400);
   }
 
-  // Super admins bypass all checks but still check ownership
-  if (isSuperAdmin(user)) {
-    const [ws] = await db
-      .select()
-      .from(workspaceTable)
-      .where(eq(workspaceTable.id, workspaceId))
-      .limit(1);
-
-    if (!ws) {
-      return c.json({ error: "Workspace not found" }, 404);
-    }
-
-    const isOwner = ws.ownerId === user.id;
-    c.set("isWorkspaceOwner", isOwner);
-    const parent = c.get("orgScope");
-    if (parent) {
-      c.set("workspaceScope", workspaceScope(parent, workspaceId, isOwner));
-    }
-    await next();
-    return;
-  }
-
-  // Fetch workspace to check ownership
+  // Fetch the workspace once for every role branch below.
   const [ws] = await db
     .select()
     .from(workspaceTable)
@@ -198,9 +177,29 @@ export const requireWorkspaceAccess = createMiddleware(async (c, next) => {
     return c.json({ error: "Workspace not found" }, 404);
   }
 
+  // Cross-org guard: the workspace must belong to the organization named in
+  // the path. Without this, an admin (or super admin) of org A who knows a
+  // workspace id in org B could operate on it via /organizations/A/workspaces/B.
+  // Reply 404 (not 403) so we don't leak the existence of other orgs' workspaces.
+  // Applies uniformly to the member, org-admin, and super-admin branches below.
+  if (orgId && ws.organizationId !== orgId) {
+    return c.json({ error: "Workspace not found" }, 404);
+  }
+
   const isOwner = ws.ownerId === user.id;
 
-  // Org admins have access to all workspaces
+  // Super admins bypass ownership checks but still record ownership.
+  if (isSuperAdmin(user)) {
+    c.set("isWorkspaceOwner", isOwner);
+    const parent = c.get("orgScope");
+    if (parent) {
+      c.set("workspaceScope", workspaceScope(parent, workspaceId, isOwner));
+    }
+    await next();
+    return;
+  }
+
+  // Org admins have access to all workspaces in their organization.
   if (orgMembership.role === "admin") {
     c.set("isWorkspaceOwner", isOwner);
     const parent = c.get("orgScope");

--- a/apps/backend/src/routes/agent.test.ts
+++ b/apps/backend/src/routes/agent.test.ts
@@ -38,7 +38,9 @@ describe("Agent Routes", () => {
       // requireOrgAccess: returns membership
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess: workspace not owned by user
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "other-user" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "other-user", organizationId: "org-1" },
+      ]);
 
       const res = await app.request(baseUrl, {
         method: "POST",
@@ -57,7 +59,9 @@ describe("Agent Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const mockAgent = { id: "agent-1", name: "New Agent", workspaceId };
       mockDb.returning.mockResolvedValueOnce([mockAgent]);
@@ -84,7 +88,9 @@ describe("Agent Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const longDescription = "a".repeat(129);
 
@@ -115,7 +121,9 @@ describe("Agent Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const mockAgents = [{ id: "agent-1", name: "Agent 1" }];
       mockDb.where
@@ -135,7 +143,9 @@ describe("Agent Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       // get agent
       mockDb.limit.mockResolvedValueOnce([]);
 
@@ -148,7 +158,9 @@ describe("Agent Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const mockAgent = { id: "agent-1", name: "Agent 1" };
       mockDb.limit.mockResolvedValueOnce([mockAgent]);
@@ -165,7 +177,9 @@ describe("Agent Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const mockAgent = { id: "agent-1", name: "Updated Agent" };
       mockDb.returning.mockResolvedValueOnce([mockAgent]);
@@ -190,7 +204,9 @@ describe("Agent Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const longDescription = "a".repeat(129);
 
@@ -220,7 +236,9 @@ describe("Agent Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       // Avatar lookup (agent has no avatar)
       mockDb.limit.mockResolvedValueOnce([{ avatarKey: null }]);
 

--- a/apps/backend/src/routes/chat.test.ts
+++ b/apps/backend/src/routes/chat.test.ts
@@ -102,7 +102,9 @@ describe("Chat Routes", () => {
     it("should list chats", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockChats = [{ id: "chat-1", title: "Chat 1" }];
       mockDb.offset.mockResolvedValueOnce(mockChats);
@@ -121,7 +123,9 @@ describe("Chat Routes", () => {
     it("should filter chats by single tag", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockChats = [
         { id: "chat-1", title: "Chat 1", tags: ["typescript"] },
@@ -142,7 +146,9 @@ describe("Chat Routes", () => {
     it("should filter chats by multiple tags (OR logic)", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockChats = [
         { id: "chat-1", title: "Chat 1", tags: ["typescript"] },
@@ -164,7 +170,9 @@ describe("Chat Routes", () => {
     it("should return empty array when tag filter has no matches", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.offset.mockResolvedValueOnce([]);
       mockDb.where
@@ -181,7 +189,9 @@ describe("Chat Routes", () => {
     it("should return all chats when tags param is not provided (backward compatible)", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockChats = [
         { id: "chat-1", title: "Chat 1", tags: ["typescript"] },
@@ -205,7 +215,9 @@ describe("Chat Routes", () => {
     it("should return chat", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockChat = { id: "chat-1", title: "Chat 1" };
       mockDb.limit.mockResolvedValueOnce([mockChat]);
@@ -224,7 +236,9 @@ describe("Chat Routes", () => {
         email: "test@example.com",
       });
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       // ChatSink.onStart upserts the chat row with status=running before
       // prepareChatTurn runs. Returning a non-empty array skips the insert
@@ -271,7 +285,9 @@ describe("Chat Routes", () => {
     it("should delete chat", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       // Mock for fetching chat record before delete (for file cleanup)
       mockDb.limit.mockResolvedValueOnce([{ id: "chat-1", messages: [] }]);
@@ -290,7 +306,9 @@ describe("Chat Routes", () => {
     it("returns 200 when cancelling an existing chat (idempotent on inactive runs)", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       // chat row lookup
       mockDb.limit.mockResolvedValueOnce([{ id: "chat-1" }]);
 
@@ -306,7 +324,9 @@ describe("Chat Routes", () => {
       for (let i = 0; i < 2; i++) {
         mockSession();
         mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-        mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+        mockDb.limit.mockResolvedValueOnce([
+          { ownerId: "user-1", organizationId: "org-1" },
+        ]);
         mockDb.limit.mockResolvedValueOnce([{ id: "chat-1" }]);
 
         const res = await app.request(`${baseUrl}/chat-1/cancel`, {
@@ -319,7 +339,9 @@ describe("Chat Routes", () => {
     it("returns 404 when the chat does not belong to the workspace", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([]); // chat lookup misses
 
       const res = await app.request(`${baseUrl}/chat-other/cancel`, {
@@ -341,7 +363,9 @@ describe("Chat Routes", () => {
     it("should update chat", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockChat = { id: "chat-1", title: "Updated Title" };
       mockDb.returning.mockResolvedValueOnce([mockChat]);
@@ -364,7 +388,9 @@ describe("Chat Routes", () => {
     it("should generate metadata", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       // Fetch chat
       mockDb.limit.mockResolvedValueOnce([{ id: "chat-1", messages: [] }]);
@@ -404,7 +430,9 @@ describe("Chat Routes", () => {
     it("should use workspace taskModelProviderId when set", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       // Fetch chat
       mockDb.limit.mockResolvedValueOnce([{ id: "chat-1", messages: [] }]);

--- a/apps/backend/src/routes/dashboard.test.ts
+++ b/apps/backend/src/routes/dashboard.test.ts
@@ -36,7 +36,9 @@ describe("Dashboard Routes", () => {
     it("lists all dashboards in workspace", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       const mockDashboards = [{ id: dashboardId, name: "Dash 1", workspaceId }];
       mockDb.orderBy.mockResolvedValueOnce(mockDashboards);
 
@@ -60,7 +62,9 @@ describe("Dashboard Routes", () => {
     it("creates a dashboard", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       const mockDash = {
         id: "test-id-123",
         name: "New Dashboard",
@@ -82,7 +86,9 @@ describe("Dashboard Routes", () => {
     it("returns 400 if name is missing", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const res = await app.request(baseUrl, {
         method: "POST",
@@ -103,7 +109,9 @@ describe("Dashboard Routes", () => {
     it("returns 404 if dashboard not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([]);
 
       const res = await app.request(`${baseUrl}/${dashboardId}`);
@@ -113,7 +121,9 @@ describe("Dashboard Routes", () => {
     it("returns dashboard", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       const mockDash = { id: dashboardId, workspaceId, name: "Dash 1" };
       mockDb.limit.mockResolvedValueOnce([mockDash]);
 
@@ -127,7 +137,9 @@ describe("Dashboard Routes", () => {
     it("returns 404 if dashboard not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([]);
 
       const res = await app.request(`${baseUrl}/${dashboardId}`, {
@@ -141,7 +153,9 @@ describe("Dashboard Routes", () => {
     it("updates dashboard", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ id: dashboardId, workspaceId }]);
       const updated = { id: dashboardId, name: "Updated", workspaceId };
       mockDb.returning.mockResolvedValueOnce([updated]);
@@ -160,7 +174,9 @@ describe("Dashboard Routes", () => {
     it("returns 404 if dashboard not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([]);
 
       const res = await app.request(`${baseUrl}/${dashboardId}`, {
@@ -172,7 +188,9 @@ describe("Dashboard Routes", () => {
     it("deletes dashboard and returns 204", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ id: dashboardId, workspaceId }]);
 
       const res = await app.request(`${baseUrl}/${dashboardId}`, {
@@ -194,7 +212,9 @@ describe("Dashboard Routes", () => {
     it("returns 404 if dashboard not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([]);
 
       const res = await app.request(`${baseUrl}/${dashboardId}/widgets`);
@@ -204,7 +224,9 @@ describe("Dashboard Routes", () => {
     it("lists widgets on a dashboard", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ id: dashboardId, workspaceId }]);
       const mockWidgets = [{ id: widgetId, dashboardId, type: "metric" }];
       mockDb.orderBy.mockResolvedValueOnce(mockWidgets);
@@ -219,7 +241,9 @@ describe("Dashboard Routes", () => {
     it("returns 404 if dashboard not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([]);
 
       const res = await app.request(`${baseUrl}/${dashboardId}/widgets`, {
@@ -233,7 +257,9 @@ describe("Dashboard Routes", () => {
     it("creates a widget", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ id: dashboardId, workspaceId }]);
       const mockWidget = {
         id: "test-id-123",
@@ -256,7 +282,9 @@ describe("Dashboard Routes", () => {
     it("returns 400 for invalid widget type", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const res = await app.request(`${baseUrl}/${dashboardId}/widgets`, {
         method: "POST",
@@ -271,7 +299,9 @@ describe("Dashboard Routes", () => {
     it("returns 404 if widget not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ id: dashboardId, workspaceId }]);
       mockDb.limit.mockResolvedValueOnce([]);
 
@@ -292,7 +322,9 @@ describe("Dashboard Routes", () => {
     it("returns 400 on widget type mismatch", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ id: dashboardId, workspaceId }]);
       mockDb.limit.mockResolvedValueOnce([
         { id: widgetId, dashboardId, type: "text" },
@@ -315,7 +347,9 @@ describe("Dashboard Routes", () => {
     it("updates widget data", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ id: dashboardId, workspaceId }]);
       mockDb.limit.mockResolvedValueOnce([
         { id: widgetId, dashboardId, type: "metric" },
@@ -348,7 +382,9 @@ describe("Dashboard Routes", () => {
     it("returns 404 if widget not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ id: dashboardId, workspaceId }]);
       mockDb.limit.mockResolvedValueOnce([]);
 
@@ -362,7 +398,9 @@ describe("Dashboard Routes", () => {
     it("deletes widget and returns 204", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ id: dashboardId, workspaceId }]);
       mockDb.limit.mockResolvedValueOnce([{ id: widgetId, dashboardId }]);
 

--- a/apps/backend/src/routes/kanban.test.ts
+++ b/apps/backend/src/routes/kanban.test.ts
@@ -34,7 +34,9 @@ describe("Kanban Routes", () => {
     it("should list all boards in workspace", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockBoards = [{ id: "board-1", name: "Board 1", workspaceId }];
       mockDb.orderBy.mockResolvedValueOnce(mockBoards);
@@ -59,7 +61,9 @@ describe("Kanban Routes", () => {
     it("should return 403 if user is not workspace owner", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "other-user" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "other-user", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const res = await app.request(baseUrl, {
         method: "POST",
@@ -72,7 +76,9 @@ describe("Kanban Routes", () => {
     it("should create board with default columns", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockBoard = { id: "test-id-123", name: "New Board", workspaceId };
       mockDb.returning.mockResolvedValueOnce([mockBoard]);
@@ -90,7 +96,9 @@ describe("Kanban Routes", () => {
     it("should return 400 if name is missing", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const res = await app.request(baseUrl, {
         method: "POST",
@@ -106,7 +114,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if board not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // get board
 
       const res = await app.request(`${baseUrl}/${boardId}`);
@@ -116,7 +126,9 @@ describe("Kanban Routes", () => {
     it("should return board if found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockBoard = { id: boardId, name: "Board 1", workspaceId };
       mockDb.limit.mockResolvedValueOnce([mockBoard]);
@@ -131,7 +143,9 @@ describe("Kanban Routes", () => {
     it("should update board if user is workspace owner", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockBoard = { id: boardId, name: "Updated Board" };
       mockDb.returning.mockResolvedValueOnce([mockBoard]);
@@ -149,7 +163,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if board not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([]);
 
@@ -167,7 +183,9 @@ describe("Kanban Routes", () => {
     it("should delete board if user is workspace owner", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([{ id: boardId }]);
 
@@ -181,7 +199,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if board not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([]);
 
@@ -196,7 +216,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if board not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // get board
 
       const res = await app.request(`${baseUrl}/${boardId}/state`);
@@ -206,7 +228,9 @@ describe("Kanban Routes", () => {
     it("should return board state with columns and cards", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockBoard = {
         id: boardId,
@@ -249,7 +273,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if board not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // get board
 
       const res = await app.request(`${baseUrl}/${boardId}/columns`, {
@@ -263,7 +289,9 @@ describe("Kanban Routes", () => {
     it("should create column", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockBoard = { id: boardId, name: "Board 1", workspaceId };
       mockDb.limit.mockResolvedValueOnce([mockBoard]);
@@ -292,7 +320,9 @@ describe("Kanban Routes", () => {
     it("should return 409 if column name already exists on board", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockBoard = { id: boardId, name: "Board 1", workspaceId };
       mockDb.limit.mockResolvedValueOnce([mockBoard]);
@@ -316,7 +346,9 @@ describe("Kanban Routes", () => {
     it("should update column", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // duplicate check
 
       const mockColumn = { id: "col-1", boardId, name: "Updated Column" };
@@ -335,7 +367,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if column not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // duplicate check
 
       mockDb.returning.mockResolvedValueOnce([]);
@@ -352,7 +386,9 @@ describe("Kanban Routes", () => {
     it("should return 409 if renaming to an existing column name", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([{ id: "other-col" }]); // duplicate check
 
       const res = await app.request(`${baseUrl}/${boardId}/columns/col-1`, {
@@ -373,7 +409,9 @@ describe("Kanban Routes", () => {
     it("should delete column", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([{ id: "col-1" }]);
 
@@ -387,7 +425,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if column not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([]);
 
@@ -402,7 +442,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if board not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // get board
 
       const res = await app.request(`${baseUrl}/${boardId}/columns/reorder`, {
@@ -416,7 +458,9 @@ describe("Kanban Routes", () => {
     it("should reorder columns", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockBoard = { id: boardId, name: "Board 1", workspaceId };
       mockDb.limit.mockResolvedValueOnce([mockBoard]);
@@ -438,7 +482,9 @@ describe("Kanban Routes", () => {
     it("should return 400 if columnIds contain IDs not belonging to board", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockBoard = { id: boardId, name: "Board 1", workspaceId };
       mockDb.limit.mockResolvedValueOnce([mockBoard]); // board found
@@ -459,7 +505,9 @@ describe("Kanban Routes", () => {
     it("should create card", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.orderBy.mockResolvedValueOnce([{ maxPos: 1.0 }]);
 
@@ -489,7 +537,9 @@ describe("Kanban Routes", () => {
     it("should return 404 when card does not belong to board", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       // card update returns empty (card not in this board)
       mockDb.returning.mockResolvedValueOnce([]);
 
@@ -509,7 +559,9 @@ describe("Kanban Routes", () => {
     it("should update card", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockCard = { id: "card-1", title: "Updated Card" };
       mockDb.returning.mockResolvedValueOnce([mockCard]);
@@ -527,7 +579,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if card not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([]);
 
@@ -544,7 +598,9 @@ describe("Kanban Routes", () => {
       it("should return 400 for invalid user assignee", async () => {
         mockSession();
         mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-        mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { ownerId: "user-1", organizationId: "org-1" },
+        ]); // requireWorkspaceAccess
         // validateAssignees: org member query (empty) then super admin query (empty)
         mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
@@ -571,7 +627,9 @@ describe("Kanban Routes", () => {
           role: "admin",
         });
         // Super admin bypasses requireOrgAccess (no DB query)
-        mockDb.limit.mockResolvedValueOnce([{ ownerId: "admin-user" }]); // requireWorkspaceAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { ownerId: "admin-user", organizationId: "org-1" },
+        ]); // requireWorkspaceAccess
         // validateAssignees queries
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
         mockDb.where.mockResolvedValueOnce([]); // org member lookup — not found
@@ -602,7 +660,9 @@ describe("Kanban Routes", () => {
       it("should allow org member to be assigned", async () => {
         mockSession();
         mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-        mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { ownerId: "user-1", organizationId: "org-1" },
+        ]); // requireWorkspaceAccess
         // validateAssignees queries
         mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
@@ -637,7 +697,9 @@ describe("Kanban Routes", () => {
     it("should move card to beginning of column", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const existingCards = [
         { id: "card-2", columnId: "col-2", position: 1.0 },
@@ -660,7 +722,9 @@ describe("Kanban Routes", () => {
     it("should move card after another card", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const existingCards = [
         { id: "card-2", columnId: "col-2", position: 1.0 },
@@ -683,7 +747,9 @@ describe("Kanban Routes", () => {
     it("should trigger rebalancing when gap is too small", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       // Cards with very small gap between positions 1 and 2
       const existingCards = [
@@ -708,7 +774,9 @@ describe("Kanban Routes", () => {
     it("should return 400 if afterCardId not found in column", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const existingCards = [
         { id: "card-2", columnId: "col-2", position: 1.0 },
@@ -734,7 +802,9 @@ describe("Kanban Routes", () => {
     it("should return 404 when card does not belong to board", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.returning.mockResolvedValueOnce([]); // delete returns empty
 
       const res = await app.request(
@@ -751,7 +821,9 @@ describe("Kanban Routes", () => {
     it("should delete card", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
 
@@ -765,7 +837,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if card not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([]);
 
@@ -802,7 +876,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if card not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // card verification → not found
 
       const res = await app.request(commentsUrl);
@@ -812,7 +888,9 @@ describe("Kanban Routes", () => {
     it("should return comments for card with createdByName resolved", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([{ id: cardId }]); // card verification → found
       mockDb.orderBy.mockResolvedValueOnce([mockComment]); // comments query
 
@@ -827,7 +905,9 @@ describe("Kanban Routes", () => {
     it("should return empty results when card has no comments", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([{ id: cardId }]); // card found
       mockDb.orderBy.mockResolvedValueOnce([]); // no comments
 
@@ -851,7 +931,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if card not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // card verification → not found
 
       const res = await app.request(commentsUrl, {
@@ -865,7 +947,9 @@ describe("Kanban Routes", () => {
     it("should create comment and return 201", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([{ id: cardId }]); // card found
       mockDb.returning.mockResolvedValueOnce([mockComment]); // insert
 
@@ -883,7 +967,9 @@ describe("Kanban Routes", () => {
     it("should return 400 if body is empty string", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const res = await app.request(commentsUrl, {
         method: "POST",
@@ -896,7 +982,9 @@ describe("Kanban Routes", () => {
     it("should return 400 if body field is missing", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const res = await app.request(commentsUrl, {
         method: "POST",
@@ -921,7 +1009,9 @@ describe("Kanban Routes", () => {
     it("should update comment and return enriched result", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ...mockComment, createdByUserId: "user-1" },
       ]); // ownership check
@@ -941,7 +1031,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if comment not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // ownership check - not found
 
       const res = await app.request(`${commentsUrl}/${commentId}`, {
@@ -959,7 +1051,9 @@ describe("Kanban Routes", () => {
         role: "user",
       });
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "other-user" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "other-user", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ...mockComment, createdByUserId: "user-1" },
       ]); // ownership check - owned by different user
@@ -982,7 +1076,9 @@ describe("Kanban Routes", () => {
         role: "user",
       });
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess - org admin
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "admin-user" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "admin-user", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ...mockComment, createdByUserId: "user-1" },
       ]); // ownership check - owned by different user
@@ -1011,7 +1107,9 @@ describe("Kanban Routes", () => {
     it("should delete comment and return success", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ...mockComment, createdByUserId: "user-1" },
       ]); // ownership check
@@ -1026,7 +1124,9 @@ describe("Kanban Routes", () => {
     it("should return 404 if comment not found", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // ownership check - not found
 
       const res = await app.request(`${commentsUrl}/${commentId}`, {
@@ -1042,7 +1142,9 @@ describe("Kanban Routes", () => {
         role: "user",
       });
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "other-user" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "other-user", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ...mockComment, createdByUserId: "user-1" },
       ]); // ownership check
@@ -1063,7 +1165,9 @@ describe("Kanban Routes", () => {
         role: "user",
       });
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess - org admin
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "admin-user" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "admin-user", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ...mockComment, createdByUserId: "user-1" },
       ]); // ownership check

--- a/apps/backend/src/routes/mcp.test.ts
+++ b/apps/backend/src/routes/mcp.test.ts
@@ -26,7 +26,9 @@ describe("MCP Routes", () => {
     it("should create MCP if workspace admin", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockMcp = { id: "mcp-1", name: "New MCP", url: "http://mcp.com" };
       mockDb.returning.mockResolvedValueOnce([mockMcp]);
@@ -58,7 +60,9 @@ describe("MCP Routes", () => {
     it("returns 403 for a non-admin owner when self-management is disabled", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([{ flag: false }]); // delegation flag
 
       const res = await app.request(baseUrl, {
@@ -72,7 +76,9 @@ describe("MCP Routes", () => {
     it("allows a non-admin owner when self-management is enabled", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ flag: true }]); // delegation flag set
       mockDb.returning.mockResolvedValueOnce([
         { id: "mcp-1", name: "New MCP" },
@@ -91,7 +97,9 @@ describe("MCP Routes", () => {
     it("should list workspace-scoped MCPs and only attached org-scoped MCPs", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const workspaceMcps = [
         { id: "mcp-ws", name: "Workspace MCP", authType: "None" },
@@ -121,7 +129,9 @@ describe("MCP Routes", () => {
     it("should test MCP connection", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const res = await app.request(`${baseUrl}/test`, {
         method: "POST",
@@ -157,7 +167,9 @@ describe("MCP Routes", () => {
     it("force=true: clears the four oauth token columns in DB and returns authorizationUrl", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([{ ...mcpRecord }]); // MCP lookup
 
       (mcpAuth as any).mockImplementationOnce(async (provider: any) => {
@@ -196,7 +208,9 @@ describe("MCP Routes", () => {
     it("no force flag: leaves token columns untouched when SDK silently refreshes", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([{ ...mcpRecord }]); // MCP lookup
 
       (mcpAuth as any).mockResolvedValueOnce("AUTHORIZED");

--- a/apps/backend/src/routes/notification.test.ts
+++ b/apps/backend/src/routes/notification.test.ts
@@ -33,7 +33,9 @@ describe("Notification Routes", () => {
     it("should return notifications with agent name, avatar URL, and read status", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockNotifications = [
         {
@@ -63,7 +65,9 @@ describe("Notification Routes", () => {
     it("should return empty array when no notifications exist", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.offset.mockResolvedValueOnce([]);
 
       const res = await app.request(baseUrl);
@@ -83,7 +87,9 @@ describe("Notification Routes", () => {
     it("should return correct unread count", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       // where() is used by middleware (sync chaining) then by handler (terminal)
       mockDb.where
         .mockReturnValueOnce(mockDb) // requireOrgAccess
@@ -99,7 +105,9 @@ describe("Notification Routes", () => {
     it("should return 0 when all notifications read", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.where
         .mockReturnValueOnce(mockDb) // requireOrgAccess
         .mockReturnValueOnce(mockDb) // requireWorkspaceAccess
@@ -124,7 +132,9 @@ describe("Notification Routes", () => {
     it("should mark notification as read", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([{ id: "notif-1" }]); // notification exists
 
       // onConflictDoNothing returns the mock chain
@@ -142,7 +152,9 @@ describe("Notification Routes", () => {
     it("should return 404 if notification does not exist", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // notification not found
 
       const res = await app.request(`${baseUrl}/notif-1/read`, {
@@ -164,7 +176,9 @@ describe("Notification Routes", () => {
     it("should mark all workspace notifications as read", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       // where() is used by middleware (sync chaining) then by handler (terminal)
       mockDb.where
@@ -196,7 +210,9 @@ describe("Notification Routes", () => {
     it("should delete notification successfully", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.returning.mockResolvedValueOnce([{ id: "notif-1" }]);
 
       const res = await app.request(`${baseUrl}/notif-1`, {
@@ -210,7 +226,9 @@ describe("Notification Routes", () => {
     it("should return 404 if notification does not exist", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.returning.mockResolvedValueOnce([]);
 
       const res = await app.request(`${baseUrl}/notif-1`, {

--- a/apps/backend/src/routes/provider.test.ts
+++ b/apps/backend/src/routes/provider.test.ts
@@ -17,7 +17,9 @@ describe("Provider Routes", () => {
     it("should create provider if workspace admin", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockProvider = { id: "p1", name: "OpenAI", providerType: "OpenAI" };
       mockDb.returning.mockResolvedValueOnce([mockProvider]);
@@ -43,7 +45,9 @@ describe("Provider Routes", () => {
     it("should return 409 if provider name already exists in workspace", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const drizzleError = new Error("DrizzleQueryError: Failed query");
       (drizzleError as any).cause = {
@@ -89,7 +93,9 @@ describe("Provider Routes", () => {
     it("returns 403 for a non-admin owner when self-management is disabled", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([{ flag: false }]); // delegation flag
 
       const res = await app.request(baseUrl, {
@@ -103,7 +109,9 @@ describe("Provider Routes", () => {
     it("allows a non-admin owner when self-management is enabled", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ flag: true }]); // delegation flag set
       mockDb.returning.mockResolvedValueOnce([{ id: "p1", name: "OpenAI" }]);
 
@@ -120,7 +128,9 @@ describe("Provider Routes", () => {
     it("should list workspace providers and only attached org providers", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const workspaceProviders = [{ id: "p1", name: "WS OpenAI" }];
       // Org-scoped query is an inner join on attachment → rows nest under `provider`.
@@ -151,7 +161,9 @@ describe("Provider Routes", () => {
     it("should return provider with scope", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockProvider = { id: "p1", name: "OpenAI", workspaceId };
       mockDb.limit.mockResolvedValueOnce([mockProvider]);

--- a/apps/backend/src/routes/sandbox.test.ts
+++ b/apps/backend/src/routes/sandbox.test.ts
@@ -25,7 +25,9 @@ describe("Sandbox Routes", () => {
     it("returns the list of registered backends with name and id only", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const res = await app.request(`${baseUrl}/backends`);
       expect(res.status).toBe(200);
@@ -48,7 +50,9 @@ describe("Sandbox Routes", () => {
     it("creates a sandbox and returns 201 with credentials stripped", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // existing-row check
 
       mockDb.returning.mockResolvedValueOnce([
@@ -78,7 +82,9 @@ describe("Sandbox Routes", () => {
     it("returns 409 when a sandbox already exists for the workspace", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([{ id: "existing-sbx" }]);
 
       const res = await app.request(baseUrl, {
@@ -95,7 +101,9 @@ describe("Sandbox Routes", () => {
     it("returns the sandbox with credentials stripped", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([
         {
           id: "sbx-1",
@@ -117,7 +125,9 @@ describe("Sandbox Routes", () => {
     it("returns 404 when no sandbox is configured", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([]);
 
       const res = await app.request(baseUrl);
@@ -129,7 +139,9 @@ describe("Sandbox Routes", () => {
     it("updates the sandbox when the backend is unchanged", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       // Existence check — same backend, no destroy will fire
       mockDb.limit.mockResolvedValueOnce([
         {
@@ -172,7 +184,9 @@ describe("Sandbox Routes", () => {
     it("returns 500 when changing backend and the previous adapter's destroy() fails", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       // Existing row uses an unregistered backend → destroy throws
       mockDb.limit.mockResolvedValueOnce([
         {
@@ -203,7 +217,9 @@ describe("Sandbox Routes", () => {
     it("skips destroy() and switches backend when ?force=true", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([
         {
           id: "sbx-1",
@@ -242,7 +258,9 @@ describe("Sandbox Routes", () => {
     it("returns 404 when no sandbox is configured", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       // Existence check returns empty
       mockDb.limit.mockResolvedValueOnce([]);
 
@@ -265,7 +283,9 @@ describe("Sandbox Routes", () => {
     it("force-deletes the sandbox without invoking destroy()", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       // Existence check
       mockDb.limit.mockResolvedValueOnce([
         {
@@ -287,7 +307,9 @@ describe("Sandbox Routes", () => {
     it("returns 500 when destroy() fails and preserves the row", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       // Existence check returns a row whose backend is not registered →
       // destroySandboxRow throws → 500.
       mockDb.limit.mockResolvedValueOnce([
@@ -310,7 +332,9 @@ describe("Sandbox Routes", () => {
     it("returns 404 when no sandbox is configured", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       // Existence check returns empty
       mockDb.limit.mockResolvedValueOnce([]);
 
@@ -324,7 +348,9 @@ describe("Sandbox Routes", () => {
     it("POST / returns 403 for a non-admin workspace owner", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess (owner)
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess (owner)
 
       const res = await app.request(baseUrl, {
         method: "POST",
@@ -337,7 +363,9 @@ describe("Sandbox Routes", () => {
     it("DELETE / returns 403 for a non-admin workspace owner", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const res = await app.request(baseUrl, { method: "DELETE" });
       expect(res.status).toBe(403);
@@ -346,7 +374,9 @@ describe("Sandbox Routes", () => {
     it("GET /networks returns 403 for a non-admin workspace owner", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const res = await app.request(`${baseUrl}/networks`);
       expect(res.status).toBe(403);
@@ -355,7 +385,9 @@ describe("Sandbox Routes", () => {
     it("POST / rejects userEnv keys that collide with adminEnv (400)", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const res = await app.request(baseUrl, {
         method: "POST",
@@ -374,7 +406,9 @@ describe("Sandbox Routes", () => {
     it("PUT / lets a non-admin owner change name and userEnv only", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       // Existing row: admin-owned backend/config plus an admin env key.
       mockDb.limit.mockResolvedValueOnce([
         {
@@ -420,7 +454,9 @@ describe("Sandbox Routes", () => {
     it("PUT / rejects a non-admin owner's userEnv that collides with stored adminEnv (400)", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       mockDb.limit.mockResolvedValueOnce([
         {
           id: "sbx-1",

--- a/apps/backend/src/routes/skill.test.ts
+++ b/apps/backend/src/routes/skill.test.ts
@@ -39,7 +39,9 @@ describe("Skill Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess: workspace owned by someone else
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "other-user" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "other-user", organizationId: "org-1" },
+      ]);
 
       const res = await app.request(baseUrl, {
         method: "POST",
@@ -59,7 +61,9 @@ describe("Skill Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const mockSkill = {
         id: "skill-1",
@@ -91,7 +95,9 @@ describe("Skill Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const res = await app.request(baseUrl, {
         method: "POST",
@@ -113,7 +119,9 @@ describe("Skill Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       const workspaceSkills = [{ id: "skill-1", name: "skill-1" }];
       // The attached org-scoped Skills come back from an inner join, shaped
@@ -153,7 +161,9 @@ describe("Skill Routes", () => {
     it("returns 404 if the workspace skill does not exist", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([]); // skill lookup → not found
 
       const res = await app.request(promoteUrl, { method: "POST" });
@@ -163,7 +173,9 @@ describe("Skill Routes", () => {
     it("re-scopes the skill to org and auto-attaches the origin workspace", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { id: "skill-1", workspaceId, name: "my-skill" },
       ]); // skill lookup
@@ -187,7 +199,9 @@ describe("Skill Routes", () => {
     it("returns 404 (no orphan attachment) when a concurrent promote already re-scoped the skill", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { id: "skill-1", workspaceId, name: "my-skill" },
       ]); // skill lookup (pre-transaction)
@@ -207,7 +221,9 @@ describe("Skill Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       // check referencing agents
       mockDb.limit.mockResolvedValueOnce([{ id: "agent-1" }]);
 
@@ -226,7 +242,9 @@ describe("Skill Routes", () => {
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       // check referencing agents (none)
       mockDb.limit.mockResolvedValueOnce([]);
       // delete skill

--- a/apps/backend/src/routes/tool.test.ts
+++ b/apps/backend/src/routes/tool.test.ts
@@ -30,7 +30,9 @@ describe("Tool Routes", () => {
     it("should list all tool sets including MCPs", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockMcps = [{ id: "mcp-1", name: "MCP 1" }];
       mockDb.where

--- a/apps/backend/src/routes/trigger.test.ts
+++ b/apps/backend/src/routes/trigger.test.ts
@@ -53,7 +53,9 @@ const eventTrigger = {
 const stubAuthLookups = () => {
   mockSession();
   mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-  mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+  mockDb.limit.mockResolvedValueOnce([
+    { ownerId: "user-1", organizationId: "org-1" },
+  ]);
 };
 
 describe("Trigger Routes", () => {

--- a/apps/backend/src/routes/webhook.test.ts
+++ b/apps/backend/src/routes/webhook.test.ts
@@ -29,7 +29,9 @@ describe("Webhook Routes", () => {
     it("should return list of webhooks", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockWebhooks = [
         {
@@ -71,7 +73,9 @@ describe("Webhook Routes", () => {
     it("should return empty results when no webhooks exist", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.where
         .mockReturnValueOnce(mockDb) // requireOrgAccess
@@ -89,7 +93,9 @@ describe("Webhook Routes", () => {
     it("should create webhook and return 201", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const mockWebhook = {
         id: "wh-1",
@@ -132,7 +138,7 @@ describe("Webhook Routes", () => {
       mockSession();
       mockDb.limit
         .mockResolvedValueOnce([{ role: "member" }]) // requireOrgAccess
-        .mockResolvedValueOnce([{ ownerId: "user-1" }]) // requireWorkspaceAccess
+        .mockResolvedValueOnce([{ ownerId: "user-1", organizationId: "org-1" }]) // requireWorkspaceAccess
         .mockResolvedValueOnce([
           {
             id: "wh-1",
@@ -157,7 +163,7 @@ describe("Webhook Routes", () => {
       mockSession();
       mockDb.limit
         .mockResolvedValueOnce([{ role: "member" }]) // requireOrgAccess
-        .mockResolvedValueOnce([{ ownerId: "user-1" }]) // requireWorkspaceAccess
+        .mockResolvedValueOnce([{ ownerId: "user-1", organizationId: "org-1" }]) // requireWorkspaceAccess
         .mockResolvedValueOnce([]); // no webhook
 
       const res = await app.request(`${baseUrl}/nonexistent`);
@@ -169,7 +175,9 @@ describe("Webhook Routes", () => {
     it("should update webhook", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([
         {
@@ -203,7 +211,9 @@ describe("Webhook Routes", () => {
     it("should return 404 for non-existent webhook", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([]);
 
@@ -223,7 +233,9 @@ describe("Webhook Routes", () => {
     it("should delete webhook", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([{ id: "wh-1" }]);
 
@@ -238,7 +250,9 @@ describe("Webhook Routes", () => {
     it("should return 404 for non-existent webhook", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([]);
 
@@ -254,7 +268,9 @@ describe("Webhook Routes", () => {
     it("should regenerate signing secret and return full record", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       const newWebhook = {
         id: "wh-1",
@@ -288,7 +304,9 @@ describe("Webhook Routes", () => {
     it("should return 404 for non-existent webhook", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
 
       mockDb.returning.mockResolvedValueOnce([]);
 

--- a/apps/backend/src/routes/workspace.test.ts
+++ b/apps/backend/src/routes/workspace.test.ts
@@ -41,7 +41,10 @@ describe("Workspace Routes", () => {
       expect(await res.json()).toEqual(mockWorkspace);
       // Owner defaults to the calling admin when no ownerId is supplied.
       const insertedValues = mockDb.values.mock.calls.at(-1)?.[0];
-      expect(insertedValues).toMatchObject({ ownerId: "user-1" });
+      expect(insertedValues).toMatchObject({
+        ownerId: "user-1",
+        organizationId: "org-1",
+      });
     });
 
     // ADR-0008: a regular member can no longer self-create Workspaces.
@@ -85,7 +88,10 @@ describe("Workspace Routes", () => {
 
       expect(res.status).toBe(201);
       const insertedValues = mockDb.values.mock.calls.at(-1)?.[0];
-      expect(insertedValues).toMatchObject({ ownerId: "member-2" });
+      expect(insertedValues).toMatchObject({
+        ownerId: "member-2",
+        organizationId: "org-1",
+      });
     });
 
     // Governance: an admin cannot hand a workspace to a non-member.
@@ -157,7 +163,9 @@ describe("Workspace Routes", () => {
       // Mock requireOrgAccess: return member role
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // Mock requireWorkspaceAccess: workspace owned by user
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
       // Mock get workspace
       mockDb.limit.mockResolvedValueOnce([mockWorkspace]);
 
@@ -187,7 +195,9 @@ describe("Workspace Routes", () => {
       // Mock requireOrgAccess: return member role
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // Mock requireWorkspaceAccess: workspace owned by user
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       // Mock update
       mockDb.returning.mockResolvedValueOnce([mockWorkspace]);
@@ -207,7 +217,9 @@ describe("Workspace Routes", () => {
     it("strips delegation flags from a non-admin owner's update", async () => {
       mockSession({ id: "user-1", role: "user" });
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
       mockDb.returning.mockResolvedValueOnce([
         { id: "ws-1", name: "My Workspace" },
       ]);
@@ -231,7 +243,9 @@ describe("Workspace Routes", () => {
     it("lets an org admin set delegation flags", async () => {
       mockSession({ id: "user-1", role: "user" });
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-2" }]); // requireWorkspaceAccess (admin, not owner)
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-2", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess (admin, not owner)
       mockDb.returning.mockResolvedValueOnce([
         { id: "ws-1", name: "My Workspace" },
       ]);
@@ -255,7 +269,9 @@ describe("Workspace Routes", () => {
       // Mock requireOrgAccess: return member role
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       // Mock requireWorkspaceAccess: workspace owned by user
-      mockDb.limit.mockResolvedValueOnce([{ ownerId: "user-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
 
       // Mock delete — order: orgAccess where (chained) → workspaceAccess where
       // (chained) → destroyWorkspaceSandboxes select-where (resolves []) →


### PR DESCRIPTION
## Summary

Closes #162.

`requireWorkspaceAccess` resolved a workspace by `:workspaceId` and authorized on ownership/org-admin role, but **never verified the workspace's `organizationId` matches the `:orgId` in the path**. Because an org admin has access to "all workspaces", an admin (or super admin) of org A who knew a workspace id in org B could operate on that org-B workspace via any `/organizations/:orgId/workspaces/:workspaceId/...` route by passing `orgId=A`. This affected **every** workspace-scoped route (providers, mcps, agents, chat, sandbox, triggers, attachments, …), so the gap is closed centrally in the middleware.

## Changes

- **Consolidated** the duplicated workspace fetch (previously fetched separately in the super-admin and non-super-admin branches) into a single lookup — same number of DB queries.
- **Added a cross-org guard** immediately after the fetch, before any role branching:
  ```ts
  if (orgId && ws.organizationId !== orgId) {
    return c.json({ error: "Workspace not found" }, 404);
  }
  ```
  Returns **404** (not 403) to avoid leaking the existence of other orgs' workspaces. Applies uniformly to the **member**, **org-admin**, and **super-admin** branches.

## Tests

- `authorization.test.ts`: routes now mount under `:orgId`, mocks carry `organizationId`, and three new cross-org rejection tests cover the member, org-admin, and super-admin branches (assert 404 + `"Workspace not found"`). Legitimate same-org access still verified.
- Added `organizationId: "org-1"` to the `requireWorkspaceAccess` workspace-lookup mocks across the affected route test files (agent, chat, dashboard, kanban, mcp, notification, provider, sandbox, skill, tool, trigger, webhook, workspace). `files.ts` has its own inline auth and is unaffected.

All 805 backend tests pass; Prettier-clean.

## Acceptance criteria

- [x] Rejects with 404 when resolved workspace's `organizationId` != path `orgId`, across all role branches
- [x] Legitimate same-org access unchanged
- [x] Tests cover cross-org rejection (member, org-admin, super-admin) and same-org success
- [x] Existing route tests updated with `organizationId` on workspace-lookup mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)