### PR TITLE
chore: document Blueprints as an experimental feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Platypus is an open-source, full-stack application designed to help you build AI
 - **🧩 Sub-Agents:** Agents can delegate specialized tasks to other agents, enabling hierarchical multi-agent workflows with isolated contexts and result streaming.
 - **📱 Responsive Design:** A fully responsive interface that works seamlessly across desktop, tablet, and mobile devices.
 - **🔌 MCP Support:** First-class support for the **Model Context Protocol** (MCP), allowing agents to securely connect to local and remote data sources.
+- **📐 Blueprints _(experimental)_:** Define a named, organization-scoped set of shared resources (Agents, Skills, MCPs, Providers) and apply it to a Workspace to attach them all in one step. Applying is additive and idempotent, and it's a snapshot — editing a Blueprint never disturbs Workspaces you've already provisioned from it.
 - **🏖️ Sandbox _(experimental)_:** Give agents shell and filesystem access inside an isolated, per-workspace execution environment. Ships with a Docker reference backend (single-node / self-hosted only — see `compose.sandbox.yaml`); the adapter interface is pluggable so other backends can be contributed.
 - **🧠 Memory:** Platypus automatically extracts facts and preferences from your conversations in the background and injects them into future chats, so agents remember things about you over time.
 - **📋 Kanban Boards:** Organize work visually with drag-and-drop Kanban boards. Agents can create, move, and update cards autonomously via built-in Kanban tools.


### PR DESCRIPTION
Adds a **Blueprints _(experimental)_** entry to the README Key Features list, following #157 / #184.

Matches the existing style and the `_(experimental)_` convention used by Sandbox and Dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)