### PR TITLE
chore: wire up turbo lint task and root pnpm lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "drizzle-kit-generate": "turbo run drizzle-kit-generate -F @platypus/backend",
     "drizzle-kit-migrate": "turbo run drizzle-kit-migrate -F @platypus/backend",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "lint": "turbo run lint",
     "test": "turbo run test"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -19,6 +19,9 @@
       "persistent": true,
       "with": ["start-local-db"]
     },
+    "lint": {
+      "outputs": []
+    },
     "drizzle-kit-push": {
       "cache": false
     },


### PR DESCRIPTION
## Summary

Wires up `pnpm lint` to run ESLint across the monorepo via Turborepo.

- Added a `lint` task to `turbo.json`
- Added a root `lint` script (`turbo run lint`) to `package.json`

## Behavior

`pnpm lint` runs `turbo run lint` across all packages in scope. Only `@platypus/frontend` defines a `lint` script today, so it's the only package that lints — `backend` and `schemas` are skipped automatically (no error). This matches the agreed "frontend only" scope.

Note: the frontend currently has pre-existing ESLint errors (mostly `react-hooks/*` rules) that this command now surfaces. Fixing those is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)