### PR TITLE
chore: document Scoped resource concept and typed-error ADR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,10 @@ _Avoid_: organization owner.
 The single User who owns a Workspace. Always manages composition (Agents, Skills, Chats); manages credential- and reach-bearing resources only where an Org Admin has delegated it.
 _Avoid_: workspace user, member.
 
+**Scoped resource**:
+An Agent, Skill, MCP, or Provider whose row lives at exactly one scope — a Workspace _or_ the Organization, mutually exclusive (the dual-scope shape). Resolved relative to a Workspace it yields a `(row, scope)` pair: Workspace-scoped rows are visible directly; Organization-scoped rows are visible only where an **Attachment** exists, and are locked against Workspace-surface mutation. The **Shared resource** is the Organization-scoped case of a Scoped resource.
+_Avoid_: dual-scope entity, polymorphic resource.
+
 **Shared resource**:
 An Agent, Skill, MCP, or Provider defined once at Organization scope and _referenced_ (not copied) by Workspaces. A single source of truth: edited only by Org Admins, surfaced as locked to Workspace Owners. A Shared resource may only reference other Shared resources — sharing is always explicit and per-resource, never implicit or cascading.
 _Avoid_: org agent, global agent.
@@ -78,7 +82,7 @@ _Avoid_: template, policy, group.
 - A **Chat turn** uses either an **Agent** or a direct **Provider** + model selection.
 - An **Agent** references one **Provider**, zero-or-more **Tool sets** (static or **MCP**-backed), zero-or-more **Skills**, and zero-or-more **Sub-Agents**.
 - A **Provider** belongs to either an **Organization** (shared) or a **Workspace** (private).
-- An **Agent**, **Skill**, **MCP**, or **Provider** may be a **Shared resource** at **Organization** scope, referenced by **Workspaces** through an **Attachment**; a Sandbox-backed **Tool set** instead rebinds to the invoking **Workspace**'s **Sandbox** at Chat-turn time.
+- An **Agent**, **Skill**, **MCP**, or **Provider** is a **Scoped resource**: its row carries either an `organizationId` or a `workspaceId`, never both. Resolved relative to a **Workspace**, an Organization-scoped one is a **Shared resource**, visible only through an **Attachment**; a Sandbox-backed **Tool set** instead rebinds to the invoking **Workspace**'s **Sandbox** at Chat-turn time.
 - A **Blueprint** names a set of **Shared resources** and, applied to a **Workspace**, creates their **Attachments** in one step.
 - **Workspaces** are created only by **Org Admins** — directly, or auto-provisioned for a member when they accept an invitation. An invitation carries an ordered set of zero-or-more **Blueprints**; on accept they are applied to the new Workspace in order (Attachments union; later Blueprints win on any single-valued pointer-setting). Members do not create their own Workspaces.
 - Authority over configuration runs **Operator** → **Org Admin** → **Workspace Owner**; each tier is bounded by the tier above it.

--- a/docs/adr/0009-typed-errors-with-central-onerror-mapping.md
+++ b/docs/adr/0009-typed-errors-with-central-onerror-mapping.md
@@ -1,0 +1,51 @@
+---
+status: accepted
+---
+
+# Domain code throws typed errors; one `app.onError` maps them to HTTP status
+
+Cross-cutting failure modes — a resource that does not exist, an Organization-scoped
+(Shared) **Scoped resource** that is locked against Workspace-surface mutation, and a
+unique-constraint violation — are raised as typed errors (`NotFoundError`, `LockedError`,
+`ConflictError`) from services and route handlers, and mapped to HTTP status in a single
+Hono `app.onError` handler (`NotFound → 404`, `Locked → 403`, `Conflict → 409`). This
+replaces the prior pattern where every route returned `c.json({ error }, status)` inline
+and each create/update route hand-rolled its own Postgres unique-violation detection.
+
+The motivating change is the `ScopedResource` read module (`services/scoped-resource.ts`):
+its `requireScoped` / `requireWorkspaceMutable` entry points throw `NotFoundError` /
+`LockedError` so the ~5 dual-scope resource routes stop re-implementing the
+"resolve → null-check → org-scope-403" branch. Pure `resolveScoped` / `listScoped`
+remain exception-free for callers that tolerate absence.
+
+## Considered Options
+
+- **Status quo — inline `c.json({ error }, status)` per route.** Rejected: the
+  visibility-resolution, lock, and uniqueness responses were duplicated across ~8 route
+  files (notably 8 byte-identical copies of `isUniqueViolation`), with no single place to
+  fix the message or the status.
+- **A shared helper returning a discriminated result the route branches on** (no throw).
+  Rejected: keeps the branch at every call site; the route still has to translate the
+  result into a response. The win is partial — locality of the _decision_ without locality
+  of the _response_.
+- **Throw only `LockedError` + `NotFoundError`; leave uniqueness per-route.** Rejected:
+  once a central `onError` exists, folding the unique-violation mapping in deletes all 8
+  copies for one extra mapping line — the larger blast radius (touching each create/update
+  catch block) is the point of the refactor, not a reason to stop short.
+
+## Consequences
+
+- New module `apps/backend/src/errors.ts` holds the typed error classes; a single
+  `app.onError` in the server entry maps them, including a catch for Postgres unique
+  violations (SQLSTATE `23505` across driver shapes) → `409`.
+- Routes that currently `return c.json({ error }, status)` for these three cases are
+  migrated to throw (or to let the module's throw propagate). Other, route-specific 4xx
+  responses (validation, sub-agent rules, `findNonSharedReferences`) stay inline — only the
+  three cross-cutting modes move to the seam.
+- The keys-only / message conventions for the lock response (`"managed at the organization
+level"`) and name conflicts move into `onError`, so they are defined once.
+- `resolveScoped` and `listScoped` deliberately do **not** throw, preserving a pure,
+  reusable predicate for callers (e.g. the Chat-turn attachment check) that treat absence
+  as a normal outcome rather than a 404.
+- Authorization is unchanged: middleware still decides actor access and returns its own
+  403s inline. The error seam covers resource-state failures, not authorization.


### PR DESCRIPTION
## What

Captures the design decisions from an architecture review of the dual-scope (Workspace vs Organization) resource duplication. Docs only — no implementation.

- **`CONTEXT.md`** — adds the **Scoped resource** term: the dual-scope umbrella (an Agent/Skill/MCP/Provider row carries either an `organizationId` or a `workspaceId`), with **Shared resource** as its Organization-scoped case. Relationships section now names the dual-scope shape explicitly.
- **ADR-0009** — domain code throws typed errors (`NotFoundError`, `LockedError`, `ConflictError`) mapped to HTTP status in a single Hono `app.onError`, replacing per-route inline `c.json(...)` and the 8 copies of `isUniqueViolation`. Records the rejected alternatives.

## Why

These two docs are the durable output of the review's grilling session. They define the seam for the `ScopedResource` read module before any code lands.

## Follow-up implementation

Sliced into AFK-ready issues:

- #187 — ScopedResource module + typed-error seam (tracer bullet, proven on Agent)
- #188 / #189 / #190 — migrate Skill / MCP / Provider routes (blocked by #187, parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)