### PR TITLE
feat: Blueprint CRUD + apply macro (Tier 1)

### DIFF
--- a/apps/backend/drizzle/0044_colorful_dracula.sql
+++ b/apps/backend/drizzle/0044_colorful_dracula.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "blueprint" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "unique_blueprint_name_org" UNIQUE("organization_id","name")
+);
+--> statement-breakpoint
+CREATE TABLE "blueprint_item" (
+	"id" text PRIMARY KEY NOT NULL,
+	"blueprint_id" text NOT NULL,
+	"resource_type" text NOT NULL,
+	"resource_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "unique_blueprint_item" UNIQUE("blueprint_id","resource_type","resource_id")
+);
+--> statement-breakpoint
+ALTER TABLE "blueprint" ADD CONSTRAINT "blueprint_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "blueprint_item" ADD CONSTRAINT "blueprint_item_blueprint_id_blueprint_id_fk" FOREIGN KEY ("blueprint_id") REFERENCES "public"."blueprint"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_blueprint_organization_id" ON "blueprint" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "idx_blueprint_item_blueprint" ON "blueprint_item" USING btree ("blueprint_id");--> statement-breakpoint
+CREATE INDEX "idx_blueprint_item_resource" ON "blueprint_item" USING btree ("resource_type","resource_id");

--- a/apps/backend/drizzle/meta/0044_snapshot.json
+++ b/apps/backend/drizzle/meta/0044_snapshot.json
@@ -1,0 +1,4117 @@
+{
+  "id": "44b1a862-f636-4e44-a960-9cbc20b779cc",
+  "prevId": "bdf4b196-f743-467d-b265-239199ff88c9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_set_ids": {
+          "name": "tool_set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "skill_ids": {
+          "name": "skill_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "sub_agent_ids": {
+          "name": "sub_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "input_placeholder": {
+          "name": "input_placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_workspace_id": {
+          "name": "idx_agent_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_organization_id": {
+          "name": "idx_agent_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_provider_id": {
+          "name": "idx_agent_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_id_workspace_id_fk": {
+          "name": "agent_workspace_id_workspace_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_provider_id_provider_id_fk": {
+          "name": "agent_provider_id_provider_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_agent_name_org": {
+          "name": "unique_agent_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment": {
+      "name": "attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_attachment_workspace": {
+          "name": "idx_attachment_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attachment_resource": {
+          "name": "idx_attachment_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_workspace_id_workspace_id_fk": {
+          "name": "attachment_workspace_id_workspace_id_fk",
+          "tableFrom": "attachment",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_attachment": {
+          "name": "unique_attachment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "resource_type",
+            "resource_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blueprint": {
+      "name": "blueprint",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blueprint_organization_id": {
+          "name": "idx_blueprint_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blueprint_organization_id_organization_id_fk": {
+          "name": "blueprint_organization_id_organization_id_fk",
+          "tableFrom": "blueprint",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_blueprint_name_org": {
+          "name": "unique_blueprint_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blueprint_item": {
+      "name": "blueprint_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blueprint_item_blueprint": {
+          "name": "idx_blueprint_item_blueprint",
+          "columns": [
+            {
+              "expression": "blueprint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_blueprint_item_resource": {
+          "name": "idx_blueprint_item_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blueprint_item_blueprint_id_blueprint_id_fk": {
+          "name": "blueprint_item_blueprint_id_blueprint_id_fk",
+          "tableFrom": "blueprint_item",
+          "tableTo": "blueprint",
+          "columnsFrom": [
+            "blueprint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_blueprint_item": {
+          "name": "unique_blueprint_item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "blueprint_id",
+            "resource_type",
+            "resource_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_memory_processed_at": {
+          "name": "last_memory_processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_status": {
+          "name": "memory_extraction_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_workspace_id": {
+          "name": "idx_chat_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_tags": {
+          "name": "idx_chat_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_chat_memory_processing": {
+          "name": "idx_chat_memory_processing",
+          "columns": [
+            {
+              "expression": "memory_extraction_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_memory_processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_workspace_id_workspace_id_fk": {
+          "name": "chat_workspace_id_workspace_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context": {
+      "name": "context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_context_user_id": {
+          "name": "idx_context_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_workspace_id": {
+          "name": "idx_context_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "context_user_id_user_id_fk": {
+          "name": "context_user_id_user_id_fk",
+          "tableFrom": "context",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "context_workspace_id_workspace_id_fk": {
+          "name": "context_workspace_id_workspace_id_fk",
+          "tableFrom": "context",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_context_user_workspace": {
+          "name": "unique_context_user_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard": {
+      "name": "dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desktop_layout": {
+          "name": "desktop_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mobile_layout": {
+          "name": "mobile_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_dashboard_workspace_id": {
+          "name": "idx_dashboard_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_dashboard_workspace_name": {
+          "name": "uq_dashboard_workspace_name",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_workspace_id_workspace_id_fk": {
+          "name": "dashboard_workspace_id_workspace_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitation_email": {
+          "name": "idx_invitation_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitation_org_id": {
+          "name": "idx_invitation_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_invited_by_user_id_fk": {
+          "name": "invitation_invited_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_invitation_org_email": {
+          "name": "unique_invitation_org_email",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_board": {
+      "name": "kanban_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_board_workspace_id": {
+          "name": "idx_kanban_board_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_board_workspace_id_workspace_id_fk": {
+          "name": "kanban_board_workspace_id_workspace_id_fk",
+          "tableFrom": "kanban_board",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_kanban_board_name_workspace": {
+          "name": "unique_kanban_board_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card": {
+      "name": "kanban_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_ids": {
+          "name": "label_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "assignees": {
+          "name": "assignees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_user_id": {
+          "name": "last_edited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_agent_id": {
+          "name": "last_edited_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_column_id": {
+          "name": "idx_kanban_card_column_id",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_label_ids": {
+          "name": "idx_kanban_card_label_ids",
+          "columns": [
+            {
+              "expression": "label_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_kanban_card_assignees": {
+          "name": "idx_kanban_card_assignees",
+          "columns": [
+            {
+              "expression": "assignees",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_kanban_card_due_date": {
+          "name": "idx_kanban_card_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_priority": {
+          "name": "idx_kanban_card_priority",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_column_position": {
+          "name": "idx_kanban_card_column_position",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_column_id_kanban_column_id_fk": {
+          "name": "kanban_card_column_id_kanban_column_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "kanban_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kanban_card_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_last_edited_by_user_id_user_id_fk": {
+          "name": "kanban_card_last_edited_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "last_edited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_last_edited_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_last_edited_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "last_edited_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card_comment": {
+      "name": "kanban_card_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_comment_card_id": {
+          "name": "idx_kanban_card_comment_card_id",
+          "columns": [
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_comment_card_id_kanban_card_id_fk": {
+          "name": "kanban_card_comment_card_id_kanban_card_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "kanban_card",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kanban_card_comment_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_comment_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_comment_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_comment_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_column": {
+      "name": "kanban_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_column_board_id": {
+          "name": "idx_kanban_column_board_id",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_column_board_id_kanban_board_id_fk": {
+          "name": "kanban_column_board_id_kanban_board_id_fk",
+          "tableFrom": "kanban_column",
+          "tableTo": "kanban_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp": {
+      "name": "mcp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_access_token": {
+          "name": "oauth_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_refresh_token": {
+          "name": "oauth_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_expires_at": {
+          "name": "oauth_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_requested_scope": {
+          "name": "oauth_requested_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_workspace_id": {
+          "name": "idx_mcp_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_organization_id": {
+          "name": "idx_mcp_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_organization_id_organization_id_fk": {
+          "name": "mcp_organization_id_organization_id_fk",
+          "tableFrom": "mcp",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_workspace_id_workspace_id_fk": {
+          "name": "mcp_workspace_id_workspace_id_fk",
+          "tableFrom": "mcp",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_mcp_name_org": {
+          "name": "unique_mcp_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        },
+        "unique_mcp_name_workspace": {
+          "name": "unique_mcp_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_state": {
+      "name": "mcp_oauth_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_oauth_state_mcp_id": {
+          "name": "idx_mcp_oauth_state_mcp_id",
+          "columns": [
+            {
+              "expression": "mcp_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_state_mcp_id_mcp_id_fk": {
+          "name": "mcp_oauth_state_mcp_id_mcp_id_fk",
+          "tableFrom": "mcp_oauth_state",
+          "tableTo": "mcp",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_daily_summary": {
+      "name": "memory_daily_summary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_date": {
+          "name": "summary_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_summary_user_workspace": {
+          "name": "idx_daily_summary_user_workspace",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_summary_date": {
+          "name": "idx_daily_summary_date",
+          "columns": [
+            {
+              "expression": "summary_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_daily_summary_user_id_user_id_fk": {
+          "name": "memory_daily_summary_user_id_user_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_daily_summary_workspace_id_workspace_id_fk": {
+          "name": "memory_daily_summary_workspace_id_workspace_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_daily_summary_user_workspace_date": {
+          "name": "unique_daily_summary_user_workspace_date",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workspace_id",
+            "summary_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_workspace_id": {
+          "name": "idx_notification_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_agent_id": {
+          "name": "idx_notification_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_created_at": {
+          "name": "idx_notification_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_workspace_id_workspace_id_fk": {
+          "name": "notification_workspace_id_workspace_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_agent_id_agent_id_fk": {
+          "name": "notification_agent_id_agent_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_read": {
+      "name": "notification_read",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_read_user_id": {
+          "name": "idx_notification_read_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_read_notification_id": {
+          "name": "idx_notification_read_notification_id",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_read_notification_id_notification_id_fk": {
+          "name": "notification_read_notification_id_notification_id_fk",
+          "tableFrom": "notification_read",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_read_user_id_user_id_fk": {
+          "name": "notification_read_user_id_user_id_fk",
+          "tableFrom": "notification_read",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_notification_read": {
+          "name": "unique_notification_read",
+          "nullsNotDistinct": false,
+          "columns": [
+            "notification_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_member": {
+      "name": "organization_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_member_org_id": {
+          "name": "idx_org_member_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_member_user_id": {
+          "name": "idx_org_member_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_member_organization_id_organization_id_fk": {
+          "name": "organization_member_organization_id_organization_id_fk",
+          "tableFrom": "organization_member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_member_user_id_user_id_fk": {
+          "name": "organization_member_user_id_user_id_fk",
+          "tableFrom": "organization_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraBody": {
+          "name": "extraBody",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_mode": {
+          "name": "api_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'responses'"
+        },
+        "native_search_enabled": {
+          "name": "native_search_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "modelIds": {
+          "name": "modelIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_model_id": {
+          "name": "task_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_extraction_model_id": {
+          "name": "memory_extraction_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_workspace_id": {
+          "name": "idx_provider_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_organization_id": {
+          "name": "idx_provider_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_organization_id_organization_id_fk": {
+          "name": "provider_organization_id_organization_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_provider_name_org": {
+          "name": "unique_provider_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        },
+        "unique_provider_name_workspace": {
+          "name": "unique_provider_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox": {
+      "name": "sandbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "admin_env": {
+          "name": "admin_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_env": {
+          "name": "user_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_sandbox_workspace_id": {
+          "name": "unique_sandbox_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_workspace_id_workspace_id_fk": {
+          "name": "sandbox_workspace_id_workspace_id_fk",
+          "tableFrom": "sandbox",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_teardown_failure": {
+      "name": "sandbox_teardown_failure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_teardown_failure_workspace_id": {
+          "name": "idx_sandbox_teardown_failure_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill": {
+      "name": "skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_workspace_id": {
+          "name": "idx_skill_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skill_organization_id": {
+          "name": "idx_skill_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_organization_id_organization_id_fk": {
+          "name": "skill_organization_id_organization_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_workspace_id_workspace_id_fk": {
+          "name": "skill_workspace_id_workspace_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_skill_name_workspace": {
+          "name": "unique_skill_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "unique_skill_name_org": {
+          "name": "unique_skill_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger": {
+      "name": "trigger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_runs_to_keep": {
+          "name": "max_runs_to_keep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "search": {
+          "name": "search",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_workspace_id": {
+          "name": "idx_trigger_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_next_run_at": {
+          "name": "idx_trigger_next_run_at",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_type": {
+          "name": "idx_trigger_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_workspace_id_workspace_id_fk": {
+          "name": "trigger_workspace_id_workspace_id_fk",
+          "tableFrom": "trigger",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_agent_id_agent_id_fk": {
+          "name": "trigger_agent_id_agent_id_fk",
+          "tableFrom": "trigger",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_run": {
+      "name": "trigger_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_run_trigger_id": {
+          "name": "idx_trigger_run_trigger_id",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_run_started_at": {
+          "name": "idx_trigger_run_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_run_trigger_id_trigger_id_fk": {
+          "name": "trigger_run_trigger_id_trigger_id_fk",
+          "tableFrom": "trigger_run",
+          "tableTo": "trigger",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Webhook'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_secret": {
+          "name": "signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhook_workspace_id": {
+          "name": "idx_webhook_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_workspace_id_workspace_id_fk": {
+          "name": "webhook_workspace_id_workspace_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget": {
+      "name": "widget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_widget_dashboard_id": {
+          "name": "idx_widget_dashboard_id",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_widget_dashboard_title": {
+          "name": "uq_widget_dashboard_title",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "widget_dashboard_id_dashboard_id_fk": {
+          "name": "widget_dashboard_id_dashboard_id_fk",
+          "tableFrom": "widget",
+          "tableTo": "dashboard",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace": {
+      "name": "workspace",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_model_provider_id": {
+          "name": "task_model_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_provider_id": {
+          "name": "memory_extraction_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_embedding_provider_id": {
+          "name": "memory_embedding_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_daily_summaries": {
+          "name": "max_daily_summaries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 90
+        },
+        "provider_self_management": {
+          "name": "provider_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mcp_self_management": {
+          "name": "mcp_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_organization_id": {
+          "name": "idx_workspace_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_owner_id": {
+          "name": "idx_workspace_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_organization_id_organization_id_fk": {
+          "name": "workspace_organization_id_organization_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_owner_id_user_id_fk": {
+          "name": "workspace_owner_id_user_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_task_model_provider_id_provider_id_fk": {
+          "name": "workspace_task_model_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "task_model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_memory_extraction_provider_id_provider_id_fk": {
+          "name": "workspace_memory_extraction_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_extraction_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_memory_embedding_provider_id_provider_id_fk": {
+          "name": "workspace_memory_embedding_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_embedding_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1780726452752,
       "tag": "0043_bizarre_fat_cobra",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1780727883893,
+      "tag": "0044_colorful_dracula",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -320,6 +320,65 @@ export const attachment = pgTable(
   ],
 );
 
+// Blueprint — a named, Organization-scoped macro that, applied to a Workspace,
+// creates the Attachments for a chosen set of Shared resources in one step
+// (ADR-0008). It is a snapshot, not a living binding: applying stamps
+// Attachments at that moment; later edits never disturb already-provisioned
+// Workspaces. Blueprints are always org-scoped (no dual scope) and managed only
+// by Org Admins.
+export const blueprint = pgTable(
+  "blueprint",
+  (t) => ({
+    id: t.text("id").primaryKey(),
+    organizationId: t
+      .text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    name: t.text("name").notNull(),
+    description: t.text("description"),
+    createdAt: t.timestamp("created_at").notNull().defaultNow(),
+    updatedAt: t.timestamp("updated_at").notNull().defaultNow(),
+  }),
+  (t) => [
+    index("idx_blueprint_organization_id").on(t.organizationId),
+    unique("unique_blueprint_name_org").on(t.organizationId, t.name),
+  ],
+);
+
+// The Shared resources a Blueprint provisions. Mirrors `attachment`: polymorphic
+// `resourceType` + `resourceId` pointing at an org-scoped resource, no FK on
+// `resourceId` (the relationship is enforced in application code, and deletion
+// of a Shared resource is blocked while any Blueprint lists it rather than
+// cascaded). The `blueprint_id` FK cascades so deleting a Blueprint drops its
+// items.
+export const blueprintItem = pgTable(
+  "blueprint_item",
+  (t) => ({
+    id: t.text("id").primaryKey(),
+    blueprintId: t
+      .text("blueprint_id")
+      .notNull()
+      .references(() => blueprint.id, { onDelete: "cascade" }),
+    resourceType: t
+      .text("resource_type")
+      .$type<"mcp" | "provider" | "skill" | "agent">()
+      .notNull(),
+    resourceId: t.text("resource_id").notNull(),
+    createdAt: t.timestamp("created_at").notNull().defaultNow(),
+  }),
+  (t) => [
+    index("idx_blueprint_item_blueprint").on(t.blueprintId),
+    // Drives the extended deletion guard ("is this resource listed in any
+    // Blueprint?")
+    index("idx_blueprint_item_resource").on(t.resourceType, t.resourceId),
+    unique("unique_blueprint_item").on(
+      t.blueprintId,
+      t.resourceType,
+      t.resourceId,
+    ),
+  ],
+);
+
 export const sandbox = pgTable(
   "sandbox",
   (t) => ({

--- a/apps/backend/src/routes/org-agent.test.ts
+++ b/apps/backend/src/routes/org-agent.test.ts
@@ -137,7 +137,8 @@ describe("Organization Agent Routes", () => {
       mockSession();
       mockDb.limit
         .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
-        .mockResolvedValueOnce([]); // attachment guard: none
+        .mockResolvedValueOnce([]) // attachment guard: none
+        .mockResolvedValueOnce([]); // blueprint guard: none
       mockDb.returning.mockResolvedValueOnce([{ id: "agent-1" }]);
 
       const res = await app.request(`${baseUrl}/agent-1`, { method: "DELETE" });
@@ -150,6 +151,17 @@ describe("Organization Agent Routes", () => {
       mockDb.limit
         .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
         .mockResolvedValueOnce([{ id: "att-1" }]); // attachment guard: attached
+
+      const res = await app.request(`${baseUrl}/agent-1`, { method: "DELETE" });
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 409 when the agent is listed in a blueprint", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]) // attachment guard: none
+        .mockResolvedValueOnce([{ id: "bpi-1" }]); // blueprint guard: listed
 
       const res = await app.request(`${baseUrl}/agent-1`, { method: "DELETE" });
       expect(res.status).toBe(409);

--- a/apps/backend/src/routes/org-agent.ts
+++ b/apps/backend/src/routes/org-agent.ts
@@ -14,6 +14,7 @@ import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { findNonSharedReferences } from "../services/agent-scope-validation.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
+import { isResourceListedInBlueprint } from "../services/blueprint-guard.ts";
 import { getStorage } from "../storage/index.ts";
 import { avatarKeyToUrl } from "../utils/avatar-url.ts";
 import { getOrigin } from "../utils/get-origin.ts";
@@ -297,6 +298,18 @@ orgAgent.delete(
         {
           error:
             "Cannot delete: this agent is attached to one or more workspaces. Detach it first.",
+        },
+        409,
+      );
+    }
+
+    // Nor while it is listed in a Blueprint (ADR-0008) — remove it from every
+    // Blueprint first, so nothing still points at it.
+    if (await isResourceListedInBlueprint("agent", agentId)) {
+      return c.json(
+        {
+          error:
+            "Cannot delete: this agent is listed in one or more blueprints. Remove it from them first.",
         },
         409,
       );

--- a/apps/backend/src/routes/org-blueprint.test.ts
+++ b/apps/backend/src/routes/org-blueprint.test.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
+import app from "../server.ts";
+
+describe("Organization Blueprint Routes", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+  });
+
+  const orgId = "org-1";
+  const baseUrl = `/organizations/${orgId}/blueprints`;
+
+  describe("POST /", () => {
+    const body = {
+      name: "Starter kit",
+      description: "Provisions the core shared resources.",
+      items: [{ resourceType: "agent", resourceId: "agent-1" }],
+    };
+
+    it("creates a blueprint when all items are org-scoped (admin)", async () => {
+      mockSession();
+      const record = {
+        id: "bp-1",
+        organizationId: orgId,
+        name: "Starter kit",
+        description: "Provisions the core shared resources.",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([record]); // final read-back
+      // requireOrgAccess where (chain), then findNonSharedItems where (resolves
+      // the org-scoped resources that exist).
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([{ id: "agent-1" }]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(201);
+      const json = await res.json();
+      expect(json.id).toBe("bp-1");
+      expect(json.items).toEqual([
+        { resourceType: "agent", resourceId: "agent-1" },
+      ]);
+    });
+
+    it("422s when an item is not an org-scoped resource", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      // findNonSharedItems finds nothing for the requested id → invalid.
+      mockDb.where.mockReturnValueOnce(mockDb).mockResolvedValueOnce([]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(422);
+      const json = await res.json();
+      expect(json.invalidItems).toEqual([
+        { resourceType: "agent", resourceId: "agent-1" },
+      ]);
+    });
+
+    it("409s on a duplicate blueprint name", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      // Empty items → no validation queries; the blueprint insert conflicts.
+      mockDb.insert.mockImplementationOnce(() => {
+        throw { code: "23505" };
+      });
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({ name: "Starter kit", items: [] }),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(409);
+    });
+
+    it("403s for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("GET /", () => {
+    it("lists blueprints with their items (admin)", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      const blueprints = [
+        { id: "bp-1", organizationId: orgId, name: "Starter kit" },
+      ];
+      const itemRows = [
+        { blueprintId: "bp-1", resourceType: "agent", resourceId: "agent-1" },
+        { blueprintId: "bp-1", resourceType: "skill", resourceId: "skill-1" },
+      ];
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockResolvedValueOnce(blueprints) // list blueprints
+        .mockResolvedValueOnce(itemRows); // loadItemsByBlueprint
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.results).toHaveLength(1);
+      expect(json.results[0].items).toHaveLength(2);
+    });
+
+    it("403s for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("GET /:blueprintId", () => {
+    it("returns a blueprint with its items", async () => {
+      mockSession();
+      const record = { id: "bp-1", organizationId: orgId, name: "Starter kit" };
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([record]); // blueprint by id
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // blueprint by id (chain to limit)
+        .mockResolvedValueOnce([
+          { blueprintId: "bp-1", resourceType: "agent", resourceId: "agent-1" },
+        ]); // loadItemsByBlueprint
+
+      const res = await app.request(`${baseUrl}/bp-1`);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.id).toBe("bp-1");
+      expect(json.items).toHaveLength(1);
+    });
+
+    it("404s when the blueprint is not in this org", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]); // blueprint by id: not found
+
+      const res = await app.request(`${baseUrl}/missing`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PUT /:blueprintId", () => {
+    const body = {
+      name: "Starter kit v2",
+      items: [{ resourceType: "skill", resourceId: "skill-1" }],
+    };
+
+    it("replaces the item set (snapshot semantics) and returns the blueprint", async () => {
+      mockSession();
+      const record = {
+        id: "bp-1",
+        organizationId: orgId,
+        name: "Starter kit v2",
+      };
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "bp-1" }]) // existing blueprint
+        .mockResolvedValueOnce([record]); // final read-back
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // existing check (chain to limit)
+        .mockResolvedValueOnce([{ id: "skill-1" }]); // findNonSharedItems
+
+      const res = await app.request(`${baseUrl}/bp-1`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.items).toEqual([
+        { resourceType: "skill", resourceId: "skill-1" },
+      ]);
+      // The old item set is deleted and re-inserted within the transaction;
+      // this never touches existing Attachments on provisioned workspaces.
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+
+    it("404s when the blueprint does not exist", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]); // existing check: not found
+
+      const res = await app.request(`${baseUrl}/missing`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("422s when an item is not org-scoped", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "bp-1" }]); // existing blueprint
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // existing check
+        .mockResolvedValueOnce([]); // findNonSharedItems: none found
+
+      const res = await app.request(`${baseUrl}/bp-1`, {
+        method: "PUT",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(422);
+    });
+  });
+
+  describe("DELETE /:blueprintId", () => {
+    it("deletes a blueprint (admin)", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.returning.mockResolvedValueOnce([{ id: "bp-1" }]);
+
+      const res = await app.request(`${baseUrl}/bp-1`, { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ message: "Blueprint deleted" });
+    });
+
+    it("404s when the blueprint does not exist", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.returning.mockResolvedValueOnce([]);
+
+      const res = await app.request(`${baseUrl}/missing`, { method: "DELETE" });
+      expect(res.status).toBe(404);
+    });
+
+    it("403s for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+
+      const res = await app.request(`${baseUrl}/bp-1`, { method: "DELETE" });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("POST /:blueprintId/apply", () => {
+    const applyUrl = `${baseUrl}/bp-1/apply`;
+    const body = { workspaceId: "ws-1" };
+    const itemRows = [
+      { blueprintId: "bp-1", resourceType: "agent", resourceId: "agent-1" },
+      { blueprintId: "bp-1", resourceType: "skill", resourceId: "skill-1" },
+    ];
+
+    it("creates the attachments and reports what was attached", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "bp-1" }]) // blueprint in org
+        .mockResolvedValueOnce([{ id: "ws-1" }]); // workspace in org
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // blueprint check
+        .mockReturnValueOnce(mockDb) // workspace check
+        .mockResolvedValueOnce(itemRows); // loadItemsByBlueprint
+      // Both items newly inserted.
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "att-1" },
+        { id: "att-2" },
+      ]);
+
+      const res = await app.request(applyUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        workspaceId: "ws-1",
+        attached: 2,
+        skipped: 0,
+        total: 2,
+      });
+    });
+
+    it("is idempotent: a re-apply where everything is attached is a no-op", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }])
+        .mockResolvedValueOnce([{ id: "bp-1" }])
+        .mockResolvedValueOnce([{ id: "ws-1" }]);
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockReturnValueOnce(mockDb)
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce(itemRows);
+      // onConflictDoNothing inserts nothing — all rows already present.
+      mockDb.returning.mockResolvedValueOnce([]);
+
+      const res = await app.request(applyUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        workspaceId: "ws-1",
+        attached: 0,
+        skipped: 2,
+        total: 2,
+      });
+    });
+
+    it("handles an empty blueprint without inserting", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }])
+        .mockResolvedValueOnce([{ id: "bp-1" }])
+        .mockResolvedValueOnce([{ id: "ws-1" }]);
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockReturnValueOnce(mockDb)
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([]); // no items
+
+      const res = await app.request(applyUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        workspaceId: "ws-1",
+        attached: 0,
+        skipped: 0,
+        total: 0,
+      });
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("404s when the blueprint is not in this org", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]); // blueprint not found
+
+      const res = await app.request(applyUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("404s when the workspace is not in this org", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "bp-1" }]) // blueprint ok
+        .mockResolvedValueOnce([]); // workspace not found
+
+      const res = await app.request(applyUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("403s for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+
+      const res = await app.request(applyUrl, {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/apps/backend/src/routes/org-blueprint.ts
+++ b/apps/backend/src/routes/org-blueprint.ts
@@ -1,0 +1,412 @@
+import { Hono } from "hono";
+import { sValidator } from "@hono/standard-validator";
+import { nanoid } from "nanoid";
+import { db } from "../index.ts";
+import {
+  blueprint as blueprintTable,
+  blueprintItem as blueprintItemTable,
+  attachment as attachmentTable,
+  agent as agentTable,
+  mcp as mcpTable,
+  provider as providerTable,
+  skill as skillTable,
+  workspace as workspaceTable,
+} from "../db/schema.ts";
+import {
+  blueprintCreateSchema,
+  blueprintUpdateSchema,
+  blueprintApplySchema,
+  type BlueprintItem,
+} from "@platypus/schemas";
+import { and, eq, inArray } from "drizzle-orm";
+import { requireAuth } from "../middleware/authentication.ts";
+import { requireOrgAccess } from "../middleware/authorization.ts";
+import type { Variables } from "../server.ts";
+
+// Blueprint — a named, Organization-scoped macro that, applied to a Workspace,
+// creates the Attachments for a chosen set of Shared resources in one step
+// (ADR-0008). It is a snapshot, not a living binding: applying stamps
+// Attachments at that moment; later edits never disturb already-provisioned
+// Workspaces. A Blueprint may only list org-scoped (Shared) resources, and all
+// management — and applying — is Org-Admin-only.
+const orgBlueprint = new Hono<{ Variables: Variables }>();
+
+const RESOURCE_TABLES = {
+  mcp: mcpTable,
+  provider: providerTable,
+  skill: skillTable,
+  agent: agentTable,
+} as const;
+
+type ResourceType = keyof typeof RESOURCE_TABLES;
+
+/** Detects a Postgres unique-constraint violation across driver shapes. */
+const isUniqueViolation = (error: any): boolean =>
+  error.code === "23505" ||
+  error.cause?.code === "23505" ||
+  error.message?.includes("unique constraint") ||
+  error.cause?.message?.includes("unique constraint");
+
+const NAME_CONFLICT = {
+  error: "A blueprint with this name already exists in this organization",
+} as const;
+
+/** Drop duplicate items (same resourceType + resourceId). */
+const dedupeItems = (items: BlueprintItem[]): BlueprintItem[] => {
+  const seen = new Set<string>();
+  const out: BlueprintItem[] = [];
+  for (const item of items) {
+    const key = `${item.resourceType}:${item.resourceId}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(item);
+    }
+  }
+  return out;
+};
+
+/**
+ * Returns the subset of `items` that do NOT resolve to an org-scoped resource
+ * in this organization. A Blueprint may only list Shared resources (ADR-0008),
+ * so any workspace-private or foreign-org reference is a blocker.
+ */
+const findNonSharedItems = async (
+  items: BlueprintItem[],
+  orgId: string,
+): Promise<BlueprintItem[]> => {
+  const byType = new Map<ResourceType, string[]>();
+  for (const item of items) {
+    const ids = byType.get(item.resourceType as ResourceType) ?? [];
+    ids.push(item.resourceId);
+    byType.set(item.resourceType as ResourceType, ids);
+  }
+
+  const invalid: BlueprintItem[] = [];
+  for (const [resourceType, ids] of byType) {
+    const table = RESOURCE_TABLES[resourceType];
+    const rows = await db
+      .select({ id: table.id })
+      .from(table)
+      .where(and(eq(table.organizationId, orgId), inArray(table.id, ids)));
+    const found = new Set(rows.map((r) => r.id));
+    for (const id of ids) {
+      if (!found.has(id)) invalid.push({ resourceType, resourceId: id });
+    }
+  }
+  return invalid;
+};
+
+/** Load the items of one or more blueprints, grouped by blueprint id. */
+const loadItemsByBlueprint = async (
+  blueprintIds: string[],
+): Promise<Map<string, BlueprintItem[]>> => {
+  const grouped = new Map<string, BlueprintItem[]>();
+  if (blueprintIds.length === 0) return grouped;
+  const rows = await db
+    .select({
+      blueprintId: blueprintItemTable.blueprintId,
+      resourceType: blueprintItemTable.resourceType,
+      resourceId: blueprintItemTable.resourceId,
+    })
+    .from(blueprintItemTable)
+    .where(inArray(blueprintItemTable.blueprintId, blueprintIds));
+  for (const row of rows) {
+    const items = grouped.get(row.blueprintId) ?? [];
+    items.push({ resourceType: row.resourceType, resourceId: row.resourceId });
+    grouped.set(row.blueprintId, items);
+  }
+  return grouped;
+};
+
+/** Create a Blueprint (admin only) */
+orgBlueprint.post(
+  "/",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  sValidator("json", blueprintCreateSchema),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const { name, description, items } = c.req.valid("json");
+    const deduped = dedupeItems(items);
+
+    const invalid = await findNonSharedItems(deduped, orgId);
+    if (invalid.length > 0) {
+      return c.json(
+        {
+          error:
+            "A blueprint may only list organization-scoped (Shared) resources",
+          invalidItems: invalid,
+        },
+        422,
+      );
+    }
+
+    const id = nanoid();
+    try {
+      await db.transaction(async (tx) => {
+        await tx.insert(blueprintTable).values({
+          id,
+          organizationId: orgId,
+          name,
+          description: description ?? null,
+        });
+        if (deduped.length > 0) {
+          await tx.insert(blueprintItemTable).values(
+            deduped.map((item) => ({
+              id: nanoid(),
+              blueprintId: id,
+              resourceType: item.resourceType,
+              resourceId: item.resourceId,
+            })),
+          );
+        }
+      });
+    } catch (error: any) {
+      if (isUniqueViolation(error)) {
+        return c.json(NAME_CONFLICT, 409);
+      }
+      throw error;
+    }
+
+    const [record] = await db
+      .select()
+      .from(blueprintTable)
+      .where(eq(blueprintTable.id, id))
+      .limit(1);
+    return c.json({ ...record, items: deduped }, 201);
+  },
+);
+
+/** List Blueprints, each with its items (admin only) */
+orgBlueprint.get("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
+  const orgId = c.req.param("orgId")!;
+  const blueprints = await db
+    .select()
+    .from(blueprintTable)
+    .where(eq(blueprintTable.organizationId, orgId));
+
+  const itemsByBlueprint = await loadItemsByBlueprint(
+    blueprints.map((b) => b.id),
+  );
+  const results = blueprints.map((b) => ({
+    ...b,
+    items: itemsByBlueprint.get(b.id) ?? [],
+  }));
+  return c.json({ results });
+});
+
+/** Get a Blueprint by ID, with its items (admin only) */
+orgBlueprint.get(
+  "/:blueprintId",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const blueprintId = c.req.param("blueprintId");
+    const [record] = await db
+      .select()
+      .from(blueprintTable)
+      .where(
+        and(
+          eq(blueprintTable.id, blueprintId),
+          eq(blueprintTable.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+    if (!record) {
+      return c.json({ error: "Blueprint not found" }, 404);
+    }
+    const itemsByBlueprint = await loadItemsByBlueprint([blueprintId]);
+    return c.json({
+      ...record,
+      items: itemsByBlueprint.get(blueprintId) ?? [],
+    });
+  },
+);
+
+/** Update a Blueprint by ID (admin only) — replaces its item set */
+orgBlueprint.put(
+  "/:blueprintId",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  sValidator("json", blueprintUpdateSchema),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const blueprintId = c.req.param("blueprintId");
+    const { name, description, items } = c.req.valid("json");
+    const deduped = dedupeItems(items);
+
+    // The blueprint must exist in this org before we touch its items.
+    const [existing] = await db
+      .select({ id: blueprintTable.id })
+      .from(blueprintTable)
+      .where(
+        and(
+          eq(blueprintTable.id, blueprintId),
+          eq(blueprintTable.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+    if (!existing) {
+      return c.json({ error: "Blueprint not found" }, 404);
+    }
+
+    const invalid = await findNonSharedItems(deduped, orgId);
+    if (invalid.length > 0) {
+      return c.json(
+        {
+          error:
+            "A blueprint may only list organization-scoped (Shared) resources",
+          invalidItems: invalid,
+        },
+        422,
+      );
+    }
+
+    try {
+      await db.transaction(async (tx) => {
+        await tx
+          .update(blueprintTable)
+          .set({
+            name,
+            description: description ?? null,
+            updatedAt: new Date(),
+          })
+          .where(eq(blueprintTable.id, blueprintId));
+        // Snapshot semantics: replacing the item set never touches already
+        // provisioned Workspaces — those Attachments stand on their own.
+        await tx
+          .delete(blueprintItemTable)
+          .where(eq(blueprintItemTable.blueprintId, blueprintId));
+        if (deduped.length > 0) {
+          await tx.insert(blueprintItemTable).values(
+            deduped.map((item) => ({
+              id: nanoid(),
+              blueprintId,
+              resourceType: item.resourceType,
+              resourceId: item.resourceId,
+            })),
+          );
+        }
+      });
+    } catch (error: any) {
+      if (isUniqueViolation(error)) {
+        return c.json(NAME_CONFLICT, 409);
+      }
+      throw error;
+    }
+
+    const [record] = await db
+      .select()
+      .from(blueprintTable)
+      .where(eq(blueprintTable.id, blueprintId))
+      .limit(1);
+    return c.json({ ...record, items: deduped }, 200);
+  },
+);
+
+/** Delete a Blueprint by ID (admin only) — items cascade */
+orgBlueprint.delete(
+  "/:blueprintId",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const blueprintId = c.req.param("blueprintId");
+    const result = await db
+      .delete(blueprintTable)
+      .where(
+        and(
+          eq(blueprintTable.id, blueprintId),
+          eq(blueprintTable.organizationId, orgId),
+        ),
+      )
+      .returning();
+    if (result.length === 0) {
+      return c.json({ error: "Blueprint not found" }, 404);
+    }
+    return c.json({ message: "Blueprint deleted" });
+  },
+);
+
+/**
+ * Apply a Blueprint to an existing Workspace (admin only). The macro creates the
+ * Attachments for the Blueprint's current items. It is additive and idempotent:
+ * re-applying, or applying a resource already attached, is a no-op (ADR-0008).
+ */
+orgBlueprint.post(
+  "/:blueprintId/apply",
+  requireAuth,
+  requireOrgAccess(["admin"]),
+  sValidator("json", blueprintApplySchema),
+  async (c) => {
+    const orgId = c.req.param("orgId")!;
+    const blueprintId = c.req.param("blueprintId");
+    const { workspaceId } = c.req.valid("json");
+
+    const [record] = await db
+      .select({ id: blueprintTable.id })
+      .from(blueprintTable)
+      .where(
+        and(
+          eq(blueprintTable.id, blueprintId),
+          eq(blueprintTable.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+    if (!record) {
+      return c.json({ error: "Blueprint not found" }, 404);
+    }
+
+    // The target workspace must belong to this organization.
+    const [ws] = await db
+      .select({ id: workspaceTable.id })
+      .from(workspaceTable)
+      .where(
+        and(
+          eq(workspaceTable.id, workspaceId),
+          eq(workspaceTable.organizationId, orgId),
+        ),
+      )
+      .limit(1);
+    if (!ws) {
+      return c.json({ error: "Workspace not found in this organization" }, 404);
+    }
+
+    const itemsByBlueprint = await loadItemsByBlueprint([blueprintId]);
+    const items = itemsByBlueprint.get(blueprintId) ?? [];
+
+    if (items.length === 0) {
+      return c.json({ workspaceId, attached: 0, skipped: 0, total: 0 }, 200);
+    }
+
+    // Additive + idempotent: onConflictDoNothing against the unique
+    // (workspace, type, id) attachment constraint, so re-runs only add what is
+    // missing. `returning()` yields just the rows actually inserted.
+    const inserted = await db
+      .insert(attachmentTable)
+      .values(
+        items.map((item) => ({
+          id: nanoid(),
+          workspaceId,
+          resourceType: item.resourceType,
+          resourceId: item.resourceId,
+        })),
+      )
+      .onConflictDoNothing()
+      .returning();
+
+    const attached = inserted.length;
+    return c.json(
+      {
+        workspaceId,
+        attached,
+        skipped: items.length - attached,
+        total: items.length,
+      },
+      200,
+    );
+  },
+);
+
+export { orgBlueprint };

--- a/apps/backend/src/routes/org-mcp.test.ts
+++ b/apps/backend/src/routes/org-mcp.test.ts
@@ -132,7 +132,8 @@ describe("Organization MCP Routes", () => {
       mockSession();
       mockDb.limit
         .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
-        .mockResolvedValueOnce([]); // attachment guard: none
+        .mockResolvedValueOnce([]) // attachment guard: none
+        .mockResolvedValueOnce([]); // blueprint guard: none
       mockDb.returning.mockResolvedValueOnce([{ id: "mcp-1" }]);
 
       const res = await app.request(`${baseUrl}/mcp-1`, { method: "DELETE" });
@@ -145,6 +146,17 @@ describe("Organization MCP Routes", () => {
       mockDb.limit
         .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
         .mockResolvedValueOnce([{ id: "att-1" }]); // attachment guard: attached
+
+      const res = await app.request(`${baseUrl}/mcp-1`, { method: "DELETE" });
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 409 when the MCP is listed in a blueprint", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]) // attachment guard: none
+        .mockResolvedValueOnce([{ id: "bpi-1" }]); // blueprint guard: listed
 
       const res = await app.request(`${baseUrl}/mcp-1`, { method: "DELETE" });
       expect(res.status).toBe(409);

--- a/apps/backend/src/routes/org-mcp.ts
+++ b/apps/backend/src/routes/org-mcp.ts
@@ -19,6 +19,7 @@ import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
+import { isResourceListedInBlueprint } from "../services/blueprint-guard.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
 import {
@@ -173,6 +174,18 @@ orgMcp.delete(
         {
           error:
             "Cannot delete: this MCP is attached to one or more workspaces. Detach it first.",
+        },
+        409,
+      );
+    }
+
+    // Nor while it is listed in a Blueprint (ADR-0008) — remove it from every
+    // Blueprint first, so nothing still points at it.
+    if (await isResourceListedInBlueprint("mcp", mcpId)) {
+      return c.json(
+        {
+          error:
+            "Cannot delete: this MCP is listed in one or more blueprints. Remove it from them first.",
         },
         409,
       );

--- a/apps/backend/src/routes/org-provider.test.ts
+++ b/apps/backend/src/routes/org-provider.test.ts
@@ -136,7 +136,8 @@ describe("Organization Provider Routes", () => {
       mockSession();
       mockDb.limit
         .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
-        .mockResolvedValueOnce([]); // attachment guard: none
+        .mockResolvedValueOnce([]) // attachment guard: none
+        .mockResolvedValueOnce([]); // blueprint guard: none
       mockDb.returning.mockResolvedValueOnce([{ id: "p1" }]);
 
       const res = await app.request(`${baseUrl}/p1`, { method: "DELETE" });
@@ -149,6 +150,17 @@ describe("Organization Provider Routes", () => {
       mockDb.limit
         .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
         .mockResolvedValueOnce([{ id: "att-1" }]); // attachment guard: attached
+
+      const res = await app.request(`${baseUrl}/p1`, { method: "DELETE" });
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 409 when the provider is listed in a blueprint", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]) // attachment guard: none
+        .mockResolvedValueOnce([{ id: "bpi-1" }]); // blueprint guard: listed
 
       const res = await app.request(`${baseUrl}/p1`, { method: "DELETE" });
       expect(res.status).toBe(409);

--- a/apps/backend/src/routes/org-provider.ts
+++ b/apps/backend/src/routes/org-provider.ts
@@ -12,6 +12,7 @@ import { handleEmbeddingConfigChange } from "../services/embedding-invalidation.
 import { dedupeArray } from "../utils.ts";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
+import { isResourceListedInBlueprint } from "../services/blueprint-guard.ts";
 import type { Variables } from "../server.ts";
 
 const orgProvider = new Hono<{ Variables: Variables }>();
@@ -182,6 +183,18 @@ orgProvider.delete(
         {
           error:
             "Cannot delete: this provider is attached to one or more workspaces. Detach it first.",
+        },
+        409,
+      );
+    }
+
+    // Nor while it is listed in a Blueprint (ADR-0008) — remove it from every
+    // Blueprint first, so nothing still points at it.
+    if (await isResourceListedInBlueprint("provider", providerId)) {
+      return c.json(
+        {
+          error:
+            "Cannot delete: this provider is listed in one or more blueprints. Remove it from them first.",
         },
         409,
       );

--- a/apps/backend/src/routes/org-skill.test.ts
+++ b/apps/backend/src/routes/org-skill.test.ts
@@ -160,7 +160,8 @@ describe("Organization Skill Routes", () => {
       mockSession();
       mockDb.limit
         .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
-        .mockResolvedValueOnce([]); // attachment guard: none
+        .mockResolvedValueOnce([]) // attachment guard: none
+        .mockResolvedValueOnce([]); // blueprint guard: none
       mockDb.returning.mockResolvedValueOnce([{ id: "skill-1" }]);
 
       const res = await app.request(`${baseUrl}/skill-1`, { method: "DELETE" });
@@ -175,6 +176,17 @@ describe("Organization Skill Routes", () => {
       mockDb.limit
         .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
         .mockResolvedValueOnce([{ id: "att-1" }]); // attachment guard: attached
+
+      const res = await app.request(`${baseUrl}/skill-1`, { method: "DELETE" });
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 409 when the skill is listed in a blueprint", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]) // attachment guard: none
+        .mockResolvedValueOnce([{ id: "bpi-1" }]); // blueprint guard: listed
 
       const res = await app.request(`${baseUrl}/skill-1`, { method: "DELETE" });
       expect(res.status).toBe(409);

--- a/apps/backend/src/routes/org-skill.ts
+++ b/apps/backend/src/routes/org-skill.ts
@@ -11,6 +11,7 @@ import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
+import { isResourceListedInBlueprint } from "../services/blueprint-guard.ts";
 import type { Variables } from "../server.ts";
 
 // Org-scoped Skills are Shared resources (ADR-0007): a single source of truth
@@ -153,6 +154,18 @@ orgSkill.delete(
         {
           error:
             "Cannot delete: this skill is attached to one or more workspaces. Detach it first.",
+        },
+        409,
+      );
+    }
+
+    // Nor while it is listed in a Blueprint (ADR-0008) — remove it from every
+    // Blueprint first, so nothing still points at it.
+    if (await isResourceListedInBlueprint("skill", skillId)) {
+      return c.json(
+        {
+          error:
+            "Cannot delete: this skill is listed in one or more blueprints. Remove it from them first.",
         },
         409,
       );

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -19,6 +19,7 @@ import { orgSkill } from "./routes/org-skill.ts";
 import { orgAgent } from "./routes/org-agent.ts";
 import { orgTool } from "./routes/org-tool.ts";
 import { orgAttachment } from "./routes/org-attachment.ts";
+import { orgBlueprint } from "./routes/org-blueprint.ts";
 import { attachment } from "./routes/attachment.ts";
 import { invitation } from "./routes/invitation.ts";
 import { userInvitation } from "./routes/user-invitation.ts";
@@ -154,6 +155,7 @@ app.route("/organizations/:orgId/skills", orgSkill);
 app.route("/organizations/:orgId/agents", orgAgent);
 app.route("/organizations/:orgId/tools", orgTool);
 app.route("/organizations/:orgId/attachments", orgAttachment);
+app.route("/organizations/:orgId/blueprints", orgBlueprint);
 app.route(
   "/organizations/:orgId/workspaces/:workspaceId/attachments",
   attachment,

--- a/apps/backend/src/services/blueprint-guard.ts
+++ b/apps/backend/src/services/blueprint-guard.ts
@@ -1,0 +1,27 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "../index.ts";
+import { blueprintItem as blueprintItemTable } from "../db/schema.ts";
+
+type SharedResourceType = "mcp" | "provider" | "skill" | "agent";
+
+/**
+ * Whether a Shared resource is listed in any Blueprint (ADR-0008). Complements
+ * the while-attached guard: a Shared resource cannot be deleted while anything
+ * still points at it — an Attachment, or a Blueprint that would re-provision it.
+ */
+export const isResourceListedInBlueprint = async (
+  resourceType: SharedResourceType,
+  resourceId: string,
+): Promise<boolean> => {
+  const [row] = await db
+    .select({ id: blueprintItemTable.id })
+    .from(blueprintItemTable)
+    .where(
+      and(
+        eq(blueprintItemTable.resourceType, resourceType),
+        eq(blueprintItemTable.resourceId, resourceId),
+      ),
+    )
+    .limit(1);
+  return Boolean(row);
+};

--- a/apps/frontend/app/[orgId]/settings/blueprints/[blueprintId]/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/blueprints/[blueprintId]/page.tsx
@@ -1,0 +1,20 @@
+import { BlueprintForm } from "@/components/blueprint-form";
+import { BackButton } from "@/components/back-button";
+
+const EditBlueprintPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string; blueprintId: string }>;
+}) => {
+  const { orgId, blueprintId } = await params;
+
+  return (
+    <div>
+      <BackButton fallbackHref={`/${orgId}/settings/blueprints`} />
+      <h1 className="text-2xl font-bold mb-4">Edit Blueprint</h1>
+      <BlueprintForm orgId={orgId} blueprintId={blueprintId} />
+    </div>
+  );
+};
+
+export default EditBlueprintPage;

--- a/apps/frontend/app/[orgId]/settings/blueprints/create/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/blueprints/create/page.tsx
@@ -1,0 +1,20 @@
+import { BlueprintForm } from "@/components/blueprint-form";
+import { BackButton } from "@/components/back-button";
+
+const CreateBlueprintPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) => {
+  const { orgId } = await params;
+
+  return (
+    <div>
+      <BackButton fallbackHref={`/${orgId}/settings/blueprints`} />
+      <h1 className="text-2xl font-bold mb-4">Create Blueprint</h1>
+      <BlueprintForm orgId={orgId} />
+    </div>
+  );
+};
+
+export default CreateBlueprintPage;

--- a/apps/frontend/app/[orgId]/settings/blueprints/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/blueprints/page.tsx
@@ -1,0 +1,23 @@
+import { BlueprintsList } from "@/components/blueprints-list";
+
+const OrgBlueprintsPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) => {
+  const { orgId } = await params;
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Blueprints</h1>
+      <p className="text-muted-foreground mb-6">
+        A blueprint is a named set of shared resources. Apply it to a workspace
+        to attach them all in one step. It is a snapshot — editing a blueprint
+        never changes workspaces you have already provisioned from it.
+      </p>
+      <BlueprintsList orgId={orgId} />
+    </div>
+  );
+};
+
+export default OrgBlueprintsPage;

--- a/apps/frontend/components/apply-blueprint-dialog.tsx
+++ b/apps/frontend/components/apply-blueprint-dialog.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Field, FieldLabel } from "@/components/ui/field";
+import type { Workspace } from "@platypus/schemas";
+import useSWR from "swr";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { useBackendUrl } from "@/app/client-context";
+import { useAuth } from "@/components/auth-provider";
+
+// Apply a Blueprint to an existing Workspace (ADR-0008). The macro is additive
+// and idempotent, so re-applying only attaches what is missing — we report the
+// outcome rather than treating an all-skipped run as an error.
+export const ApplyBlueprintDialog = ({
+  orgId,
+  blueprintId,
+  blueprintName,
+  open,
+  onOpenChange,
+}: {
+  orgId: string;
+  blueprintId: string;
+  blueprintName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const { user } = useAuth();
+  const backendUrl = useBackendUrl();
+  const [workspaceId, setWorkspaceId] = useState<string>("");
+  const [applying, setApplying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{
+    attached: number;
+    skipped: number;
+    total: number;
+  } | null>(null);
+
+  const { data } = useSWR<{ results: Workspace[] }>(
+    backendUrl && user && open
+      ? joinUrl(backendUrl, `/organizations/${orgId}/workspaces`)
+      : null,
+    fetcher,
+  );
+  const workspaces = [...(data?.results || [])].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  const reset = () => {
+    setWorkspaceId("");
+    setError(null);
+    setResult(null);
+    setApplying(false);
+  };
+
+  const handleApply = async () => {
+    if (!workspaceId || !backendUrl) return;
+    setApplying(true);
+    setError(null);
+    setResult(null);
+    try {
+      const response = await fetch(
+        joinUrl(
+          backendUrl,
+          `/organizations/${orgId}/blueprints/${blueprintId}/apply`,
+        ),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ workspaceId }),
+          credentials: "include",
+        },
+      );
+      if (response.ok) {
+        setResult(await response.json());
+      } else {
+        const info = await response.json().catch(() => ({}));
+        setError(info.error || "Failed to apply blueprint.");
+      }
+    } catch {
+      setError("An unexpected error occurred.");
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!applying) {
+          if (!next) reset();
+          onOpenChange(next);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Apply “{blueprintName}”</DialogTitle>
+          <DialogDescription>
+            Attach this blueprint’s shared resources to a workspace. Re-applying
+            is safe — only what isn’t already attached is added.
+          </DialogDescription>
+        </DialogHeader>
+
+        {result ? (
+          <div className="py-2 px-4 bg-muted text-sm rounded">
+            Attached {result.attached} of {result.total} resource
+            {result.total !== 1 ? "s" : ""}
+            {result.skipped > 0
+              ? ` (${result.skipped} already attached).`
+              : "."}
+          </div>
+        ) : (
+          <Field>
+            <FieldLabel htmlFor="apply-workspace">Workspace</FieldLabel>
+            <Select value={workspaceId} onValueChange={setWorkspaceId}>
+              <SelectTrigger id="apply-workspace" disabled={applying}>
+                <SelectValue placeholder="Select a workspace" />
+              </SelectTrigger>
+              <SelectContent>
+                {workspaces.map((ws) => (
+                  <SelectItem key={ws.id} value={ws.id}>
+                    {ws.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+        )}
+
+        {error && (
+          <div className="py-2 px-4 bg-destructive/10 text-destructive text-sm rounded">
+            {error}
+          </div>
+        )}
+
+        <DialogFooter>
+          {result ? (
+            <Button
+              onClick={() => {
+                reset();
+                onOpenChange(false);
+              }}
+            >
+              Done
+            </Button>
+          ) : (
+            <>
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  reset();
+                  onOpenChange(false);
+                }}
+                disabled={applying}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleApply} disabled={applying || !workspaceId}>
+                Apply
+              </Button>
+            </>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/apps/frontend/components/blueprint-form.tsx
+++ b/apps/frontend/components/blueprint-form.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import {
+  Field,
+  FieldLabel,
+  FieldGroup,
+  FieldSet,
+  FieldDescription,
+  FieldError,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { ExpandableTextarea } from "@/components/expandable-textarea";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
+import { useRouter } from "next/navigation";
+import { Bot, Plug, Sparkles, Trash2, Unplug } from "lucide-react";
+import type {
+  Blueprint,
+  BlueprintItem,
+  AttachmentResourceType,
+} from "@platypus/schemas";
+import useSWR from "swr";
+import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import { useBackendUrl } from "@/app/client-context";
+import { useAuth } from "@/components/auth-provider";
+
+// The composer lists every Shared resource the org owns, grouped by type. A
+// Blueprint may only list org-scoped resources, so these org collections are
+// exactly the eligible set (ADR-0008).
+const RESOURCE_GROUPS: {
+  type: AttachmentResourceType;
+  label: string;
+  collection: string;
+  icon: typeof Bot;
+}[] = [
+  { type: "agent", label: "Agents", collection: "agents", icon: Bot },
+  { type: "skill", label: "Skills", collection: "skills", icon: Sparkles },
+  { type: "mcp", label: "MCP servers", collection: "mcps", icon: Plug },
+  {
+    type: "provider",
+    label: "Providers",
+    collection: "providers",
+    icon: Unplug,
+  },
+];
+
+type SharedResource = { id: string; name: string; description?: string };
+
+const itemKey = (type: AttachmentResourceType, id: string) => `${type}:${id}`;
+
+const ResourceGroup = ({
+  orgId,
+  type,
+  label,
+  collection,
+  icon: Icon,
+  selected,
+  onToggle,
+  disabled,
+}: {
+  orgId: string;
+  type: AttachmentResourceType;
+  label: string;
+  collection: string;
+  icon: typeof Bot;
+  selected: Set<string>;
+  onToggle: (type: AttachmentResourceType, id: string, on: boolean) => void;
+  disabled: boolean;
+}) => {
+  const { user } = useAuth();
+  const backendUrl = useBackendUrl();
+  const { data } = useSWR<{ results: SharedResource[] }>(
+    backendUrl && user
+      ? joinUrl(backendUrl, `/organizations/${orgId}/${collection}`)
+      : null,
+    fetcher,
+  );
+  const resources = [...(data?.results || [])].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  return (
+    <Card className="mb-4">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Icon className="size-4" /> {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {resources.length === 0 ? (
+          <FieldDescription>
+            No shared {label.toLowerCase()} in this organization yet.
+          </FieldDescription>
+        ) : (
+          <FieldGroup className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {resources.map((resource) => {
+              const key = itemKey(type, resource.id);
+              return (
+                <Field key={resource.id} orientation="horizontal">
+                  <Switch
+                    id={key}
+                    className="cursor-pointer"
+                    checked={selected.has(key)}
+                    onCheckedChange={(checked) =>
+                      onToggle(type, resource.id, checked)
+                    }
+                    disabled={disabled}
+                  />
+                  <FieldLabel htmlFor={key}>
+                    <div className="flex flex-col">
+                      <p>{resource.name}</p>
+                      {resource.description && (
+                        <p className="text-xs text-muted-foreground line-clamp-1">
+                          {resource.description}
+                        </p>
+                      )}
+                    </div>
+                  </FieldLabel>
+                </Field>
+              );
+            })}
+          </FieldGroup>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+const BlueprintForm = ({
+  classNames,
+  orgId,
+  blueprintId,
+}: {
+  classNames?: string;
+  orgId: string;
+  blueprintId?: string;
+}) => {
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const { user } = useAuth();
+  const backendUrl = useBackendUrl();
+
+  const collectionUrl = `/organizations/${orgId}/blueprints`;
+  const returnPath = `/${orgId}/settings/blueprints`;
+
+  const { data: blueprint, isLoading } = useSWR<Blueprint>(
+    blueprintId && user
+      ? joinUrl(backendUrl, `${collectionUrl}/${blueprintId}`)
+      : null,
+    fetcher,
+  );
+
+  const [formData, setFormData] = useState({ name: "", description: "" });
+  // Selected items as a Set of `${type}:${id}` keys for cheap toggling.
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [validationErrors, setValidationErrors] = useState<
+    Record<string, string>
+  >({});
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const router = useRouter();
+
+  useResetOnChange(blueprint, () => {
+    if (blueprint) {
+      setFormData({
+        name: blueprint.name,
+        description: blueprint.description ?? "",
+      });
+      setSelected(
+        new Set(
+          blueprint.items.map((i) => itemKey(i.resourceType, i.resourceId)),
+        ),
+      );
+    }
+  });
+
+  if (isLoading) {
+    return <div className={classNames}>Loading...</div>;
+  }
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { id, value } = e.target;
+    if (validationErrors[id]) {
+      setValidationErrors((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+    }
+    setFormData((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const toggleItem = (
+    type: AttachmentResourceType,
+    id: string,
+    on: boolean,
+  ) => {
+    const key = itemKey(type, id);
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(key);
+      else next.delete(key);
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true);
+    setValidationErrors({});
+    setFormError(null);
+    try {
+      const items: BlueprintItem[] = [...selected].map((key) => {
+        const [resourceType, resourceId] = key.split(":");
+        return {
+          resourceType: resourceType as AttachmentResourceType,
+          resourceId,
+        };
+      });
+      const payload = {
+        name: formData.name,
+        description: formData.description || undefined,
+        items,
+      };
+
+      const url = blueprintId
+        ? joinUrl(backendUrl, `${collectionUrl}/${blueprintId}`)
+        : joinUrl(backendUrl, collectionUrl);
+      const method = blueprintId ? "PUT" : "POST";
+
+      const response = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+        credentials: "include",
+      });
+
+      if (response.ok) {
+        router.push(returnPath);
+      } else {
+        const errorData = await response.json();
+        if (response.status === 409) {
+          setValidationErrors({ name: errorData.error || errorData.message });
+        } else if (response.status === 422) {
+          setFormError(
+            errorData.error ||
+              "A blueprint may only list organization-scoped resources.",
+          );
+        } else {
+          setValidationErrors(parseValidationErrors(errorData));
+        }
+      }
+    } catch (error) {
+      console.error("Error saving blueprint:", error);
+      setFormError("An unexpected error occurred.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!blueprintId) return;
+    setIsDeleting(true);
+    setDeleteError(null);
+    try {
+      const response = await fetch(
+        joinUrl(backendUrl, `${collectionUrl}/${blueprintId}`),
+        { method: "DELETE", credentials: "include" },
+      );
+      if (response.ok) {
+        router.push(returnPath);
+      } else {
+        const errorData = await response.json();
+        setDeleteError(
+          errorData.error || errorData.message || "Failed to delete blueprint",
+        );
+        setIsDeleting(false);
+      }
+    } catch (error) {
+      console.error("Error deleting blueprint:", error);
+      setDeleteError("An unexpected error occurred");
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className={classNames}>
+      <FieldSet className="mb-6">
+        <FieldGroup className="gap-4">
+          <Field data-invalid={!!validationErrors.name}>
+            <FieldLabel htmlFor="name">Name</FieldLabel>
+            <Input
+              id="name"
+              placeholder="Starter kit"
+              value={formData.name}
+              onChange={handleChange}
+              disabled={isSubmitting}
+              aria-invalid={!!validationErrors.name}
+              autoFocus
+            />
+            <div className="flex justify-between mt-1">
+              {validationErrors.name ? (
+                <FieldError>{validationErrors.name}</FieldError>
+              ) : (
+                <div />
+              )}
+              <p className="text-xs text-muted-foreground">
+                {formData.name.length}/100
+              </p>
+            </div>
+          </Field>
+          <Field data-invalid={!!validationErrors.description}>
+            <ExpandableTextarea
+              id="description"
+              label="Description"
+              placeholder="What this blueprint provisions..."
+              value={formData.description}
+              onChange={handleChange}
+              disabled={isSubmitting}
+              maxLength={500}
+              aria-invalid={!!validationErrors.description}
+              error={validationErrors.description}
+            />
+          </Field>
+        </FieldGroup>
+      </FieldSet>
+
+      <h2 className="text-lg font-semibold mb-1">Shared resources</h2>
+      <p className="text-sm text-muted-foreground mb-4">
+        Pick the shared resources this blueprint provisions. Applying it to a
+        workspace attaches each of these in one step.
+      </p>
+
+      {RESOURCE_GROUPS.map((group) => (
+        <ResourceGroup
+          key={group.type}
+          orgId={orgId}
+          type={group.type}
+          label={group.label}
+          collection={group.collection}
+          icon={group.icon}
+          selected={selected}
+          onToggle={toggleItem}
+          disabled={isSubmitting}
+        />
+      ))}
+
+      {formError && <FieldError className="mb-4">{formError}</FieldError>}
+
+      <div className="flex gap-2">
+        <Button
+          className="cursor-pointer"
+          onClick={handleSubmit}
+          disabled={isSubmitting}
+        >
+          {blueprintId ? "Update" : "Save"}
+        </Button>
+
+        {blueprintId && (
+          <Button
+            className="cursor-pointer"
+            variant="outline"
+            onClick={() => setIsDeleteDialogOpen(true)}
+            disabled={isSubmitting}
+          >
+            <Trash2 /> Delete
+          </Button>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={(open) => {
+          setIsDeleteDialogOpen(open);
+          if (!open) setDeleteError(null);
+        }}
+        title="Delete Blueprint"
+        description="Are you sure you want to delete this blueprint? Workspaces already provisioned from it are unaffected."
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        onConfirm={handleDelete}
+        loading={isDeleting}
+        error={deleteError}
+      />
+    </div>
+  );
+};
+
+export { BlueprintForm };

--- a/apps/frontend/components/blueprints-list.tsx
+++ b/apps/frontend/components/blueprints-list.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Item,
+  ItemTitle,
+  ItemActions,
+  ItemDescription,
+  ItemContent,
+} from "@/components/ui/item";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { EllipsisVertical, Pencil, Play, Plus, Trash2 } from "lucide-react";
+import type { Blueprint } from "@platypus/schemas";
+import useSWR from "swr";
+import { fetcher, joinUrl } from "@/lib/utils";
+import Link from "next/link";
+import { useBackendUrl } from "@/app/client-context";
+import { useAuth } from "@/components/auth-provider";
+import { ApplyBlueprintDialog } from "@/components/apply-blueprint-dialog";
+
+export const BlueprintsList = ({ orgId }: { orgId: string }) => {
+  const { user } = useAuth();
+  const backendUrl = useBackendUrl();
+  const editBasePath = `/${orgId}/settings/blueprints`;
+
+  const [blueprintToDelete, setBlueprintToDelete] = useState<Blueprint | null>(
+    null,
+  );
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [blueprintToApply, setBlueprintToApply] = useState<Blueprint | null>(
+    null,
+  );
+
+  const { data, isLoading, mutate } = useSWR<{ results: Blueprint[] }>(
+    backendUrl && user
+      ? joinUrl(backendUrl, `/organizations/${orgId}/blueprints`)
+      : null,
+    fetcher,
+  );
+
+  const blueprints = [...(data?.results || [])].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+
+  const handleDeleteConfirm = async () => {
+    if (!blueprintToDelete || !backendUrl) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const response = await fetch(
+        joinUrl(
+          backendUrl,
+          `/organizations/${orgId}/blueprints/${blueprintToDelete.id}`,
+        ),
+        { method: "DELETE", credentials: "include" },
+      );
+      if (response.ok) {
+        await mutate();
+        setBlueprintToDelete(null);
+      } else {
+        const info = await response.json().catch(() => ({}));
+        setDeleteError(info.error || "Failed to delete blueprint.");
+      }
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <>
+      {blueprints.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No blueprints yet. Create one to provision new workspaces with a set
+          of shared resources in a single step.
+        </p>
+      ) : (
+        <ul className="grid grid-cols-1 lg:grid-cols-2 gap-2 lg:gap-4">
+          {blueprints.map((blueprint) => {
+            const count = blueprint.items.length;
+            return (
+              <li key={blueprint.id}>
+                <Item
+                  variant="outline"
+                  className="h-full cursor-pointer"
+                  asChild
+                >
+                  <Link href={`${editBasePath}/${blueprint.id}`}>
+                    <ItemContent>
+                      <ItemTitle>{blueprint.name}</ItemTitle>
+                      {blueprint.description && (
+                        <ItemDescription className="text-xs line-clamp-2">
+                          {blueprint.description}
+                        </ItemDescription>
+                      )}
+                      <div className="mt-1 text-xs text-muted-foreground">
+                        {count} shared resource{count !== 1 ? "s" : ""}
+                      </div>
+                    </ItemContent>
+                    <ItemActions>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            className="cursor-pointer text-muted-foreground"
+                            variant="ghost"
+                            size="icon"
+                            onClick={(e) => e.preventDefault()}
+                          >
+                            <EllipsisVertical className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                          onClick={(e) => e.preventDefault()}
+                        >
+                          <DropdownMenuItem
+                            className="cursor-pointer"
+                            onSelect={() => setBlueprintToApply(blueprint)}
+                          >
+                            <Play /> Apply to workspace
+                          </DropdownMenuItem>
+                          <DropdownMenuItem asChild>
+                            <Link
+                              className="cursor-pointer"
+                              href={`${editBasePath}/${blueprint.id}`}
+                            >
+                              <Pencil /> Edit
+                            </Link>
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            className="cursor-pointer text-destructive focus:text-destructive"
+                            onSelect={() => {
+                              setDeleteError(null);
+                              setBlueprintToDelete(blueprint);
+                            }}
+                          >
+                            <Trash2 /> Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </ItemActions>
+                  </Link>
+                </Item>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="mt-4 flex gap-2">
+        <Button variant="outline" asChild>
+          <Link href={`${editBasePath}/create`}>
+            <Plus /> Create Blueprint
+          </Link>
+        </Button>
+      </div>
+
+      {blueprintToApply && (
+        <ApplyBlueprintDialog
+          orgId={orgId}
+          blueprintId={blueprintToApply.id}
+          blueprintName={blueprintToApply.name}
+          open={!!blueprintToApply}
+          onOpenChange={(open) => !open && setBlueprintToApply(null)}
+        />
+      )}
+
+      <ConfirmDialog
+        open={!!blueprintToDelete}
+        onOpenChange={(open) => {
+          if (!open) {
+            setBlueprintToDelete(null);
+            setDeleteError(null);
+          }
+        }}
+        title="Delete Blueprint"
+        description={`Are you sure you want to delete "${blueprintToDelete?.name}"? Workspaces already provisioned from it are unaffected.`}
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        onConfirm={handleDeleteConfirm}
+        loading={deleting}
+        error={deleteError}
+      />
+    </>
+  );
+};

--- a/apps/frontend/components/org-settings-menu.tsx
+++ b/apps/frontend/components/org-settings-menu.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/sidebar";
 import {
   Bot,
+  Layers,
   Mail,
   Plug,
   Settings,
@@ -33,6 +34,7 @@ export function OrgSettingsMenu({ orgId }: OrgSettingsMenuProps) {
   const mcpHref = `/${orgId}/settings/mcp`;
   const skillsHref = `/${orgId}/settings/skills`;
   const agentsHref = `/${orgId}/settings/agents`;
+  const blueprintsHref = `/${orgId}/settings/blueprints`;
 
   return (
     <SidebarContent>
@@ -103,6 +105,16 @@ export function OrgSettingsMenu({ orgId }: OrgSettingsMenuProps) {
               >
                 <Link href={agentsHref}>
                   <Bot /> Agents
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                asChild
+                isActive={pathname.startsWith(blueprintsHref)}
+              >
+                <Link href={blueprintsHref}>
+                  <Layers /> Blueprints
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -479,6 +479,54 @@ export const attachmentCreateSchema = attachmentBaseSchema.pick({
 });
 export type AttachmentCreateData = z.infer<typeof attachmentCreateSchema>;
 
+// Blueprint — a named, Organization-scoped macro that, applied to a Workspace,
+// creates the Attachments for a chosen set of Shared resources in one step
+// (ADR-0008). It is a snapshot, not a living binding: applying stamps
+// Attachments at that moment; later edits never disturb already-provisioned
+// Workspaces. A Blueprint may only list org-scoped (Shared) resources, so its
+// items reuse the Attachment resource-type set.
+
+const blueprintItemSchema = z.object({
+  resourceType: attachmentResourceTypeSchema,
+  resourceId: z.string(),
+});
+export type BlueprintItem = z.infer<typeof blueprintItemSchema>;
+
+const blueprintBaseSchema = z.object({
+  id: z.string(),
+  organizationId: z.string(),
+  name: z.string().min(3).max(100),
+  description: z.string().max(500).nullable().optional(),
+  // The Shared resources this Blueprint provisions. Deduped/validated by the
+  // route; each must be an org-scoped resource in the same organization.
+  items: z.array(blueprintItemSchema),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export const blueprintSchema = blueprintBaseSchema;
+export type Blueprint = z.infer<typeof blueprintSchema>;
+
+export const blueprintCreateSchema = blueprintBaseSchema.pick({
+  name: true,
+  description: true,
+  items: true,
+});
+export type BlueprintCreateData = z.infer<typeof blueprintCreateSchema>;
+
+export const blueprintUpdateSchema = blueprintBaseSchema.pick({
+  name: true,
+  description: true,
+  items: true,
+});
+export type BlueprintUpdateData = z.infer<typeof blueprintUpdateSchema>;
+
+// Apply a Blueprint to an existing Workspace (admin only, ad-hoc re-apply).
+export const blueprintApplySchema = z.object({
+  workspaceId: z.string(),
+});
+export type BlueprintApplyData = z.infer<typeof blueprintApplySchema>;
+
 // Provider
 
 export const providerApiModeSchema = z.enum(["chat", "responses"]);


### PR DESCRIPTION
Implements **#157** — the Blueprint (ADR-0008): a named, Organization-scoped macro that, applied to a Workspace, creates the Attachments for a chosen set of Shared resources in one step. It is a **snapshot, not a living binding** — applying stamps Attachments at that moment, and later edits never disturb already-provisioned Workspaces.

## Backend

- **Data model** (`schema.ts` + migration `0044`): `blueprint` (org-scoped, unique name per org) and `blueprint_item` (polymorphic `(resourceType, resourceId)` mirroring `attachment`, cascade-deleted with its blueprint, indexed for the deletion guard).
- **Schemas** (`@platypus/schemas`): `blueprintSchema`/`create`/`update` + `blueprintApplySchema`, reusing the attachment resource-type set so a Blueprint may only list the four Shared resource types.
- **Routes** (`org-blueprint.ts`, admin-only): CRUD with org-scoped-reference validation (422 + `invalidItems` when a referenced resource isn't Shared in this org), and `POST /:id/apply` which creates Attachments **additively and idempotently** via `onConflictDoNothing`, returning `{ attached, skipped, total }`.
- **Snapshot semantics**: `PUT` only rewrites `blueprint_item`; it never touches the `attachment` table, so editing a Blueprint leaves provisioned Workspaces untouched.
- **Extended deletion guard** (`services/blueprint-guard.ts`): a Shared resource (MCP/Skill/Agent/Provider) cannot be deleted while listed in any Blueprint — complements the while-attached guard from #154.

## Frontend

- Blueprints entry in the org settings nav; list / create / edit pages under `settings/blueprints/`.
- `blueprint-form` with a resource composer (toggle Agents/Skills/MCPs/Providers).
- `apply-blueprint-dialog` to pick a Workspace and apply, reporting how many resources were attached vs. already present.

## Acceptance criteria

- [x] Admin-only Blueprint CRUD on the Organization surface, including a composer of Shared resources
- [x] A Blueprint can only reference org-scoped resources
- [x] Apply-to-Workspace creates the Attachments; additive and idempotent on re-run
- [x] Editing a Blueprint does not alter already-provisioned Workspaces (snapshot semantics)
- [x] Deleting a Shared resource is blocked while it is listed in any Blueprint
- [x] Tests cover CRUD, apply (incl. idempotent re-apply), snapshot semantics, and the extended deletion guard

## Testing

- `pnpm test` — backend 875, schemas 37, frontend all pass; ESLint + tsc clean.
- New `org-blueprint.test.ts` (20 cases) plus a "listed in a blueprint" 409 case added to each of the four Shared-resource delete handlers.

> **Note:** migration `0044` is pure DDL — run `pnpm drizzle-kit-push` (with `pnpm dev` running) to apply the new tables in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)