### PR TITLE
feat: org-scoped agents + promote, shared-resource editing & central attachments

### DIFF
--- a/apps/backend/drizzle/0042_org_scoped_agents.sql
+++ b/apps/backend/drizzle/0042_org_scoped_agents.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "agent" ALTER COLUMN "workspace_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "agent" ADD COLUMN "organization_id" text;--> statement-breakpoint
+ALTER TABLE "agent" ADD CONSTRAINT "agent_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_agent_organization_id" ON "agent" USING btree ("organization_id");--> statement-breakpoint
+ALTER TABLE "agent" ADD CONSTRAINT "unique_agent_name_org" UNIQUE("organization_id","name");

--- a/apps/backend/drizzle/meta/0042_snapshot.json
+++ b/apps/backend/drizzle/meta/0042_snapshot.json
@@ -1,0 +1,3915 @@
+{
+  "id": "0bfe794b-8681-4b8e-bb76-6eb83712ecdf",
+  "prevId": "a1004c13-a4a5-4363-bc40-0caab0fdf8ad",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_set_ids": {
+          "name": "tool_set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "skill_ids": {
+          "name": "skill_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "sub_agent_ids": {
+          "name": "sub_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "input_placeholder": {
+          "name": "input_placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_workspace_id": {
+          "name": "idx_agent_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_organization_id": {
+          "name": "idx_agent_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_provider_id": {
+          "name": "idx_agent_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_id_workspace_id_fk": {
+          "name": "agent_workspace_id_workspace_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_provider_id_provider_id_fk": {
+          "name": "agent_provider_id_provider_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_agent_name_org": {
+          "name": "unique_agent_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment": {
+      "name": "attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_attachment_workspace": {
+          "name": "idx_attachment_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attachment_resource": {
+          "name": "idx_attachment_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_workspace_id_workspace_id_fk": {
+          "name": "attachment_workspace_id_workspace_id_fk",
+          "tableFrom": "attachment",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_attachment": {
+          "name": "unique_attachment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "resource_type",
+            "resource_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_memory_processed_at": {
+          "name": "last_memory_processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_status": {
+          "name": "memory_extraction_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_workspace_id": {
+          "name": "idx_chat_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_tags": {
+          "name": "idx_chat_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_chat_memory_processing": {
+          "name": "idx_chat_memory_processing",
+          "columns": [
+            {
+              "expression": "memory_extraction_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_memory_processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_workspace_id_workspace_id_fk": {
+          "name": "chat_workspace_id_workspace_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context": {
+      "name": "context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_context_user_id": {
+          "name": "idx_context_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_workspace_id": {
+          "name": "idx_context_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "context_user_id_user_id_fk": {
+          "name": "context_user_id_user_id_fk",
+          "tableFrom": "context",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "context_workspace_id_workspace_id_fk": {
+          "name": "context_workspace_id_workspace_id_fk",
+          "tableFrom": "context",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_context_user_workspace": {
+          "name": "unique_context_user_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard": {
+      "name": "dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desktop_layout": {
+          "name": "desktop_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mobile_layout": {
+          "name": "mobile_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_dashboard_workspace_id": {
+          "name": "idx_dashboard_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_dashboard_workspace_name": {
+          "name": "uq_dashboard_workspace_name",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_workspace_id_workspace_id_fk": {
+          "name": "dashboard_workspace_id_workspace_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitation_email": {
+          "name": "idx_invitation_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitation_org_id": {
+          "name": "idx_invitation_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_invited_by_user_id_fk": {
+          "name": "invitation_invited_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_invitation_org_email": {
+          "name": "unique_invitation_org_email",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_board": {
+      "name": "kanban_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_board_workspace_id": {
+          "name": "idx_kanban_board_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_board_workspace_id_workspace_id_fk": {
+          "name": "kanban_board_workspace_id_workspace_id_fk",
+          "tableFrom": "kanban_board",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_kanban_board_name_workspace": {
+          "name": "unique_kanban_board_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card": {
+      "name": "kanban_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_ids": {
+          "name": "label_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "assignees": {
+          "name": "assignees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_user_id": {
+          "name": "last_edited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_agent_id": {
+          "name": "last_edited_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_column_id": {
+          "name": "idx_kanban_card_column_id",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_label_ids": {
+          "name": "idx_kanban_card_label_ids",
+          "columns": [
+            {
+              "expression": "label_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_kanban_card_assignees": {
+          "name": "idx_kanban_card_assignees",
+          "columns": [
+            {
+              "expression": "assignees",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_kanban_card_due_date": {
+          "name": "idx_kanban_card_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_priority": {
+          "name": "idx_kanban_card_priority",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_column_position": {
+          "name": "idx_kanban_card_column_position",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_column_id_kanban_column_id_fk": {
+          "name": "kanban_card_column_id_kanban_column_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "kanban_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kanban_card_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_last_edited_by_user_id_user_id_fk": {
+          "name": "kanban_card_last_edited_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "last_edited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_last_edited_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_last_edited_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "last_edited_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card_comment": {
+      "name": "kanban_card_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_comment_card_id": {
+          "name": "idx_kanban_card_comment_card_id",
+          "columns": [
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_comment_card_id_kanban_card_id_fk": {
+          "name": "kanban_card_comment_card_id_kanban_card_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "kanban_card",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kanban_card_comment_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_comment_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_comment_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_comment_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_column": {
+      "name": "kanban_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_column_board_id": {
+          "name": "idx_kanban_column_board_id",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_column_board_id_kanban_board_id_fk": {
+          "name": "kanban_column_board_id_kanban_board_id_fk",
+          "tableFrom": "kanban_column",
+          "tableTo": "kanban_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp": {
+      "name": "mcp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_access_token": {
+          "name": "oauth_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_refresh_token": {
+          "name": "oauth_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_expires_at": {
+          "name": "oauth_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_requested_scope": {
+          "name": "oauth_requested_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_workspace_id": {
+          "name": "idx_mcp_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_organization_id": {
+          "name": "idx_mcp_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_organization_id_organization_id_fk": {
+          "name": "mcp_organization_id_organization_id_fk",
+          "tableFrom": "mcp",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_workspace_id_workspace_id_fk": {
+          "name": "mcp_workspace_id_workspace_id_fk",
+          "tableFrom": "mcp",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_mcp_name_org": {
+          "name": "unique_mcp_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        },
+        "unique_mcp_name_workspace": {
+          "name": "unique_mcp_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_state": {
+      "name": "mcp_oauth_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_oauth_state_mcp_id": {
+          "name": "idx_mcp_oauth_state_mcp_id",
+          "columns": [
+            {
+              "expression": "mcp_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_state_mcp_id_mcp_id_fk": {
+          "name": "mcp_oauth_state_mcp_id_mcp_id_fk",
+          "tableFrom": "mcp_oauth_state",
+          "tableTo": "mcp",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_daily_summary": {
+      "name": "memory_daily_summary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_date": {
+          "name": "summary_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_summary_user_workspace": {
+          "name": "idx_daily_summary_user_workspace",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_summary_date": {
+          "name": "idx_daily_summary_date",
+          "columns": [
+            {
+              "expression": "summary_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_daily_summary_user_id_user_id_fk": {
+          "name": "memory_daily_summary_user_id_user_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_daily_summary_workspace_id_workspace_id_fk": {
+          "name": "memory_daily_summary_workspace_id_workspace_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_daily_summary_user_workspace_date": {
+          "name": "unique_daily_summary_user_workspace_date",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workspace_id",
+            "summary_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_workspace_id": {
+          "name": "idx_notification_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_agent_id": {
+          "name": "idx_notification_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_created_at": {
+          "name": "idx_notification_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_workspace_id_workspace_id_fk": {
+          "name": "notification_workspace_id_workspace_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_agent_id_agent_id_fk": {
+          "name": "notification_agent_id_agent_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_read": {
+      "name": "notification_read",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_read_user_id": {
+          "name": "idx_notification_read_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_read_notification_id": {
+          "name": "idx_notification_read_notification_id",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_read_notification_id_notification_id_fk": {
+          "name": "notification_read_notification_id_notification_id_fk",
+          "tableFrom": "notification_read",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_read_user_id_user_id_fk": {
+          "name": "notification_read_user_id_user_id_fk",
+          "tableFrom": "notification_read",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_notification_read": {
+          "name": "unique_notification_read",
+          "nullsNotDistinct": false,
+          "columns": [
+            "notification_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_member": {
+      "name": "organization_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_member_org_id": {
+          "name": "idx_org_member_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_member_user_id": {
+          "name": "idx_org_member_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_member_organization_id_organization_id_fk": {
+          "name": "organization_member_organization_id_organization_id_fk",
+          "tableFrom": "organization_member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_member_user_id_user_id_fk": {
+          "name": "organization_member_user_id_user_id_fk",
+          "tableFrom": "organization_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraBody": {
+          "name": "extraBody",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_mode": {
+          "name": "api_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'responses'"
+        },
+        "modelIds": {
+          "name": "modelIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_model_id": {
+          "name": "task_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_extraction_model_id": {
+          "name": "memory_extraction_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_workspace_id": {
+          "name": "idx_provider_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_organization_id": {
+          "name": "idx_provider_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_organization_id_organization_id_fk": {
+          "name": "provider_organization_id_organization_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_provider_name_org": {
+          "name": "unique_provider_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        },
+        "unique_provider_name_workspace": {
+          "name": "unique_provider_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox": {
+      "name": "sandbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "admin_env": {
+          "name": "admin_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_env": {
+          "name": "user_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_sandbox_workspace_id": {
+          "name": "unique_sandbox_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_workspace_id_workspace_id_fk": {
+          "name": "sandbox_workspace_id_workspace_id_fk",
+          "tableFrom": "sandbox",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_teardown_failure": {
+      "name": "sandbox_teardown_failure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_teardown_failure_workspace_id": {
+          "name": "idx_sandbox_teardown_failure_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill": {
+      "name": "skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_workspace_id": {
+          "name": "idx_skill_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skill_organization_id": {
+          "name": "idx_skill_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_organization_id_organization_id_fk": {
+          "name": "skill_organization_id_organization_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_workspace_id_workspace_id_fk": {
+          "name": "skill_workspace_id_workspace_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_skill_name_workspace": {
+          "name": "unique_skill_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "unique_skill_name_org": {
+          "name": "unique_skill_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger": {
+      "name": "trigger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_runs_to_keep": {
+          "name": "max_runs_to_keep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "search": {
+          "name": "search",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_workspace_id": {
+          "name": "idx_trigger_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_next_run_at": {
+          "name": "idx_trigger_next_run_at",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_type": {
+          "name": "idx_trigger_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_workspace_id_workspace_id_fk": {
+          "name": "trigger_workspace_id_workspace_id_fk",
+          "tableFrom": "trigger",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_agent_id_agent_id_fk": {
+          "name": "trigger_agent_id_agent_id_fk",
+          "tableFrom": "trigger",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_run": {
+      "name": "trigger_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_run_trigger_id": {
+          "name": "idx_trigger_run_trigger_id",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_run_started_at": {
+          "name": "idx_trigger_run_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_run_trigger_id_trigger_id_fk": {
+          "name": "trigger_run_trigger_id_trigger_id_fk",
+          "tableFrom": "trigger_run",
+          "tableTo": "trigger",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Webhook'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_secret": {
+          "name": "signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhook_workspace_id": {
+          "name": "idx_webhook_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_workspace_id_workspace_id_fk": {
+          "name": "webhook_workspace_id_workspace_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget": {
+      "name": "widget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_widget_dashboard_id": {
+          "name": "idx_widget_dashboard_id",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_widget_dashboard_title": {
+          "name": "uq_widget_dashboard_title",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "widget_dashboard_id_dashboard_id_fk": {
+          "name": "widget_dashboard_id_dashboard_id_fk",
+          "tableFrom": "widget",
+          "tableTo": "dashboard",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace": {
+      "name": "workspace",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_model_provider_id": {
+          "name": "task_model_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_provider_id": {
+          "name": "memory_extraction_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_embedding_provider_id": {
+          "name": "memory_embedding_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_daily_summaries": {
+          "name": "max_daily_summaries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 90
+        },
+        "provider_self_management": {
+          "name": "provider_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mcp_self_management": {
+          "name": "mcp_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_organization_id": {
+          "name": "idx_workspace_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_owner_id": {
+          "name": "idx_workspace_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_organization_id_organization_id_fk": {
+          "name": "workspace_organization_id_organization_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_owner_id_user_id_fk": {
+          "name": "workspace_owner_id_user_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_task_model_provider_id_provider_id_fk": {
+          "name": "workspace_task_model_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "task_model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_memory_extraction_provider_id_provider_id_fk": {
+          "name": "workspace_memory_extraction_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_extraction_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_memory_embedding_provider_id_provider_id_fk": {
+          "name": "workspace_memory_embedding_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_embedding_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1780220802520,
       "tag": "0041_org_scoped_skills",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1780305022847,
+      "tag": "0042_org_scoped_agents",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -182,12 +182,18 @@ export const agent = pgTable(
   "agent",
   (t) => ({
     id: t.text("id").primaryKey(),
-    workspaceId: t
-      .text("workspace_id")
-      .notNull()
-      .references(() => workspace.id, {
+    // An Agent is scoped to either an Organization or a Workspace (mutually
+    // exclusive), mirroring the dual-scope shape of `provider`/`mcp`/`skill`.
+    // Org-scoped Agents are Shared resources managed by Org Admins (ADR-0007);
+    // the XOR is enforced in the Zod schema and by the routes/Promote action.
+    organizationId: t
+      .text("organization_id")
+      .references(() => organization.id, {
         onDelete: "cascade",
       }),
+    workspaceId: t.text("workspace_id").references(() => workspace.id, {
+      onDelete: "cascade",
+    }),
     providerId: t
       .text("provider_id")
       .notNull()
@@ -215,7 +221,11 @@ export const agent = pgTable(
   }),
   (t) => [
     index("idx_agent_workspace_id").on(t.workspaceId),
+    index("idx_agent_organization_id").on(t.organizationId),
     index("idx_agent_provider_id").on(t.providerId),
+    // Shared Agents must have unique names within an Organization so Promote
+    // surfaces a clean conflict. Workspace Agent names stay unconstrained.
+    unique("unique_agent_name_org").on(t.organizationId, t.name),
   ],
 );
 
@@ -293,7 +303,7 @@ export const attachment = pgTable(
       .references(() => workspace.id, { onDelete: "cascade" }),
     resourceType: t
       .text("resource_type")
-      .$type<"mcp" | "provider" | "skill">()
+      .$type<"mcp" | "provider" | "skill" | "agent">()
       .notNull(),
     resourceId: t.text("resource_id").notNull(),
     createdAt: t.timestamp("created_at").notNull().defaultNow(),

--- a/apps/backend/src/routes/agent.test.ts
+++ b/apps/backend/src/routes/agent.test.ts
@@ -85,9 +85,7 @@ describe("Agent Routes", () => {
 
     it("should return 400 if description is too long", async () => {
       mockSession();
-      // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
@@ -116,70 +114,121 @@ describe("Agent Routes", () => {
   });
 
   describe("GET /", () => {
-    it("should list all agents in workspace", async () => {
+    it("should list workspace and attached org agents tagged with scope", async () => {
       mockSession();
-      // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
 
-      const mockAgents = [{ id: "agent-1", name: "Agent 1" }];
+      const workspaceAgents = [{ id: "agent-1", name: "Agent 1" }];
+      // The attached org-scoped Agents come back from an inner join, shaped
+      // { agent: {...} }.
+      const attachedOrgRows = [
+        { agent: { id: "org-agent-1", name: "Shared Agent" } },
+      ];
       mockDb.where
-        .mockReturnValueOnce(mockDb)
-        .mockReturnValueOnce(mockDb)
-        .mockResolvedValueOnce(mockAgents);
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // requireWorkspaceAccess
+        .mockResolvedValueOnce(workspaceAgents) // workspace-scoped query
+        .mockResolvedValueOnce(attachedOrgRows); // attached org-scoped query
 
       const res = await app.request(baseUrl);
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ results: mockAgents });
+      expect(await res.json()).toEqual({
+        results: [
+          { id: "org-agent-1", name: "Shared Agent", scope: "organization" },
+          { id: "agent-1", name: "Agent 1", scope: "workspace" },
+        ],
+      });
     });
   });
 
   describe("GET /:agentId", () => {
     it("should return 404 if agent not found", async () => {
       mockSession();
-      // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
-      // get agent
+      // findVisibleAgent lookup → none
       mockDb.limit.mockResolvedValueOnce([]);
 
       const res = await app.request(`${baseUrl}/agent-1`);
       expect(res.status).toBe(404);
     });
 
-    it("should return agent if found", async () => {
+    it("should return a workspace agent tagged scope workspace", async () => {
       mockSession();
-      // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
-
-      const mockAgent = { id: "agent-1", name: "Agent 1" };
-      mockDb.limit.mockResolvedValueOnce([mockAgent]);
+      // findVisibleAgent lookup → workspace-scoped agent
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "agent-1", name: "Agent 1", workspaceId },
+      ]);
 
       const res = await app.request(`${baseUrl}/agent-1`);
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual(mockAgent);
+      expect(await res.json()).toEqual({
+        id: "agent-1",
+        name: "Agent 1",
+        workspaceId,
+        scope: "workspace",
+      });
+    });
+
+    it("should return an attached org agent tagged scope organization", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // findVisibleAgent lookup → org-scoped agent
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "org-agent-1", name: "Shared", organizationId: orgId },
+      ]);
+      // attachment check → attached here
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]);
+
+      const res = await app.request(`${baseUrl}/org-agent-1`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        id: "org-agent-1",
+        name: "Shared",
+        organizationId: orgId,
+        scope: "organization",
+      });
+    });
+
+    it("should 404 an org agent that is not attached here", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // findVisibleAgent lookup → org-scoped agent
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "org-agent-1", name: "Shared", organizationId: orgId },
+      ]);
+      // attachment check → not attached
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const res = await app.request(`${baseUrl}/org-agent-1`);
+      expect(res.status).toBe(404);
     });
   });
 
   describe("PUT /:agentId", () => {
-    it("should update agent if user is editor", async () => {
+    it("should update a workspace agent if user is editor", async () => {
       mockSession();
-      // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
+      // findVisibleAgent → workspace-scoped agent
+      mockDb.limit.mockResolvedValueOnce([{ id: "agent-1", workspaceId }]);
 
       const mockAgent = { id: "agent-1", name: "Updated Agent" };
       mockDb.returning.mockResolvedValueOnce([mockAgent]);
@@ -199,47 +248,72 @@ describe("Agent Routes", () => {
       expect(await res.json()).toEqual(mockAgent);
     });
 
-    it("should return 400 if description is too long on update", async () => {
+    it("should lock a shared agent for a workspace owner (non-admin)", async () => {
       mockSession();
-      // requireOrgAccess
+      // requireOrgAccess → member
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
+      // findVisibleAgent → org-scoped agent
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "org-agent-1", name: "Shared", organizationId: orgId },
+      ]);
+      // attachment check → attached here
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]);
 
-      const longDescription = "a".repeat(129);
-
-      const res = await app.request(`${baseUrl}/agent-1`, {
+      const res = await app.request(`${baseUrl}/org-agent-1`, {
         method: "PUT",
         body: JSON.stringify({
-          name: "Updated Agent",
+          name: "Hacked",
+          description: "nope",
           providerId: "p1",
           modelId: "m1",
-          description: longDescription,
         }),
         headers: { "Content-Type": "application/json" },
       });
+      expect(res.status).toBe(403);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
 
-      expect(res.status).toBe(400);
-      const body = await res.json();
-      expect(body.success).toBe(false);
-      expect(Array.isArray(body.error)).toBe(true);
-      expect(body.error[0].code).toBe("too_big");
-      expect(body.error[0].path).toContain("description");
+    it("locks a shared agent in the workspace even for an org admin (edit on org surface)", async () => {
+      mockSession();
+      // requireOrgAccess → admin
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // findVisibleAgent → org-scoped agent
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "org-agent-1", name: "Shared", organizationId: orgId },
+      ]);
+      // attachment check → attached here
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]);
+
+      const res = await app.request(`${baseUrl}/org-agent-1`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "Renamed",
+          description: "An updated shared agent",
+          providerId: "p1",
+          modelId: "m1",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      // Shared agents are edited only on the Organization surface (ADR-0007).
+      expect(res.status).toBe(403);
+      expect(mockDb.update).not.toHaveBeenCalled();
     });
   });
 
   describe("DELETE /:agentId", () => {
-    it("should delete agent if user is workspace owner", async () => {
+    it("should delete a workspace agent if user is workspace owner", async () => {
       mockSession();
-      // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
-      // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
-      // Avatar lookup (agent has no avatar)
+      // Avatar lookup (agent has no avatar) — also confirms workspace row exists
       mockDb.limit.mockResolvedValueOnce([{ avatarKey: null }]);
 
       const res = await app.request(`${baseUrl}/agent-1`, {
@@ -247,6 +321,160 @@ describe("Agent Routes", () => {
       });
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ message: "Agent deleted" });
+    });
+
+    it("should 404 when deleting a shared agent from the workspace", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // No workspace row matches (agent is org-scoped) → 404
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const res = await app.request(`${baseUrl}/org-agent-1`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /:agentId/promote", () => {
+    const promoteUrl = `${baseUrl}/agent-1/promote`;
+
+    it("returns 403 if not org admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+
+      const res = await app.request(promoteUrl, { method: "POST" });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns 404 if the workspace agent does not exist", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // agent lookup → not found
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const res = await app.request(promoteUrl, { method: "POST" });
+      expect(res.status).toBe(404);
+    });
+
+    it("blocks promotion and lists workspace-private references (no-cascade)", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // agent lookup: org-scoped provider, but a workspace-private skill
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "agent-1",
+          providerId: "p1",
+          workspaceId,
+          skillIds: ["s1"],
+          subAgentIds: [],
+          toolSetIds: [],
+        },
+      ]);
+
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // requireWorkspaceAccess
+        .mockReturnValueOnce(mockDb) // agent lookup
+        .mockResolvedValueOnce([
+          { id: "p1", name: "Shared Provider", organizationId: orgId },
+        ]) // provider validation → org-scoped, OK
+        .mockResolvedValueOnce([
+          { id: "s1", name: "ws-skill", organizationId: null },
+        ]); // skills validation → workspace-private, blocker
+
+      const res = await app.request(promoteUrl, { method: "POST" });
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body.blockers).toEqual([
+        { type: "skill", id: "s1", name: "ws-skill" },
+      ]);
+      expect(mockDb.transaction).not.toHaveBeenCalled();
+    });
+
+    it("re-scopes the agent to org and auto-attaches the origin workspace", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // agent lookup: only an org-scoped provider reference
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "agent-1",
+          providerId: "p1",
+          workspaceId,
+          skillIds: [],
+          subAgentIds: [],
+          toolSetIds: [],
+        },
+      ]);
+
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // requireWorkspaceAccess
+        .mockReturnValueOnce(mockDb) // agent lookup
+        .mockResolvedValueOnce([
+          { id: "p1", name: "Shared Provider", organizationId: orgId },
+        ]); // provider validation → org-scoped, OK
+
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "agent-1", organizationId: orgId, workspaceId: null },
+      ]);
+
+      const res = await app.request(promoteUrl, { method: "POST" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        id: "agent-1",
+        organizationId: orgId,
+        workspaceId: null,
+        scope: "organization",
+      });
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(mockDb.onConflictDoNothing).toHaveBeenCalled();
+    });
+
+    it("returns 404 (no orphan attachment) on a lost promote race", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "agent-1",
+          providerId: "p1",
+          workspaceId,
+          skillIds: [],
+          subAgentIds: [],
+          toolSetIds: [],
+        },
+      ]);
+
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // requireWorkspaceAccess
+        .mockReturnValueOnce(mockDb) // agent lookup
+        .mockResolvedValueOnce([
+          { id: "p1", name: "Shared Provider", organizationId: orgId },
+        ]); // provider validation → OK
+
+      // Transaction update matches no row (already re-scoped) → rollback
+      mockDb.returning.mockResolvedValueOnce([]);
+
+      const res = await app.request(promoteUrl, { method: "POST" });
+      expect(res.status).toBe(404);
+      expect(mockDb.onConflictDoNothing).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -2,9 +2,12 @@ import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import { agent as agentTable } from "../db/schema.ts";
+import {
+  agent as agentTable,
+  attachment as attachmentTable,
+} from "../db/schema.ts";
 import { agentCreateSchema, agentUpdateSchema } from "@platypus/schemas";
-import { eq, and } from "drizzle-orm";
+import { eq, and, or, inArray } from "drizzle-orm";
 import { dedupeArray } from "../utils.ts";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
@@ -13,6 +16,7 @@ import {
 } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { validateSubAgentAssignment } from "../services/sub-agent-validation.ts";
+import { findNonSharedReferences } from "../services/agent-scope-validation.ts";
 import { getStorage } from "../storage/index.ts";
 import sharp from "sharp";
 import { avatarKeyToUrl } from "../utils/avatar-url.ts";
@@ -28,6 +32,9 @@ const MAX_AVATAR_SIZE = 5 * 1024 * 1024;
 const MIN_AVATAR_DIMENSION = 64;
 const AVATAR_SIZE = 512;
 
+type AgentRow = typeof agentTable.$inferSelect;
+type AgentScope = "organization" | "workspace";
+
 function agentWithAvatarUrl(
   agent: Record<string, unknown>,
   baseUrl: string,
@@ -37,9 +44,63 @@ function agentWithAvatarUrl(
   return { ...rest, avatarUrl: avatarKeyToUrl(key, baseUrl) ?? undefined };
 }
 
+/** Detects a Postgres unique-constraint violation across driver shapes. */
+const isUniqueViolation = (error: any): boolean =>
+  error.code === "23505" ||
+  error.cause?.code === "23505" ||
+  error.message?.includes("unique constraint") ||
+  error.cause?.message?.includes("unique constraint");
+
+/**
+ * Resolves an Agent visible inside this Workspace: a Workspace-scoped Agent in
+ * the Workspace, or an Organization-scoped (Shared) Agent attached to it
+ * (ADR-0007). Returns the row plus its scope, or null when not visible here.
+ */
+const findVisibleAgent = async (
+  agentId: string,
+  orgId: string,
+  workspaceId: string,
+): Promise<{ row: AgentRow; scope: AgentScope } | null> => {
+  const rows = await db
+    .select()
+    .from(agentTable)
+    .where(
+      and(
+        eq(agentTable.id, agentId),
+        or(
+          eq(agentTable.workspaceId, workspaceId),
+          eq(agentTable.organizationId, orgId),
+        ),
+      ),
+    )
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+
+  const isOrgScoped = !!row.organizationId && !row.workspaceId;
+  if (!isOrgScoped) {
+    return { row, scope: "workspace" };
+  }
+
+  // An org-scoped (Shared) Agent is only visible here where attached.
+  const [attached] = await db
+    .select({ id: attachmentTable.id })
+    .from(attachmentTable)
+    .where(
+      and(
+        eq(attachmentTable.workspaceId, workspaceId),
+        eq(attachmentTable.resourceType, "agent"),
+        eq(attachmentTable.resourceId, agentId),
+      ),
+    )
+    .limit(1);
+  if (!attached) return null;
+  return { row, scope: "organization" };
+};
+
 const agent = new Hono<{ Variables: Variables }>();
 
-/** Create a new agent (admin or editor) */
+/** Create a new agent (admin or editor) — always Workspace-scoped */
 agent.post(
   "/",
   requireAuth,
@@ -74,37 +135,69 @@ agent.post(
     }
 
     const baseUrl = getOrigin(c);
+    // The workspace route only ever creates Workspace-scoped Agents; the scope
+    // comes from the route, never the body (org-scoped Agents arrive via
+    // Promote).
     const record = await db
       .insert(agentTable)
       .values({
         id: nanoid(),
         ...data,
+        workspaceId,
+        organizationId: null,
       })
       .returning();
     return c.json(agentWithAvatarUrl(record[0], baseUrl), 201);
   },
 );
 
-/** List all agents */
+/** List agents visible in this workspace (workspace-scoped + attached org-scoped) */
 agent.get(
   "/",
   requireAuth,
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
     const baseUrl = getOrigin(c);
-    const results = await db
+
+    const workspaceAgents = await db
       .select()
       .from(agentTable)
       .where(eq(agentTable.workspaceId, workspaceId));
-    return c.json({
-      results: results.map((r) => agentWithAvatarUrl(r, baseUrl)),
-    });
+
+    // Org-scoped (Shared) Agents appear in a Workspace only where attached
+    // (ADR-0007) — gate by an inner join on the Attachment table.
+    const attachedOrgRows = await db
+      .select()
+      .from(agentTable)
+      .innerJoin(
+        attachmentTable,
+        and(
+          eq(attachmentTable.resourceId, agentTable.id),
+          eq(attachmentTable.resourceType, "agent"),
+          eq(attachmentTable.workspaceId, workspaceId),
+        ),
+      )
+      .where(eq(agentTable.organizationId, orgId));
+    const orgAgents = attachedOrgRows.map((r) => r.agent);
+
+    const results = [
+      ...orgAgents.map((a) => ({
+        ...agentWithAvatarUrl(a, baseUrl),
+        scope: "organization" as const,
+      })),
+      ...workspaceAgents.map((a) => ({
+        ...agentWithAvatarUrl(a, baseUrl),
+        scope: "workspace" as const,
+      })),
+    ];
+    return c.json({ results });
   },
 );
 
-/** Get an agent by ID */
+/** Get an agent by ID (workspace-scoped, or attached org-scoped) */
 agent.get(
   "/:agentId",
   requireAuth,
@@ -112,26 +205,22 @@ agent.get(
   requireWorkspaceAccess,
   async (c) => {
     const agentId = c.req.param("agentId");
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
     const baseUrl = getOrigin(c);
-    const record = await db
-      .select()
-      .from(agentTable)
-      .where(
-        and(
-          eq(agentTable.id, agentId),
-          eq(agentTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
-    if (record.length === 0) {
+
+    const found = await findVisibleAgent(agentId, orgId, workspaceId);
+    if (!found) {
       return c.json({ error: "Agent not found" }, 404);
     }
-    return c.json(agentWithAvatarUrl(record[0], baseUrl));
+    return c.json({
+      ...agentWithAvatarUrl(found.row, baseUrl),
+      scope: found.scope,
+    });
   },
 );
 
-/** Update an agent by ID (admin or editor) */
+/** Update an agent by ID (workspace-scoped only; Shared agents edit on org surface) */
 agent.put(
   "/:agentId",
   requireAuth,
@@ -141,6 +230,7 @@ agent.put(
   async (c) => {
     const agentId = c.req.param("agentId");
     const data = c.req.valid("json");
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
 
     // Deduplicate arrays
@@ -154,7 +244,23 @@ agent.put(
       data.subAgentIds = dedupeArray(data.subAgentIds);
     }
 
-    // Validate sub-agent assignments
+    const found = await findVisibleAgent(agentId, orgId, workspaceId);
+    if (!found) {
+      return c.json({ error: "Agent not found" }, 404);
+    }
+
+    const baseUrl = getOrigin(c);
+
+    // A Shared Agent is a single source of truth edited only on the Organization
+    // surface (ADR-0007); it is locked in every Workspace, even to Org Admins.
+    if (found.scope === "organization") {
+      return c.json(
+        { error: "This agent is managed at the organization level" },
+        403,
+      );
+    }
+
+    // Workspace-scoped update.
     if (data.subAgentIds) {
       const validation = await validateSubAgentAssignment(
         workspaceId,
@@ -166,7 +272,6 @@ agent.put(
       }
     }
 
-    const baseUrl = getOrigin(c);
     const record = await db
       .update(agentTable)
       .set({
@@ -195,6 +300,18 @@ agent.post(
     const workspaceId = c.req.param("workspaceId")!;
     const orgId = c.req.param("orgId")!;
     const baseUrl = getOrigin(c);
+
+    const found = await findVisibleAgent(agentId, orgId, workspaceId);
+    if (!found) {
+      return c.json({ error: "Agent not found" }, 404);
+    }
+    // Shared agents are managed only on the Organization surface (ADR-0007).
+    if (found.scope === "organization") {
+      return c.json(
+        { error: "This agent is managed at the organization level" },
+        403,
+      );
+    }
 
     const body = await c.req.parseBody();
     const file = body["file"];
@@ -238,23 +355,16 @@ agent.post(
       .webp()
       .toBuffer();
 
-    const key = `${orgId}/${workspaceId}/agents/${agentId}/avatar-${nanoid()}.webp`;
+    // Avatars are keyed by the Agent's (globally unique) id, independent of
+    // scope — so the path never goes stale when a workspace Agent is Promoted
+    // to the Organization (ADR-0007). The exact key is stored on the row, so
+    // deletion never needs to reconstruct it.
+    const key = `agents/${agentId}/avatar-${nanoid()}.webp`;
 
-    const existing = await db
-      .select({ avatarKey: agentTable.avatarKey })
-      .from(agentTable)
-      .where(
-        and(
-          eq(agentTable.id, agentId),
-          eq(agentTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
-
-    if (existing[0]?.avatarKey) {
+    if (found.row.avatarKey) {
       try {
         const storage = getStorage();
-        await storage.delete(existing[0].avatarKey);
+        await storage.delete(found.row.avatarKey);
       } catch {
         // Ignore deletion errors
       }
@@ -286,24 +396,26 @@ agent.delete(
   requireWorkspaceAccess,
   async (c) => {
     const agentId = c.req.param("agentId");
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
     const baseUrl = getOrigin(c);
 
-    const existing = await db
-      .select({ avatarKey: agentTable.avatarKey })
-      .from(agentTable)
-      .where(
-        and(
-          eq(agentTable.id, agentId),
-          eq(agentTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
+    const found = await findVisibleAgent(agentId, orgId, workspaceId);
+    if (!found) {
+      return c.json({ error: "Agent not found" }, 404);
+    }
+    // Shared agents are managed only on the Organization surface (ADR-0007).
+    if (found.scope === "organization") {
+      return c.json(
+        { error: "This agent is managed at the organization level" },
+        403,
+      );
+    }
 
-    if (existing[0]?.avatarKey) {
+    if (found.row.avatarKey) {
       try {
         const storage = getStorage();
-        await storage.delete(existing[0].avatarKey);
+        await storage.delete(found.row.avatarKey);
       } catch {
         // Ignore deletion errors
       }
@@ -324,7 +436,7 @@ agent.delete(
   },
 );
 
-/** Delete an agent by ID (admin only) */
+/** Delete an agent by ID — Workspace-scoped only (Shared agents via org surface) */
 agent.delete(
   "/:agentId",
   requireAuth,
@@ -335,7 +447,9 @@ agent.delete(
     const workspaceId = c.req.param("workspaceId")!;
 
     const existing = await db
-      .select({ avatarKey: agentTable.avatarKey })
+      .select({
+        avatarKey: agentTable.avatarKey,
+      })
       .from(agentTable)
       .where(
         and(
@@ -344,6 +458,12 @@ agent.delete(
         ),
       )
       .limit(1);
+
+    // A Shared Agent attached here has no workspace row to match; it must be
+    // detached or deleted from the Organization surface (ADR-0007).
+    if (existing.length === 0) {
+      return c.json({ error: "Agent not found" }, 404);
+    }
 
     if (existing[0]?.avatarKey) {
       try {
@@ -363,6 +483,124 @@ agent.delete(
         ),
       );
     return c.json({ message: "Agent deleted" });
+  },
+);
+
+/**
+ * Promote a workspace-scoped Agent to Organization scope (admin only — ADR-0007).
+ *
+ * Enforces the no-cascade rule: a Shared Agent may reference only other Shared
+ * resources, so Promotion is blocked unless the Agent's Provider, every Skill,
+ * every sub-Agent, and every MCP-backed tool set is already Organization-scoped.
+ * When blocked, the offending references are returned as `blockers` so the UI
+ * can present a fix-this checklist. On success the Agent re-scopes to the
+ * Organization and its origin Workspace is auto-attached so it stays visible
+ * and usable there; editing thereafter happens on the Organization surface.
+ */
+agent.post(
+  "/:agentId/promote",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  requireWorkspaceAccess,
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const workspaceId = c.req.param("workspaceId")!;
+    const agentId = c.req.param("agentId");
+    const baseUrl = getOrigin(c);
+
+    // Only a workspace-scoped Agent in this workspace can be promoted.
+    const [existing] = await db
+      .select()
+      .from(agentTable)
+      .where(
+        and(
+          eq(agentTable.id, agentId),
+          eq(agentTable.workspaceId, workspaceId),
+        ),
+      )
+      .limit(1);
+    if (!existing) {
+      return c.json({ error: "Agent not found" }, 404);
+    }
+
+    // No-cascade guard (ADR-0007): every travels-with reference must already be
+    // Organization-scoped, or Promotion is blocked with a fix-this checklist.
+    const blockers = await findNonSharedReferences(orgId, {
+      providerId: existing.providerId,
+      skillIds: existing.skillIds,
+      subAgentIds: existing.subAgentIds,
+      toolSetIds: existing.toolSetIds,
+    });
+    if (blockers.length > 0) {
+      return c.json(
+        {
+          error:
+            "Promote blocked: this agent references workspace-private resources. Promote them first.",
+          blockers,
+        },
+        422,
+      );
+    }
+
+    // Sentinel for a lost TOCTOU race: the Agent was re-scoped or deleted between
+    // the lookup above and the in-transaction update. Throwing rolls back the
+    // auto-attach so we never leave a dangling Attachment.
+    const PROMOTE_RACE = "agent_no_longer_workspace_scoped";
+
+    try {
+      const promoted = await db.transaction(async (tx) => {
+        const [record] = await tx
+          .update(agentTable)
+          .set({
+            organizationId: orgId,
+            workspaceId: null,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(agentTable.id, agentId),
+              eq(agentTable.workspaceId, workspaceId),
+            ),
+          )
+          .returning();
+
+        if (!record) {
+          throw new Error(PROMOTE_RACE);
+        }
+
+        // Auto-attach the origin Workspace so it keeps seeing the Agent.
+        await tx
+          .insert(attachmentTable)
+          .values({
+            id: nanoid(),
+            workspaceId,
+            resourceType: "agent",
+            resourceId: agentId,
+          })
+          .onConflictDoNothing();
+
+        return record;
+      });
+
+      return c.json(
+        { ...agentWithAvatarUrl(promoted, baseUrl), scope: "organization" },
+        200,
+      );
+    } catch (error: any) {
+      if (error?.message === PROMOTE_RACE) {
+        return c.json({ error: "Agent not found" }, 404);
+      }
+      if (isUniqueViolation(error)) {
+        return c.json(
+          {
+            error:
+              "An agent with this name already exists in this organization",
+          },
+          409,
+        );
+      }
+      throw error;
+    }
   },
 );
 

--- a/apps/backend/src/routes/attachment.ts
+++ b/apps/backend/src/routes/attachment.ts
@@ -4,6 +4,7 @@ import { nanoid } from "nanoid";
 import { db } from "../index.ts";
 import {
   attachment as attachmentTable,
+  agent as agentTable,
   mcp as mcpTable,
   provider as providerTable,
   skill as skillTable,
@@ -65,7 +66,9 @@ attachment.post(
         ? mcpTable
         : resourceType === "skill"
           ? skillTable
-          : providerTable;
+          : resourceType === "agent"
+            ? agentTable
+            : providerTable;
     const resource = await db
       .select({ id: table.id })
       .from(table)
@@ -114,7 +117,7 @@ attachment.delete(
           eq(attachmentTable.workspaceId, workspaceId),
           eq(
             attachmentTable.resourceType,
-            resourceType as "mcp" | "provider" | "skill",
+            resourceType as "mcp" | "provider" | "skill" | "agent",
           ),
           eq(attachmentTable.resourceId, resourceId),
         ),

--- a/apps/backend/src/routes/org-agent.test.ts
+++ b/apps/backend/src/routes/org-agent.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
+import app from "../server.ts";
+
+describe("Organization Agent Routes", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+  });
+
+  const orgId = "org-1";
+  const baseUrl = `/organizations/${orgId}/agents`;
+
+  describe("GET /", () => {
+    it("lists org agents for any member", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      const agents = [{ id: "agent-1", name: "Shared Agent" }];
+      mockDb.where.mockReturnValueOnce(mockDb).mockResolvedValueOnce(agents);
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ results: agents });
+    });
+  });
+
+  describe("GET /:agentId", () => {
+    it("returns an org agent", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      const agent = {
+        id: "agent-1",
+        name: "Shared Agent",
+        organizationId: orgId,
+      };
+      mockDb.limit.mockResolvedValueOnce([agent]);
+
+      const res = await app.request(`${baseUrl}/agent-1`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(agent);
+    });
+
+    it("returns 404 if not found", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const res = await app.request(`${baseUrl}/missing`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PUT /:agentId", () => {
+    it("updates an org agent if org admin and references stay shared", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockResolvedValueOnce([
+          { id: "p1", name: "Shared Provider", organizationId: orgId },
+        ]); // provider validation → org-scoped
+
+      const updated = {
+        id: "agent-1",
+        name: "Renamed",
+        organizationId: orgId,
+      };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const res = await app.request(`${baseUrl}/agent-1`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "Renamed",
+          description: "A shared agent",
+          providerId: "p1",
+          modelId: "m1",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(updated);
+    });
+
+    it("blocks an update that references a workspace-private resource", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockResolvedValueOnce([
+          { id: "p1", name: "WS Provider", organizationId: null },
+        ]); // provider validation → workspace-private, blocker
+
+      const res = await app.request(`${baseUrl}/agent-1`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "Renamed",
+          description: "A shared agent",
+          providerId: "p1",
+          modelId: "m1",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body.blockers).toEqual([
+        { type: "provider", id: "p1", name: "WS Provider" },
+      ]);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+
+      const res = await app.request(`${baseUrl}/agent-1`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "Renamed",
+          description: "A shared agent",
+          providerId: "p1",
+          modelId: "m1",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("DELETE /:agentId", () => {
+    it("deletes an org agent if org admin and not attached", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]); // attachment guard: none
+      mockDb.returning.mockResolvedValueOnce([{ id: "agent-1" }]);
+
+      const res = await app.request(`${baseUrl}/agent-1`, { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ message: "Agent deleted" });
+    });
+
+    it("returns 409 when the agent is attached to a workspace", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attachment guard: attached
+
+      const res = await app.request(`${baseUrl}/agent-1`, { method: "DELETE" });
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 403 for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+
+      const res = await app.request(`${baseUrl}/agent-1`, { method: "DELETE" });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("avatar routes", () => {
+    it("POST avatar returns 403 for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+
+      const res = await app.request(`${baseUrl}/agent-1/avatar`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("POST avatar 404s when the org agent does not exist", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([]); // agent lookup → none
+
+      const res = await app.request(`${baseUrl}/agent-1/avatar`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("DELETE avatar clears the avatar for an org admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([{ avatarKey: null }]); // agent lookup
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "agent-1", avatarKey: null },
+      ]);
+
+      const res = await app.request(`${baseUrl}/agent-1/avatar`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("DELETE avatar 404s when the org agent does not exist", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([]); // agent lookup → none
+
+      const res = await app.request(`${baseUrl}/agent-1/avatar`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/apps/backend/src/routes/org-agent.ts
+++ b/apps/backend/src/routes/org-agent.ts
@@ -1,0 +1,326 @@
+import { Hono } from "hono";
+import { sValidator } from "@hono/standard-validator";
+import { nanoid } from "nanoid";
+import sharp from "sharp";
+import { db } from "../index.ts";
+import {
+  agent as agentTable,
+  attachment as attachmentTable,
+} from "../db/schema.ts";
+import { agentUpdateSchema } from "@platypus/schemas";
+import { eq, and } from "drizzle-orm";
+import { dedupeArray } from "../utils.ts";
+import { requireAuth } from "../middleware/authentication.ts";
+import { requireOrgAccess } from "../middleware/authorization.ts";
+import { findNonSharedReferences } from "../services/agent-scope-validation.ts";
+import { scrubDeletedAgentReference } from "../services/agent-references.ts";
+import { getStorage } from "../storage/index.ts";
+import { avatarKeyToUrl } from "../utils/avatar-url.ts";
+import { getOrigin } from "../utils/get-origin.ts";
+import type { Variables } from "../server.ts";
+
+const ALLOWED_AVATAR_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+];
+const MAX_AVATAR_SIZE = 5 * 1024 * 1024;
+const MIN_AVATAR_DIMENSION = 64;
+const AVATAR_SIZE = 512;
+
+// Org-scoped Agents are Shared resources (ADR-0007): a single source of truth
+// defined once at Organization scope (via Promote) and referenced by Workspaces
+// through an Attachment. They are managed only by Org Admins on the Organization
+// surface, so all mutations are org-admin-only; any member may read them.
+const orgAgent = new Hono<{ Variables: Variables }>();
+
+function agentWithAvatarUrl(
+  agent: Record<string, unknown>,
+  baseUrl: string,
+): Record<string, unknown> {
+  const key = agent.avatarKey as string | null | undefined;
+  const { avatarKey: _avatarKey, ...rest } = agent;
+  return { ...rest, avatarUrl: avatarKeyToUrl(key, baseUrl) ?? undefined };
+}
+
+/** Detects a Postgres unique-constraint violation across driver shapes. */
+const isUniqueViolation = (error: any): boolean =>
+  error.code === "23505" ||
+  error.cause?.code === "23505" ||
+  error.message?.includes("unique constraint") ||
+  error.cause?.message?.includes("unique constraint");
+
+const NAME_CONFLICT = {
+  error: "An agent with this name already exists in this organization",
+} as const;
+
+/** List org-scoped Agents */
+orgAgent.get("/", requireAuth, requireOrgAccess(), async (c) => {
+  const orgId = c.req.param("orgId")!;
+  const baseUrl = getOrigin(c);
+  const results = await db
+    .select()
+    .from(agentTable)
+    .where(eq(agentTable.organizationId, orgId));
+  return c.json({
+    results: results.map((r) => agentWithAvatarUrl(r, baseUrl)),
+  });
+});
+
+/** Get an org-scoped Agent by ID */
+orgAgent.get("/:agentId", requireAuth, requireOrgAccess(), async (c) => {
+  const orgId = c.req.param("orgId")!;
+  const agentId = c.req.param("agentId");
+  const baseUrl = getOrigin(c);
+  const record = await db
+    .select()
+    .from(agentTable)
+    .where(
+      and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
+    )
+    .limit(1);
+  if (record.length === 0) {
+    return c.json({ error: "Agent not found" }, 404);
+  }
+  return c.json(agentWithAvatarUrl(record[0], baseUrl));
+});
+
+/** Update an org-scoped Agent by ID (admin only) */
+orgAgent.put(
+  "/:agentId",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  sValidator("json", agentUpdateSchema),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const agentId = c.req.param("agentId");
+    const data = c.req.valid("json");
+    const baseUrl = getOrigin(c);
+
+    if (data.toolSetIds) data.toolSetIds = dedupeArray(data.toolSetIds);
+    if (data.skillIds) data.skillIds = dedupeArray(data.skillIds);
+    if (data.subAgentIds) data.subAgentIds = dedupeArray(data.subAgentIds);
+
+    if (data.subAgentIds?.includes(agentId)) {
+      return c.json(
+        { error: "An agent cannot assign itself as a sub-agent" },
+        400,
+      );
+    }
+
+    // A Shared Agent may reference only other Shared resources (ADR-0007).
+    const blockers = await findNonSharedReferences(orgId, {
+      providerId: data.providerId,
+      skillIds: data.skillIds,
+      subAgentIds: data.subAgentIds,
+      toolSetIds: data.toolSetIds,
+    });
+    if (blockers.length > 0) {
+      return c.json(
+        {
+          error:
+            "A shared agent may only reference other shared (organization-scoped) resources",
+          blockers,
+        },
+        422,
+      );
+    }
+
+    try {
+      const record = await db
+        .update(agentTable)
+        .set({ ...data, updatedAt: new Date() })
+        .where(
+          and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
+        )
+        .returning();
+      if (record.length === 0) {
+        return c.json({ error: "Agent not found" }, 404);
+      }
+      return c.json(agentWithAvatarUrl(record[0], baseUrl), 200);
+    } catch (error: any) {
+      if (isUniqueViolation(error)) {
+        return c.json(NAME_CONFLICT, 409);
+      }
+      throw error;
+    }
+  },
+);
+
+/** Upload avatar for an org-scoped Agent (admin only) */
+orgAgent.post(
+  "/:agentId/avatar",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const agentId = c.req.param("agentId");
+    const baseUrl = getOrigin(c);
+
+    const [existing] = await db
+      .select({ avatarKey: agentTable.avatarKey })
+      .from(agentTable)
+      .where(
+        and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
+      )
+      .limit(1);
+    if (!existing) {
+      return c.json({ error: "Agent not found" }, 404);
+    }
+
+    const body = await c.req.parseBody();
+    const file = body["file"];
+    if (!file || !(file instanceof File)) {
+      return c.json({ error: "No file provided" }, 400);
+    }
+    if (!ALLOWED_AVATAR_TYPES.includes(file.type)) {
+      return c.json({ error: "Invalid file type" }, 400);
+    }
+    if (file.size > MAX_AVATAR_SIZE) {
+      return c.json({ error: "File too large (max 5MB)" }, 400);
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    let metadata: sharp.Metadata;
+    try {
+      metadata = await sharp(buffer).metadata();
+    } catch {
+      return c.json({ error: "Invalid image" }, 400);
+    }
+    if (
+      metadata.width &&
+      metadata.height &&
+      (metadata.width < MIN_AVATAR_DIMENSION ||
+        metadata.height < MIN_AVATAR_DIMENSION)
+    ) {
+      return c.json(
+        {
+          error: `Image must be at least ${MIN_AVATAR_DIMENSION}x${MIN_AVATAR_DIMENSION} pixels`,
+        },
+        400,
+      );
+    }
+
+    const processedBuffer = await sharp(buffer)
+      .resize(AVATAR_SIZE, AVATAR_SIZE, { fit: "cover" })
+      .webp()
+      .toBuffer();
+
+    // Avatars are keyed by the Agent's globally-unique id, independent of scope.
+    const key = `agents/${agentId}/avatar-${nanoid()}.webp`;
+
+    if (existing.avatarKey) {
+      try {
+        await getStorage().delete(existing.avatarKey);
+      } catch {
+        // Ignore deletion errors
+      }
+    }
+
+    await getStorage().put(key, processedBuffer, "image/webp");
+
+    const record = await db
+      .update(agentTable)
+      .set({ avatarKey: key, updatedAt: new Date() })
+      .where(
+        and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
+      )
+      .returning();
+    return c.json(agentWithAvatarUrl(record[0], baseUrl));
+  },
+);
+
+/** Delete avatar for an org-scoped Agent (admin only) */
+orgAgent.delete(
+  "/:agentId/avatar",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const agentId = c.req.param("agentId");
+    const baseUrl = getOrigin(c);
+
+    const [existing] = await db
+      .select({ avatarKey: agentTable.avatarKey })
+      .from(agentTable)
+      .where(
+        and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
+      )
+      .limit(1);
+    if (!existing) {
+      return c.json({ error: "Agent not found" }, 404);
+    }
+
+    if (existing.avatarKey) {
+      try {
+        await getStorage().delete(existing.avatarKey);
+      } catch {
+        // Ignore deletion errors
+      }
+    }
+
+    const record = await db
+      .update(agentTable)
+      .set({ avatarKey: null, updatedAt: new Date() })
+      .where(
+        and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
+      )
+      .returning();
+    return c.json(agentWithAvatarUrl(record[0], baseUrl));
+  },
+);
+
+/** Delete an org-scoped Agent by ID (admin only) */
+orgAgent.delete(
+  "/:agentId",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const agentId = c.req.param("agentId");
+
+    // A Shared resource cannot be deleted while any Attachment references it
+    // (ADR-0007) — detach it from every Workspace first.
+    const [attached] = await db
+      .select()
+      .from(attachmentTable)
+      .where(
+        and(
+          eq(attachmentTable.resourceType, "agent"),
+          eq(attachmentTable.resourceId, agentId),
+        ),
+      )
+      .limit(1);
+    if (attached) {
+      return c.json(
+        {
+          error:
+            "Cannot delete: this agent is attached to one or more workspaces. Detach it first.",
+        },
+        409,
+      );
+    }
+
+    // Delete the Agent and scrub its (now-dead) id from any Agent's subAgentIds
+    // in the same transaction, so deletion never leaves dangling references.
+    const result = await db.transaction(async (tx) => {
+      const rows = await tx
+        .delete(agentTable)
+        .where(
+          and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
+        )
+        .returning();
+      if (rows.length > 0) {
+        await scrubDeletedAgentReference(tx, "subAgentIds", agentId);
+      }
+      return rows;
+    });
+    if (result.length === 0) {
+      return c.json({ error: "Agent not found" }, 404);
+    }
+    return c.json({ message: "Agent deleted" });
+  },
+);
+
+export { orgAgent };

--- a/apps/backend/src/routes/org-attachment.test.ts
+++ b/apps/backend/src/routes/org-attachment.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
+import app from "../server.ts";
+
+describe("Organization Attachment (central sharing) Routes", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+  });
+
+  const orgId = "org-1";
+  const baseUrl = `/organizations/${orgId}/attachments`;
+
+  describe("GET /", () => {
+    it("lists the workspaces a shared resource is attached to", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      const rows = [
+        { workspaceId: "ws-1", workspaceName: "Alpha", createdAt: new Date() },
+        { workspaceId: "ws-2", workspaceName: "Beta", createdAt: new Date() },
+      ];
+      mockDb.where.mockReturnValueOnce(mockDb).mockResolvedValueOnce(rows);
+
+      const res = await app.request(
+        `${baseUrl}?resourceType=agent&resourceId=agent-1`,
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results).toHaveLength(2);
+      expect(body.results[0].workspaceName).toBe("Alpha");
+    });
+
+    it("returns 400 without resourceType/resourceId", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 403 for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+
+      const res = await app.request(
+        `${baseUrl}?resourceType=agent&resourceId=agent-1`,
+      );
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("POST /", () => {
+    const body = {
+      resourceType: "agent",
+      resourceId: "agent-1",
+      workspaceId: "ws-1",
+    };
+
+    it("attaches a shared resource to a workspace", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "ws-1" }]) // workspace belongs to org
+        .mockResolvedValueOnce([{ id: "agent-1" }]); // org-scoped resource exists
+      const att = {
+        id: "att-1",
+        workspaceId: "ws-1",
+        resourceType: "agent",
+        resourceId: "agent-1",
+      };
+      mockDb.returning.mockResolvedValueOnce([att]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(201);
+      expect(await res.json()).toEqual(att);
+    });
+
+    it("404s when the workspace is not in this org", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }])
+        .mockResolvedValueOnce([]); // workspace not found in org
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("404s when the resource is not an org-scoped resource in this org", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }])
+        .mockResolvedValueOnce([{ id: "ws-1" }]) // workspace ok
+        .mockResolvedValueOnce([]); // resource not org-scoped here
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 403 for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("DELETE /:resourceType/:resourceId/:workspaceId", () => {
+    const delUrl = `${baseUrl}/agent/agent-1/ws-1`;
+
+    it("detaches a shared resource from a workspace", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "ws-1" }]); // workspace in org
+      mockDb.returning.mockResolvedValueOnce([{ id: "att-1" }]);
+
+      const res = await app.request(delUrl, { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ message: "Detached" });
+    });
+
+    it("404s when no such attachment exists", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }])
+        .mockResolvedValueOnce([{ id: "ws-1" }]);
+      mockDb.returning.mockResolvedValueOnce([]); // nothing deleted
+
+      const res = await app.request(delUrl, { method: "DELETE" });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 403 for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+
+      const res = await app.request(delUrl, { method: "DELETE" });
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/apps/backend/src/routes/org-attachment.ts
+++ b/apps/backend/src/routes/org-attachment.ts
@@ -1,0 +1,205 @@
+import { Hono } from "hono";
+import { nanoid } from "nanoid";
+import { db } from "../index.ts";
+import {
+  attachment as attachmentTable,
+  agent as agentTable,
+  mcp as mcpTable,
+  provider as providerTable,
+  skill as skillTable,
+  workspace as workspaceTable,
+} from "../db/schema.ts";
+import { and, eq } from "drizzle-orm";
+import { requireAuth } from "../middleware/authentication.ts";
+import { requireOrgAccess } from "../middleware/authorization.ts";
+import type { Variables } from "../server.ts";
+
+// Org-surface management of where a Shared resource is attached (ADR-0007).
+// Where the per-Workspace `attachment` route answers "what is attached to THIS
+// workspace?", this route answers "which workspaces is THIS resource shared
+// with?" and lets an Org Admin attach/detach workspaces centrally — the natural
+// place to manage sharing across many workspaces. All routes are admin-only.
+const orgAttachment = new Hono<{ Variables: Variables }>();
+
+const RESOURCE_TABLES = {
+  mcp: mcpTable,
+  provider: providerTable,
+  skill: skillTable,
+  agent: agentTable,
+} as const;
+
+type ResourceType = keyof typeof RESOURCE_TABLES;
+
+const isResourceType = (v: string | undefined): v is ResourceType =>
+  v === "mcp" || v === "provider" || v === "skill" || v === "agent";
+
+/** Detects a Postgres unique-constraint violation across driver shapes. */
+const isUniqueViolation = (error: any): boolean =>
+  error.code === "23505" ||
+  error.cause?.code === "23505" ||
+  error.message?.includes("unique constraint") ||
+  error.cause?.message?.includes("unique constraint");
+
+/**
+ * Confirms a resource is org-scoped and belongs to this organization — you can
+ * only manage sharing for a Shared resource, never a workspace-private one.
+ */
+const orgResourceExists = async (
+  resourceType: ResourceType,
+  resourceId: string,
+  orgId: string,
+): Promise<boolean> => {
+  const table = RESOURCE_TABLES[resourceType];
+  const rows = await db
+    .select({ id: table.id })
+    .from(table)
+    .where(and(eq(table.id, resourceId), eq(table.organizationId, orgId)))
+    .limit(1);
+  return rows.length > 0;
+};
+
+/**
+ * List the workspaces a Shared resource is attached to (admin only).
+ * Requires `resourceType` and `resourceId` query params; returns each
+ * attachment with its workspace name so the org surface can show "Shared with".
+ */
+orgAttachment.get("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
+  const orgId = c.req.param("orgId")!;
+  const resourceType = c.req.query("resourceType");
+  const resourceId = c.req.query("resourceId");
+
+  if (!isResourceType(resourceType) || !resourceId) {
+    return c.json(
+      { error: "resourceType and resourceId query params are required" },
+      400,
+    );
+  }
+
+  // Join through workspace so we only ever surface this org's workspaces (and
+  // their names), never attachments leaked from another org.
+  const rows = await db
+    .select({
+      workspaceId: attachmentTable.workspaceId,
+      workspaceName: workspaceTable.name,
+      createdAt: attachmentTable.createdAt,
+    })
+    .from(attachmentTable)
+    .innerJoin(
+      workspaceTable,
+      eq(workspaceTable.id, attachmentTable.workspaceId),
+    )
+    .where(
+      and(
+        eq(attachmentTable.resourceType, resourceType),
+        eq(attachmentTable.resourceId, resourceId),
+        eq(workspaceTable.organizationId, orgId),
+      ),
+    );
+
+  return c.json({ results: rows });
+});
+
+/** Attach an org-scoped Shared resource to a workspace (admin only) */
+orgAttachment.post("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
+  const orgId = c.req.param("orgId")!;
+  const body = (await c.req.json().catch(() => ({}))) as {
+    resourceType?: string;
+    resourceId?: string;
+    workspaceId?: string;
+  };
+  const { resourceType, resourceId, workspaceId } = body;
+
+  if (!isResourceType(resourceType)) {
+    return c.json({ error: "Invalid resourceType" }, 400);
+  }
+  if (!resourceId || !workspaceId) {
+    return c.json({ error: "resourceId and workspaceId are required" }, 400);
+  }
+
+  // The target workspace must belong to this organization.
+  const [ws] = await db
+    .select({ id: workspaceTable.id })
+    .from(workspaceTable)
+    .where(
+      and(
+        eq(workspaceTable.id, workspaceId),
+        eq(workspaceTable.organizationId, orgId),
+      ),
+    )
+    .limit(1);
+  if (!ws) {
+    return c.json({ error: "Workspace not found in this organization" }, 404);
+  }
+
+  if (!(await orgResourceExists(resourceType, resourceId, orgId))) {
+    return c.json(
+      { error: "Org-scoped resource not found in this organization" },
+      404,
+    );
+  }
+
+  try {
+    const record = await db
+      .insert(attachmentTable)
+      .values({ id: nanoid(), workspaceId, resourceType, resourceId })
+      .returning();
+    return c.json(record[0], 201);
+  } catch (error: any) {
+    if (isUniqueViolation(error)) {
+      return c.json(
+        { error: "This resource is already attached to that workspace" },
+        409,
+      );
+    }
+    throw error;
+  }
+});
+
+/** Detach an org-scoped Shared resource from a workspace (admin only) */
+orgAttachment.delete(
+  "/:resourceType/:resourceId/:workspaceId",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const resourceType = c.req.param("resourceType");
+    const resourceId = c.req.param("resourceId");
+    const workspaceId = c.req.param("workspaceId");
+
+    if (!isResourceType(resourceType)) {
+      return c.json({ error: "Invalid resourceType" }, 400);
+    }
+
+    // Guard against detaching across orgs: the workspace must be in this org.
+    const [ws] = await db
+      .select({ id: workspaceTable.id })
+      .from(workspaceTable)
+      .where(
+        and(
+          eq(workspaceTable.id, workspaceId),
+          eq(workspaceTable.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+    if (!ws) {
+      return c.json({ error: "Workspace not found in this organization" }, 404);
+    }
+
+    const result = await db
+      .delete(attachmentTable)
+      .where(
+        and(
+          eq(attachmentTable.workspaceId, workspaceId),
+          eq(attachmentTable.resourceType, resourceType),
+          eq(attachmentTable.resourceId, resourceId),
+        ),
+      )
+      .returning();
+    if (result.length === 0) {
+      return c.json({ error: "Attachment not found" }, 404);
+    }
+    return c.json({ message: "Detached" });
+  },
+);
+
+export { orgAttachment };

--- a/apps/backend/src/routes/org-mcp.ts
+++ b/apps/backend/src/routes/org-mcp.ts
@@ -18,6 +18,7 @@ import {
 import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
+import { scrubDeletedAgentReference } from "../services/agent-references.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
 import {
@@ -177,10 +178,18 @@ orgMcp.delete(
       );
     }
 
-    const result = await db
-      .delete(mcpTable)
-      .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.organizationId, orgId)))
-      .returning();
+    // Delete the MCP and scrub its (now-dead) id from any Agent's toolSetIds in
+    // the same transaction, so deletion never leaves dangling references.
+    const result = await db.transaction(async (tx) => {
+      const rows = await tx
+        .delete(mcpTable)
+        .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.organizationId, orgId)))
+        .returning();
+      if (rows.length > 0) {
+        await scrubDeletedAgentReference(tx, "toolSetIds", mcpId);
+      }
+      return rows;
+    });
     if (result.length === 0) {
       return c.json({ error: "MCP not found" }, 404);
     }

--- a/apps/backend/src/routes/org-skill.test.ts
+++ b/apps/backend/src/routes/org-skill.test.ts
@@ -166,6 +166,8 @@ describe("Organization Skill Routes", () => {
       const res = await app.request(`${baseUrl}/skill-1`, { method: "DELETE" });
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ message: "Skill deleted" });
+      // The dead skill id is scrubbed from referencing agents in the same tx.
+      expect(mockDb.update).toHaveBeenCalled();
     });
 
     it("returns 409 when the skill is attached to a workspace", async () => {

--- a/apps/backend/src/routes/org-skill.ts
+++ b/apps/backend/src/routes/org-skill.ts
@@ -10,6 +10,7 @@ import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
 import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
+import { scrubDeletedAgentReference } from "../services/agent-references.ts";
 import type { Variables } from "../server.ts";
 
 // Org-scoped Skills are Shared resources (ADR-0007): a single source of truth
@@ -157,12 +158,20 @@ orgSkill.delete(
       );
     }
 
-    const result = await db
-      .delete(skillTable)
-      .where(
-        and(eq(skillTable.id, skillId), eq(skillTable.organizationId, orgId)),
-      )
-      .returning();
+    // Delete the Skill and scrub its (now-dead) id from any Agent's skillIds in
+    // the same transaction, so deletion never leaves dangling references.
+    const result = await db.transaction(async (tx) => {
+      const rows = await tx
+        .delete(skillTable)
+        .where(
+          and(eq(skillTable.id, skillId), eq(skillTable.organizationId, orgId)),
+        )
+        .returning();
+      if (rows.length > 0) {
+        await scrubDeletedAgentReference(tx, "skillIds", skillId);
+      }
+      return rows;
+    });
     if (result.length === 0) {
       return c.json({ error: "Skill not found" }, 404);
     }

--- a/apps/backend/src/routes/org-tool.test.ts
+++ b/apps/backend/src/routes/org-tool.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
+import app from "../server.ts";
+
+describe("Organization Tool Routes", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+  });
+
+  const orgId = "org-1";
+  const baseUrl = `/organizations/${orgId}/tools`;
+
+  it("lists static tool sets plus org-scoped MCPs for any member", async () => {
+    mockSession();
+    mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+    // org MCP query terminates at .where
+    mockDb.where
+      .mockReturnValueOnce(mockDb) // requireOrgAccess
+      .mockResolvedValueOnce([
+        { id: "mcp-1", name: "Shared MCP", organizationId: orgId },
+      ]);
+
+    const res = await app.request(baseUrl);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // The org MCP is surfaced as an "MCP" tool set...
+    expect(body.results).toContainEqual({
+      id: "mcp-1",
+      name: "Shared MCP",
+      category: "MCP",
+    });
+    // ...alongside statically registered tool sets.
+    expect(
+      body.results.some((t: { category: string }) => t.category !== "MCP"),
+    ).toBe(true);
+  });
+
+  it("returns 403 when not a member of the organization", async () => {
+    mockSession();
+    mockDb.limit.mockResolvedValueOnce([]); // requireOrgAccess → not a member
+
+    const res = await app.request(baseUrl);
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/backend/src/routes/org-tool.ts
+++ b/apps/backend/src/routes/org-tool.ts
@@ -1,0 +1,47 @@
+import { Hono } from "hono";
+import { getToolSets } from "../tools/index.ts";
+import { db } from "../index.ts";
+import { mcp as mcpTable } from "../db/schema.ts";
+import { eq } from "drizzle-orm";
+import { requireAuth } from "../middleware/authentication.ts";
+import { requireOrgAccess } from "../middleware/authorization.ts";
+import type { Variables } from "../server.ts";
+
+// Tool sets available to an org-scoped (Shared) Agent: the statically
+// registered sets (including the Sandbox set, which rebinds per Workspace at
+// Chat-turn time) plus org-scoped MCPs. This mirrors the per-workspace `tool`
+// route but lists org MCPs rather than workspace MCPs, so the org-surface Agent
+// editor only offers references that satisfy the no-cascade rule (ADR-0007).
+const orgTool = new Hono<{ Variables: Variables }>();
+
+orgTool.get("/", requireAuth, requireOrgAccess(), async (c) => {
+  const orgId = c.req.param("orgId")!;
+
+  const toolSetsList = Object.entries(getToolSets()).map(([id, toolSet]) => ({
+    id,
+    name: toolSet.name,
+    category: toolSet.category,
+    description: toolSet.description,
+    tools:
+      typeof toolSet.tools === "function"
+        ? []
+        : Object.entries(toolSet.tools).map(([toolId, tool]) => ({
+            id: toolId,
+            description: tool.description || "No description",
+          })),
+  }));
+
+  const mcps = await db
+    .select()
+    .from(mcpTable)
+    .where(eq(mcpTable.organizationId, orgId));
+  const mcpList = mcps.map((mcp) => ({
+    id: mcp.id,
+    name: mcp.name,
+    category: "MCP",
+  }));
+
+  return c.json({ results: [...toolSetsList, ...mcpList] });
+});
+
+export { orgTool };

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -16,6 +16,9 @@ import { provider } from "./routes/provider.ts";
 import { orgProvider } from "./routes/org-provider.ts";
 import { orgMcp } from "./routes/org-mcp.ts";
 import { orgSkill } from "./routes/org-skill.ts";
+import { orgAgent } from "./routes/org-agent.ts";
+import { orgTool } from "./routes/org-tool.ts";
+import { orgAttachment } from "./routes/org-attachment.ts";
 import { attachment } from "./routes/attachment.ts";
 import { invitation } from "./routes/invitation.ts";
 import { userInvitation } from "./routes/user-invitation.ts";
@@ -148,6 +151,9 @@ app.route("/organizations/:orgId/workspaces/:workspaceId/providers", provider);
 app.route("/organizations/:orgId/providers", orgProvider);
 app.route("/organizations/:orgId/mcps", orgMcp);
 app.route("/organizations/:orgId/skills", orgSkill);
+app.route("/organizations/:orgId/agents", orgAgent);
+app.route("/organizations/:orgId/tools", orgTool);
+app.route("/organizations/:orgId/attachments", orgAttachment);
 app.route(
   "/organizations/:orgId/workspaces/:workspaceId/attachments",
   attachment,

--- a/apps/backend/src/services/agent-references.test.ts
+++ b/apps/backend/src/services/agent-references.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockDb, resetMockDb } from "../test-utils.ts";
+import { scrubDeletedAgentReference } from "./agent-references.ts";
+
+describe("scrubDeletedAgentReference", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+  });
+
+  it("updates agents to drop a deleted skill id from skillIds", async () => {
+    await scrubDeletedAgentReference(mockDb as never, "skillIds", "skill-1");
+    expect(mockDb.update).toHaveBeenCalled();
+    expect(mockDb.set).toHaveBeenCalled();
+    expect(mockDb.where).toHaveBeenCalled();
+  });
+
+  it("updates agents to drop a deleted sub-agent id from subAgentIds", async () => {
+    await scrubDeletedAgentReference(mockDb as never, "subAgentIds", "agent-9");
+    expect(mockDb.update).toHaveBeenCalled();
+    expect(mockDb.set).toHaveBeenCalled();
+  });
+
+  it("updates agents to drop a deleted MCP id from toolSetIds", async () => {
+    await scrubDeletedAgentReference(mockDb as never, "toolSetIds", "mcp-2");
+    expect(mockDb.update).toHaveBeenCalled();
+    expect(mockDb.set).toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/services/agent-references.ts
+++ b/apps/backend/src/services/agent-references.ts
@@ -1,0 +1,55 @@
+import { db } from "../index.ts";
+import { agent as agentTable } from "../db/schema.ts";
+import { sql } from "drizzle-orm";
+
+type ArrayRefField = "skillIds" | "subAgentIds" | "toolSetIds";
+
+// Accepts either the db handle or a transaction so the scrub can run atomically
+// with the delete that triggered it.
+type Executor = Pick<typeof db, "update">;
+
+/**
+ * Remove a now-deleted Shared resource's id from every Agent that references it.
+ *
+ * Agent references are stored as ids in a jsonb array (`skillIds`,
+ * `subAgentIds`, `toolSetIds`) with no foreign key to cascade, so deleting the
+ * resource would otherwise leave dangling ids behind (ADR-0007). Those ids are
+ * inert (they no longer resolve), but they are clutter; scrubbing them on delete
+ * keeps Agent references honest. Uses the jsonb `-` operator to drop the
+ * matching string from the array, and `@>` so only Agents that actually hold the
+ * id are written.
+ */
+export const scrubDeletedAgentReference = async (
+  executor: Executor,
+  field: ArrayRefField,
+  resourceId: string,
+): Promise<void> => {
+  const holdsId = JSON.stringify([resourceId]);
+  // Explicit per-field branches keep the column references typed (no dynamic
+  // key) while sharing the jsonb idiom.
+  if (field === "skillIds") {
+    await executor
+      .update(agentTable)
+      .set({
+        skillIds: sql`${agentTable.skillIds} - ${resourceId}`,
+        updatedAt: new Date(),
+      })
+      .where(sql`${agentTable.skillIds} @> ${holdsId}::jsonb`);
+  } else if (field === "subAgentIds") {
+    await executor
+      .update(agentTable)
+      .set({
+        subAgentIds: sql`${agentTable.subAgentIds} - ${resourceId}`,
+        updatedAt: new Date(),
+      })
+      .where(sql`${agentTable.subAgentIds} @> ${holdsId}::jsonb`);
+  } else {
+    await executor
+      .update(agentTable)
+      .set({
+        toolSetIds: sql`${agentTable.toolSetIds} - ${resourceId}`,
+        updatedAt: new Date(),
+      })
+      .where(sql`${agentTable.toolSetIds} @> ${holdsId}::jsonb`);
+  }
+};

--- a/apps/backend/src/services/agent-scope-validation.test.ts
+++ b/apps/backend/src/services/agent-scope-validation.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockDb, resetMockDb } from "../test-utils.ts";
+import { findNonSharedReferences } from "./agent-scope-validation.ts";
+import { SANDBOX_TOOLSET_ID } from "../tools/index.ts";
+
+const orgId = "org-1";
+
+describe("findNonSharedReferences (no-cascade rule)", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+  });
+
+  it("returns no blockers when every reference is org-scoped", async () => {
+    // Query order: provider, skills, sub-agents, MCPs.
+    mockDb.where
+      .mockResolvedValueOnce([{ id: "p1", name: "P", organizationId: orgId }])
+      .mockResolvedValueOnce([{ id: "s1", name: "S", organizationId: orgId }])
+      .mockResolvedValueOnce([{ id: "a1", name: "A", organizationId: orgId }])
+      .mockResolvedValueOnce([
+        { id: "mcp1", name: "M", organizationId: orgId },
+      ]);
+
+    const blockers = await findNonSharedReferences(orgId, {
+      providerId: "p1",
+      skillIds: ["s1"],
+      subAgentIds: ["a1"],
+      toolSetIds: ["mcp1"],
+    });
+
+    expect(blockers).toEqual([]);
+  });
+
+  it("flags every workspace-private reference as a blocker", async () => {
+    mockDb.where
+      .mockResolvedValueOnce([
+        { id: "p1", name: "WS Provider", organizationId: null },
+      ])
+      .mockResolvedValueOnce([
+        { id: "s1", name: "WS Skill", organizationId: null },
+      ])
+      .mockResolvedValueOnce([
+        { id: "a1", name: "WS Agent", organizationId: null },
+      ])
+      .mockResolvedValueOnce([
+        { id: "mcp1", name: "WS Mcp", organizationId: null },
+      ]);
+
+    const blockers = await findNonSharedReferences(orgId, {
+      providerId: "p1",
+      skillIds: ["s1"],
+      subAgentIds: ["a1"],
+      toolSetIds: ["mcp1"],
+    });
+
+    expect(blockers).toEqual([
+      { type: "provider", id: "p1", name: "WS Provider" },
+      { type: "skill", id: "s1", name: "WS Skill" },
+      { type: "subAgent", id: "a1", name: "WS Agent" },
+      { type: "mcp", id: "mcp1", name: "WS Mcp" },
+    ]);
+  });
+
+  it("treats statically-registered tool sets (incl. Sandbox) as always allowed", async () => {
+    // Only the provider is queried; the Sandbox/static tool set never hits the
+    // MCP table because it is registered, so no MCP lookup runs.
+    mockDb.where.mockResolvedValueOnce([
+      { id: "p1", name: "Shared Provider", organizationId: orgId },
+    ]);
+
+    const blockers = await findNonSharedReferences(orgId, {
+      providerId: "p1",
+      toolSetIds: [SANDBOX_TOOLSET_ID],
+    });
+
+    expect(blockers).toEqual([]);
+  });
+
+  it("flags a missing reference using its id as the name fallback", async () => {
+    mockDb.where
+      .mockResolvedValueOnce([{ id: "p1", name: "P", organizationId: orgId }])
+      .mockResolvedValueOnce([]); // skill 'ghost' does not exist
+
+    const blockers = await findNonSharedReferences(orgId, {
+      providerId: "p1",
+      skillIds: ["ghost"],
+    });
+
+    expect(blockers).toEqual([{ type: "skill", id: "ghost", name: "ghost" }]);
+  });
+});

--- a/apps/backend/src/services/agent-scope-validation.ts
+++ b/apps/backend/src/services/agent-scope-validation.ts
@@ -1,0 +1,135 @@
+import { db } from "../index.ts";
+import {
+  agent as agentTable,
+  mcp as mcpTable,
+  provider as providerTable,
+  skill as skillTable,
+} from "../db/schema.ts";
+import { eq, inArray } from "drizzle-orm";
+import { getToolSets } from "../tools/index.ts";
+
+/**
+ * A reference that blocks Promotion because it is not itself Organization-scoped
+ * (ADR-0007 no-cascade rule). `name` is included so the UI can render a
+ * fix-this checklist that names the offending Workspace-private references.
+ */
+export type ReferenceBlocker = {
+  type: "provider" | "skill" | "subAgent" | "mcp";
+  id: string;
+  name: string;
+};
+
+type AgentReferences = {
+  providerId: string;
+  skillIds?: string[] | null;
+  subAgentIds?: string[] | null;
+  toolSetIds?: string[] | null;
+};
+
+/**
+ * The defining rule of a Shared resource: it may reference only other Shared
+ * (Organization-scoped) resources (ADR-0007). Returns every reference of the
+ * given Agent that is NOT org-scoped and therefore blocks Promotion — an empty
+ * array means the Agent is safe to promote.
+ *
+ * Reference buckets (ADR-0007 Consequences):
+ * - **travels-with** — `providerId`, `skillIds`, `subAgentIds`, and MCP-backed
+ *   tool sets must already be Organization-scoped; each that isn't is a blocker.
+ * - **rebinds-per-Workspace** — the Sandbox tool set is statically registered
+ *   and rebinds to the invoking Workspace at Chat-turn time, so it never blocks.
+ * - **always-available** — every other statically registered tool set is always
+ *   present and never blocks.
+ *
+ * Any tool-set id that is not a statically registered set is treated as an
+ * MCP-backed tool set and must resolve to an Organization-scoped MCP.
+ */
+export const findNonSharedReferences = async (
+  orgId: string,
+  refs: AgentReferences,
+): Promise<ReferenceBlocker[]> => {
+  const blockers: ReferenceBlocker[] = [];
+
+  // Provider — exactly one, always required.
+  const providerRows = await db
+    .select({
+      id: providerTable.id,
+      name: providerTable.name,
+      organizationId: providerTable.organizationId,
+    })
+    .from(providerTable)
+    .where(eq(providerTable.id, refs.providerId));
+  const prov = providerRows[0];
+  if (!prov || prov.organizationId !== orgId) {
+    blockers.push({
+      type: "provider",
+      id: refs.providerId,
+      name: prov?.name ?? refs.providerId,
+    });
+  }
+
+  // Skills — each must be org-scoped.
+  const skillIds = refs.skillIds ?? [];
+  if (skillIds.length > 0) {
+    const rows = await db
+      .select({
+        id: skillTable.id,
+        name: skillTable.name,
+        organizationId: skillTable.organizationId,
+      })
+      .from(skillTable)
+      .where(inArray(skillTable.id, skillIds));
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    for (const id of skillIds) {
+      const row = byId.get(id);
+      if (!row || row.organizationId !== orgId) {
+        blockers.push({ type: "skill", id, name: row?.name ?? id });
+      }
+    }
+  }
+
+  // Sub-Agents — each must be org-scoped.
+  const subAgentIds = refs.subAgentIds ?? [];
+  if (subAgentIds.length > 0) {
+    const rows = await db
+      .select({
+        id: agentTable.id,
+        name: agentTable.name,
+        organizationId: agentTable.organizationId,
+      })
+      .from(agentTable)
+      .where(inArray(agentTable.id, subAgentIds));
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    for (const id of subAgentIds) {
+      const row = byId.get(id);
+      if (!row || row.organizationId !== orgId) {
+        blockers.push({ type: "subAgent", id, name: row?.name ?? id });
+      }
+    }
+  }
+
+  // Tool sets — statically registered sets (including the Sandbox set) are
+  // always allowed; any other id is an MCP-backed tool set and must resolve to
+  // an org-scoped MCP.
+  const toolSetIds = refs.toolSetIds ?? [];
+  const registry = getToolSets();
+  const mcpIds = toolSetIds.filter((id) => !(id in registry));
+  if (mcpIds.length > 0) {
+    const rows = await db
+      .select({
+        id: mcpTable.id,
+        name: mcpTable.name,
+        organizationId: mcpTable.organizationId,
+      })
+      .from(mcpTable)
+      .where(inArray(mcpTable.id, mcpIds));
+    const byId = new Map(rows.map((r) => [r.id, r]));
+    for (const id of mcpIds) {
+      const row = byId.get(id);
+      if (!row || row.organizationId !== orgId) {
+        blockers.push({ type: "mcp", id, name: row?.name ?? id });
+      }
+    }
+  }
+
+  return blockers;
+};

--- a/apps/backend/src/services/chat-execution.test-fixtures.ts
+++ b/apps/backend/src/services/chat-execution.test-fixtures.ts
@@ -27,7 +27,7 @@ export type ChatTurnQueriesFixtures = {
   // org-scoped Provider/MCP/Skill resolves at Chat-turn time only where attached.
   attachments?: Array<{
     workspaceId: string;
-    resourceType: "mcp" | "provider" | "skill";
+    resourceType: "mcp" | "provider" | "skill" | "agent";
     resourceId: string;
   }>;
   userContexts?: Array<{
@@ -47,7 +47,7 @@ export const createInMemoryChatTurnQueries = (
   fx: ChatTurnQueriesFixtures = {},
 ): ChatTurnQueries => {
   const isAttached = (
-    resourceType: "mcp" | "provider" | "skill",
+    resourceType: "mcp" | "provider" | "skill" | "agent",
     resourceId: string,
     workspaceId: string,
   ) =>
@@ -63,11 +63,20 @@ export const createInMemoryChatTurnQueries = (
       return fx.workspaces?.find((w) => w.id === id) ?? null;
     },
 
-    async getAgent(id, workspaceId) {
-      return (
-        fx.agents?.find((a) => a.id === id && a.workspaceId === workspaceId) ??
-        null
-      );
+    async getAgent(id, orgId, workspaceId) {
+      const a = fx.agents?.find((a) => a.id === id) ?? null;
+      if (!a) return null;
+      // Workspace-scoped Agent in this workspace.
+      if (a.workspaceId === workspaceId) return a;
+      // Org-scoped (Shared) Agent resolves only where attached (ADR-0007).
+      if (
+        a.organizationId === orgId &&
+        !a.workspaceId &&
+        isAttached("agent", id, workspaceId)
+      ) {
+        return a;
+      }
+      return null;
     },
 
     async getProvider(id, orgId, workspaceId) {

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -228,6 +228,71 @@ describe("chat-execution", () => {
       expect(detachedTurn.stream.tools).not.toHaveProperty("loadSkill");
     });
 
+    it("runs a Shared (org-scoped) Agent invoked from a borrowing Workspace where attached", async () => {
+      const borrowingWorkspace = { ...baseWorkspace, id: "ws-2" };
+      const orgProvider = {
+        ...baseProvider,
+        id: "p-org",
+        organizationId: "org-1",
+        workspaceId: null,
+      };
+      const sharedAgent = {
+        ...baseAgent,
+        id: "shared-agent",
+        organizationId: "org-1",
+        workspaceId: null,
+        providerId: "p-org",
+      };
+
+      // Attached to the borrowing Workspace → the Shared Agent (and its
+      // org-scoped Provider) resolve against that Workspace (ADR-0007).
+      const attached = createInMemoryChatTurnQueries({
+        workspaces: [borrowingWorkspace],
+        agents: [sharedAgent as any],
+        providers: [orgProvider as any],
+        attachments: [
+          {
+            workspaceId: "ws-2",
+            resourceType: "agent",
+            resourceId: "shared-agent",
+          },
+          {
+            workspaceId: "ws-2",
+            resourceType: "provider",
+            resourceId: "p-org",
+          },
+        ],
+      });
+
+      const turn = await prepareChatTurn(
+        {
+          ...baseInput,
+          workspaceId: "ws-2",
+          request: { id: "chat-shared", agentId: "shared-agent" },
+        },
+        attached,
+      );
+      expect(turn.resolved.agentId).toBe("shared-agent");
+      expect(turn.resolved.providerId).toBe("p-org");
+
+      // Not attached → the Shared Agent is invisible to this Workspace.
+      const detached = createInMemoryChatTurnQueries({
+        workspaces: [borrowingWorkspace],
+        agents: [sharedAgent as any],
+        providers: [orgProvider as any],
+      });
+      await expect(
+        prepareChatTurn(
+          {
+            ...baseInput,
+            workspaceId: "ws-2",
+            request: { id: "chat-shared2", agentId: "shared-agent" },
+          },
+          detached,
+        ),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
     it("Direct Provider+Model selection populates resolved.systemPrompt and merges request overrides", async () => {
       const queries = createInMemoryChatTurnQueries({
         workspaces: [baseWorkspace],

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -178,7 +178,11 @@ export type ToolActivityEvent = {
  */
 export type ChatTurnQueries = {
   getWorkspace(id: string): Promise<WorkspaceRow | null>;
-  getAgent(id: string, workspaceId: string): Promise<AgentRow | null>;
+  getAgent(
+    id: string,
+    orgId: string,
+    workspaceId: string,
+  ): Promise<AgentRow | null>;
   getProvider(
     id: string,
     orgId: string,
@@ -215,7 +219,7 @@ export type ChatTurnQueries = {
  * (ADR-0007). Org-scoped resources resolve at Chat-turn time only where attached.
  */
 const isAttached = async (
-  resourceType: "mcp" | "provider" | "skill",
+  resourceType: "mcp" | "provider" | "skill" | "agent",
   resourceId: string,
   workspaceId: string,
 ): Promise<boolean> => {
@@ -243,15 +247,34 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
     return rows[0] ?? null;
   },
 
-  async getAgent(id, workspaceId) {
+  async getAgent(id, orgId, workspaceId) {
+    // Resolve an Agent at either scope: the invoking workspace, or the
+    // organization (a Shared Agent — ADR-0007).
     const rows = await db
       .select()
       .from(agentTable)
       .where(
-        and(eq(agentTable.id, id), eq(agentTable.workspaceId, workspaceId)),
+        and(
+          eq(agentTable.id, id),
+          or(
+            eq(agentTable.workspaceId, workspaceId),
+            eq(agentTable.organizationId, orgId),
+          ),
+        ),
       )
       .limit(1);
-    return rows[0] ?? null;
+    const row = rows[0];
+    if (!row) return null;
+    // A Shared Agent runs only in a Workspace it is attached to (ADR-0007); its
+    // Sandbox/MCP tools still rebind to that invoking Workspace via loadTools.
+    if (
+      row.organizationId &&
+      !row.workspaceId &&
+      !(await isAttached("agent", id, workspaceId))
+    ) {
+      return null;
+    }
+    return row;
   },
 
   async getProvider(id, orgId, workspaceId) {
@@ -704,7 +727,7 @@ const resolveChatContext = async (
 
   if (agentId) {
     resolvedAgentId = agentId;
-    const found = await queries.getAgent(agentId, workspaceId);
+    const found = await queries.getAgent(agentId, orgId, workspaceId);
     if (!found) throw new NotFoundError(`Agent '${agentId}' not found`);
     agent = found;
     resolvedProviderId = agent.providerId;

--- a/apps/frontend/app/[orgId]/settings/agents/[agentId]/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/agents/[agentId]/page.tsx
@@ -1,0 +1,47 @@
+import { AgentForm } from "@/components/agent-form";
+import { headers } from "next/headers";
+import { BackButton } from "@/components/back-button";
+import { type ToolSet } from "@platypus/schemas";
+import { joinUrl } from "@/lib/utils";
+
+const OrgAgentEditPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string; agentId: string }>;
+}) => {
+  const { orgId, agentId } = await params;
+
+  // Use internal URL for SSR, fallback to BACKEND_URL for local dev
+  const backendUrl =
+    process.env.INTERNAL_BACKEND_URL || process.env.BACKEND_URL;
+
+  // Org-scoped tool sets: static sets + org MCPs (the only ones a Shared agent
+  // may reference under the no-cascade rule).
+  const headersList = await headers();
+  const toolSetsResponse = await fetch(
+    joinUrl(backendUrl || "", `/organizations/${orgId}/tools`),
+    {
+      headers: {
+        cookie: headersList.get("cookie") || "",
+      },
+    },
+  );
+
+  const toolSetsData = await toolSetsResponse.json();
+  const toolSets: ToolSet[] = toolSetsData.results;
+
+  return (
+    <div>
+      <BackButton fallbackHref={`/${orgId}/settings/agents`} />
+      <h1 className="text-2xl mb-4 font-bold">Edit Shared Agent</h1>
+      <AgentForm
+        orgId={orgId}
+        agentId={agentId}
+        toolSets={toolSets}
+        orgScoped
+      />
+    </div>
+  );
+};
+
+export default OrgAgentEditPage;

--- a/apps/frontend/app/[orgId]/settings/agents/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/agents/page.tsx
@@ -1,0 +1,23 @@
+import { OrgAgentsList } from "@/components/org-agents-list";
+
+const OrgAgentsPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) => {
+  const { orgId } = await params;
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Organization Agents</h1>
+      <p className="text-muted-foreground mb-6">
+        Shared agents are promoted from a workspace and run in any workspace
+        they are attached to. They are managed here on the organization surface
+        and can only be deleted once detached from every workspace.
+      </p>
+      <OrgAgentsList orgId={orgId} />
+    </div>
+  );
+};
+
+export default OrgAgentsPage;

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/page.tsx
@@ -390,13 +390,8 @@ const Workspace = () => {
                 </p>
               </div>
             </div>
-            {/* Reusing the existing AgentsList component which handles empty states */}
+            {/* AgentsList renders the Create / Attach buttons and empty states */}
             <AgentsList orgId={orgId} workspaceId={workspaceId} />
-            <Button variant="outline" asChild>
-              <Link href={`/${orgId}/workspace/${workspaceId}/agents/create`}>
-                <Plus /> Create Agent
-              </Link>
-            </Button>
           </div>
 
           <Separator />

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -22,7 +22,15 @@ import {
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronsUpDown, Trash2, ImageIcon, Camera, X } from "lucide-react";
+import Link from "next/link";
+import {
+  ChevronsUpDown,
+  Trash2,
+  ImageIcon,
+  Camera,
+  X,
+  Building,
+} from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -53,13 +61,18 @@ const AgentForm = ({
   agentId,
   toolSets,
   agents: propAgents,
+  orgScoped = false,
 }: {
   classNames?: string;
   orgId: string;
-  workspaceId: string;
+  workspaceId?: string;
   agentId?: string;
   toolSets: ToolSet[];
   agents?: Agent[];
+  // When true the form edits an org-scoped (Shared) Agent on the Organization
+  // surface, pulling its references from org-scoped lists and writing via the
+  // org Agent routes (ADR-0007). Otherwise it edits a workspace Agent.
+  orgScoped?: boolean;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -69,54 +82,54 @@ const AgentForm = ({
   const backendUrl = useBackendUrl();
   const { mutate } = useSWRConfig();
 
+  // Resource base paths differ by scope: the Organization surface lists/writes
+  // org-scoped references, the Workspace surface its own.
+  const agentsBase = orgScoped
+    ? `/organizations/${orgId}/agents`
+    : `/organizations/${orgId}/workspaces/${workspaceId}/agents`;
+  const providersBase = orgScoped
+    ? `/organizations/${orgId}/providers`
+    : `/organizations/${orgId}/workspaces/${workspaceId}/providers`;
+  const skillsBase = orgScoped
+    ? `/organizations/${orgId}/skills`
+    : `/organizations/${orgId}/workspaces/${workspaceId}/skills`;
+  const doneHref = orgScoped
+    ? `/${orgId}/settings/agents`
+    : `/${orgId}/workspace/${workspaceId}`;
+
   // Fetch providers
   const { data: providersData, isLoading: providersLoading } = useSWR<{
     results: Provider[];
-  }>(
-    backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/providers`,
-        )
-      : null,
-    fetcher,
-  );
+  }>(backendUrl && user ? joinUrl(backendUrl, providersBase) : null, fetcher);
   const providers = providersData?.results || [];
 
   // Fetch skills
   const { data: skillsData } = useSWR<{ results: Skill[] }>(
-    backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/skills`,
-        )
-      : null,
+    backendUrl && user ? joinUrl(backendUrl, skillsBase) : null,
     fetcher,
   );
   const skills = skillsData?.results || [];
 
   // Fetch agents for sub-agent selection
   const { data: agentsData } = useSWR<{ results: Agent[] }>(
-    backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/agents`,
-        )
-      : null,
+    backendUrl && user ? joinUrl(backendUrl, agentsBase) : null,
     fetcher,
   );
   const agents = propAgents || agentsData?.results || [];
 
   // Fetch existing agent data if editing
-  const { data: agent, isLoading: agentLoading } = useSWR<Agent>(
-    agentId && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/agents/${agentId}`,
-        )
-      : null,
+  const { data: agent, isLoading: agentLoading } = useSWR<
+    Agent & { scope?: "organization" | "workspace" }
+  >(
+    agentId && user ? joinUrl(backendUrl, `${agentsBase}/${agentId}`) : null,
     fetcher,
   );
+
+  // A Shared Agent opened on the Workspace surface is read-only for everyone —
+  // it is edited only on the Organization surface (ADR-0007). In org mode the
+  // form is the canonical editor, so it is always editable.
+  const isOrgScoped = agent?.scope === "organization";
+  const readOnly = isOrgScoped && !orgScoped;
 
   const [formData, setFormData] = useState({
     name: "",
@@ -286,7 +299,8 @@ const AgentForm = ({
     setValidationErrors({});
     try {
       const payload: Omit<Agent, "id" | "createdAt" | "updatedAt"> = {
-        workspaceId,
+        // Scope comes from the route, not the body; the org PUT ignores this.
+        workspaceId: orgScoped ? undefined : workspaceId,
         providerId: formData.providerId,
         name: formData.name,
         description: formData.description,
@@ -306,14 +320,8 @@ const AgentForm = ({
       };
 
       const url = agentId
-        ? joinUrl(
-            backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}/agents/${agentId}`,
-          )
-        : joinUrl(
-            backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}/agents`,
-          );
+        ? joinUrl(backendUrl, `${agentsBase}/${agentId}`)
+        : joinUrl(backendUrl, agentsBase);
 
       const method = agentId ? "PUT" : "POST";
 
@@ -332,10 +340,7 @@ const AgentForm = ({
 
         if (avatarDeleted && agentId) {
           await fetch(
-            joinUrl(
-              backendUrl,
-              `/organizations/${orgId}/workspaces/${workspaceId}/agents/${savedAgentId}/avatar`,
-            ),
+            joinUrl(backendUrl, `${agentsBase}/${savedAgentId}/avatar`),
             {
               method: "DELETE",
               credentials: "include",
@@ -345,10 +350,7 @@ const AgentForm = ({
           const avatarFormData = new FormData();
           avatarFormData.append("file", avatarFile);
           await fetch(
-            joinUrl(
-              backendUrl,
-              `/organizations/${orgId}/workspaces/${workspaceId}/agents/${savedAgentId}/avatar`,
-            ),
+            joinUrl(backendUrl, `${agentsBase}/${savedAgentId}/avatar`),
             {
               method: "POST",
               body: avatarFormData,
@@ -357,13 +359,8 @@ const AgentForm = ({
           );
         }
 
-        await mutate(
-          joinUrl(
-            backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}/agents`,
-          ),
-        );
-        router.push(`/${orgId}/workspace/${workspaceId}`);
+        await mutate(joinUrl(backendUrl, agentsBase));
+        router.push(doneHref);
       } else {
         // Parse standardschema.dev validation errors
         const errorData = await response.json();
@@ -384,10 +381,7 @@ const AgentForm = ({
     setIsDeleting(true);
     try {
       const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/agents/${agentId}`,
-        ),
+        joinUrl(backendUrl, `${agentsBase}/${agentId}`),
         {
           method: "DELETE",
           credentials: "include",
@@ -395,7 +389,7 @@ const AgentForm = ({
       );
 
       if (response.ok) {
-        router.push(`/${orgId}/workspace/${workspaceId}`);
+        router.push(doneHref);
       } else {
         console.error("Failed to delete agent");
         toast.error("Failed to delete agent");
@@ -453,6 +447,22 @@ const AgentForm = ({
 
   return (
     <div className={classNames}>
+      {readOnly && (
+        <div className="mb-6 rounded-md border bg-secondary/50 p-3 text-sm flex items-center gap-2">
+          <Building className="size-4 shrink-0" />
+          <span>
+            This is a shared organization agent and is read-only here. Edit it
+            in{" "}
+            <Link
+              href={`/${orgId}/settings/agents/${agentId}`}
+              className="underline"
+            >
+              Organization settings
+            </Link>
+            .
+          </span>
+        </div>
+      )}
       <FieldSet className="mb-6">
         <div className="flex flex-col items-center">
           <div className="relative">
@@ -460,7 +470,7 @@ const AgentForm = ({
               type="button"
               onClick={() => avatarInputRef.current?.click()}
               className="relative group cursor-pointer flex"
-              disabled={isSubmitting}
+              disabled={isSubmitting || readOnly}
             >
               <div className="w-20 h-20 rounded-2xl bg-muted flex items-center justify-center overflow-hidden border-2 border-dashed border-muted-foreground/20 hover:border-muted-foreground/40 transition-colors">
                 {avatarPreviewUrl ? (
@@ -486,7 +496,7 @@ const AgentForm = ({
                 type="button"
                 onClick={handleAvatarDelete}
                 className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-destructive whitespace-nowrap"
-                disabled={isSubmitting}
+                disabled={isSubmitting || readOnly}
               >
                 <X className="w-4 h-4" />
                 Remove
@@ -499,7 +509,7 @@ const AgentForm = ({
             accept="image/*"
             onChange={handleAvatarChange}
             className="hidden"
-            disabled={isSubmitting}
+            disabled={isSubmitting || readOnly}
           />
         </div>
 
@@ -511,7 +521,7 @@ const AgentForm = ({
               placeholder="Name"
               value={formData.name}
               onChange={handleChange}
-              disabled={isSubmitting}
+              disabled={isSubmitting || readOnly}
               aria-invalid={!!validationErrors.name}
               autoFocus
             />
@@ -527,7 +537,7 @@ const AgentForm = ({
               placeholder="Description of the agent..."
               value={formData.description}
               onChange={handleChange}
-              disabled={isSubmitting}
+              disabled={isSubmitting || readOnly}
               maxLength={128}
               aria-invalid={!!validationErrors.description}
               error={validationErrors.description}
@@ -542,7 +552,7 @@ const AgentForm = ({
               placeholder="What would you like to know?"
               value={formData.inputPlaceholder}
               onChange={handleChange}
-              disabled={isSubmitting}
+              disabled={isSubmitting || readOnly}
               maxLength={100}
               aria-invalid={!!validationErrors.inputPlaceholder}
             />
@@ -561,7 +571,7 @@ const AgentForm = ({
               placeholder="You are a helpful agent..."
               value={formData.systemPrompt}
               onChange={handleChange}
-              disabled={isSubmitting}
+              disabled={isSubmitting || readOnly}
               className="!font-mono"
             />
           </Field>
@@ -570,9 +580,9 @@ const AgentForm = ({
             <Select
               value={`provider:${formData.providerId}:${formData.modelId}`}
               onValueChange={handleModelChange}
-              disabled={isSubmitting}
+              disabled={isSubmitting || readOnly}
             >
-              <SelectTrigger disabled={isSubmitting}>
+              <SelectTrigger disabled={isSubmitting || readOnly}>
                 <SelectValue placeholder="Select a model" />
               </SelectTrigger>
               <SelectContent>
@@ -600,7 +610,7 @@ const AgentForm = ({
               min="1"
               value={formData.maxSteps}
               onChange={(e) => handleNumberChange("maxSteps", e.target.value)}
-              disabled={isSubmitting}
+              disabled={isSubmitting || readOnly}
             />
             <FieldDescription>
               Controls when a tool-calling loop should stop based on the number
@@ -661,7 +671,7 @@ const AgentForm = ({
                                 };
                               });
                             }}
-                            disabled={isSubmitting}
+                            disabled={isSubmitting || readOnly}
                           />
                           <FieldLabel htmlFor={toolSet.id}>
                             <div className="flex flex-col">
@@ -707,7 +717,7 @@ const AgentForm = ({
                           };
                         });
                       }}
-                      disabled={isSubmitting}
+                      disabled={isSubmitting || readOnly}
                     />
                     <FieldLabel htmlFor={`skill-${skill.id}`}>
                       <div className="flex flex-col">
@@ -754,7 +764,7 @@ const AgentForm = ({
                                 ),
                           }));
                         }}
-                        disabled={isSubmitting}
+                        disabled={isSubmitting || readOnly}
                       />
                       <FieldLabel htmlFor={`subagent-${agent.id}`}>
                         <div className="flex items-center gap-2">
@@ -801,7 +811,7 @@ const AgentForm = ({
                   onChange={(e) =>
                     handleFloatChange("temperature", e.target.value)
                   }
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || readOnly}
                 />
               </Field>
               <Field>
@@ -811,7 +821,7 @@ const AgentForm = ({
                   type="number"
                   value={formData.seed ?? ""}
                   onChange={(e) => handleNumberChange("seed", e.target.value)}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || readOnly}
                 />
               </Field>
               <Field>
@@ -824,7 +834,7 @@ const AgentForm = ({
                   step="0.1"
                   value={formData.topP ?? ""}
                   onChange={(e) => handleFloatChange("topP", e.target.value)}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || readOnly}
                 />
               </Field>
               <Field>
@@ -835,7 +845,7 @@ const AgentForm = ({
                   min="1"
                   value={formData.topK ?? ""}
                   onChange={(e) => handleNumberChange("topK", e.target.value)}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || readOnly}
                 />
               </Field>
               <Field>
@@ -852,7 +862,7 @@ const AgentForm = ({
                   onChange={(e) =>
                     handleFloatChange("presencePenalty", e.target.value)
                   }
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || readOnly}
                 />
               </Field>
               <Field>
@@ -869,7 +879,7 @@ const AgentForm = ({
                   onChange={(e) =>
                     handleFloatChange("frequencyPenalty", e.target.value)
                   }
-                  disabled={isSubmitting}
+                  disabled={isSubmitting || readOnly}
                 />
               </Field>
             </FieldGroup>
@@ -881,12 +891,14 @@ const AgentForm = ({
         <Button
           className="cursor-pointer"
           onClick={handleSubmit}
-          disabled={isSubmitting || Object.keys(validationErrors).length > 0}
+          disabled={
+            isSubmitting || readOnly || Object.keys(validationErrors).length > 0
+          }
         >
           {agentId ? "Update" : "Save"}
         </Button>
 
-        {agentId && (
+        {agentId && !isOrgScoped && (
           <Button
             className="cursor-pointer"
             variant="outline"

--- a/apps/frontend/components/agents-list.tsx
+++ b/apps/frontend/components/agents-list.tsx
@@ -34,12 +34,18 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import {
+  ArrowUpFromLine,
   Bot,
   BotMessageSquare,
+  Building,
   Copy,
   EllipsisVertical,
+  ExternalLink,
+  Link2,
   Pencil,
+  Plus,
   Trash2,
+  Unlink,
   Wrench,
   Sparkles,
 } from "lucide-react";
@@ -56,6 +62,25 @@ import { useRouter } from "next/navigation";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { NoProvidersEmptyState } from "@/components/no-providers-empty-state";
+import { AttachSharedResourceDialog } from "@/components/attach-shared-resource-dialog";
+
+// The Agent is shown either in a Workspace, where it may be a workspace-scoped
+// Agent or an attached org-scoped (Shared) Agent rendered with an Organization
+// badge (ADR-0007). The backend tags each row with its scope.
+type AgentWithScope = Agent & { scope?: "organization" | "workspace" };
+
+type PromoteBlocker = {
+  type: "provider" | "skill" | "subAgent" | "mcp";
+  id: string;
+  name: string;
+};
+
+const BLOCKER_LABEL: Record<PromoteBlocker["type"], string> = {
+  provider: "Provider",
+  skill: "Skill",
+  subAgent: "Sub-agent",
+  mcp: "MCP tool set",
+};
 
 export const AgentsList = ({
   orgId,
@@ -64,7 +89,7 @@ export const AgentsList = ({
   orgId: string;
   workspaceId: string;
 }) => {
-  const { user } = useAuth();
+  const { user, isOrgAdmin } = useAuth();
   const backendUrl = useBackendUrl();
   const router = useRouter();
   const [cloneDialogOpen, setCloneDialogOpen] = useState(false);
@@ -73,13 +98,23 @@ export const AgentsList = ({
   const [cloneError, setCloneError] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [agentToDelete, setAgentToDelete] = useState<Agent | null>(null);
+  const [attachOpen, setAttachOpen] = useState(false);
+  const [selectedOrgAgent, setSelectedOrgAgent] =
+    useState<AgentWithScope | null>(null);
+  const [detaching, setDetaching] = useState(false);
+  const [agentToPromote, setAgentToPromote] = useState<AgentWithScope | null>(
+    null,
+  );
+  const [promoting, setPromoting] = useState(false);
+  const [promoteError, setPromoteError] = useState<string | null>(null);
+  const [promoteBlockers, setPromoteBlockers] = useState<PromoteBlocker[]>([]);
 
   const {
     data: agentsData,
     isLoading: isLoadingAgents,
     mutate,
   } = useSWR<{
-    results: Agent[];
+    results: AgentWithScope[];
   }>(
     backendUrl && user
       ? joinUrl(
@@ -132,6 +167,12 @@ export const AgentsList = ({
   const providers = providersData?.results || [];
   const toolSets = toolSetsData?.results || [];
   const skills = skillsData?.results || [];
+
+  // Promote and attach are Org Admin actions (ADR-0007).
+  const canManageShared = isOrgAdmin;
+  const attachedOrgIds = agents
+    .filter((a) => a.scope === "organization")
+    .map((a) => a.id);
 
   const getToolSetNames = (toolSetIds: string[] | undefined) => {
     if (!toolSetIds?.length) return [];
@@ -196,11 +237,20 @@ export const AgentsList = ({
 
     setCloneError(null);
 
-    const { id, createdAt, updatedAt, avatarUrl, ...cloneData } = agentToClone;
+    const {
+      id,
+      createdAt,
+      updatedAt,
+      avatarUrl,
+      scope,
+      organizationId,
+      ...cloneData
+    } = agentToClone as AgentWithScope;
 
     const sanitizedData = Object.fromEntries(
       Object.entries({
         ...cloneData,
+        workspaceId,
         name: cloneName,
       }).map(([key, value]) => [key, value === null ? undefined : value]),
     );
@@ -242,6 +292,52 @@ export const AgentsList = ({
     }
   };
 
+  const handlePromoteConfirm = async () => {
+    if (!agentToPromote || !backendUrl) return;
+    setPromoting(true);
+    setPromoteError(null);
+    setPromoteBlockers([]);
+    try {
+      const response = await fetch(
+        joinUrl(
+          backendUrl,
+          `/organizations/${orgId}/workspaces/${workspaceId}/agents/${agentToPromote.id}/promote`,
+        ),
+        { method: "POST", credentials: "include" },
+      );
+      if (response.ok) {
+        await mutate();
+        setAgentToPromote(null);
+      } else {
+        const info = await response.json().catch(() => ({}));
+        if (Array.isArray(info.blockers) && info.blockers.length > 0) {
+          setPromoteBlockers(info.blockers);
+        }
+        setPromoteError(info.error || "Failed to promote agent.");
+      }
+    } finally {
+      setPromoting(false);
+    }
+  };
+
+  const detachOrgAgent = async (agentId: string) => {
+    if (!backendUrl) return;
+    setDetaching(true);
+    try {
+      await fetch(
+        joinUrl(
+          backendUrl,
+          `/organizations/${orgId}/workspaces/${workspaceId}/attachments/agent/${agentId}`,
+        ),
+        { method: "DELETE", credentials: "include" },
+      );
+      setSelectedOrgAgent(null);
+      await mutate();
+    } finally {
+      setDetaching(false);
+    }
+  };
+
   if (isLoadingAgents || isLoadingProviders) {
     return <div>Loading...</div>;
   }
@@ -256,195 +352,367 @@ export const AgentsList = ({
     );
   }
 
-  if (!agents.length) {
-    return null;
-  }
+  const renderMenuItems = (agent: AgentWithScope) => {
+    const isOrgScoped = agent.scope === "organization";
+    return (
+      <>
+        {isOrgScoped ? (
+          // A Shared Agent is locked in the Workspace; only an Org Admin can
+          // open it in the org settings editor or detach it here (ADR-0007).
+          isOrgAdmin && (
+            <>
+              <DropdownMenuItem asChild>
+                <Link
+                  className="cursor-pointer"
+                  href={`/${orgId}/settings/agents/${agent.id}`}
+                >
+                  <Pencil /> Edit in org settings
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onSelect={() => setSelectedOrgAgent(agent)}
+              >
+                <Unlink /> Detach
+              </DropdownMenuItem>
+            </>
+          )
+        ) : (
+          <>
+            <DropdownMenuItem asChild>
+              <Link
+                className="cursor-pointer"
+                href={`/${orgId}/workspace/${workspaceId}/agents/${agent.id}`}
+              >
+                <Pencil /> Edit
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onSelect={() => handleCloneClick(agent)}
+            >
+              <Copy /> Clone
+            </DropdownMenuItem>
+            {canManageShared && (
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onSelect={() => {
+                  setPromoteError(null);
+                  setPromoteBlockers([]);
+                  setAgentToPromote(agent);
+                }}
+              >
+                <ArrowUpFromLine /> Promote to organization
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="cursor-pointer text-destructive focus:text-destructive"
+              onSelect={() => handleDeleteClick(agent)}
+            >
+              <Trash2 /> Delete
+            </DropdownMenuItem>
+          </>
+        )}
+      </>
+    );
+  };
+
+  // A Shared Agent with no admin actions has an empty menu; hide the trigger.
+  const hasMenu = (agent: AgentWithScope) =>
+    agent.scope !== "organization" || isOrgAdmin;
 
   return (
     <>
       <ul className="grid grid-cols-1 lg:grid-cols-2 grid-rows-1 gap-2 lg:gap-4">
-        {agents.map((agent) => (
-          <li key={agent.id}>
-            <Item variant="outline" className="h-full items-stretch">
-              {agent.avatarUrl ? (
-                <ItemMedia variant="image" className="size-12 rounded-lg">
-                  <img
-                    src={agent.avatarUrl}
-                    alt={agent.name}
-                    className="size-full object-cover"
-                  />
-                </ItemMedia>
-              ) : (
-                <ItemMedia
-                  variant="icon"
-                  className="size-12 rounded-lg [&_svg]:!size-7"
-                >
-                  <Bot className="h-7 w-7 text-muted-foreground" />
-                </ItemMedia>
-              )}
-              <ItemContent>
-                <ItemTitle>{agent.name}</ItemTitle>
-                <ItemDescription className="text-xs line-clamp-3">
-                  {agent.description}
-                </ItemDescription>
-                <div className="flex gap-3 mt-auto text-xs text-muted-foreground">
-                  {agent.toolSetIds?.length ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="flex items-center gap-1 cursor-default">
-                          <Wrench className="h-3 w-3" />
-                          {agent.toolSetIds.length} tool sets
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <ul className="text-left">
-                          {getToolSetNames(agent.toolSetIds).map((name) => (
-                            <li key={name}>{name}</li>
-                          ))}
-                        </ul>
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : (
-                    <span className="flex items-center gap-1 cursor-default">
-                      <Wrench className="h-3 w-3" />0 tool sets
-                    </span>
-                  )}
-                  {agent.skillIds?.length ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="flex items-center gap-1 cursor-default">
-                          <Sparkles className="h-3 w-3" />
-                          {agent.skillIds.length} skill
-                          {agent.skillIds.length !== 1 && "s"}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <ul className="text-left">
-                          {getSkillNames(agent.skillIds).map((name) => (
-                            <li key={name}>{name}</li>
-                          ))}
-                        </ul>
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : (
-                    <span className="flex items-center gap-1 cursor-default">
-                      <Sparkles className="h-3 w-3" />0 skills
-                    </span>
-                  )}
-                  {agent.subAgentIds?.length ? (
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="flex items-center gap-1 cursor-default">
-                          <Bot className="h-3 w-3" />
-                          {agent.subAgentIds.length} sub-agent
-                          {agent.subAgentIds.length !== 1 && "s"}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <ul className="text-left">
-                          {getSubAgentNames(agent.subAgentIds).map((name) => (
-                            <li key={name}>{name}</li>
-                          ))}
-                        </ul>
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : (
-                    <span className="flex items-center gap-1 cursor-default">
-                      <Bot className="h-3 w-3" />0 sub-agents
-                    </span>
-                  )}
-                </div>
-              </ItemContent>
-              <ItemActions className="hidden xl:flex">
-                <Button size="sm" asChild>
-                  <Link
-                    href={`/${orgId}/workspace/${workspaceId}/chat?agentId=${agent.id}`}
+        {agents.map((agent) => {
+          const isOrgScoped = agent.scope === "organization";
+          // Count and list only references that actually resolve in this
+          // workspace, so the badge count matches the tooltip — a detached
+          // shared resource drops out of both (it is no longer active here).
+          const toolSetNames = getToolSetNames(agent.toolSetIds);
+          const skillNames = getSkillNames(agent.skillIds);
+          const subAgentNames = getSubAgentNames(agent.subAgentIds);
+          return (
+            <li key={agent.id}>
+              <Item variant="outline" className="h-full items-stretch">
+                {agent.avatarUrl ? (
+                  <ItemMedia variant="image" className="size-12 rounded-lg">
+                    <img
+                      src={agent.avatarUrl}
+                      alt={agent.name}
+                      className="size-full object-cover"
+                    />
+                  </ItemMedia>
+                ) : (
+                  <ItemMedia
+                    variant="icon"
+                    className="size-12 rounded-lg [&_svg]:!size-7"
                   >
-                    <BotMessageSquare /> New Chat
-                  </Link>
-                </Button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      className="cursor-pointer text-muted-foreground"
-                      variant="ghost"
-                      size="icon"
+                    <Bot className="h-7 w-7 text-muted-foreground" />
+                  </ItemMedia>
+                )}
+                <ItemContent>
+                  <div className="flex items-center gap-2">
+                    <ItemTitle>{agent.name}</ItemTitle>
+                    {isOrgScoped && (
+                      <div className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-secondary text-[10px] font-medium text-secondary-foreground uppercase tracking-wider">
+                        <Building className="size-3" />
+                        Organization
+                      </div>
+                    )}
+                  </div>
+                  <ItemDescription className="text-xs line-clamp-3">
+                    {agent.description}
+                  </ItemDescription>
+                  <div className="flex gap-3 mt-auto text-xs text-muted-foreground">
+                    {toolSetNames.length ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="flex items-center gap-1 cursor-default">
+                            <Wrench className="h-3 w-3" />
+                            {toolSetNames.length} tool set
+                            {toolSetNames.length !== 1 && "s"}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <ul className="text-left">
+                            {toolSetNames.map((name) => (
+                              <li key={name}>{name}</li>
+                            ))}
+                          </ul>
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <span className="flex items-center gap-1 cursor-default">
+                        <Wrench className="h-3 w-3" />0 tool sets
+                      </span>
+                    )}
+                    {skillNames.length ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="flex items-center gap-1 cursor-default">
+                            <Sparkles className="h-3 w-3" />
+                            {skillNames.length} skill
+                            {skillNames.length !== 1 && "s"}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <ul className="text-left">
+                            {skillNames.map((name) => (
+                              <li key={name}>{name}</li>
+                            ))}
+                          </ul>
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <span className="flex items-center gap-1 cursor-default">
+                        <Sparkles className="h-3 w-3" />0 skills
+                      </span>
+                    )}
+                    {subAgentNames.length ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="flex items-center gap-1 cursor-default">
+                            <Bot className="h-3 w-3" />
+                            {subAgentNames.length} sub-agent
+                            {subAgentNames.length !== 1 && "s"}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <ul className="text-left">
+                            {subAgentNames.map((name) => (
+                              <li key={name}>{name}</li>
+                            ))}
+                          </ul>
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <span className="flex items-center gap-1 cursor-default">
+                        <Bot className="h-3 w-3" />0 sub-agents
+                      </span>
+                    )}
+                  </div>
+                </ItemContent>
+                <ItemActions className="hidden xl:flex">
+                  <Button size="sm" asChild>
+                    <Link
+                      href={`/${orgId}/workspace/${workspaceId}/chat?agentId=${agent.id}`}
                     >
-                      <EllipsisVertical className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent>
-                    <DropdownMenuItem asChild>
-                      <Link
-                        className="cursor-pointer"
-                        href={`/${orgId}/workspace/${workspaceId}/agents/${agent.id}`}
-                      >
-                        <Pencil /> Edit
-                      </Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      className="cursor-pointer"
-                      onSelect={() => handleCloneClick(agent)}
+                      <BotMessageSquare /> New Chat
+                    </Link>
+                  </Button>
+                  {hasMenu(agent) && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          className="cursor-pointer text-muted-foreground"
+                          variant="ghost"
+                          size="icon"
+                        >
+                          <EllipsisVertical className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent>
+                        {renderMenuItems(agent)}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </ItemActions>
+                <ItemFooter className="xl:hidden mt-0 pl-16">
+                  <Button size="sm" asChild>
+                    <Link
+                      href={`/${orgId}/workspace/${workspaceId}/chat?agentId=${agent.id}`}
                     >
-                      <Copy /> Clone
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      className="cursor-pointer text-destructive focus:text-destructive"
-                      onSelect={() => handleDeleteClick(agent)}
-                    >
-                      <Trash2 /> Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </ItemActions>
-              <ItemFooter className="xl:hidden mt-0 pl-16">
-                <Button size="sm" asChild>
-                  <Link
-                    href={`/${orgId}/workspace/${workspaceId}/chat?agentId=${agent.id}`}
-                  >
-                    <BotMessageSquare /> New Chat
-                  </Link>
-                </Button>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      className="cursor-pointer text-muted-foreground"
-                      variant="ghost"
-                      size="icon"
-                    >
-                      <EllipsisVertical className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent>
-                    <DropdownMenuItem asChild>
-                      <Link
-                        className="cursor-pointer"
-                        href={`/${orgId}/workspace/${workspaceId}/agents/${agent.id}`}
-                      >
-                        <Pencil /> Edit
-                      </Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      className="cursor-pointer"
-                      onSelect={() => handleCloneClick(agent)}
-                    >
-                      <Copy /> Clone
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      className="cursor-pointer text-destructive focus:text-destructive"
-                      onSelect={() => handleDeleteClick(agent)}
-                    >
-                      <Trash2 /> Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </ItemFooter>
-            </Item>
-          </li>
-        ))}
+                      <BotMessageSquare /> New Chat
+                    </Link>
+                  </Button>
+                  {hasMenu(agent) && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          className="cursor-pointer text-muted-foreground"
+                          variant="ghost"
+                          size="icon"
+                        >
+                          <EllipsisVertical className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent>
+                        {renderMenuItems(agent)}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </ItemFooter>
+              </Item>
+            </li>
+          );
+        })}
       </ul>
+
+      <div className="mt-4 flex gap-2">
+        <Button variant="outline" asChild>
+          <Link href={`/${orgId}/workspace/${workspaceId}/agents/create`}>
+            <Plus /> Create Agent
+          </Link>
+        </Button>
+        {canManageShared && (
+          <Button variant="outline" onClick={() => setAttachOpen(true)}>
+            <Link2 className="size-4" /> Attach shared agent
+          </Button>
+        )}
+      </div>
+
+      {canManageShared && (
+        <AttachSharedResourceDialog
+          open={attachOpen}
+          onOpenChange={setAttachOpen}
+          orgId={orgId}
+          workspaceId={workspaceId}
+          resourceType="agent"
+          attachedIds={attachedOrgIds}
+          onAttached={() => {
+            setAttachOpen(false);
+            mutate();
+          }}
+        />
+      )}
+
+      <Dialog
+        open={!!selectedOrgAgent}
+        onOpenChange={(open) => !open && setSelectedOrgAgent(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Detach shared agent</DialogTitle>
+            <DialogDescription>
+              Detach <strong>{selectedOrgAgent?.name}</strong> from this
+              workspace? The shared agent itself is not deleted; it just stops
+              appearing here.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setSelectedOrgAgent(null)}>
+              Close
+            </Button>
+            {isOrgAdmin && selectedOrgAgent && (
+              <Button asChild variant="ghost">
+                <Link href={`/${orgId}/settings/agents`}>
+                  <ExternalLink className="size-4" />
+                  Org settings
+                </Link>
+              </Button>
+            )}
+            {selectedOrgAgent && (
+              <Button
+                variant="destructive"
+                disabled={detaching}
+                onClick={() => detachOrgAgent(selectedOrgAgent.id)}
+              >
+                <Unlink className="size-4" />
+                Detach
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={!!agentToPromote}
+        onOpenChange={(open) => {
+          if (!open) {
+            setAgentToPromote(null);
+            setPromoteError(null);
+            setPromoteBlockers([]);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Promote to organization</DialogTitle>
+            <DialogDescription>
+              Promote <strong>{agentToPromote?.name}</strong> to an
+              organization-shared agent? It will be managed by org admins and
+              remain attached to this workspace.
+            </DialogDescription>
+          </DialogHeader>
+          {promoteBlockers.length > 0 && (
+            <div className="rounded-md border border-warning bg-warning/10 p-3 text-sm">
+              <p className="mb-2 font-medium">
+                Promote the following workspace-private references first:
+              </p>
+              <ul className="space-y-1">
+                {promoteBlockers.map((b) => (
+                  <li key={`${b.type}-${b.id}`} className="flex gap-2">
+                    <span className="text-muted-foreground">
+                      {BLOCKER_LABEL[b.type]}:
+                    </span>
+                    <span className="font-medium">{b.name}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {promoteError && promoteBlockers.length === 0 && (
+            <p className="text-sm text-destructive">{promoteError}</p>
+          )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setAgentToPromote(null);
+                setPromoteError(null);
+                setPromoteBlockers([]);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handlePromoteConfirm} disabled={promoting}>
+              Promote
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={cloneDialogOpen} onOpenChange={setCloneDialogOpen}>
         <DialogContent>

--- a/apps/frontend/components/attach-shared-resource-dialog.tsx
+++ b/apps/frontend/components/attach-shared-resource-dialog.tsx
@@ -15,18 +15,20 @@ import {
 import { Item, ItemActions, ItemContent, ItemTitle } from "./ui/item";
 import { useState } from "react";
 
-type ResourceType = "mcp" | "provider" | "skill";
+type ResourceType = "mcp" | "provider" | "skill" | "agent";
 
 const COLLECTION: Record<ResourceType, string> = {
   mcp: "mcps",
   provider: "providers",
   skill: "skills",
+  agent: "agents",
 };
 
 const LABEL: Record<ResourceType, string> = {
   mcp: "MCP server",
   provider: "provider",
   skill: "skill",
+  agent: "agent",
 };
 
 /**

--- a/apps/frontend/components/manage-sharing.tsx
+++ b/apps/frontend/components/manage-sharing.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import useSWR from "swr";
+import { Check, FolderClosed, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useState } from "react";
+import { cn, fetcher, joinUrl } from "@/lib/utils";
+import { useBackendUrl } from "@/app/client-context";
+
+type ResourceType = "mcp" | "provider" | "skill" | "agent";
+
+const LABEL: Record<ResourceType, string> = {
+  mcp: "MCP server",
+  provider: "provider",
+  skill: "skill",
+  agent: "agent",
+};
+
+type AttachedWorkspace = { workspaceId: string; workspaceName: string };
+
+const attachmentsUrl = (
+  backendUrl: string,
+  orgId: string,
+  resourceType: ResourceType,
+  resourceId: string,
+) =>
+  joinUrl(
+    backendUrl,
+    `/organizations/${orgId}/attachments?resourceType=${resourceType}&resourceId=${resourceId}`,
+  );
+
+/**
+ * Read-only affordance shown on an org-surface card: "Shared with N workspaces"
+ * with a hover tooltip listing the workspaces (ADR-0007). Mirrors the
+ * tool-set/skill hover summaries on the workspace home page. Managing the
+ * attachments themselves happens via {@link ManageAttachmentsDialog}.
+ */
+export const SharedWithBadge = ({
+  orgId,
+  resourceType,
+  resourceId,
+}: {
+  orgId: string;
+  resourceType: ResourceType;
+  resourceId: string;
+}) => {
+  const backendUrl = useBackendUrl();
+  const { data } = useSWR<{ results: AttachedWorkspace[] }>(
+    backendUrl
+      ? attachmentsUrl(backendUrl, orgId, resourceType, resourceId)
+      : null,
+    fetcher,
+  );
+  const attached = data?.results ?? [];
+  const count = attached.length;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        className="flex items-center gap-1 cursor-default text-xs text-muted-foreground"
+        onClick={(e) => e.preventDefault()}
+      >
+        <FolderClosed className="size-3" />
+        {count} workspace{count !== 1 && "s"}
+      </TooltipTrigger>
+      {count > 0 && (
+        <TooltipContent>
+          <ul className="text-left">
+            {attached.map((a) => (
+              <li key={a.workspaceId}>{a.workspaceName}</li>
+            ))}
+          </ul>
+        </TooltipContent>
+      )}
+    </Tooltip>
+  );
+};
+
+/**
+ * Org Admin dialog to manage where a Shared resource is attached (ADR-0007).
+ * A searchable multi-select that scales to many workspaces: attached
+ * workspaces show as removable chips and the list filters as you type.
+ * Controlled by the caller (opened from the card's "Manage attachments" menu).
+ */
+export const ManageAttachmentsDialog = ({
+  orgId,
+  resourceType,
+  resourceId,
+  resourceName,
+  open,
+  onOpenChange,
+}: {
+  orgId: string;
+  resourceType: ResourceType;
+  resourceId: string;
+  resourceName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const backendUrl = useBackendUrl();
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const { data: attData, mutate: mutateAtt } = useSWR<{
+    results: AttachedWorkspace[];
+  }>(
+    backendUrl
+      ? attachmentsUrl(backendUrl, orgId, resourceType, resourceId)
+      : null,
+    fetcher,
+  );
+  const attached = attData?.results ?? [];
+  const attachedIds = new Set(attached.map((a) => a.workspaceId));
+
+  // The full workspace list is only needed while the dialog is open.
+  const { data: wsData } = useSWR<{ results: { id: string; name: string }[] }>(
+    open && backendUrl
+      ? joinUrl(backendUrl, `/organizations/${orgId}/workspaces`)
+      : null,
+    fetcher,
+  );
+  const workspaces = [...(wsData?.results ?? [])].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  const toggle = async (workspaceId: string, isAttached: boolean) => {
+    if (!backendUrl) return;
+    setBusyId(workspaceId);
+    try {
+      if (isAttached) {
+        await fetch(
+          joinUrl(
+            backendUrl,
+            `/organizations/${orgId}/attachments/${resourceType}/${resourceId}/${workspaceId}`,
+          ),
+          { method: "DELETE", credentials: "include" },
+        );
+      } else {
+        await fetch(
+          joinUrl(backendUrl, `/organizations/${orgId}/attachments`),
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "include",
+            body: JSON.stringify({ resourceType, resourceId, workspaceId }),
+          },
+        );
+      }
+      await mutateAtt();
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const count = attached.length;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Share “{resourceName}”</DialogTitle>
+          <DialogDescription>
+            Choose which workspaces this {LABEL[resourceType]} appears in. It
+            runs against each workspace&apos;s own resources.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Currently-attached workspaces as removable chips. */}
+        {count > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {attached.map((a) => (
+              <Badge key={a.workspaceId} variant="secondary" className="gap-1">
+                {a.workspaceName}
+                <button
+                  type="button"
+                  aria-label={`Detach ${a.workspaceName}`}
+                  disabled={busyId === a.workspaceId}
+                  onClick={() => toggle(a.workspaceId, true)}
+                  className="cursor-pointer rounded-sm hover:text-destructive disabled:opacity-50"
+                >
+                  <X className="size-3" />
+                </button>
+              </Badge>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            Not shared with any workspace yet.
+          </p>
+        )}
+
+        {/* Searchable multi-select — scales to many workspaces. */}
+        <Command>
+          <CommandInput placeholder="Search workspaces…" />
+          <CommandList>
+            <CommandEmpty>No workspaces found.</CommandEmpty>
+            <CommandGroup>
+              {workspaces.map((ws) => {
+                const isAtt = attachedIds.has(ws.id);
+                return (
+                  <CommandItem
+                    key={ws.id}
+                    // Include the id so the search value stays unique even if
+                    // two workspaces share a name; search still matches name.
+                    value={`${ws.name} ${ws.id}`}
+                    disabled={busyId === ws.id}
+                    onSelect={() => toggle(ws.id, isAtt)}
+                  >
+                    <Check
+                      className={cn(
+                        "mr-2 size-4",
+                        isAtt ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                    {ws.name}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/frontend/components/org-agents-list.tsx
+++ b/apps/frontend/components/org-agents-list.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Bot, EllipsisVertical, Pencil, Share2, Trash2 } from "lucide-react";
+import { type Agent } from "@platypus/schemas";
+import useSWR from "swr";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { useBackendUrl } from "@/app/client-context";
+import { useAuth } from "@/components/auth-provider";
+import {
+  ManageAttachmentsDialog,
+  SharedWithBadge,
+} from "@/components/manage-sharing";
+import Link from "next/link";
+
+// The Organization surface for Shared Agents (ADR-0007): Org Admins see and
+// manage every Shared Agent, attached or not. Promotion (from a Workspace) is
+// the way a Shared Agent is created; it is then edited, shared, and deleted
+// here on the Organization surface — in Workspaces it is locked.
+export const OrgAgentsList = ({ orgId }: { orgId: string }) => {
+  const { user, isOrgAdmin } = useAuth();
+  const backendUrl = useBackendUrl();
+  const [agentToDelete, setAgentToDelete] = useState<Agent | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [agentToManage, setAgentToManage] = useState<Agent | null>(null);
+  const [deleteBlocked, setDeleteBlocked] = useState<{
+    agent: Agent;
+    count: number;
+  } | null>(null);
+
+  const { data, isLoading, mutate } = useSWR<{ results: Agent[] }>(
+    backendUrl && user
+      ? joinUrl(backendUrl, `/organizations/${orgId}/agents`)
+      : null,
+    fetcher,
+  );
+
+  const agents = [...(data?.results || [])].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  // A Shared resource can't be deleted while attached (ADR-0007). Check the
+  // live attachment count first so we explain the blocker up front instead of
+  // offering a Delete button that is guaranteed to fail.
+  const requestDelete = async (agent: Agent) => {
+    if (!backendUrl) return;
+    try {
+      const res = await fetch(
+        joinUrl(
+          backendUrl,
+          `/organizations/${orgId}/attachments?resourceType=agent&resourceId=${agent.id}`,
+        ),
+        { credentials: "include" },
+      );
+      const info = await res.json().catch(() => ({ results: [] }));
+      const count = (info.results ?? []).length;
+      if (count > 0) {
+        setDeleteBlocked({ agent, count });
+        return;
+      }
+    } catch {
+      // If the check fails, fall through — the backend still guards with a 409.
+    }
+    setDeleteError(null);
+    setAgentToDelete(agent);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!agentToDelete || !backendUrl) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const response = await fetch(
+        joinUrl(
+          backendUrl,
+          `/organizations/${orgId}/agents/${agentToDelete.id}`,
+        ),
+        { method: "DELETE", credentials: "include" },
+      );
+      if (response.ok) {
+        await mutate();
+        setAgentToDelete(null);
+      } else {
+        const info = await response.json().catch(() => ({}));
+        setDeleteError(info.error || "Failed to delete agent.");
+      }
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (agents.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No shared agents yet. Promote a workspace agent to the organization to
+        share it across workspaces.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <ul className="grid grid-cols-1 lg:grid-cols-2 gap-2 lg:gap-4">
+        {agents.map((agent) => (
+          <li key={agent.id}>
+            <Item variant="outline" className="h-full">
+              {agent.avatarUrl ? (
+                <ItemMedia variant="image" className="size-12 rounded-lg">
+                  <img
+                    src={agent.avatarUrl}
+                    alt={agent.name}
+                    className="size-full object-cover"
+                  />
+                </ItemMedia>
+              ) : (
+                <ItemMedia
+                  variant="icon"
+                  className="size-12 rounded-lg [&_svg]:!size-7"
+                >
+                  <Bot className="h-7 w-7 text-muted-foreground" />
+                </ItemMedia>
+              )}
+              <ItemContent>
+                <ItemTitle>{agent.name}</ItemTitle>
+                <ItemDescription className="text-xs line-clamp-3">
+                  {agent.description}
+                </ItemDescription>
+                {isOrgAdmin && (
+                  <div className="mt-1">
+                    <SharedWithBadge
+                      orgId={orgId}
+                      resourceType="agent"
+                      resourceId={agent.id}
+                    />
+                  </div>
+                )}
+              </ItemContent>
+              {isOrgAdmin && (
+                <ItemActions>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        className="cursor-pointer text-muted-foreground"
+                        variant="ghost"
+                        size="icon"
+                      >
+                        <EllipsisVertical className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent>
+                      <DropdownMenuItem asChild>
+                        <Link
+                          className="cursor-pointer"
+                          href={`/${orgId}/settings/agents/${agent.id}`}
+                        >
+                          <Pencil /> Edit
+                        </Link>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="cursor-pointer"
+                        onSelect={() => setAgentToManage(agent)}
+                      >
+                        <Share2 /> Manage attachments
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="cursor-pointer text-destructive focus:text-destructive"
+                        onSelect={() => requestDelete(agent)}
+                      >
+                        <Trash2 /> Delete
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </ItemActions>
+              )}
+            </Item>
+          </li>
+        ))}
+      </ul>
+
+      {agentToManage && (
+        <ManageAttachmentsDialog
+          orgId={orgId}
+          resourceType="agent"
+          resourceId={agentToManage.id}
+          resourceName={agentToManage.name}
+          open={!!agentToManage}
+          onOpenChange={(open) => !open && setAgentToManage(null)}
+        />
+      )}
+
+      <ConfirmDialog
+        open={!!agentToDelete}
+        onOpenChange={(open) => {
+          if (!open) {
+            setAgentToDelete(null);
+            setDeleteError(null);
+          }
+        }}
+        title="Delete shared agent"
+        description={`Delete "${agentToDelete?.name}"? This cannot be undone.`}
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        onConfirm={handleDeleteConfirm}
+        loading={deleting}
+        error={deleteError}
+      />
+
+      <ConfirmDialog
+        open={!!deleteBlocked}
+        onOpenChange={(open) => !open && setDeleteBlocked(null)}
+        title="Can't delete shared agent"
+        description={
+          deleteBlocked
+            ? `“${deleteBlocked.agent.name}” is shared with ${deleteBlocked.count} workspace${
+                deleteBlocked.count !== 1 ? "s" : ""
+              }. Detach it from every workspace before deleting.`
+            : ""
+        }
+        confirmLabel="Manage attachments"
+        cancelLabel="Close"
+        onConfirm={() => {
+          const agent = deleteBlocked?.agent ?? null;
+          setDeleteBlocked(null);
+          setAgentToManage(agent);
+        }}
+      />
+    </>
+  );
+};

--- a/apps/frontend/components/org-settings-menu.tsx
+++ b/apps/frontend/components/org-settings-menu.tsx
@@ -8,7 +8,15 @@ import {
   SidebarMenuItem,
   SidebarMenu,
 } from "@/components/ui/sidebar";
-import { Mail, Plug, Settings, Sparkles, Unplug, Users } from "lucide-react";
+import {
+  Bot,
+  Mail,
+  Plug,
+  Settings,
+  Sparkles,
+  Unplug,
+  Users,
+} from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -24,6 +32,7 @@ export function OrgSettingsMenu({ orgId }: OrgSettingsMenuProps) {
   const providersHref = `/${orgId}/settings/providers`;
   const mcpHref = `/${orgId}/settings/mcp`;
   const skillsHref = `/${orgId}/settings/skills`;
+  const agentsHref = `/${orgId}/settings/agents`;
 
   return (
     <SidebarContent>
@@ -84,6 +93,16 @@ export function OrgSettingsMenu({ orgId }: OrgSettingsMenuProps) {
               >
                 <Link href={skillsHref}>
                   <Sparkles /> Skills
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                asChild
+                isActive={pathname.startsWith(agentsHref)}
+              >
+                <Link href={agentsHref}>
+                  <Bot /> Agents
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>

--- a/apps/frontend/components/skills-list.tsx
+++ b/apps/frontend/components/skills-list.tsx
@@ -39,6 +39,7 @@ import {
   Link2,
   Pencil,
   Plus,
+  Share2,
   Trash2,
   TriangleAlert,
   Unlink,
@@ -50,6 +51,10 @@ import Link from "next/link";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { AttachSharedResourceDialog } from "@/components/attach-shared-resource-dialog";
+import {
+  ManageAttachmentsDialog,
+  SharedWithBadge,
+} from "@/components/manage-sharing";
 
 // The list serves two surfaces: a Workspace (workspaceId provided) where it
 // shows workspace-scoped Skills plus attached org-scoped Shared Skills as
@@ -81,6 +86,13 @@ export const SkillsList = ({
   );
   const [promoting, setPromoting] = useState(false);
   const [promoteError, setPromoteError] = useState<string | null>(null);
+  const [skillToManage, setSkillToManage] = useState<SkillWithScope | null>(
+    null,
+  );
+  const [deleteBlocked, setDeleteBlocked] = useState<{
+    skill: SkillWithScope;
+    count: number;
+  } | null>(null);
 
   const listUrl = workspaceId
     ? `/organizations/${orgId}/workspaces/${workspaceId}/skills`
@@ -129,9 +141,31 @@ export const SkillsList = ({
   const getAgentsForSkill = (skillId: string) =>
     agents.filter((agent) => agent.skillIds?.includes(skillId));
 
-  const handleDeleteClick = (skill: SkillWithScope) => {
-    setSkillToDelete(skill);
+  const handleDeleteClick = async (skill: SkillWithScope) => {
     setDeleteError(null);
+    // On the Organization surface a Shared Skill can't be deleted while attached
+    // (ADR-0007) — check the live count first and explain the blocker up front
+    // instead of offering a Delete button that is guaranteed to fail.
+    if (!workspaceId && backendUrl) {
+      try {
+        const res = await fetch(
+          joinUrl(
+            backendUrl,
+            `/organizations/${orgId}/attachments?resourceType=skill&resourceId=${skill.id}`,
+          ),
+          { credentials: "include" },
+        );
+        const info = await res.json().catch(() => ({ results: [] }));
+        const count = (info.results ?? []).length;
+        if (count > 0) {
+          setDeleteBlocked({ skill, count });
+          return;
+        }
+      } catch {
+        // If the check fails, fall through — the backend still guards with 409.
+      }
+    }
+    setSkillToDelete(skill);
     setDeleteDialogOpen(true);
   };
 
@@ -292,6 +326,15 @@ export const SkillsList = ({
                         )}
                       </div>
                     )}
+                    {!workspaceId && isOrgAdmin && (
+                      <div className="mt-1">
+                        <SharedWithBadge
+                          orgId={orgId}
+                          resourceType="skill"
+                          resourceId={skill.id}
+                        />
+                      </div>
+                    )}
                   </ItemContent>
                   <ItemActions>
                     <DropdownMenu>
@@ -325,6 +368,14 @@ export const SkillsList = ({
                             <ArrowUpFromLine /> Promote to organization
                           </DropdownMenuItem>
                         )}
+                        {!workspaceId && isOrgAdmin && (
+                          <DropdownMenuItem
+                            className="cursor-pointer"
+                            onSelect={() => setSkillToManage(skill)}
+                          >
+                            <Share2 /> Manage attachments
+                          </DropdownMenuItem>
+                        )}
                         <DropdownMenuSeparator />
                         <DropdownMenuItem
                           className="cursor-pointer text-destructive focus:text-destructive"
@@ -354,6 +405,17 @@ export const SkillsList = ({
           </Button>
         )}
       </div>
+
+      {skillToManage && (
+        <ManageAttachmentsDialog
+          orgId={orgId}
+          resourceType="skill"
+          resourceId={skillToManage.id}
+          resourceName={skillToManage.name}
+          open={!!skillToManage}
+          onOpenChange={(open) => !open && setSkillToManage(null)}
+        />
+      )}
 
       {canAttach && workspaceId && (
         <AttachSharedResourceDialog
@@ -441,6 +503,26 @@ export const SkillsList = ({
         onConfirm={handleDeleteConfirm}
         loading={deleting}
         error={deleteError}
+      />
+
+      <ConfirmDialog
+        open={!!deleteBlocked}
+        onOpenChange={(open) => !open && setDeleteBlocked(null)}
+        title="Can't delete shared skill"
+        description={
+          deleteBlocked
+            ? `“${deleteBlocked.skill.name}” is shared with ${deleteBlocked.count} workspace${
+                deleteBlocked.count !== 1 ? "s" : ""
+              }. Detach it from every workspace before deleting.`
+            : ""
+        }
+        confirmLabel="Manage attachments"
+        cancelLabel="Close"
+        onConfirm={() => {
+          const skill = deleteBlocked?.skill ?? null;
+          setDeleteBlocked(null);
+          setSkillToManage(skill);
+        }}
       />
     </>
   );

--- a/docs/adr/0007-organization-scoped-shared-resources.md
+++ b/docs/adr/0007-organization-scoped-shared-resources.md
@@ -53,14 +53,23 @@ never cascading.
   `Provider`) before a Shared Agent can reference one; Chat-turn MCP resolution, today
   workspace-scoped, must also resolve Organization-scoped MCPs. A down Shared MCP has
   org-wide blast radius, so its resolution should fail soft rather than throw.
-- **Role-based editing.** Org Admins edit a Shared resource where it is attached and via
-  the Organization management surface; Workspace Owners see it locked. Because only Org
-  Admins can Promote, the author is always an Org Admin and keeps their edit/test loop in
-  place. A non-admin who authored a resource is locked out of editing it once it is
+- **Role-based editing (Edit 1).** A Shared resource is edited **only on the
+  Organization management surface**; it is locked in every Workspace — to Workspace
+  Owners _and_ Org Admins alike (the Workspace renders it as a locked card that links out
+  to the Organization editor). Because only Org Admins can Promote, the author is always
+  an Org Admin; a non-admin who authored a resource is locked out of editing it once it is
   Shared — intentional, consistent with ADR-0006 (high-blast-radius config is
-  admin-managed).
+  admin-managed). _Originally specified as also editable in place in the Workspace where
+  attached; narrowed to org-surface-only so there is a single edit locus and no
+  "which-Workspace-do-I-open?" ambiguity, matching how Skills already behaved._
 - **Visibility.** A Shared resource appears in a Workspace only where attached; Promotion
   auto-attaches the origin Workspace. Org Admins see and manage every Shared resource,
   attached or not, only on the Organization management surface — not implicitly inside
   every Workspace.
 - **Deletion.** Deleting a Shared resource is blocked while any Attachment exists.
+  **(Edit 1)** On delete, the resource's id is scrubbed from every Agent that referenced
+  it (`skillIds`, `subAgentIds`, and MCP-backed `toolSetIds`), in the same transaction, so
+  deletion never leaves dangling references; `providerId` needs no scrub as it is a
+  foreign key with `onDelete: restrict`. **Detach** is deliberately _not_ scrubbed — it is
+  reversible, so an Agent's reference is preserved and resolves again if the resource is
+  re-attached.

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -74,12 +74,23 @@ describe("Attachment Schema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects an unknown resource type", () => {
+  it("validates an agent attachment", () => {
     const result = attachmentSchema.safeParse({
       id: "att-1",
       workspaceId: "ws-1",
       resourceType: "agent",
       resourceId: "agent-1",
+      createdAt: new Date(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown resource type", () => {
+    const result = attachmentSchema.safeParse({
+      id: "att-1",
+      workspaceId: "ws-1",
+      resourceType: "blueprint",
+      resourceId: "bp-1",
       createdAt: new Date(),
     });
     expect(result.success).toBe(false);

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -177,9 +177,15 @@ export type ChatList = z.infer<typeof chatListSchema>;
 
 // Agent
 
-export const agentSchema = z.object({
+// An Agent is scoped to either a Workspace or an Organization (mutually
+// exclusive), mirroring the dual-scope shape of `provider`/`mcp`/`skill`.
+// Org-scoped Agents are Shared resources managed by Org Admins (ADR-0007);
+// the XOR is enforced on `agentSchema` below, while the create routes inject
+// the scope and Promote re-scopes a Workspace Agent to the Organization.
+const agentBaseSchema = z.object({
   id: z.string(),
-  workspaceId: z.string(),
+  organizationId: z.string().optional(),
+  workspaceId: z.string().optional(),
   providerId: z.string(),
   name: z.string().min(3).max(30),
   description: z.string().min(1).max(128),
@@ -201,9 +207,22 @@ export const agentSchema = z.object({
   updatedAt: z.date(),
 });
 
+export const agentSchema = agentBaseSchema.refine(
+  (data) => {
+    const hasOrg = Boolean(data.organizationId);
+    const hasWorkspace = Boolean(data.workspaceId);
+    return (hasOrg || hasWorkspace) && !(hasOrg && hasWorkspace);
+  },
+  {
+    message:
+      "Agent must have either organizationId or workspaceId, but not both",
+    path: ["organizationId"],
+  },
+);
+
 export type Agent = z.infer<typeof agentSchema>;
 
-export const agentCreateSchema = agentSchema.pick({
+export const agentCreateSchema = agentBaseSchema.pick({
   workspaceId: true,
   providerId: true,
   name: true,
@@ -223,7 +242,7 @@ export const agentCreateSchema = agentSchema.pick({
   inputPlaceholder: true,
 });
 
-export const agentUpdateSchema = agentSchema.pick({
+export const agentUpdateSchema = agentBaseSchema.pick({
   providerId: true,
   name: true,
   description: true,
@@ -437,6 +456,7 @@ export const attachmentResourceTypeSchema = z.enum([
   "mcp",
   "provider",
   "skill",
+  "agent",
 ]);
 export type AttachmentResourceType = z.infer<
   typeof attachmentResourceTypeSchema


### PR DESCRIPTION
Closes #156.

Gives **Agents** the dual-scope shape and a **Promote** action (workspace → organization), enforcing the ADR-0007 **no-cascade** rule, then layers on the editing/governance refinements agreed in review.

## Backend
- **Dual scope + migration `0042`** — `agent` gains `organization_id` (+ `unique(org, name)`), `workspace_id` becomes nullable. Mutually-exclusive scope, mirroring `provider`/`mcp`/`skill`.
- **Promote (`POST /agents/:id/promote`)** — re-scopes a workspace Agent to the org and auto-attaches the origin workspace. Blocked unless Provider, Skills, sub-Agents, and MCP-backed tool sets are all org-scoped; returns the offending references as a `blockers` checklist. Static + Sandbox tool sets are always allowed (Sandbox rebinds per workspace).
- **Org-surface-only editing** — Shared Agents are managed on the Organization surface (`org-agent` CRUD + avatar routes); the workspace PUT/avatar routes return **403** for org-scoped agents (locked to Owners *and* Admins).
- **Cross-workspace execution** — chat-turn `getAgent` resolves a Shared Agent invoked from a borrowing workspace (gated by attachment); Sandbox/MCP tools still resolve against the invoking workspace.
- **Central attach/detach** — `org-attachment` route (list "where shared", attach, detach) + `GET /organizations/:orgId/tools` (static sets + org MCPs) for the org editor.
- **Scrub-on-delete** — deleting a shared resource removes its now-dead id from every referencing agent (`skillIds`/`subAgentIds`/`toolSetIds`) in the same transaction. Providers are FK `onDelete: restrict`.
- **Avatars** keyed scope-independently (`agents/<id>/...`) so Promote never leaves a stale path.

## Frontend
- Workspace agents list shows attached Shared Agents as **locked cards** (still runnable), with admin **Promote** (no-cascade checklist), **Attach**, and a link to the org editor.
- `agent-form` gains an **org mode**; new `/[orgId]/settings/agents` list + editor.
- **"Manage attachments"** searchable multi-select dialog + hover **"N workspaces"** badge on org agent/skill cards.
- Smarter delete: when still attached, blocks with a *Manage attachments* prompt instead of a doomed Delete button.

## Docs
- **ADR-0007 amended (Edit 1):** role-based editing narrowed to org-surface-only; scrub-on-delete documented.

## Tests
- All backend suites green (**847 tests**); frontend type-checks clean. New coverage: scoping, no-cascade (pass/fail + blockers), role-based lock, cross-workspace execution, org-tool/org-attachment/org-agent routes, and the reference scrub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)