### PR TITLE
fix(frontend): resolve deferred react-hooks & no-img-element lint errors

### DIFF
--- a/apps/frontend/app/oauth/mcp/callback/oauth-callback-handler.tsx
+++ b/apps/frontend/app/oauth/mcp/callback/oauth-callback-handler.tsx
@@ -29,13 +29,17 @@ export const OAuthCallbackHandler = ({
   state?: string;
 }) => {
   const backendUrl = useBackendUrl();
-  const [error, setError] = useState<string | null>(null);
-  const [isProcessing, setIsProcessing] = useState(true);
+  // code/state come from the URL and are fixed for the lifetime of this view,
+  // so the missing-parameter state is derived at init rather than set in an
+  // effect.
+  const missingParams = !code || !state;
+  const [error, setError] = useState<string | null>(
+    missingParams ? "Missing authorization code or state parameter." : null,
+  );
+  const [isProcessing, setIsProcessing] = useState(!missingParams);
 
   useEffect(() => {
     if (!code || !state) {
-      setError("Missing authorization code or state parameter.");
-      setIsProcessing(false);
       return;
     }
 

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -19,7 +19,7 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty";
 import { useAuth } from "@/components/auth-provider";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 
 export default function Home() {
@@ -32,7 +32,7 @@ export default function Home() {
     fetcher,
   );
 
-  const organizations = data?.results || [];
+  const organizations = useMemo(() => data?.results || [], [data]);
 
   // Redirect to first organization if available
   useEffect(() => {

--- a/apps/frontend/app/settings/contexts/page.tsx
+++ b/apps/frontend/app/settings/contexts/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useAuth } from "@/components/auth-provider";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
@@ -24,14 +24,17 @@ const ContextsPage = () => {
     results: ContextWithWorkspaceName[];
   }>(user ? joinUrl(backendUrl, "/users/me/contexts") : null, fetcher);
 
-  // Sync global context content to local state
-  useEffect(() => {
-    const globalCtx = contexts?.results.find((c) => !c.workspaceId);
-    setGlobalContextContent(globalCtx?.content || "");
-  }, [contexts]);
-
   const [globalContextContent, setGlobalContextContent] = useState("");
   const [isSavingGlobal, setIsSavingGlobal] = useState(false);
+
+  // Sync server-provided global context into editable local state whenever the
+  // fetched data changes, using React's "adjust state during render" pattern.
+  const [prevContexts, setPrevContexts] = useState(contexts);
+  if (contexts !== prevContexts) {
+    setPrevContexts(contexts);
+    const globalCtx = contexts?.results.find((c) => !c.workspaceId);
+    setGlobalContextContent(globalCtx?.content || "");
+  }
 
   const handleSaveGlobal = async () => {
     const globalCtx = contexts?.results.find((c) => !c.workspaceId);

--- a/apps/frontend/app/settings/page.tsx
+++ b/apps/frontend/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useAuth } from "@/components/auth-provider";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -14,11 +15,11 @@ const UserSettingsPage = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  useEffect(() => {
+  useResetOnChange(user?.name, () => {
     if (user?.name) {
       setName(user.name);
     }
-  }, [user?.name]);
+  });
 
   if (!user) return null;
 

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -20,8 +20,9 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import Link from "next/link";
 import {
   ChevronsUpDown,
@@ -101,7 +102,10 @@ const AgentForm = ({
   const { data: providersData, isLoading: providersLoading } = useSWR<{
     results: Provider[];
   }>(backendUrl && user ? joinUrl(backendUrl, providersBase) : null, fetcher);
-  const providers = providersData?.results || [];
+  const providers = useMemo(
+    () => providersData?.results || [],
+    [providersData],
+  );
 
   // Fetch skills
   const { data: skillsData } = useSWR<{ results: Skill[] }>(
@@ -161,23 +165,26 @@ const AgentForm = ({
   const router = useRouter();
 
   // Initialize with first provider's first model once providers are loaded
-  useEffect(() => {
-    if (
-      providers.length > 0 &&
-      !formData.modelId &&
-      !formData.providerId &&
-      !agentId
-    ) {
-      setFormData((prevData) => ({
-        ...prevData,
-        modelId: providers[0].modelIds[0],
-        providerId: providers[0].id,
-      }));
-    }
-  }, [providers, formData.modelId, formData.providerId, agentId]);
+  useResetOnChange(
+    `${providers.length}:${formData.modelId ?? ""}:${formData.providerId ?? ""}:${agentId ?? ""}`,
+    () => {
+      if (
+        providers.length > 0 &&
+        !formData.modelId &&
+        !formData.providerId &&
+        !agentId
+      ) {
+        setFormData((prevData) => ({
+          ...prevData,
+          modelId: providers[0].modelIds[0],
+          providerId: providers[0].id,
+        }));
+      }
+    },
+  );
 
   // Initialize form with existing agent data when editing
-  useEffect(() => {
+  useResetOnChange(agent, () => {
     if (agent) {
       setFormData({
         name: agent.name,
@@ -202,7 +209,7 @@ const AgentForm = ({
         setAvatarDeleted(false);
       }
     }
-  }, [agent]);
+  });
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -238,20 +245,23 @@ const AgentForm = ({
     }));
   };
 
+  const setAvatarFromFile = useCallback(
+    (file: File) => {
+      if (avatarPreviewUrl) {
+        URL.revokeObjectURL(avatarPreviewUrl);
+      }
+      setAvatarFile(file);
+      setAvatarPreviewUrl(URL.createObjectURL(file));
+      setAvatarDeleted(false);
+    },
+    [avatarPreviewUrl],
+  );
+
   const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
       setAvatarFromFile(file);
     }
-  };
-
-  const setAvatarFromFile = (file: File) => {
-    if (avatarPreviewUrl) {
-      URL.revokeObjectURL(avatarPreviewUrl);
-    }
-    setAvatarFile(file);
-    setAvatarPreviewUrl(URL.createObjectURL(file));
-    setAvatarDeleted(false);
   };
 
   const handleAvatarDelete = () => {
@@ -279,7 +289,7 @@ const AgentForm = ({
     };
     document.addEventListener("paste", handlePaste);
     return () => document.removeEventListener("paste", handlePaste);
-  }, [avatarPreviewUrl]);
+  }, [setAvatarFromFile]);
 
   const handleModelChange = (value: string) => {
     if (value.startsWith("provider:")) {
@@ -474,6 +484,9 @@ const AgentForm = ({
             >
               <div className="w-20 h-20 rounded-2xl bg-muted flex items-center justify-center overflow-hidden border-2 border-dashed border-muted-foreground/20 hover:border-muted-foreground/40 transition-colors">
                 {avatarPreviewUrl ? (
+                  // Local blob:/object-URL preview of the chosen file; the Next
+                  // image optimizer cannot process object URLs.
+                  // eslint-disable-next-line @next/next/no-img-element
                   <img
                     src={avatarPreviewUrl}
                     alt="Avatar"

--- a/apps/frontend/components/agents-list.tsx
+++ b/apps/frontend/components/agents-list.tsx
@@ -438,6 +438,9 @@ export const AgentsList = ({
               <Item variant="outline" className="h-full items-stretch">
                 {agent.avatarUrl ? (
                   <ItemMedia variant="image" className="size-12 rounded-lg">
+                    {/* Agent avatar URL is user-supplied (arbitrary host); not
+                    routable through the Next image optimizer. */}
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={agent.avatarUrl}
                       alt={agent.name}

--- a/apps/frontend/components/ai-elements/message.tsx
+++ b/apps/frontend/components/ai-elements/message.tsx
@@ -23,7 +23,14 @@ import type {
   ReactElement,
   ReactNode,
 } from "react";
-import { createContext, memo, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  memo,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { Streamdown } from "streamdown";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
@@ -203,7 +210,10 @@ export const MessageBranchContent = ({
   ...props
 }: MessageBranchContentProps) => {
   const { currentBranch, setBranches, branches } = useMessageBranch();
-  const childrenArray = Array.isArray(children) ? children : [children];
+  const childrenArray = useMemo(
+    () => (Array.isArray(children) ? children : [children]),
+    [children],
+  );
 
   // Use useEffect to update branches when they change
   useEffect(() => {
@@ -376,6 +386,9 @@ export function MessageAttachment({
     >
       {isImage ? (
         <>
+          {/* Attachment served from a blob:/data:/backend URL; not routable
+          through the Next image optimizer. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             alt={filename || "attachment"}
             className="size-full object-cover"

--- a/apps/frontend/components/ai-elements/model-selector.tsx
+++ b/apps/frontend/components/ai-elements/model-selector.tsx
@@ -175,6 +175,9 @@ export const ModelSelectorLogo = ({
   className,
   ...props
 }: ModelSelectorLogoProps) => (
+  // External SVG logo from models.dev; serving via the Next image optimizer
+  // would require whitelisting the host and dangerouslyAllowSVG.
+  // eslint-disable-next-line @next/next/no-img-element
   <img
     {...props}
     alt={`${provider} logo`}

--- a/apps/frontend/components/ai-elements/prompt-input.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.tsx
@@ -296,6 +296,9 @@ export function PromptInputAttachment({
           <div className="relative size-5 shrink-0">
             <div className="absolute inset-0 flex size-5 items-center justify-center overflow-hidden rounded bg-background transition-opacity group-hover:opacity-0">
               {isImage ? (
+                // Attachment served from a blob:/data:/backend URL; not
+                // routable through the Next image optimizer.
+                // eslint-disable-next-line @next/next/no-img-element
                 <img
                   alt={filename || "attachment"}
                   className="size-5 object-cover"
@@ -331,6 +334,9 @@ export function PromptInputAttachment({
         <div className="w-auto space-y-3">
           {isImage && (
             <div className="flex max-h-96 w-96 items-center justify-center overflow-hidden rounded-md border">
+              {/* Attachment served from a blob:/data:/backend URL; not
+              routable through the Next image optimizer. */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 alt={filename || "attachment preview"}
                 className="max-h-full max-w-full object-contain"
@@ -544,36 +550,51 @@ export const PromptInput = ({
     [matchesAccept, maxFiles, maxFileSize, onError],
   );
 
-  const add = usingProvider
-    ? (files: File[] | FileList) => controller.attachments.add(files)
-    : addLocal;
+  const add = useCallback(
+    (files: File[] | FileList) =>
+      usingProvider ? controller.attachments.add(files) : addLocal(files),
+    [usingProvider, controller, addLocal],
+  );
 
-  const remove = usingProvider
-    ? (id: string) => controller.attachments.remove(id)
-    : (id: string) =>
-        setItems((prev) => {
-          const found = prev.find((file) => file.id === id);
-          if (found?.url) {
-            URL.revokeObjectURL(found.url);
-          }
-          return prev.filter((file) => file.id !== id);
-        });
+  const remove = useCallback(
+    (id: string) => {
+      if (usingProvider) {
+        controller.attachments.remove(id);
+        return;
+      }
+      setItems((prev) => {
+        const found = prev.find((file) => file.id === id);
+        if (found?.url) {
+          URL.revokeObjectURL(found.url);
+        }
+        return prev.filter((file) => file.id !== id);
+      });
+    },
+    [usingProvider, controller],
+  );
 
-  const clear = usingProvider
-    ? () => controller.attachments.clear()
-    : () =>
-        setItems((prev) => {
-          for (const file of prev) {
-            if (file.url) {
-              URL.revokeObjectURL(file.url);
-            }
-          }
-          return [];
-        });
+  const clear = useCallback(() => {
+    if (usingProvider) {
+      controller.attachments.clear();
+      return;
+    }
+    setItems((prev) => {
+      for (const file of prev) {
+        if (file.url) {
+          URL.revokeObjectURL(file.url);
+        }
+      }
+      return [];
+    });
+  }, [usingProvider, controller]);
 
-  const openFileDialog = usingProvider
-    ? () => controller.attachments.openFileDialog()
-    : openFileDialogLocal;
+  const openFileDialog = useCallback(
+    () =>
+      usingProvider
+        ? controller.attachments.openFileDialog()
+        : openFileDialogLocal(),
+    [usingProvider, controller, openFileDialogLocal],
+  );
 
   // Let provider know about our hidden file input so external menus can call openFileDialog()
   useEffect(() => {
@@ -1154,6 +1175,10 @@ export const PromptInputSpeechButton = ({
       };
 
       recognitionRef.current = speechRecognition;
+      // Expose the constructed SpeechRecognition (an external browser API,
+      // only available after mount) to render so the mic button can enable;
+      // the setState here is part of initialising that external system.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setRecognition(speechRecognition);
     }
 

--- a/apps/frontend/components/ai-elements/reasoning.tsx
+++ b/apps/frontend/components/ai-elements/reasoning.tsx
@@ -65,10 +65,13 @@ export const Reasoning = memo(
     const [hasAutoClosed, setHasAutoClosed] = useState(false);
     const [startTime, setStartTime] = useState<number | null>(null);
 
-    // Track duration when streaming starts and ends
+    // Track duration when streaming starts and ends. This measures wall-clock
+    // time at the streaming transition (Date.now()), which can't be derived
+    // during render, so recording it via setState in this effect is intended.
     useEffect(() => {
       if (isStreaming) {
         if (startTime === null) {
+          // eslint-disable-next-line react-hooks/set-state-in-effect
           setStartTime(Date.now());
         }
       } else if (startTime !== null) {

--- a/apps/frontend/components/ai-elements/shimmer.tsx
+++ b/apps/frontend/components/ai-elements/shimmer.tsx
@@ -18,6 +18,23 @@ export type TextShimmerProps = {
   spread?: number;
 };
 
+// Cache motion components per element type. motion.create() must not run during
+// render (it would create a new component each time); caching keeps the
+// resulting component stable across renders. Typed as a generic HTML motion
+// component (motion.div) so it accepts the common HTML motion props used below.
+const motionComponentCache = new Map<ElementType, typeof motion.div>();
+
+const getMotionComponent = (component: ElementType) => {
+  let motionComponent = motionComponentCache.get(component);
+  if (!motionComponent) {
+    motionComponent = motion.create(
+      component as keyof JSX.IntrinsicElements,
+    ) as typeof motion.div;
+    motionComponentCache.set(component, motionComponent);
+  }
+  return motionComponent;
+};
+
 const ShimmerComponent = ({
   children,
   as: Component = "p",
@@ -25,16 +42,18 @@ const ShimmerComponent = ({
   duration = 2,
   spread = 2,
 }: TextShimmerProps) => {
-  const MotionComponent = motion.create(
-    Component as keyof JSX.IntrinsicElements,
-  );
-
   const dynamicSpread = useMemo(
     () => (children?.length ?? 0) * spread,
     [children, spread],
   );
 
+  // getMotionComponent returns a stable, module-cached component (keyed by the
+  // `as` element type, which never changes for a mounted instance), so it is
+  // not a new component created during render despite the rule's heuristic.
+  const MotionComponent = getMotionComponent(Component);
+
   return (
+    // eslint-disable-next-line react-hooks/static-components -- MotionComponent is module-cached and stable per `as` value
     <MotionComponent
       animate={{ backgroundPosition: "0% center" }}
       className={cn(

--- a/apps/frontend/components/ai-elements/tool.tsx
+++ b/apps/frontend/components/ai-elements/tool.tsx
@@ -33,7 +33,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
-import { isValidElement } from "react";
+import { createElement, isValidElement } from "react";
 import { CodeBlock } from "./code-block";
 
 /**
@@ -212,7 +212,9 @@ export const ToolHeader = ({
   state,
   ...props
 }: ToolHeaderProps) => {
-  const Icon = getToolIcon(type);
+  // getToolIcon returns a stable module-level Lucide icon; render via
+  // createElement so the dynamic selection isn't flagged as a component
+  // created during render.
   return (
     <CollapsibleTrigger
       className={cn(
@@ -222,7 +224,9 @@ export const ToolHeader = ({
       {...props}
     >
       <div className="flex items-center gap-2 min-w-0">
-        <Icon className="size-4 shrink-0 text-muted-foreground" />
+        {createElement(getToolIcon(type), {
+          className: "size-4 shrink-0 text-muted-foreground",
+        })}
         <span className="font-medium text-sm truncate select-text">
           {title ?? humanizeToolType(type)}
           {label && (

--- a/apps/frontend/components/auth-provider.tsx
+++ b/apps/frontend/components/auth-provider.tsx
@@ -90,10 +90,16 @@ export function AuthProvider({
 
   const orgId = params.orgId as string | undefined;
   const workspaceId = params.workspaceId as string | undefined;
+  // Depend on the user id rather than the user object so SWR revalidations
+  // (which produce a new object identity) don't re-trigger these fetches.
+  const userId = data?.user?.id;
 
-  // Fetch org membership when orgId changes
+  // Manually fetch org membership when the org/user changes. This is a
+  // data-fetching effect; the synchronous resets and loading flags below are
+  // part of its fetch lifecycle (a future refactor could move this to SWR).
   useEffect(() => {
-    if (!data?.user || !orgId) {
+    /* eslint-disable react-hooks/set-state-in-effect */
+    if (!userId || !orgId) {
       setOrgMembership(null);
       setHasFetchedOrg(false);
       setIsOrgMembershipLoading(false);
@@ -108,6 +114,7 @@ export function AuthProvider({
     setOrgMembership(null);
     setHasFetchedOrg(false);
     setIsOrgMembershipLoading(true);
+    /* eslint-enable react-hooks/set-state-in-effect */
     fetch(`${backendUrl}/organizations/${orgId}/membership`, {
       credentials: "include",
     })
@@ -122,11 +129,14 @@ export function AuthProvider({
         setIsOrgMembershipLoading(false);
         setHasFetchedOrg(true);
       });
-  }, [data?.user?.id, orgId, backendUrl]);
+  }, [userId, orgId, backendUrl, orgMembership?.organizationId]);
 
-  // Fetch workspace data when workspaceId changes (to determine ownership)
+  // Manually fetch workspace data when the workspace/org/user changes (to
+  // determine ownership). Data-fetching effect; the synchronous resets and
+  // loading flags below are part of its fetch lifecycle.
   useEffect(() => {
-    if (!data?.user || !workspaceId || !orgId) {
+    /* eslint-disable react-hooks/set-state-in-effect */
+    if (!userId || !workspaceId || !orgId) {
       setWorkspaceData(null);
       setHasFetchedWorkspace(false);
       setIsWorkspaceLoading(false);
@@ -136,6 +146,7 @@ export function AuthProvider({
     setWorkspaceData(null);
     setHasFetchedWorkspace(false);
     setIsWorkspaceLoading(true);
+    /* eslint-enable react-hooks/set-state-in-effect */
     fetch(`${backendUrl}/organizations/${orgId}/workspaces/${workspaceId}`, {
       credentials: "include",
     })
@@ -150,7 +161,7 @@ export function AuthProvider({
         setIsWorkspaceLoading(false);
         setHasFetchedWorkspace(true);
       });
-  }, [data?.user?.id, orgId, workspaceId, backendUrl]);
+  }, [userId, orgId, workspaceId, backendUrl]);
 
   // Computed permissions
   const isOrgAdmin = orgMembership?.role === "admin";

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -107,6 +107,9 @@ export const ChatMessage = memo(function ChatMessage({
   const assistantAvatar =
     message.role === "assistant" &&
     (messageAgent?.avatarUrl ? (
+      // Agent avatar URL is user-supplied (arbitrary host); not routable
+      // through the Next image optimizer.
+      // eslint-disable-next-line @next/next/no-img-element
       <img
         src={messageAgent.avatarUrl}
         alt={messageAgent.name}
@@ -270,6 +273,9 @@ export const ChatMessage = memo(function ChatMessage({
               avatar={assistantAvatar}
             >
               <MessageContent className="max-w-full">
+                {/* Generated/uploaded image served from a backend or data: URL;
+                not routable through the Next image optimizer. */}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   src={filePart.url}
                   alt={filePart.filename || "Generated image"}

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -36,6 +36,7 @@ import {
 import { type PlatypusUIMessage } from "@platypus/backend/src/types";
 import useSWR from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useChatSettings } from "@/hooks/use-chat-settings";
 import { useModelSelection } from "@/hooks/use-model-selection";
 import { useMessageEditing } from "@/hooks/use-message-editing";
@@ -174,7 +175,10 @@ export const Chat = ({
     // Transport: `body` is a function so it's re-evaluated on every request.
     // This ensures dynamic values like agentId and model config are always current.
     // We use `getRequestBodyRef` (a ref) to avoid stale closures since this
-    // transport instance is created once and captured by useChat.
+    // transport instance is created once and captured by useChat. The `body`
+    // callback reads the ref at request time (not during render), which the
+    // static analysis can't prove from the construction site.
+    // eslint-disable-next-line react-hooks/refs
     transport: new DefaultChatTransport({
       api: joinUrl(
         backendUrl || "",
@@ -280,8 +284,11 @@ export const Chat = ({
     search,
   ]);
 
-  // Update ref whenever getRequestBody changes
-  getRequestBodyRef.current = getRequestBody;
+  // Update ref whenever getRequestBody changes. Written in an effect (not
+  // during render) so the transport body callback reads the latest value.
+  useEffect(() => {
+    getRequestBodyRef.current = getRequestBody;
+  }, [getRequestBody]);
 
   // Message editing hook (needs getRequestBody to be defined)
   const messageEditing = useMessageEditing(
@@ -305,7 +312,11 @@ export const Chat = ({
   // the streaming status transitions. Without this, ending a stream would
   // trigger the effect and overwrite the fresh messages with stale SWR data.
   const statusRef = useRef(status);
-  statusRef.current = status;
+  // Written in an effect (not during render) so the hydrate effect below reads
+  // the status committed by the previous render.
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
 
   useEffect(() => {
     if (
@@ -339,9 +350,7 @@ export const Chat = ({
   }, [initialAgentId, agentId, chatData, modelSetters]);
 
   // Reset search when model or provider changes
-  useEffect(() => {
-    setSearch(false);
-  }, [modelId, providerId]);
+  useResetOnChange(`${modelId}:${providerId}`, () => setSearch(false));
 
   const handleCopyMessage = useCallback(
     async (content: string, messageId: string) => {

--- a/apps/frontend/components/collapsible-section.tsx
+++ b/apps/frontend/components/collapsible-section.tsx
@@ -26,8 +26,12 @@ export function CollapsibleSection({
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
+    // Reads localStorage (client-only) to restore the persisted open state
+    // after mount. Doing this during render would break SSR/hydration, so the
+    // setState here is intentional.
     const stored = localStorage.getItem(storageKey);
     if (stored !== null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setOpen(stored !== "false");
     }
   }, [storageKey]);

--- a/apps/frontend/components/expandable-textarea.tsx
+++ b/apps/frontend/components/expandable-textarea.tsx
@@ -36,23 +36,28 @@ function ExpandableTextarea({
   );
   const [draftValue, setDraftValue] = React.useState("");
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+  // Mirror draftValue into a ref so commitDraft reads the latest value even
+  // from the Escape-key effect's stale closure. Updated in an effect rather
+  // than during render (refs must not be written during render).
   const draftRef = React.useRef(draftValue);
-  draftRef.current = draftValue;
+  React.useEffect(() => {
+    draftRef.current = draftValue;
+  }, [draftValue]);
 
-  const commitDraft = () => {
+  const commitDraft = React.useCallback(() => {
     if (onChange && draftRef.current !== value) {
       const event = {
         target: { value: draftRef.current, id: id ?? "" },
       } as React.ChangeEvent<HTMLTextAreaElement>;
       onChange(event);
     }
-  };
+  }, [onChange, value, id]);
 
-  const closeExpanded = () => {
+  const closeExpanded = React.useCallback(() => {
     commitDraft();
     setActiveTab("write");
     setIsExpanded(false);
-  };
+  }, [commitDraft]);
 
   const openExpanded = () => {
     setDraftValue(typeof value === "string" ? value : "");
@@ -75,7 +80,7 @@ function ExpandableTextarea({
     };
     window.addEventListener("keydown", handleEsc);
     return () => window.removeEventListener("keydown", handleEsc);
-  }, [isExpanded]);
+  }, [isExpanded, closeExpanded]);
 
   const displayValue = isExpanded ? draftValue : value;
   const currentLength =

--- a/apps/frontend/components/kanban-board.tsx
+++ b/apps/frontend/components/kanban-board.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import {
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+} from "react";
 import useSWR from "swr";
 import {
   DndContext,
@@ -165,24 +172,38 @@ export function KanbanBoard({
   const [deleteColumnId, setDeleteColumnId] = useState<string | null>(null);
   const [deleteColumnHasCards, setDeleteColumnHasCards] = useState(false);
 
-  const columns: ColumnWithCards[] = localColumns ?? data?.columns ?? [];
+  const columns: ColumnWithCards[] = useMemo(
+    () => localColumns ?? data?.columns ?? [],
+    [localColumns, data],
+  );
   const labels = data?.board.labels ?? [];
 
-  const prevDataRef = useRef(data);
-  if (data !== prevDataRef.current && !activeId) {
-    prevDataRef.current = data;
-    if (localColumns) setLocalColumns(null);
+  // When fresh server data arrives (and we're not mid-drag), drop the local
+  // optimistic copy so the board reflects the server. Uses React's "adjust
+  // state during render" pattern (state, not a ref, to avoid reading/writing
+  // a ref during render).
+  const [prevData, setPrevData] = useState(data);
+  if (data !== prevData && !activeId) {
+    setPrevData(data);
+    // Use the raw state setter here: setLocalColumns writes localColumnsRef,
+    // and refs must not be written during render. The ref is re-synced on the
+    // next drag start (and only ever read inside drag handlers), so leaving it
+    // until then is safe.
+    if (localColumns) _setLocalColumns(null);
   }
 
-  // Detect desktop via pointer: fine media query to disable drag on touch devices
-  const [isDesktop, setIsDesktop] = useState(false);
-  useEffect(() => {
-    const mql = window.matchMedia("(pointer: fine)");
-    setIsDesktop(mql.matches);
-    const onChange = () => setIsDesktop(mql.matches);
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
+  // Detect desktop via pointer: fine media query to disable drag on touch
+  // devices. useSyncExternalStore subscribes to the media query without a
+  // setState-in-effect and stays SSR-safe (server snapshot is false).
+  const isDesktop = useSyncExternalStore(
+    (onChange) => {
+      const mql = window.matchMedia("(pointer: fine)");
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    },
+    () => window.matchMedia("(pointer: fine)").matches,
+    () => false,
+  );
 
   const updateCardIdParam = useCallback(
     (cardId: string | null) => {
@@ -198,7 +219,9 @@ export function KanbanBoard({
     [searchParams, router, pathname],
   );
 
-  // Open card dialog from URL query param on initial data load
+  // Open card dialog from URL query param on initial data load. Runs once when
+  // data first arrives, reads the URL, and may navigate (updateCardIdParam) —
+  // genuine effect work, so opening the dialog via setState here is intended.
   const deepLinkHandledRef = useRef(false);
   useEffect(() => {
     if (deepLinkHandledRef.current || !data) return;
@@ -209,6 +232,7 @@ export function KanbanBoard({
       .flatMap((col) => col.cards)
       .find((c) => c.id === cardId);
     if (card) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedCard(card);
       setDialogOpen(true);
     } else {
@@ -257,99 +281,102 @@ export function KanbanBoard({
       activeTypeRef.current = type;
       setLocalColumns([...columns.map((c) => ({ ...c, cards: [...c.cards] }))]);
     },
-    [columns],
+    [columns, setLocalColumns],
   );
 
-  const handleDragOver = useCallback((event: DragOverEvent) => {
-    const { active, over } = event;
-    if (!over || activeTypeRef.current !== "card") return;
+  const handleDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const { active, over } = event;
+      if (!over || activeTypeRef.current !== "card") return;
 
-    // Skip if we already scheduled an update this frame: a previous
-    // drag-over already set localColumns, and processing another one before
-    // React flushes can re-trigger this handler off the resulting layout
-    // shift.
-    if (dragOverFrameRef.current !== null) return;
+      // Skip if we already scheduled an update this frame: a previous
+      // drag-over already set localColumns, and processing another one before
+      // React flushes can re-trigger this handler off the resulting layout
+      // shift.
+      if (dragOverFrameRef.current !== null) return;
 
-    const cols = localColumnsRef.current;
-    if (!cols) return;
+      const cols = localColumnsRef.current;
+      if (!cols) return;
 
-    const activeColumn = cols.find((col) =>
-      col.cards.some((c) => c.id === active.id),
-    );
-    const overId = String(over.id);
-    const droppableColumnId = parseDropZoneId(overId);
-    const overColumn =
-      (droppableColumnId
-        ? cols.find((col) => col.id === droppableColumnId)
-        : null) ??
-      cols.find((col) => col.id === over.id) ??
-      cols.find((col) => col.cards.some((c) => c.id === over.id));
-
-    if (!activeColumn || !overColumn) return;
-
-    const scheduleNextFrame = () => {
-      dragOverFrameRef.current = requestAnimationFrame(() => {
-        dragOverFrameRef.current = null;
-      });
-    };
-
-    // Same column reorder
-    if (activeColumn.id === overColumn.id) {
-      const activeIndex = activeColumn.cards.findIndex(
-        (c) => c.id === active.id,
+      const activeColumn = cols.find((col) =>
+        col.cards.some((c) => c.id === active.id),
       );
-      const overIndex = overColumn.cards.findIndex((c) => c.id === over.id);
-      // overIndex === -1 means hovering over the column drop zone → move to end
-      const targetIndex =
-        overIndex === -1 ? activeColumn.cards.length - 1 : overIndex;
-      if (activeIndex !== targetIndex) {
-        scheduleNextFrame();
-        setLocalColumns((prev) => {
-          if (!prev) return prev;
-          return prev.map((c) =>
-            c.id === activeColumn.id
-              ? { ...c, cards: arrayMove(c.cards, activeIndex, targetIndex) }
-              : c,
-          );
-        });
-      }
-      return;
-    }
+      const overId = String(over.id);
+      const droppableColumnId = parseDropZoneId(overId);
+      const overColumn =
+        (droppableColumnId
+          ? cols.find((col) => col.id === droppableColumnId)
+          : null) ??
+        cols.find((col) => col.id === over.id) ??
+        cols.find((col) => col.cards.some((c) => c.id === over.id));
 
-    // Cross-column move
-    const activeColId = activeColumn.id;
-    const overColId = overColumn.id;
-    const overCardId = over.id;
-    scheduleNextFrame();
-    setLocalColumns((prev) => {
-      if (!prev) return prev;
-      return prev.map((c) => {
-        if (c.id === activeColId) {
-          return {
-            ...c,
-            cards: c.cards.filter((card) => card.id !== active.id),
-          };
+      if (!activeColumn || !overColumn) return;
+
+      const scheduleNextFrame = () => {
+        dragOverFrameRef.current = requestAnimationFrame(() => {
+          dragOverFrameRef.current = null;
+        });
+      };
+
+      // Same column reorder
+      if (activeColumn.id === overColumn.id) {
+        const activeIndex = activeColumn.cards.findIndex(
+          (c) => c.id === active.id,
+        );
+        const overIndex = overColumn.cards.findIndex((c) => c.id === over.id);
+        // overIndex === -1 means hovering over the column drop zone → move to end
+        const targetIndex =
+          overIndex === -1 ? activeColumn.cards.length - 1 : overIndex;
+        if (activeIndex !== targetIndex) {
+          scheduleNextFrame();
+          setLocalColumns((prev) => {
+            if (!prev) return prev;
+            return prev.map((c) =>
+              c.id === activeColumn.id
+                ? { ...c, cards: arrayMove(c.cards, activeIndex, targetIndex) }
+                : c,
+            );
+          });
         }
-        if (c.id === overColId) {
-          const movedCard = activeColumn.cards.find(
-            (card) => card.id === active.id,
-          );
-          if (!movedCard) return c;
-          const newCards = [...c.cards];
-          const overIndex = newCards.findIndex(
-            (card) => card.id === overCardId,
-          );
-          if (overIndex >= 0) {
-            newCards.splice(overIndex, 0, movedCard);
-          } else {
-            newCards.push(movedCard);
+        return;
+      }
+
+      // Cross-column move
+      const activeColId = activeColumn.id;
+      const overColId = overColumn.id;
+      const overCardId = over.id;
+      scheduleNextFrame();
+      setLocalColumns((prev) => {
+        if (!prev) return prev;
+        return prev.map((c) => {
+          if (c.id === activeColId) {
+            return {
+              ...c,
+              cards: c.cards.filter((card) => card.id !== active.id),
+            };
           }
-          return { ...c, cards: newCards };
-        }
-        return c;
+          if (c.id === overColId) {
+            const movedCard = activeColumn.cards.find(
+              (card) => card.id === active.id,
+            );
+            if (!movedCard) return c;
+            const newCards = [...c.cards];
+            const overIndex = newCards.findIndex(
+              (card) => card.id === overCardId,
+            );
+            if (overIndex >= 0) {
+              newCards.splice(overIndex, 0, movedCard);
+            } else {
+              newCards.push(movedCard);
+            }
+            return { ...c, cards: newCards };
+          }
+          return c;
+        });
       });
-    });
-  }, []);
+    },
+    [setLocalColumns],
+  );
 
   const handleDragEnd = useCallback(
     async (event: DragEndEvent) => {
@@ -514,7 +541,7 @@ export function KanbanBoard({
         setLocalColumns(null);
       }
     },
-    [baseUrl, mutate],
+    [baseUrl, mutate, setLocalColumns],
   );
 
   const handleAddColumn = useCallback(() => {
@@ -646,7 +673,7 @@ export function KanbanBoard({
         setLocalColumns(null);
       }
     },
-    [data?.columns, baseUrl, mutate],
+    [data?.columns, baseUrl, mutate, setLocalColumns],
   );
 
   const handleCardSave = useCallback(

--- a/apps/frontend/components/kanban-card-dialog.tsx
+++ b/apps/frontend/components/kanban-card-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { format } from "date-fns";
@@ -282,20 +283,25 @@ export function KanbanCardDialog({
     setIsEditing(true);
   };
 
-  useEffect(() => {
-    if (card) {
-      setTitle(card.title);
-      setBody(card.body ?? "");
-      setSelectedLabelIds(card.labelIds ?? []);
-      setSelectedAssignees(card.assignees ?? []);
-      setSelectedDueDate((card.dueDate as string) ?? null);
-      setSelectedPriority(card.priority ?? "none");
-      setSelectedColumnId(initialColumnId);
-      setIsEditing(false);
-      setNewCommentBody("");
-      setEditingCommentId(null);
-    }
-  }, [card, initialColumnId]);
+  // Re-initialise the dialog whenever a different card is shown, the card is
+  // updated server-side, or the target column changes.
+  useResetOnChange(
+    `${card?.id ?? ""}:${String(card?.updatedAt ?? "")}:${initialColumnId ?? ""}`,
+    () => {
+      if (card) {
+        setTitle(card.title);
+        setBody(card.body ?? "");
+        setSelectedLabelIds(card.labelIds ?? []);
+        setSelectedAssignees(card.assignees ?? []);
+        setSelectedDueDate((card.dueDate as string) ?? null);
+        setSelectedPriority(card.priority ?? "none");
+        setSelectedColumnId(initialColumnId);
+        setIsEditing(false);
+        setNewCommentBody("");
+        setEditingCommentId(null);
+      }
+    },
+  );
 
   if (!card) return null;
 

--- a/apps/frontend/components/kanban-column.tsx
+++ b/apps/frontend/components/kanban-column.tsx
@@ -179,12 +179,13 @@ function ColumnContent({
   );
 }
 
-const KanbanColumnComponentInner = function KanbanColumnComponent({
+// Sortable variant: owns the dnd-kit hooks. Kept separate from the overlay
+// path so the hooks below are never called conditionally (rules-of-hooks).
+function SortableKanbanColumn({
   column,
   labels,
   draggable = true,
   isDraggingColumn = false,
-  overlay = false,
   isFirst = false,
   isLast = false,
   onCardClick,
@@ -193,27 +194,6 @@ const KanbanColumnComponentInner = function KanbanColumnComponent({
   onDeleteColumn,
   onMoveColumn,
 }: KanbanColumnProps) {
-  // Overlay instances render as plain static elements — no dnd hooks
-  if (overlay) {
-    return (
-      <div className="flex flex-col w-80 min-w-80 shrink-0 bg-muted/50 rounded-lg">
-        <ColumnContent
-          column={column}
-          labels={labels}
-          draggable={false}
-          isFirst={isFirst}
-          isLast={isLast}
-          onCardClick={onCardClick}
-          onAddCard={onAddCard}
-          onEditColumn={onEditColumn}
-          onDeleteColumn={onDeleteColumn}
-          onMoveColumn={onMoveColumn}
-          overlay
-        />
-      </div>
-    );
-  }
-
   const {
     attributes,
     listeners,
@@ -277,6 +257,32 @@ const KanbanColumnComponentInner = function KanbanColumnComponent({
       />
     </div>
   );
-};
+}
+
+function KanbanColumnComponentInner(props: KanbanColumnProps) {
+  // Overlay instances render as plain static elements — no dnd hooks. Delegate
+  // the interactive case to SortableKanbanColumn so its hooks always run.
+  if (props.overlay) {
+    return (
+      <div className="flex flex-col w-80 min-w-80 shrink-0 bg-muted/50 rounded-lg">
+        <ColumnContent
+          column={props.column}
+          labels={props.labels}
+          draggable={false}
+          isFirst={props.isFirst}
+          isLast={props.isLast}
+          onCardClick={props.onCardClick}
+          onAddCard={props.onAddCard}
+          onEditColumn={props.onEditColumn}
+          onDeleteColumn={props.onDeleteColumn}
+          onMoveColumn={props.onMoveColumn}
+          overlay
+        />
+      </div>
+    );
+  }
+
+  return <SortableKanbanColumn {...props} />;
+}
 
 export const KanbanColumnComponent = memo(KanbanColumnComponentInner);

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { useState, useEffect } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type MCP } from "@platypus/schemas";
 import useSWR from "swr";
@@ -116,7 +117,7 @@ const McpForm = ({
     fetcher,
   );
 
-  useEffect(() => {
+  useResetOnChange(mcp, () => {
     if (mcp) {
       const existingHeaders = (mcp as { headers?: Record<string, string> })
         .headers;
@@ -137,7 +138,7 @@ const McpForm = ({
         headerRows,
       });
     }
-  }, [mcp]);
+  });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;

--- a/apps/frontend/components/members-list.tsx
+++ b/apps/frontend/components/members-list.tsx
@@ -55,6 +55,9 @@ export function MembersList({ orgId, members, onUpdate }: MembersListProps) {
                   <div className="flex items-center gap-3">
                     <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center overflow-hidden">
                       {member.user.image ? (
+                        // Avatar URL comes from an arbitrary OAuth/external
+                        // host; not routable through the Next image optimizer.
+                        // eslint-disable-next-line @next/next/no-img-element
                         <img
                           src={member.user.image}
                           alt={member.user.name}

--- a/apps/frontend/components/org-agents-list.tsx
+++ b/apps/frontend/components/org-agents-list.tsx
@@ -127,6 +127,9 @@ export const OrgAgentsList = ({ orgId }: { orgId: string }) => {
             <Item variant="outline" className="h-full">
               {agent.avatarUrl ? (
                 <ItemMedia variant="image" className="size-12 rounded-lg">
+                  {/* Agent avatar URL is user-supplied (arbitrary host); not
+                  routable through the Next image optimizer. */}
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src={agent.avatarUrl}
                     alt={agent.name}

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -17,7 +17,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type Organization } from "@platypus/schemas";
 import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
@@ -54,11 +55,11 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
   const [deleteInput, setDeleteInput] = useState("");
   const [isDeleting, setIsDeleting] = useState(false);
 
-  useEffect(() => {
+  useResetOnChange(organization, () => {
     if (organization) {
       setFormData({ name: organization.name });
     }
-  }, [organization]);
+  });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;

--- a/apps/frontend/components/sandbox-settings.tsx
+++ b/apps/frontend/components/sandbox-settings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useMemo, useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import useSWR from "swr";
 import { toast } from "sonner";
 import { Box, Plus, Trash2, X } from "lucide-react";
@@ -229,7 +230,7 @@ const SandboxSettings = ({
   const { data: backendsData, isLoading: backendsLoading } = useSWR<{
     results: SandboxBackend[];
   }>(backendUrl && user ? `${sandboxUrl}/backends` : null, fetcher);
-  const backends = backendsData?.results ?? [];
+  const backends = useMemo(() => backendsData?.results ?? [], [backendsData]);
 
   // Operator network allowlist — admin-only endpoint (ADR-0005).
   const { data: networksData } = useSWR<{ results: string[] }>(
@@ -255,7 +256,7 @@ const SandboxSettings = ({
   }>({ open: false, kind: null, message: "" });
   const [isForcing, setIsForcing] = useState(false);
 
-  useEffect(() => {
+  useResetOnChange(data, () => {
     if (data) {
       const config = (data.config ?? {}) as {
         networks?: string[];
@@ -269,12 +270,18 @@ const SandboxSettings = ({
         networks: config.networks ?? [],
         extraHosts: extraHostsToRows(config.extraHosts),
       });
-    } else if (backends.length > 0) {
+    }
+  });
+
+  // When creating (no existing record), default the backend to the first
+  // available one until the user picks another.
+  useResetOnChange(backends, () => {
+    if (!data && backends.length > 0) {
       setFormData((prev) =>
         prev.backend ? prev : { ...prev, backend: backends[0].backend },
       );
     }
-  }, [data, backends]);
+  });
 
   const clearError = (field: string) => {
     if (validationErrors[field]) {

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -14,7 +14,8 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 import { type Skill, type Agent } from "@platypus/schemas";
@@ -87,7 +88,7 @@ const SkillForm = ({
   const router = useRouter();
 
   // Initialize form with existing skill data when editing
-  useEffect(() => {
+  useResetOnChange(skill, () => {
     if (skill) {
       setFormData({
         name: skill.name,
@@ -95,14 +96,14 @@ const SkillForm = ({
         body: skill.body,
       });
     }
-  }, [skill]);
+  });
 
   // Initialize agent selections from the skill's agentIds
-  useEffect(() => {
+  useResetOnChange(skill, () => {
     if (skill?.agentIds) {
       setSelectedAgentIds(skill.agentIds);
     }
-  }, [skill]);
+  });
 
   if (skillLoading) {
     return <div className={classNames}>Loading...</div>;

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -14,7 +14,8 @@ import { AgentAvatar } from "@/components/agent-avatar";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 import {
@@ -298,7 +299,7 @@ const TriggerForm = ({
       : null,
     fetcher,
   );
-  const agents = agentsData?.results || [];
+  const agents = useMemo(() => agentsData?.results || [], [agentsData]);
 
   const { data: boardsData } = useSWR<{
     results: KanbanBoard[];
@@ -376,7 +377,7 @@ const TriggerForm = ({
 
   const router = useRouter();
 
-  useEffect(() => {
+  useResetOnChange(trigger, () => {
     if (trigger) {
       setTriggerType(trigger.type);
       setFormData({
@@ -416,13 +417,19 @@ const TriggerForm = ({
         setFilterBoardId(eventConfig.filters?.boardId || "");
         setFilterColumnId(eventConfig.filters?.columnId || "");
       }
-    } else if (agents.length > 0) {
+    }
+  });
+
+  // When creating (no existing trigger), default the agent to the first
+  // available one until the user picks another.
+  useResetOnChange(agents, () => {
+    if (!trigger && agents.length > 0) {
       setFormData((prev) => ({
         ...prev,
         agentId: agents[0].id,
       }));
     }
-  }, [trigger, agents]);
+  });
 
   const effectiveCronExpression = useMemo(() => {
     if (scheduleMode === "simple") {

--- a/apps/frontend/components/ui/carousel.tsx
+++ b/apps/frontend/components/ui/carousel.tsx
@@ -95,6 +95,10 @@ function Carousel({
 
   React.useEffect(() => {
     if (!api) return;
+    // Subscribe to the embla carousel (an external system) and take an initial
+    // snapshot of its state; the synchronous sync here is the documented
+    // subscribe-and-sync pattern.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     onSelect(api);
     api.on("reInit", onSelect);
     api.on("select", onSelect);

--- a/apps/frontend/components/ui/sidebar.tsx
+++ b/apps/frontend/components/ui/sidebar.tsx
@@ -614,10 +614,16 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<"div"> & {
   showIcon?: boolean;
 }) {
-  // Random width between 50 to 90%.
+  // Pseudo-random width between 50 and 90%, derived deterministically from a
+  // stable id so render stays pure (no Math.random() during render).
+  const id = React.useId();
   const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+    let hash = 0;
+    for (let i = 0; i < id.length; i++) {
+      hash = (hash * 31 + id.charCodeAt(i)) | 0;
+    }
+    return `${(Math.abs(hash) % 40) + 50}%`;
+  }, [id]);
 
   return (
     <div

--- a/apps/frontend/components/webhook-form.tsx
+++ b/apps/frontend/components/webhook-form.tsx
@@ -12,7 +12,8 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
@@ -40,31 +41,30 @@ interface WebhookFormProps {
   webhookId?: string;
 }
 
+const ALL_EVENTS = [
+  "notification.created",
+  "notification.updated",
+  "notification.read",
+  "notification.dismissed",
+  "card.created",
+  "card.updated",
+  "card.deleted",
+] as const;
+
+const EVENT_LABELS: Record<string, string> = {
+  "notification.created": "Notification created",
+  "notification.updated": "Notification updated",
+  "notification.read": "Notification read",
+  "notification.dismissed": "Notification dismissed",
+  "card.created": "Card created",
+  "card.updated": "Card updated",
+  "card.deleted": "Card deleted",
+};
+
 const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
   const { user } = useAuth();
   const backendUrl = useBackendUrl();
   const router = useRouter();
-  const hasInitialized = useRef(false);
-
-  const ALL_EVENTS = [
-    "notification.created",
-    "notification.updated",
-    "notification.read",
-    "notification.dismissed",
-    "card.created",
-    "card.updated",
-    "card.deleted",
-  ] as const;
-
-  const EVENT_LABELS: Record<string, string> = {
-    "notification.created": "Notification created",
-    "notification.updated": "Notification updated",
-    "notification.read": "Notification read",
-    "notification.dismissed": "Notification dismissed",
-    "card.created": "Card created",
-    "card.updated": "Card updated",
-    "card.deleted": "Card deleted",
-  };
 
   const [name, setName] = useState("");
   const [url, setUrl] = useState("");
@@ -84,11 +84,6 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
 
   const isEditMode = !!webhookId;
 
-  // Reset initialization when webhookId changes
-  useEffect(() => {
-    hasInitialized.current = false;
-  }, [webhookId]);
-
   const fetchUrl =
     webhookId && user
       ? joinUrl(
@@ -103,8 +98,9 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
     mutate,
   } = useSWR<Webhook>(fetchUrl, fetcher);
 
-  useEffect(() => {
-    if (webhook && !hasInitialized.current) {
+  // Initialise the form from the loaded webhook, once per webhook id.
+  useResetOnChange(webhook?.id, () => {
+    if (webhook) {
       setName(webhook.name);
       setUrl(webhook.url);
       setEnabled(webhook.enabled);
@@ -119,9 +115,8 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
       } else {
         setHeaders([]);
       }
-      hasInitialized.current = true;
     }
-  }, [webhook]);
+  });
 
   const toggleEvent = (event: string) => {
     setEvents((prev) => {

--- a/apps/frontend/components/widgets/BarChartWidget.tsx
+++ b/apps/frontend/components/widgets/BarChartWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from "recharts";
 import type { Widget, BarChartWidgetData } from "@platypus/schemas";
 import {
@@ -43,17 +44,13 @@ export function BarChartWidget({
     toSeriesEntries(data?.series),
   );
 
-  useEffect(() => {
-    setTitle(widget.title);
-  }, [widget.title]);
-
-  useEffect(() => {
+  useResetOnChange(widget.title, () => setTitle(widget.title));
+  // updatedAt tracks server-side changes; array refs are not stable across renders
+  useResetOnChange(String(widget.updatedAt), () => {
     setYAxisLabel(data?.yAxisLabel ?? "");
     setCategoriesText(data?.categories?.join(", ") ?? "");
     setSeries(toSeriesEntries(data?.series));
-    // updatedAt tracks server-side changes; array refs are not stable across renders
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [String(widget.updatedAt)]);
+  });
 
   if (editing) {
     return (

--- a/apps/frontend/components/widgets/ImageWidget.tsx
+++ b/apps/frontend/components/widgets/ImageWidget.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import type { Widget } from "@platypus/schemas";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -20,13 +21,8 @@ export function ImageWidget({
   const [title, setTitle] = useState(widget.title);
   const [url, setUrl] = useState(data?.url ?? "");
 
-  useEffect(() => {
-    setTitle(widget.title);
-  }, [widget.title]);
-
-  useEffect(() => {
-    setUrl(data?.url ?? "");
-  }, [data?.url]);
+  useResetOnChange(widget.title, () => setTitle(widget.title));
+  useResetOnChange(data?.url, () => setUrl(data?.url ?? ""));
 
   if (editing) {
     return (

--- a/apps/frontend/components/widgets/LineChartWidget.tsx
+++ b/apps/frontend/components/widgets/LineChartWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid } from "recharts";
 import type { Widget, LineChartWidgetData } from "@platypus/schemas";
 import {
@@ -43,17 +44,13 @@ export function LineChartWidget({
     toSeriesEntries(data?.series),
   );
 
-  useEffect(() => {
-    setTitle(widget.title);
-  }, [widget.title]);
-
-  useEffect(() => {
+  useResetOnChange(widget.title, () => setTitle(widget.title));
+  // updatedAt tracks server-side changes; array refs are not stable across renders
+  useResetOnChange(String(widget.updatedAt), () => {
     setYAxisLabel(data?.yAxisLabel ?? "");
     setCategoriesText(data?.categories?.join(", ") ?? "");
     setSeries(toSeriesEntries(data?.series));
-    // updatedAt tracks server-side changes; array refs are not stable across renders
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [String(widget.updatedAt)]);
+  });
 
   if (editing) {
     return (

--- a/apps/frontend/components/widgets/MetricWidget.tsx
+++ b/apps/frontend/components/widgets/MetricWidget.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import type { Widget } from "@platypus/schemas";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -50,16 +51,13 @@ export function MetricWidget({
     return () => ro.disconnect();
   }, [data?.value, data?.unit, editing]);
 
-  useEffect(() => {
-    setTitle(widget.title);
-  }, [widget.title]);
-
-  useEffect(() => {
+  useResetOnChange(widget.title, () => setTitle(widget.title));
+  useResetOnChange(String(widget.updatedAt), () => {
     setValue(String(data?.value ?? ""));
     setLabel(data?.label ?? "");
     setUnit(data?.unit ?? "");
     setChange(data?.change ?? "");
-  }, [data?.value, data?.label, data?.unit, data?.change]);
+  });
 
   if (editing) {
     return (

--- a/apps/frontend/components/widgets/PieChartWidget.tsx
+++ b/apps/frontend/components/widgets/PieChartWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { Pie, PieChart, Cell, Label as RechartsLabel } from "recharts";
 import type { Widget, PieChartWidgetData } from "@platypus/schemas";
 import {
@@ -52,17 +53,13 @@ export function PieChartWidget({
     toSegmentEntries(data?.segments),
   );
 
-  useEffect(() => {
-    setTitle(widget.title);
-  }, [widget.title]);
-
-  useEffect(() => {
+  useResetOnChange(widget.title, () => setTitle(widget.title));
+  // updatedAt tracks server-side changes; array refs are not stable across renders
+  useResetOnChange(String(widget.updatedAt), () => {
     setCenterLabel(data?.centerLabel ?? "");
     setCenterSubLabel(data?.centerSubLabel ?? "");
     setSegments(toSegmentEntries(data?.segments));
-    // updatedAt tracks server-side changes; array refs are not stable across renders
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [String(widget.updatedAt)]);
+  });
 
   if (editing) {
     const handleAddSegment = () =>

--- a/apps/frontend/components/widgets/TextWidget.tsx
+++ b/apps/frontend/components/widgets/TextWidget.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Widget } from "@platypus/schemas";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -23,13 +24,8 @@ export function TextWidget({
   const [title, setTitle] = useState(widget.title);
   const [content, setContent] = useState(data?.content ?? "");
 
-  useEffect(() => {
-    setTitle(widget.title);
-  }, [widget.title]);
-
-  useEffect(() => {
-    setContent(data?.content ?? "");
-  }, [data?.content]);
+  useResetOnChange(widget.title, () => setTitle(widget.title));
+  useResetOnChange(data?.content, () => setContent(data?.content ?? ""));
 
   if (editing) {
     return (

--- a/apps/frontend/components/widgets/WeatherWidget.tsx
+++ b/apps/frontend/components/widgets/WeatherWidget.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Image from "next/image";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import type {
   Widget,
   WeatherWidgetData,
@@ -93,11 +94,8 @@ export function WeatherWidget({
   const [lowC, setLowC] = useState(String(data?.lowC ?? ""));
   const [unit, setUnit] = useState<"C" | "F">(data?.unit ?? "C");
 
-  useEffect(() => {
-    setTitle(widget.title);
-  }, [widget.title]);
-
-  useEffect(() => {
+  useResetOnChange(widget.title, () => setTitle(widget.title));
+  useResetOnChange(String(widget.updatedAt), () => {
     setLocation(data?.location ?? "");
     setDate(data?.date ?? new Date().toISOString().split("T")[0]);
     setCondition(data?.condition ?? "clear-day");
@@ -106,16 +104,7 @@ export function WeatherWidget({
     setHighC(String(data?.highC ?? ""));
     setLowC(String(data?.lowC ?? ""));
     setUnit(data?.unit ?? "C");
-  }, [
-    data?.location,
-    data?.date,
-    data?.condition,
-    data?.description,
-    data?.temperatureC,
-    data?.highC,
-    data?.lowC,
-    data?.unit,
-  ]);
+  });
 
   if (editing) {
     return (

--- a/apps/frontend/components/workspace-context-form.tsx
+++ b/apps/frontend/components/workspace-context-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -102,14 +103,14 @@ export const WorkspaceContextForm = ({ contextId }: { contextId?: string }) => {
   }, [orgs, backendUrl]);
 
   // Set form data when editing
-  useEffect(() => {
+  useResetOnChange(contextData, () => {
     if (contextData) {
       setFormData({
         content: contextData.content,
         workspaceId: contextData.workspaceId || "",
       });
     }
-  }, [contextData]);
+  });
 
   // Filter out workspaces that already have contexts (unless we're editing that context)
   const existingWorkspaceIds = new Set(

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -27,7 +27,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type Workspace, type Provider } from "@platypus/schemas";
 import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
@@ -106,15 +107,15 @@ const WorkspaceForm = ({
 
   // When creating, default the owner to the current admin until they pick
   // another member.
-  useEffect(() => {
+  useResetOnChange(`${workspaceId ?? ""}:${user?.id ?? ""}`, () => {
     if (!workspaceId && user) {
       setFormData((prev) =>
         prev.ownerId ? prev : { ...prev, ownerId: user.id },
       );
     }
-  }, [workspaceId, user]);
+  });
 
-  useEffect(() => {
+  useResetOnChange(workspace, () => {
     if (workspace) {
       setFormData({
         name: workspace.name,
@@ -129,7 +130,7 @@ const WorkspaceForm = ({
         mcpSelfManagement: workspace.mcpSelfManagement ?? false,
       });
     }
-  }, [workspace]);
+  });
 
   const handleChange = (
     e:

--- a/apps/frontend/hooks/use-chat-settings.ts
+++ b/apps/frontend/hooks/use-chat-settings.ts
@@ -1,5 +1,6 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Chat } from "@platypus/schemas";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 
 export interface ChatSettings {
   systemPrompt: string;
@@ -25,8 +26,10 @@ export const useChatSettings = (
     number | undefined
   >();
 
-  // Initialize chat settings from existing chat data
-  useEffect(() => {
+  // Initialize chat settings from existing chat data (only when no agent is
+  // selected — an agent supplies its own settings). Re-syncs when either the
+  // chat data or the selected agent changes.
+  const initializeFromChat = () => {
     if (chatData && !agentId) {
       setSystemPrompt(chatData.systemPrompt || "");
       setTemperature(chatData.temperature ?? undefined);
@@ -36,7 +39,9 @@ export const useChatSettings = (
       setPresencePenalty(chatData.presencePenalty ?? undefined);
       setFrequencyPenalty(chatData.frequencyPenalty ?? undefined);
     }
-  }, [chatData, agentId]);
+  };
+  useResetOnChange(chatData, initializeFromChat);
+  useResetOnChange(agentId, initializeFromChat);
 
   const settings: ChatSettings = {
     systemPrompt,

--- a/apps/frontend/hooks/use-chat-ui.ts
+++ b/apps/frontend/hooks/use-chat-ui.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 
 export const useChatUI = (error: Error | undefined) => {
   const [isModelSelectorOpen, setIsModelSelectorOpen] = useState(false);
@@ -9,12 +10,13 @@ export const useChatUI = (error: Error | undefined) => {
   const [showErrorDialog, setShowErrorDialog] = useState(false);
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
 
-  // Show error dialog if there's an error from useChat
-  useEffect(() => {
+  // Show error dialog when a new error arrives from useChat. Keyed on the error
+  // so the user can still dismiss the dialog while the error persists.
+  useResetOnChange(error, () => {
     if (error) {
       setShowErrorDialog(true);
     }
-  }, [error]);
+  });
 
   return {
     isModelSelectorOpen,

--- a/apps/frontend/hooks/use-mobile.ts
+++ b/apps/frontend/hooks/use-mobile.ts
@@ -3,19 +3,16 @@ import * as React from "react";
 const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined,
+  // useSyncExternalStore subscribes to the media query and snapshots the
+  // current match, avoiding a setState-in-effect while staying SSR-safe
+  // (the server snapshot is `false`).
+  return React.useSyncExternalStore(
+    (onChange) => {
+      const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    },
+    () => window.innerWidth < MOBILE_BREAKPOINT,
+    () => false,
   );
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
-    mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
-
-  return !!isMobile;
 }

--- a/apps/frontend/hooks/use-model-selection.ts
+++ b/apps/frontend/hooks/use-model-selection.ts
@@ -38,8 +38,13 @@ export const useModelSelection = (
     }
   };
 
-  // Restore persisted agent/provider/model from chat data or localStorage, with validation and fallback
+  // Restore persisted agent/provider/model from chat data or localStorage, with
+  // validation and fallback. This runs once the async providers/agents/chat
+  // data are available (and only while nothing is selected), reading
+  // client-only localStorage — work that belongs in an effect, so the
+  // restoring setState calls below are intentional.
   useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect */
     if (isLoading || providers.length === 0) return;
 
     // If we already have a selection, do nothing
@@ -132,6 +137,7 @@ export const useModelSelection = (
     // PRIORITY 3: Fall back to first provider's first model (for new chats, invalid persisted data, or missing chatData)
     setModelId(providers[0].modelIds[0]);
     setProviderId(providers[0].id);
+    /* eslint-enable react-hooks/set-state-in-effect */
   }, [
     chatData,
     providers,

--- a/apps/frontend/hooks/use-reset-on-change.ts
+++ b/apps/frontend/hooks/use-reset-on-change.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+
+/**
+ * Re-initialises local state whenever `key` changes, using React's documented
+ * "adjust state during render" pattern instead of a `setState`-in-effect.
+ *
+ * `reset` is invoked synchronously during render (only when `key` differs from
+ * the previous render), so React discards the in-progress render and restarts
+ * with the new state — no cascading effect-triggered re-render. Use this for
+ * editable fields that should track a server/prop value until the user edits
+ * them, then re-sync when that value changes.
+ *
+ * @param key   A primitive (or identity-stable) value that changes when the
+ *              synced source changes — e.g. `widget.title` or
+ *              `String(widget.updatedAt)`.
+ * @param reset Applies the latest source values to local state.
+ */
+export function useResetOnChange(key: unknown, reset: () => void) {
+  const [prevKey, setPrevKey] = useState(key);
+  if (key !== prevKey) {
+    setPrevKey(key);
+    reset();
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #172. Fixes the behavioral lint findings deferred from #169 (the ESLint 10 / react-hooks v7 work). `pnpm --filter @platypus/frontend lint` now exits clean — all 88 findings addressed.

Worked lowest → highest count, verifying each rule group individually rather than bulk-applying.

| Rule | Count | Approach |
|---|---|---|
| `react-hooks/immutability` | 1 | Reorder state decl; convert surfaced sync-effect to adjust-state-during-render |
| `react-hooks/purity` | 1 | `sidebar` skeleton width derived deterministically from `useId` (no `Math.random()` in render) |
| `react-hooks/static-components` | 2 | `shimmer` → module-cached motion component; `tool` icon → `createElement` |
| `react-hooks/rules-of-hooks` | 3 | Split `kanban-column` into `SortableKanbanColumn` so dnd hooks are never conditional |
| `react-hooks/refs` | 6 | Ref writes moved into effects; `kanban-board` prev-value tracking switched ref → state |
| `@next/next/no-img-element` | 10 | Justified suppressions (arbitrary-host / `blob:` / external-SVG URLs) |
| `react-hooks/exhaustive-deps` | 23 | `useMemo`-wrap derived arrays, `useCallback`-stabilize handlers, align/add deps |
| `react-hooks/set-state-in-effect` | 42 | See below |

## `set-state-in-effect`

Added a shared helper **`hooks/use-reset-on-change.ts`** (React's documented *adjust-state-during-render* pattern) and applied it to the ~30 "sync server/prop data → editable local state" cases across 7 widgets, 9 forms and several hooks. `use-mobile` + `kanban-board` desktop detection → `useSyncExternalStore`; `oauth-callback` validation moved to initial state.

**Justified inline suppressions** (effects where `setState` is genuinely correct): manual data-fetch effects (`auth-provider`), external subscriptions (`carousel` embla, `prompt-input` Web Speech API), wall-clock timing (`reasoning`), client-only `localStorage` (`collapsible-section`), URL deep-link + navigation (`kanban-board`), async-data restoration (`use-model-selection`), and the request-time transport callback in `chat.tsx` (`refs`).

## Verification

- `pnpm --filter @platypus/frontend lint` → **exit 0**
- `tsc --noEmit` → **exit 0**
- `vitest run` → **16/16 passing**; Prettier clean

## ⚠️ Manual verification still recommended

Automated tests don't cover these UI behaviors. Per the issue's acceptance criteria, a manual pass over the higher-risk components is advisable before merge: widget edit→save, the forms (workspace/agent/mcp/skill/trigger/webhook/sandbox), chat model/agent restore, and kanban drag + card deep-link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)