### PR TITLE
feat: blueprints on invitations + Tier 2 workspace settings

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,7 +71,7 @@ The explicit reference that makes a Shared resource appear inside a Workspace. A
 The Org-Admin action that re-scopes a Workspace-private resource to Organization scope, turning it into a Shared resource and auto-attaching its origin Workspace. The resource becomes Org-Admin-governed.
 
 **Blueprint**:
-A named, Organization-scoped macro that, applied to a Workspace, creates the Attachments for a chosen set of Shared resources in one step — run once at provisioning (or re-run on demand), never a live link. Editing a Blueprint affects only later applications; already-provisioned Workspaces are unchanged. The primary tool for provisioning a ready-to-use Workspace during onboarding.
+A named, Organization-scoped macro that, applied to a Workspace, both creates the Attachments for a chosen set of Shared resources (Tier 1) and sets the Workspace's pointer-settings — task/memory Providers and a default Context (Tier 2) — in one step. Run once at provisioning (or re-run on demand), never a live link. A Tier 2 Provider must also be one the Blueprint attaches. Editing a Blueprint affects only later applications; already-provisioned Workspaces are unchanged. The primary tool for provisioning a ready-to-use Workspace during onboarding.
 _Avoid_: template, policy, group.
 
 ## Relationships

--- a/apps/backend/drizzle/0045_married_roxanne_simpson.sql
+++ b/apps/backend/drizzle/0045_married_roxanne_simpson.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "invitation_blueprint" (
+	"id" text PRIMARY KEY NOT NULL,
+	"invitation_id" text NOT NULL,
+	"blueprint_id" text NOT NULL,
+	"position" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "unique_invitation_blueprint" UNIQUE("invitation_id","blueprint_id")
+);
+--> statement-breakpoint
+ALTER TABLE "blueprint" ADD COLUMN "task_model_provider_id" text;--> statement-breakpoint
+ALTER TABLE "blueprint" ADD COLUMN "memory_extraction_provider_id" text;--> statement-breakpoint
+ALTER TABLE "blueprint" ADD COLUMN "memory_embedding_provider_id" text;--> statement-breakpoint
+ALTER TABLE "blueprint" ADD COLUMN "context" text;--> statement-breakpoint
+ALTER TABLE "invitation_blueprint" ADD CONSTRAINT "invitation_blueprint_invitation_id_invitation_id_fk" FOREIGN KEY ("invitation_id") REFERENCES "public"."invitation"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invitation_blueprint" ADD CONSTRAINT "invitation_blueprint_blueprint_id_blueprint_id_fk" FOREIGN KEY ("blueprint_id") REFERENCES "public"."blueprint"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_invitation_blueprint_invitation" ON "invitation_blueprint" USING btree ("invitation_id");--> statement-breakpoint
+CREATE INDEX "idx_invitation_blueprint_blueprint" ON "invitation_blueprint" USING btree ("blueprint_id");--> statement-breakpoint
+ALTER TABLE "blueprint" ADD CONSTRAINT "blueprint_task_model_provider_id_provider_id_fk" FOREIGN KEY ("task_model_provider_id") REFERENCES "public"."provider"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "blueprint" ADD CONSTRAINT "blueprint_memory_extraction_provider_id_provider_id_fk" FOREIGN KEY ("memory_extraction_provider_id") REFERENCES "public"."provider"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "blueprint" ADD CONSTRAINT "blueprint_memory_embedding_provider_id_provider_id_fk" FOREIGN KEY ("memory_embedding_provider_id") REFERENCES "public"."provider"("id") ON DELETE set null ON UPDATE no action;

--- a/apps/backend/drizzle/meta/0045_snapshot.json
+++ b/apps/backend/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,4291 @@
+{
+  "id": "668db7b6-9bad-46e6-b6bc-2533fce5ce32",
+  "prevId": "44b1a862-f636-4e44-a960-9cbc20b779cc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_set_ids": {
+          "name": "tool_set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "skill_ids": {
+          "name": "skill_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "sub_agent_ids": {
+          "name": "sub_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "input_placeholder": {
+          "name": "input_placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_workspace_id": {
+          "name": "idx_agent_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_organization_id": {
+          "name": "idx_agent_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_provider_id": {
+          "name": "idx_agent_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_id_workspace_id_fk": {
+          "name": "agent_workspace_id_workspace_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_provider_id_provider_id_fk": {
+          "name": "agent_provider_id_provider_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_agent_name_org": {
+          "name": "unique_agent_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment": {
+      "name": "attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_attachment_workspace": {
+          "name": "idx_attachment_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attachment_resource": {
+          "name": "idx_attachment_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_workspace_id_workspace_id_fk": {
+          "name": "attachment_workspace_id_workspace_id_fk",
+          "tableFrom": "attachment",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_attachment": {
+          "name": "unique_attachment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "resource_type",
+            "resource_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blueprint": {
+      "name": "blueprint",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_model_provider_id": {
+          "name": "task_model_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_provider_id": {
+          "name": "memory_extraction_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_embedding_provider_id": {
+          "name": "memory_embedding_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blueprint_organization_id": {
+          "name": "idx_blueprint_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blueprint_organization_id_organization_id_fk": {
+          "name": "blueprint_organization_id_organization_id_fk",
+          "tableFrom": "blueprint",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blueprint_task_model_provider_id_provider_id_fk": {
+          "name": "blueprint_task_model_provider_id_provider_id_fk",
+          "tableFrom": "blueprint",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "task_model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "blueprint_memory_extraction_provider_id_provider_id_fk": {
+          "name": "blueprint_memory_extraction_provider_id_provider_id_fk",
+          "tableFrom": "blueprint",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_extraction_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "blueprint_memory_embedding_provider_id_provider_id_fk": {
+          "name": "blueprint_memory_embedding_provider_id_provider_id_fk",
+          "tableFrom": "blueprint",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_embedding_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_blueprint_name_org": {
+          "name": "unique_blueprint_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blueprint_item": {
+      "name": "blueprint_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blueprint_item_blueprint": {
+          "name": "idx_blueprint_item_blueprint",
+          "columns": [
+            {
+              "expression": "blueprint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_blueprint_item_resource": {
+          "name": "idx_blueprint_item_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blueprint_item_blueprint_id_blueprint_id_fk": {
+          "name": "blueprint_item_blueprint_id_blueprint_id_fk",
+          "tableFrom": "blueprint_item",
+          "tableTo": "blueprint",
+          "columnsFrom": [
+            "blueprint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_blueprint_item": {
+          "name": "unique_blueprint_item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "blueprint_id",
+            "resource_type",
+            "resource_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_memory_processed_at": {
+          "name": "last_memory_processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_status": {
+          "name": "memory_extraction_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_workspace_id": {
+          "name": "idx_chat_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_tags": {
+          "name": "idx_chat_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_chat_memory_processing": {
+          "name": "idx_chat_memory_processing",
+          "columns": [
+            {
+              "expression": "memory_extraction_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_memory_processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_workspace_id_workspace_id_fk": {
+          "name": "chat_workspace_id_workspace_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context": {
+      "name": "context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_context_user_id": {
+          "name": "idx_context_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_workspace_id": {
+          "name": "idx_context_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "context_user_id_user_id_fk": {
+          "name": "context_user_id_user_id_fk",
+          "tableFrom": "context",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "context_workspace_id_workspace_id_fk": {
+          "name": "context_workspace_id_workspace_id_fk",
+          "tableFrom": "context",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_context_user_workspace": {
+          "name": "unique_context_user_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard": {
+      "name": "dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desktop_layout": {
+          "name": "desktop_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mobile_layout": {
+          "name": "mobile_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_dashboard_workspace_id": {
+          "name": "idx_dashboard_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_dashboard_workspace_name": {
+          "name": "uq_dashboard_workspace_name",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_workspace_id_workspace_id_fk": {
+          "name": "dashboard_workspace_id_workspace_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitation_email": {
+          "name": "idx_invitation_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitation_org_id": {
+          "name": "idx_invitation_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_invited_by_user_id_fk": {
+          "name": "invitation_invited_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_invitation_org_email": {
+          "name": "unique_invitation_org_email",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_blueprint": {
+      "name": "invitation_blueprint",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitation_blueprint_invitation": {
+          "name": "idx_invitation_blueprint_invitation",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitation_blueprint_blueprint": {
+          "name": "idx_invitation_blueprint_blueprint",
+          "columns": [
+            {
+              "expression": "blueprint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_blueprint_invitation_id_invitation_id_fk": {
+          "name": "invitation_blueprint_invitation_id_invitation_id_fk",
+          "tableFrom": "invitation_blueprint",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_blueprint_blueprint_id_blueprint_id_fk": {
+          "name": "invitation_blueprint_blueprint_id_blueprint_id_fk",
+          "tableFrom": "invitation_blueprint",
+          "tableTo": "blueprint",
+          "columnsFrom": [
+            "blueprint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_invitation_blueprint": {
+          "name": "unique_invitation_blueprint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitation_id",
+            "blueprint_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_board": {
+      "name": "kanban_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_board_workspace_id": {
+          "name": "idx_kanban_board_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_board_workspace_id_workspace_id_fk": {
+          "name": "kanban_board_workspace_id_workspace_id_fk",
+          "tableFrom": "kanban_board",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_kanban_board_name_workspace": {
+          "name": "unique_kanban_board_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card": {
+      "name": "kanban_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_ids": {
+          "name": "label_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "assignees": {
+          "name": "assignees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_user_id": {
+          "name": "last_edited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_agent_id": {
+          "name": "last_edited_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_column_id": {
+          "name": "idx_kanban_card_column_id",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_label_ids": {
+          "name": "idx_kanban_card_label_ids",
+          "columns": [
+            {
+              "expression": "label_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_kanban_card_assignees": {
+          "name": "idx_kanban_card_assignees",
+          "columns": [
+            {
+              "expression": "assignees",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_kanban_card_due_date": {
+          "name": "idx_kanban_card_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_priority": {
+          "name": "idx_kanban_card_priority",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_column_position": {
+          "name": "idx_kanban_card_column_position",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_column_id_kanban_column_id_fk": {
+          "name": "kanban_card_column_id_kanban_column_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "kanban_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kanban_card_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_last_edited_by_user_id_user_id_fk": {
+          "name": "kanban_card_last_edited_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "last_edited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_last_edited_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_last_edited_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "last_edited_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card_comment": {
+      "name": "kanban_card_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_comment_card_id": {
+          "name": "idx_kanban_card_comment_card_id",
+          "columns": [
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_comment_card_id_kanban_card_id_fk": {
+          "name": "kanban_card_comment_card_id_kanban_card_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "kanban_card",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kanban_card_comment_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_comment_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_comment_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_comment_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_column": {
+      "name": "kanban_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_column_board_id": {
+          "name": "idx_kanban_column_board_id",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_column_board_id_kanban_board_id_fk": {
+          "name": "kanban_column_board_id_kanban_board_id_fk",
+          "tableFrom": "kanban_column",
+          "tableTo": "kanban_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp": {
+      "name": "mcp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_access_token": {
+          "name": "oauth_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_refresh_token": {
+          "name": "oauth_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_expires_at": {
+          "name": "oauth_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_requested_scope": {
+          "name": "oauth_requested_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_workspace_id": {
+          "name": "idx_mcp_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_organization_id": {
+          "name": "idx_mcp_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_organization_id_organization_id_fk": {
+          "name": "mcp_organization_id_organization_id_fk",
+          "tableFrom": "mcp",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_workspace_id_workspace_id_fk": {
+          "name": "mcp_workspace_id_workspace_id_fk",
+          "tableFrom": "mcp",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_mcp_name_org": {
+          "name": "unique_mcp_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        },
+        "unique_mcp_name_workspace": {
+          "name": "unique_mcp_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_state": {
+      "name": "mcp_oauth_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_oauth_state_mcp_id": {
+          "name": "idx_mcp_oauth_state_mcp_id",
+          "columns": [
+            {
+              "expression": "mcp_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_state_mcp_id_mcp_id_fk": {
+          "name": "mcp_oauth_state_mcp_id_mcp_id_fk",
+          "tableFrom": "mcp_oauth_state",
+          "tableTo": "mcp",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_daily_summary": {
+      "name": "memory_daily_summary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_date": {
+          "name": "summary_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_summary_user_workspace": {
+          "name": "idx_daily_summary_user_workspace",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_summary_date": {
+          "name": "idx_daily_summary_date",
+          "columns": [
+            {
+              "expression": "summary_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_daily_summary_user_id_user_id_fk": {
+          "name": "memory_daily_summary_user_id_user_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_daily_summary_workspace_id_workspace_id_fk": {
+          "name": "memory_daily_summary_workspace_id_workspace_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_daily_summary_user_workspace_date": {
+          "name": "unique_daily_summary_user_workspace_date",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workspace_id",
+            "summary_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_workspace_id": {
+          "name": "idx_notification_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_agent_id": {
+          "name": "idx_notification_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_created_at": {
+          "name": "idx_notification_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_workspace_id_workspace_id_fk": {
+          "name": "notification_workspace_id_workspace_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_agent_id_agent_id_fk": {
+          "name": "notification_agent_id_agent_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_read": {
+      "name": "notification_read",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_read_user_id": {
+          "name": "idx_notification_read_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_read_notification_id": {
+          "name": "idx_notification_read_notification_id",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_read_notification_id_notification_id_fk": {
+          "name": "notification_read_notification_id_notification_id_fk",
+          "tableFrom": "notification_read",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_read_user_id_user_id_fk": {
+          "name": "notification_read_user_id_user_id_fk",
+          "tableFrom": "notification_read",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_notification_read": {
+          "name": "unique_notification_read",
+          "nullsNotDistinct": false,
+          "columns": [
+            "notification_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_member": {
+      "name": "organization_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_member_org_id": {
+          "name": "idx_org_member_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_member_user_id": {
+          "name": "idx_org_member_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_member_organization_id_organization_id_fk": {
+          "name": "organization_member_organization_id_organization_id_fk",
+          "tableFrom": "organization_member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_member_user_id_user_id_fk": {
+          "name": "organization_member_user_id_user_id_fk",
+          "tableFrom": "organization_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraBody": {
+          "name": "extraBody",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_mode": {
+          "name": "api_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'responses'"
+        },
+        "native_search_enabled": {
+          "name": "native_search_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "modelIds": {
+          "name": "modelIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_model_id": {
+          "name": "task_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_extraction_model_id": {
+          "name": "memory_extraction_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_workspace_id": {
+          "name": "idx_provider_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_organization_id": {
+          "name": "idx_provider_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_organization_id_organization_id_fk": {
+          "name": "provider_organization_id_organization_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_provider_name_org": {
+          "name": "unique_provider_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        },
+        "unique_provider_name_workspace": {
+          "name": "unique_provider_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox": {
+      "name": "sandbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "admin_env": {
+          "name": "admin_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_env": {
+          "name": "user_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_sandbox_workspace_id": {
+          "name": "unique_sandbox_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_workspace_id_workspace_id_fk": {
+          "name": "sandbox_workspace_id_workspace_id_fk",
+          "tableFrom": "sandbox",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_teardown_failure": {
+      "name": "sandbox_teardown_failure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_teardown_failure_workspace_id": {
+          "name": "idx_sandbox_teardown_failure_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill": {
+      "name": "skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_workspace_id": {
+          "name": "idx_skill_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skill_organization_id": {
+          "name": "idx_skill_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_organization_id_organization_id_fk": {
+          "name": "skill_organization_id_organization_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_workspace_id_workspace_id_fk": {
+          "name": "skill_workspace_id_workspace_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_skill_name_workspace": {
+          "name": "unique_skill_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "unique_skill_name_org": {
+          "name": "unique_skill_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger": {
+      "name": "trigger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_runs_to_keep": {
+          "name": "max_runs_to_keep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "search": {
+          "name": "search",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_workspace_id": {
+          "name": "idx_trigger_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_next_run_at": {
+          "name": "idx_trigger_next_run_at",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_type": {
+          "name": "idx_trigger_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_workspace_id_workspace_id_fk": {
+          "name": "trigger_workspace_id_workspace_id_fk",
+          "tableFrom": "trigger",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_agent_id_agent_id_fk": {
+          "name": "trigger_agent_id_agent_id_fk",
+          "tableFrom": "trigger",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_run": {
+      "name": "trigger_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_run_trigger_id": {
+          "name": "idx_trigger_run_trigger_id",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_run_started_at": {
+          "name": "idx_trigger_run_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_run_trigger_id_trigger_id_fk": {
+          "name": "trigger_run_trigger_id_trigger_id_fk",
+          "tableFrom": "trigger_run",
+          "tableTo": "trigger",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Webhook'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_secret": {
+          "name": "signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhook_workspace_id": {
+          "name": "idx_webhook_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_workspace_id_workspace_id_fk": {
+          "name": "webhook_workspace_id_workspace_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget": {
+      "name": "widget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_widget_dashboard_id": {
+          "name": "idx_widget_dashboard_id",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_widget_dashboard_title": {
+          "name": "uq_widget_dashboard_title",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "widget_dashboard_id_dashboard_id_fk": {
+          "name": "widget_dashboard_id_dashboard_id_fk",
+          "tableFrom": "widget",
+          "tableTo": "dashboard",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace": {
+      "name": "workspace",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_model_provider_id": {
+          "name": "task_model_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_provider_id": {
+          "name": "memory_extraction_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_embedding_provider_id": {
+          "name": "memory_embedding_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_daily_summaries": {
+          "name": "max_daily_summaries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 90
+        },
+        "provider_self_management": {
+          "name": "provider_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mcp_self_management": {
+          "name": "mcp_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_organization_id": {
+          "name": "idx_workspace_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_owner_id": {
+          "name": "idx_workspace_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_organization_id_organization_id_fk": {
+          "name": "workspace_organization_id_organization_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_owner_id_user_id_fk": {
+          "name": "workspace_owner_id_user_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_task_model_provider_id_provider_id_fk": {
+          "name": "workspace_task_model_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "task_model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_memory_extraction_provider_id_provider_id_fk": {
+          "name": "workspace_memory_extraction_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_extraction_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_memory_embedding_provider_id_provider_id_fk": {
+          "name": "workspace_memory_embedding_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_embedding_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1780727883893,
       "tag": "0044_colorful_dracula",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1780816408681,
+      "tag": "0045_married_roxanne_simpson",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -336,6 +336,24 @@ export const blueprint = pgTable(
       .references(() => organization.id, { onDelete: "cascade" }),
     name: t.text("name").notNull(),
     description: t.text("description"),
+
+    // Tier 2 pointer-settings (ADR-0008): the Workspace settings a Blueprint
+    // stamps on apply, mirroring the Workspace's own columns. All three provider
+    // references must be org-scoped (Shared) — enforced in the route. `context`
+    // is the default Workspace context text. Deleting a referenced provider sets
+    // these null (SET NULL), matching the Workspace's pointer-setting behavior;
+    // the blueprint_item deletion guard does not cover Tier 2 references.
+    taskModelProviderId: t
+      .text("task_model_provider_id")
+      .references(() => provider.id, { onDelete: "set null" }),
+    memoryExtractionProviderId: t
+      .text("memory_extraction_provider_id")
+      .references(() => provider.id, { onDelete: "set null" }),
+    memoryEmbeddingProviderId: t
+      .text("memory_embedding_provider_id")
+      .references(() => provider.id, { onDelete: "set null" }),
+    context: t.text("context"),
+
     createdAt: t.timestamp("created_at").notNull().defaultNow(),
     updatedAt: t.timestamp("updated_at").notNull().defaultNow(),
   }),
@@ -485,6 +503,36 @@ export const invitation = pgTable(
     index("idx_invitation_email").on(t.email),
     index("idx_invitation_org_id").on(t.organizationId),
     unique("unique_invitation_org_email").on(t.organizationId, t.email),
+  ],
+);
+
+// The ordered set of Blueprints an invitation carries (ADR-0009). On accept,
+// each Blueprint's macro runs in `position` order against the freshly
+// provisioned Workspace. Mirrors `blueprint_item`: `position` makes order
+// first-class, and the real `blueprint_id` FK powers the deletion guard
+// (a Blueprint cannot be deleted while a live pending invitation references it).
+// Both FKs cascade — deleting an invitation or a (legitimately deletable)
+// Blueprint cleans up the junction rows.
+export const invitationBlueprint = pgTable(
+  "invitation_blueprint",
+  (t) => ({
+    id: t.text("id").primaryKey(),
+    invitationId: t
+      .text("invitation_id")
+      .notNull()
+      .references(() => invitation.id, { onDelete: "cascade" }),
+    blueprintId: t
+      .text("blueprint_id")
+      .notNull()
+      .references(() => blueprint.id, { onDelete: "cascade" }),
+    position: t.integer("position").notNull(),
+    createdAt: t.timestamp("created_at").notNull().defaultNow(),
+  }),
+  (t) => [
+    index("idx_invitation_blueprint_invitation").on(t.invitationId),
+    // Drives the deletion guard ("is this Blueprint referenced by an invite?")
+    index("idx_invitation_blueprint_blueprint").on(t.blueprintId),
+    unique("unique_invitation_blueprint").on(t.invitationId, t.blueprintId),
   ],
 );
 

--- a/apps/backend/src/routes/invitation.test.ts
+++ b/apps/backend/src/routes/invitation.test.ts
@@ -41,7 +41,63 @@ describe("Invitation Routes", () => {
       });
 
       expect(res.status).toBe(201);
-      expect(await res.json()).toEqual(mockInvitation);
+      // The response echoes the ordered blueprint set (empty here, ADR-0009).
+      expect(await res.json()).toEqual({ ...mockInvitation, blueprintIds: [] });
+    });
+
+    // ADR-0009: an invitation carries an ordered set of Blueprints, stored in
+    // the invitation_blueprint junction with `position`.
+    it("persists an ordered set of blueprints", async () => {
+      mockSession({ id: "admin-1", email: "admin@example.com", role: "user" });
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      // Blueprint validation: both ids resolve to org-scoped blueprints.
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "bp-1" }, { id: "bp-2" }]); // validation
+      mockDb.returning.mockResolvedValueOnce([{ id: "inv-1" }]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          email: "user@example.com",
+          // Duplicate bp-1 — the set dedupes while preserving order.
+          blueprintIds: ["bp-1", "bp-2", "bp-1"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(201);
+      expect((await res.json()).blueprintIds).toEqual(["bp-1", "bp-2"]);
+
+      // The junction insert carries the ordered, deduped set with positions.
+      const junctionInsert = mockDb.values.mock.calls
+        .map((c) => c[0])
+        .find((v) => Array.isArray(v) && v[0]?.blueprintId);
+      expect(junctionInsert).toEqual([
+        expect.objectContaining({ blueprintId: "bp-1", position: 0 }),
+        expect.objectContaining({ blueprintId: "bp-2", position: 1 }),
+      ]);
+    });
+
+    it("422s when a blueprint is not in this organization", async () => {
+      mockSession({ id: "admin-1", email: "admin@example.com", role: "user" });
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      // Only bp-1 resolves; bp-2 is foreign / missing.
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "bp-1" }]); // validation
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          email: "user@example.com",
+          blueprintIds: ["bp-1", "bp-2"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(422);
+      expect((await res.json()).missingBlueprintIds).toEqual(["bp-2"]);
     });
 
     // ADR-0008: the invitation carries an optional Workspace name used to
@@ -91,21 +147,30 @@ describe("Invitation Routes", () => {
   });
 
   describe("GET /", () => {
-    it("should list invitations", async () => {
+    it("should list invitations, each with its ordered blueprint set", async () => {
       mockSession();
       // requireOrgAccess
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
 
       const mockInvitations = [
-        { id: "inv-1", email: "user@example.com", workspaceName: "WS 1" },
+        { id: "inv-1", email: "a@example.com", workspaceName: "WS 1" },
+        { id: "inv-2", email: "b@example.com", workspaceName: "WS 2" },
       ];
       mockDb.where
-        .mockReturnValueOnce(mockDb)
-        .mockResolvedValueOnce(mockInvitations);
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockResolvedValueOnce(mockInvitations); // list invitations
+      // Junction rows for the listed invitations (already in position order).
+      mockDb.orderBy.mockResolvedValueOnce([
+        { invitationId: "inv-1", blueprintId: "bp-1" },
+        { invitationId: "inv-1", blueprintId: "bp-2" },
+      ]);
 
       const res = await app.request(baseUrl);
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ results: mockInvitations });
+      const json = await res.json();
+      expect(json.results[0].blueprintIds).toEqual(["bp-1", "bp-2"]);
+      // An invite with no blueprints reports an empty set, not undefined.
+      expect(json.results[1].blueprintIds).toEqual([]);
     });
   });
 

--- a/apps/backend/src/routes/invitation.ts
+++ b/apps/backend/src/routes/invitation.ts
@@ -2,9 +2,13 @@ import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import { invitation as invitationTable } from "../db/schema.ts";
+import {
+  invitation as invitationTable,
+  invitationBlueprint as invitationBlueprintTable,
+  blueprint as blueprintTable,
+} from "../db/schema.ts";
 import { invitationCreateSchema } from "@platypus/schemas";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray, asc } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
@@ -31,24 +35,66 @@ invitation.post(
       return c.json({ error: "You cannot invite yourself" }, 400);
     }
 
+    // The invitation carries an ordered set of Blueprints (ADR-0009). Dedupe
+    // while preserving order — it is a *set*, and `position` makes the order
+    // first-class. Each must be a Blueprint in this organization.
+    const blueprintIds = [...new Set(data.blueprintIds ?? [])];
+    if (blueprintIds.length > 0) {
+      const found = await db
+        .select({ id: blueprintTable.id })
+        .from(blueprintTable)
+        .where(
+          and(
+            eq(blueprintTable.organizationId, orgId),
+            inArray(blueprintTable.id, blueprintIds),
+          ),
+        );
+      const foundSet = new Set(found.map((b) => b.id));
+      const missing = blueprintIds.filter((id) => !foundSet.has(id));
+      if (missing.length > 0) {
+        return c.json(
+          {
+            error: "One or more blueprints were not found in this organization",
+            missingBlueprintIds: missing,
+          },
+          422,
+        );
+      }
+    }
+
     const expiresAt = new Date();
     expiresAt.setDate(expiresAt.getDate() + INVITATION_EXPIRY_DAYS);
 
+    const invitationId = nanoid();
     try {
-      const record = await db
-        .insert(invitationTable)
-        .values({
-          id: nanoid(),
-          email: data.email,
-          organizationId: orgId,
-          invitedBy: user.id,
-          status: "pending",
-          workspaceName: data.workspaceName ?? null,
-          expiresAt,
-        })
-        .returning();
+      const record = await db.transaction(async (tx) => {
+        const [row] = await tx
+          .insert(invitationTable)
+          .values({
+            id: invitationId,
+            email: data.email,
+            organizationId: orgId,
+            invitedBy: user.id,
+            status: "pending",
+            workspaceName: data.workspaceName ?? null,
+            expiresAt,
+          })
+          .returning();
 
-      return c.json(record[0], 201);
+        if (blueprintIds.length > 0) {
+          await tx.insert(invitationBlueprintTable).values(
+            blueprintIds.map((blueprintId, position) => ({
+              id: nanoid(),
+              invitationId,
+              blueprintId,
+              position,
+            })),
+          );
+        }
+        return row;
+      });
+
+      return c.json({ ...record, blueprintIds }, 201);
     } catch (error: any) {
       const isDuplicate =
         error.code === "23505" ||
@@ -81,7 +127,32 @@ invitation.get("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
     .from(invitationTable)
     .where(eq(invitationTable.organizationId, orgId));
 
-  return c.json({ results });
+  // Attach each invitation's ordered set of Blueprints (ADR-0009), in
+  // `position` order, so the admin can see what a pending invite will provision.
+  const byInvitation = new Map<string, string[]>();
+  const invitationIds = results.map((r) => r.id);
+  if (invitationIds.length > 0) {
+    const rows = await db
+      .select({
+        invitationId: invitationBlueprintTable.invitationId,
+        blueprintId: invitationBlueprintTable.blueprintId,
+      })
+      .from(invitationBlueprintTable)
+      .where(inArray(invitationBlueprintTable.invitationId, invitationIds))
+      .orderBy(asc(invitationBlueprintTable.position));
+    for (const row of rows) {
+      const ids = byInvitation.get(row.invitationId) ?? [];
+      ids.push(row.blueprintId);
+      byInvitation.set(row.invitationId, ids);
+    }
+  }
+
+  return c.json({
+    results: results.map((r) => ({
+      ...r,
+      blueprintIds: byInvitation.get(r.id) ?? [],
+    })),
+  });
 });
 
 /** Delete an invitation (org admin only) */

--- a/apps/backend/src/routes/org-blueprint.test.ts
+++ b/apps/backend/src/routes/org-blueprint.test.ts
@@ -96,6 +96,129 @@ describe("Organization Blueprint Routes", () => {
       });
       expect(res.status).toBe(403);
     });
+
+    // ADR-0008 Tier 2: a Blueprint can carry Workspace pointer-settings, but a
+    // Tier 2 provider must be one the blueprint also attaches.
+    it("persists Tier 2 settings when the provider is also an attached item", async () => {
+      mockSession();
+      const record = {
+        id: "bp-1",
+        organizationId: orgId,
+        name: "Starter kit",
+        taskModelProviderId: "prov-1",
+        context: "Default context",
+      };
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([record]); // final read-back
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "prov-1" }]); // findNonSharedItems (provider)
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Starter kit",
+          // The Tier 2 provider is attached as a Tier 1 item.
+          items: [{ resourceType: "provider", resourceId: "prov-1" }],
+          taskModelProviderId: "prov-1",
+          context: "Default context",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(201);
+      const json = await res.json();
+      expect(json.taskModelProviderId).toBe("prov-1");
+      expect(json.context).toBe("Default context");
+    });
+
+    it("422s when a Tier 2 provider is not attached by the blueprint", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      // Empty items → no item query; the Tier 2 provider is not attached.
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Starter kit",
+          items: [],
+          memoryEmbeddingProviderId: "prov-x",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(422);
+      expect((await res.json()).invalidProviderIds).toEqual(["prov-x"]);
+    });
+
+    // Parity with the workspace route: a memory provider must expose the model
+    // its slot needs, so apply never stamps an unusable memory config.
+    it("422s when the memory embedding provider has no embedding model", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "prov-1" }]) // findNonSharedItems (provider attached)
+        .mockResolvedValueOnce([
+          {
+            id: "prov-1",
+            memoryExtractionModelId: "m",
+            embeddingModelId: null,
+          },
+        ]); // findInvalidMemoryProviders
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Starter kit",
+          items: [{ resourceType: "provider", resourceId: "prov-1" }],
+          memoryEmbeddingProviderId: "prov-1",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(422);
+      const json = await res.json();
+      expect(json.invalidMemoryProviders).toEqual([
+        expect.objectContaining({
+          field: "memoryEmbeddingProviderId",
+          providerId: "prov-1",
+        }),
+      ]);
+    });
+
+    it("creates when the memory embedding provider has an embedding model", async () => {
+      mockSession();
+      const record = {
+        id: "bp-1",
+        organizationId: orgId,
+        name: "Starter kit",
+        memoryEmbeddingProviderId: "prov-1",
+      };
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([record]); // read-back
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockResolvedValueOnce([{ id: "prov-1" }]) // findNonSharedItems
+        .mockResolvedValueOnce([
+          {
+            id: "prov-1",
+            memoryExtractionModelId: "m",
+            embeddingModelId: "emb-model",
+          },
+        ]); // findInvalidMemoryProviders: valid
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Starter kit",
+          items: [{ resourceType: "provider", resourceId: "prov-1" }],
+          memoryEmbeddingProviderId: "prov-1",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(201);
+      expect((await res.json()).memoryEmbeddingProviderId).toBe("prov-1");
+    });
   });
 
   describe("GET /", () => {
@@ -233,9 +356,11 @@ describe("Organization Blueprint Routes", () => {
   });
 
   describe("DELETE /:blueprintId", () => {
-    it("deletes a blueprint (admin)", async () => {
+    it("deletes a blueprint (admin) when no live invitation references it", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      // Deletion guard: no pending invitations reference this blueprint.
+      mockDb.where.mockReturnValueOnce(mockDb).mockResolvedValueOnce([]);
       mockDb.returning.mockResolvedValueOnce([{ id: "bp-1" }]);
 
       const res = await app.request(`${baseUrl}/bp-1`, { method: "DELETE" });
@@ -246,10 +371,46 @@ describe("Organization Blueprint Routes", () => {
     it("404s when the blueprint does not exist", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.where.mockReturnValueOnce(mockDb).mockResolvedValueOnce([]); // guard: clear
       mockDb.returning.mockResolvedValueOnce([]);
 
       const res = await app.request(`${baseUrl}/missing`, { method: "DELETE" });
       expect(res.status).toBe(404);
+    });
+
+    // ADR-0009: a Blueprint cannot be deleted while a live pending invitation
+    // references it (status = 'pending' AND expiresAt > now()).
+    it("409s when a live pending invitation references the blueprint", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      const future = new Date();
+      future.setDate(future.getDate() + 7);
+      // Guard query returns a still-live pending invitation.
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([{ expiresAt: future.toISOString() }]);
+
+      const res = await app.request(`${baseUrl}/bp-1`, { method: "DELETE" });
+      expect(res.status).toBe(409);
+      // The delete must not run while the guard blocks.
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    // Expiry is lazy with write-back: a row past expiresAt may still read
+    // 'pending'. The guard excludes it in app code, so deletion proceeds.
+    it("allows deletion when the only referencing invitation is lazily-expired", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      const past = new Date();
+      past.setDate(past.getDate() - 1);
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([{ expiresAt: past.toISOString() }]);
+      mockDb.returning.mockResolvedValueOnce([{ id: "bp-1" }]);
+
+      const res = await app.request(`${baseUrl}/bp-1`, { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ message: "Blueprint deleted" });
     });
 
     it("403s for a non-admin", async () => {
@@ -265,11 +426,24 @@ describe("Organization Blueprint Routes", () => {
     const applyUrl = `${baseUrl}/bp-1/apply`;
     const body = { workspaceId: "ws-1" };
     const itemRows = [
-      { blueprintId: "bp-1", resourceType: "agent", resourceId: "agent-1" },
-      { blueprintId: "bp-1", resourceType: "skill", resourceId: "skill-1" },
+      { resourceType: "agent", resourceId: "agent-1" },
+      { resourceType: "skill", resourceId: "skill-1" },
+    ];
+    // Tier 2 source row for bp-1 (the apply service reads these settings).
+    const tier2Rows = [
+      {
+        id: "bp-1",
+        taskModelProviderId: "prov-1",
+        memoryExtractionProviderId: null,
+        memoryEmbeddingProviderId: null,
+        context: "Default context",
+      },
     ];
 
-    it("creates the attachments and reports what was attached", async () => {
+    // The apply service (inside the route's transaction) runs two selects —
+    // Tier 2 settings then items — so the where mocks resolve in that order
+    // after the route's blueprint/workspace org checks.
+    it("creates the attachments and stamps Tier 2 settings", async () => {
       mockSession();
       mockDb.limit
         .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
@@ -279,7 +453,8 @@ describe("Organization Blueprint Routes", () => {
         .mockReturnValueOnce(mockDb) // requireOrgAccess
         .mockReturnValueOnce(mockDb) // blueprint check
         .mockReturnValueOnce(mockDb) // workspace check
-        .mockResolvedValueOnce(itemRows); // loadItemsByBlueprint
+        .mockResolvedValueOnce(tier2Rows) // service: Tier 2 select
+        .mockResolvedValueOnce(itemRows); // service: items select
       // Both items newly inserted.
       mockDb.returning.mockResolvedValueOnce([
         { id: "att-1" },
@@ -298,6 +473,14 @@ describe("Organization Blueprint Routes", () => {
         skipped: 0,
         total: 2,
       });
+      // Tier 2: the workspace is updated with the blueprint's non-null slots.
+      const tier2Set = mockDb.set.mock.calls
+        .map((c) => c[0])
+        .find((v) => v?.taskModelProviderId !== undefined);
+      expect(tier2Set).toMatchObject({
+        taskModelProviderId: "prov-1",
+        context: "Default context",
+      });
     });
 
     it("is idempotent: a re-apply where everything is attached is a no-op", async () => {
@@ -310,7 +493,8 @@ describe("Organization Blueprint Routes", () => {
         .mockReturnValueOnce(mockDb)
         .mockReturnValueOnce(mockDb)
         .mockReturnValueOnce(mockDb)
-        .mockResolvedValueOnce(itemRows);
+        .mockResolvedValueOnce(tier2Rows) // Tier 2 select
+        .mockResolvedValueOnce(itemRows); // items select
       // onConflictDoNothing inserts nothing — all rows already present.
       mockDb.returning.mockResolvedValueOnce([]);
 
@@ -328,7 +512,7 @@ describe("Organization Blueprint Routes", () => {
       });
     });
 
-    it("handles an empty blueprint without inserting", async () => {
+    it("handles an empty blueprint without inserting attachments", async () => {
       mockSession();
       mockDb.limit
         .mockResolvedValueOnce([{ role: "admin" }])
@@ -338,7 +522,16 @@ describe("Organization Blueprint Routes", () => {
         .mockReturnValueOnce(mockDb)
         .mockReturnValueOnce(mockDb)
         .mockReturnValueOnce(mockDb)
-        .mockResolvedValueOnce([]); // no items
+        .mockResolvedValueOnce([
+          {
+            id: "bp-1",
+            taskModelProviderId: null,
+            memoryExtractionProviderId: null,
+            memoryEmbeddingProviderId: null,
+            context: null,
+          },
+        ]) // Tier 2 select: nothing set
+        .mockResolvedValueOnce([]); // items select: no items
 
       const res = await app.request(applyUrl, {
         method: "POST",

--- a/apps/backend/src/routes/org-blueprint.ts
+++ b/apps/backend/src/routes/org-blueprint.ts
@@ -5,7 +5,6 @@ import { db } from "../index.ts";
 import {
   blueprint as blueprintTable,
   blueprintItem as blueprintItemTable,
-  attachment as attachmentTable,
   agent as agentTable,
   mcp as mcpTable,
   provider as providerTable,
@@ -22,6 +21,8 @@ import { and, eq, inArray } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
+import { applyBlueprintsToWorkspace } from "../services/blueprint-apply.ts";
+import { isBlueprintReferencedByLiveInvitation } from "../services/blueprint-guard.ts";
 
 // Blueprint — a named, Organization-scoped macro that, applied to a Workspace,
 // creates the Attachments for a chosen set of Shared resources in one step
@@ -96,6 +97,111 @@ const findNonSharedItems = async (
   return invalid;
 };
 
+/** The non-null Tier 2 provider references carried by a create/update body. */
+const tier2ProviderIds = (data: {
+  taskModelProviderId?: string | null;
+  memoryExtractionProviderId?: string | null;
+  memoryEmbeddingProviderId?: string | null;
+}): string[] =>
+  [
+    data.taskModelProviderId,
+    data.memoryExtractionProviderId,
+    data.memoryEmbeddingProviderId,
+  ].filter((id): id is string => Boolean(id));
+
+/**
+ * Returns the Tier 2 provider references that the Blueprint does NOT also
+ * attach. A Tier 2 pointer-setting only makes sense for a provider the
+ * Blueprint provisions — applying it both attaches the provider and points the
+ * Workspace at it, so a pointer to an unattached provider would leave the
+ * Workspace referencing something it can't see. Because Tier 1 items are
+ * already validated org-scoped, "is an attached provider item" also implies
+ * org-scoped (ADR-0008).
+ */
+const tier2ProvidersNotAttached = (
+  data: {
+    taskModelProviderId?: string | null;
+    memoryExtractionProviderId?: string | null;
+    memoryEmbeddingProviderId?: string | null;
+  },
+  items: BlueprintItem[],
+): string[] => {
+  const attached = new Set(
+    items.filter((i) => i.resourceType === "provider").map((i) => i.resourceId),
+  );
+  return tier2ProviderIds(data).filter((id) => !attached.has(id));
+};
+
+/**
+ * Tier 2 memory settings whose chosen Provider lacks the model that slot needs
+ * — parity with the Workspace route, which rejects a memory-embedding Provider
+ * with no embedding model (and a memory-extraction Provider with no extraction
+ * model). Stamping such a Provider on apply would produce an unusable Workspace
+ * memory config, so it is blocked when the Blueprint is authored.
+ */
+const findInvalidMemoryProviders = async (
+  data: {
+    memoryExtractionProviderId?: string | null;
+    memoryEmbeddingProviderId?: string | null;
+  },
+  orgId: string,
+): Promise<{ field: string; providerId: string; reason: string }[]> => {
+  const checks: {
+    field: string;
+    providerId: string;
+    column: "memoryExtractionModelId" | "embeddingModelId";
+    reason: string;
+  }[] = [];
+  if (data.memoryExtractionProviderId) {
+    checks.push({
+      field: "memoryExtractionProviderId",
+      providerId: data.memoryExtractionProviderId,
+      column: "memoryExtractionModelId",
+      reason: "does not have a memory extraction model configured",
+    });
+  }
+  if (data.memoryEmbeddingProviderId) {
+    checks.push({
+      field: "memoryEmbeddingProviderId",
+      providerId: data.memoryEmbeddingProviderId,
+      column: "embeddingModelId",
+      reason: "does not have an embedding model configured",
+    });
+  }
+  if (checks.length === 0) return [];
+
+  const rows = await db
+    .select({
+      id: providerTable.id,
+      memoryExtractionModelId: providerTable.memoryExtractionModelId,
+      embeddingModelId: providerTable.embeddingModelId,
+    })
+    .from(providerTable)
+    .where(
+      and(
+        eq(providerTable.organizationId, orgId),
+        inArray(
+          providerTable.id,
+          checks.map((c) => c.providerId),
+        ),
+      ),
+    );
+  const byId = new Map(rows.map((r) => [r.id, r]));
+
+  const invalid: { field: string; providerId: string; reason: string }[] = [];
+  for (const c of checks) {
+    const provider = byId.get(c.providerId);
+    if (!provider || !provider[c.column]) {
+      invalid.push({
+        field: c.field,
+        providerId: c.providerId,
+        reason: c.reason,
+      });
+    }
+  }
+  return invalid;
+};
+
 /** Load the items of one or more blueprints, grouped by blueprint id. */
 const loadItemsByBlueprint = async (
   blueprintIds: string[],
@@ -126,7 +232,15 @@ orgBlueprint.post(
   sValidator("json", blueprintCreateSchema),
   async (c) => {
     const orgId = c.req.param("orgId")!;
-    const { name, description, items } = c.req.valid("json");
+    const {
+      name,
+      description,
+      items,
+      taskModelProviderId,
+      memoryExtractionProviderId,
+      memoryEmbeddingProviderId,
+      context,
+    } = c.req.valid("json");
     const deduped = dedupeItems(items);
 
     const invalid = await findNonSharedItems(deduped, orgId);
@@ -141,6 +255,38 @@ orgBlueprint.post(
       );
     }
 
+    // Tier 2 provider settings may only reference providers the blueprint also
+    // attaches (ADR-0008) — so applying it never points a workspace at an
+    // unattached provider.
+    const unattached = tier2ProvidersNotAttached(c.req.valid("json"), deduped);
+    if (unattached.length > 0) {
+      return c.json(
+        {
+          error:
+            "A blueprint's provider settings must reference providers the blueprint also attaches",
+          invalidProviderIds: unattached,
+        },
+        422,
+      );
+    }
+
+    // A memory provider must expose the model its slot needs (parity with the
+    // workspace route), so apply never stamps an unusable memory config.
+    const invalidMemory = await findInvalidMemoryProviders(
+      c.req.valid("json"),
+      orgId,
+    );
+    if (invalidMemory.length > 0) {
+      return c.json(
+        {
+          error:
+            "A blueprint's memory provider setting references a provider without the required model",
+          invalidMemoryProviders: invalidMemory,
+        },
+        422,
+      );
+    }
+
     const id = nanoid();
     try {
       await db.transaction(async (tx) => {
@@ -149,6 +295,10 @@ orgBlueprint.post(
           organizationId: orgId,
           name,
           description: description ?? null,
+          taskModelProviderId: taskModelProviderId ?? null,
+          memoryExtractionProviderId: memoryExtractionProviderId ?? null,
+          memoryEmbeddingProviderId: memoryEmbeddingProviderId ?? null,
+          context: context ?? null,
         });
         if (deduped.length > 0) {
           await tx.insert(blueprintItemTable).values(
@@ -233,7 +383,15 @@ orgBlueprint.put(
   async (c) => {
     const orgId = c.req.param("orgId")!;
     const blueprintId = c.req.param("blueprintId");
-    const { name, description, items } = c.req.valid("json");
+    const {
+      name,
+      description,
+      items,
+      taskModelProviderId,
+      memoryExtractionProviderId,
+      memoryEmbeddingProviderId,
+      context,
+    } = c.req.valid("json");
     const deduped = dedupeItems(items);
 
     // The blueprint must exist in this org before we touch its items.
@@ -263,6 +421,33 @@ orgBlueprint.put(
       );
     }
 
+    const unattached = tier2ProvidersNotAttached(c.req.valid("json"), deduped);
+    if (unattached.length > 0) {
+      return c.json(
+        {
+          error:
+            "A blueprint's provider settings must reference providers the blueprint also attaches",
+          invalidProviderIds: unattached,
+        },
+        422,
+      );
+    }
+
+    const invalidMemory = await findInvalidMemoryProviders(
+      c.req.valid("json"),
+      orgId,
+    );
+    if (invalidMemory.length > 0) {
+      return c.json(
+        {
+          error:
+            "A blueprint's memory provider setting references a provider without the required model",
+          invalidMemoryProviders: invalidMemory,
+        },
+        422,
+      );
+    }
+
     try {
       await db.transaction(async (tx) => {
         await tx
@@ -270,6 +455,10 @@ orgBlueprint.put(
           .set({
             name,
             description: description ?? null,
+            taskModelProviderId: taskModelProviderId ?? null,
+            memoryExtractionProviderId: memoryExtractionProviderId ?? null,
+            memoryEmbeddingProviderId: memoryEmbeddingProviderId ?? null,
+            context: context ?? null,
             updatedAt: new Date(),
           })
           .where(eq(blueprintTable.id, blueprintId));
@@ -313,6 +502,20 @@ orgBlueprint.delete(
   async (c) => {
     const orgId = c.req.param("orgId")!;
     const blueprintId = c.req.param("blueprintId");
+
+    // A Blueprint cannot be deleted while a live pending invitation references
+    // it (ADR-0009) — accept-time provisioning would otherwise dereference a
+    // missing Blueprint. A lazily-expired invite does not block.
+    if (await isBlueprintReferencedByLiveInvitation(blueprintId)) {
+      return c.json(
+        {
+          error:
+            "Cannot delete: this blueprint is referenced by one or more pending invitations. Delete those invitations first.",
+        },
+        409,
+      );
+    }
+
     const result = await db
       .delete(blueprintTable)
       .where(
@@ -331,8 +534,11 @@ orgBlueprint.delete(
 
 /**
  * Apply a Blueprint to an existing Workspace (admin only). The macro creates the
- * Attachments for the Blueprint's current items. It is additive and idempotent:
- * re-applying, or applying a resource already attached, is a no-op (ADR-0008).
+ * Tier 1 Attachments for the Blueprint's current items and stamps its Tier 2
+ * pointer-settings onto the Workspace. It is additive and idempotent on Tier 1
+ * (re-applying, or applying a resource already attached, is a no-op) and
+ * last-write-wins on Tier 2 (ADR-0008). Ad-hoc apply stays single-Blueprint;
+ * the ordered set lives only on invitations (ADR-0009).
  */
 orgBlueprint.post(
   "/:blueprintId/apply",
@@ -373,39 +579,12 @@ orgBlueprint.post(
       return c.json({ error: "Workspace not found in this organization" }, 404);
     }
 
-    const itemsByBlueprint = await loadItemsByBlueprint([blueprintId]);
-    const items = itemsByBlueprint.get(blueprintId) ?? [];
-
-    if (items.length === 0) {
-      return c.json({ workspaceId, attached: 0, skipped: 0, total: 0 }, 200);
-    }
-
-    // Additive + idempotent: onConflictDoNothing against the unique
-    // (workspace, type, id) attachment constraint, so re-runs only add what is
-    // missing. `returning()` yields just the rows actually inserted.
-    const inserted = await db
-      .insert(attachmentTable)
-      .values(
-        items.map((item) => ({
-          id: nanoid(),
-          workspaceId,
-          resourceType: item.resourceType,
-          resourceId: item.resourceId,
-        })),
-      )
-      .onConflictDoNothing()
-      .returning();
-
-    const attached = inserted.length;
-    return c.json(
-      {
-        workspaceId,
-        attached,
-        skipped: items.length - attached,
-        total: items.length,
-      },
-      200,
+    // Tier 1 Attachments + Tier 2 settings commit together.
+    const result = await db.transaction((tx) =>
+      applyBlueprintsToWorkspace(tx, workspaceId, [blueprintId]),
     );
+
+    return c.json({ workspaceId, ...result }, 200);
   },
 );
 

--- a/apps/backend/src/routes/user-invitation.test.ts
+++ b/apps/backend/src/routes/user-invitation.test.ts
@@ -64,6 +64,7 @@ describe("User Invitation Routes", () => {
 
       // Transaction mocks
       mockDb.limit.mockResolvedValueOnce([]); // check org membership (none)
+      mockDb.orderBy.mockResolvedValueOnce([]); // no blueprints on the invite
 
       const res = await app.request(`${baseUrl}/inv-1/accept`, {
         method: "POST",
@@ -108,6 +109,7 @@ describe("User Invitation Routes", () => {
         },
       ]); // fetch invitation
       mockDb.limit.mockResolvedValueOnce([]); // check org membership (none)
+      mockDb.orderBy.mockResolvedValueOnce([]); // no blueprints on the invite
 
       const res = await app.request(`${baseUrl}/inv-1/accept`, {
         method: "POST",
@@ -145,6 +147,7 @@ describe("User Invitation Routes", () => {
         },
       ]); // fetch invitation
       mockDb.limit.mockResolvedValueOnce([]); // check org membership (none)
+      mockDb.orderBy.mockResolvedValueOnce([]); // no blueprints on the invite
 
       const res = await app.request(`${baseUrl}/inv-1/accept`, {
         method: "POST",
@@ -180,6 +183,7 @@ describe("User Invitation Routes", () => {
         },
       ]); // fetch invitation
       mockDb.limit.mockResolvedValueOnce([]); // check org membership (none)
+      mockDb.orderBy.mockResolvedValueOnce([]); // no blueprints on the invite
 
       const res = await app.request(`${baseUrl}/inv-1/accept`, {
         method: "POST",
@@ -190,6 +194,134 @@ describe("User Invitation Routes", () => {
       const provisioned = insertedValues.find((v) => v?.name);
       expect(provisioned.name.length).toBeLessThanOrEqual(30);
       expect(provisioned.name.endsWith(" Workspace")).toBe(true);
+    });
+
+    // ADR-0009: accepting a Blueprint-bearing invite provisions the Workspace
+    // and runs each macro in order — Tier 1 Attachments compose as a union;
+    // Tier 2 conflicts resolve last-write-wins by position.
+    it("applies the invitation's ordered blueprints (Tier 1 union, Tier 2 last-write-wins)", async () => {
+      mockSession({
+        id: "u1",
+        email: "user@example.com",
+        name: "Jane",
+        role: "user",
+      });
+
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 7);
+
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "inv-1",
+          email: "user@example.com",
+          status: "pending",
+          expiresAt: futureDate.toISOString(),
+          organizationId: "org-1",
+          workspaceName: "Provisioned",
+        },
+      ]); // fetch invitation
+      mockDb.limit.mockResolvedValueOnce([]); // check org membership (none)
+      // Ordered set: bp-1 then bp-2.
+      mockDb.orderBy.mockResolvedValueOnce([
+        { blueprintId: "bp-1" },
+        { blueprintId: "bp-2" },
+      ]);
+      // applyBlueprintsToWorkspace: Tier 2 source rows (unordered), then items.
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // fetch invitation -> limit
+        .mockReturnValueOnce(mockDb) // org membership -> limit
+        .mockReturnValueOnce(mockDb) // ordered blueprints -> orderBy
+        .mockResolvedValueOnce([
+          // bp-1 sets the task provider; bp-2 overrides it (last wins).
+          {
+            id: "bp-1",
+            taskModelProviderId: "prov-A",
+            memoryExtractionProviderId: null,
+            memoryEmbeddingProviderId: null,
+            context: "ctx-1",
+          },
+          {
+            id: "bp-2",
+            taskModelProviderId: "prov-B",
+            memoryExtractionProviderId: null,
+            memoryEmbeddingProviderId: null,
+            context: null,
+          },
+        ]) // blueprint Tier 2 select
+        .mockResolvedValueOnce([
+          // Union: agent-1 appears in both blueprints; skill-1 only in bp-2.
+          { resourceType: "agent", resourceId: "agent-1" },
+          { resourceType: "agent", resourceId: "agent-1" },
+          { resourceType: "skill", resourceId: "skill-1" },
+        ]); // blueprint items select
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "att-1" },
+        { id: "att-2" },
+      ]); // attachments inserted
+
+      const res = await app.request(`${baseUrl}/inv-1/accept`, {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(200);
+
+      // Tier 1: the attachment insert receives the deduped union (2 distinct).
+      const attachInsert = mockDb.values.mock.calls
+        .map((c) => c[0])
+        .find((v) => Array.isArray(v) && v[0]?.resourceType);
+      expect(attachInsert).toHaveLength(2);
+      expect(attachInsert.map((a: any) => a.resourceId).sort()).toEqual([
+        "agent-1",
+        "skill-1",
+      ]);
+
+      // Tier 2: the later blueprint (bp-2) wins on taskModelProviderId; the
+      // null slot it leaves does not clobber bp-1's earlier context.
+      const tier2Set = mockDb.set.mock.calls
+        .map((c) => c[0])
+        .find((v) => v?.taskModelProviderId !== undefined);
+      expect(tier2Set).toMatchObject({
+        taskModelProviderId: "prov-B",
+        context: "ctx-1",
+      });
+    });
+
+    // ADR-0009: a Blueprint-less invite still provisions an empty Workspace and
+    // applies nothing (unchanged from #153).
+    it("provisions an empty workspace and attaches nothing for a blueprint-less invite", async () => {
+      mockSession({
+        id: "u1",
+        email: "user@example.com",
+        name: "Jane",
+        role: "user",
+      });
+
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 7);
+
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "inv-1",
+          email: "user@example.com",
+          status: "pending",
+          expiresAt: futureDate.toISOString(),
+          organizationId: "org-1",
+          workspaceName: null,
+        },
+      ]); // fetch invitation
+      mockDb.limit.mockResolvedValueOnce([]); // check org membership (none)
+      mockDb.orderBy.mockResolvedValueOnce([]); // no blueprints
+
+      const res = await app.request(`${baseUrl}/inv-1/accept`, {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(200);
+      // No attachment insert ran — the service early-returns on an empty set.
+      const attachInsert = mockDb.values.mock.calls
+        .map((c) => c[0])
+        .find((v) => Array.isArray(v) && v[0]?.resourceType);
+      expect(attachInsert).toBeUndefined();
     });
 
     it("should return 410 if invitation expired", async () => {

--- a/apps/backend/src/routes/user-invitation.ts
+++ b/apps/backend/src/routes/user-invitation.ts
@@ -2,16 +2,18 @@ import { Hono } from "hono";
 import { db } from "../index.ts";
 import {
   invitation as invitationTable,
+  invitationBlueprint as invitationBlueprintTable,
   organization as organizationTable,
   organizationMember,
   user as userTable,
   workspace as workspaceTable,
 } from "../db/schema.ts";
-import { eq, and } from "drizzle-orm";
+import { eq, and, asc } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import type { Variables } from "../server.ts";
 import { WORKSPACE_NAME_MAX_LENGTH } from "@platypus/schemas";
 import { nanoid } from "nanoid";
+import { applyBlueprintsToWorkspace } from "../services/blueprint-apply.ts";
 
 const userInvitation = new Hono<{ Variables: Variables }>();
 
@@ -127,12 +129,29 @@ userInvitation.post("/:invitationId/accept", requireAuth, async (c) => {
     // Accepting an invitation always provisions a Workspace owned by the
     // accepting member (ADR-0008). With no Blueprint it is empty; the invite's
     // workspaceName defaults to "<member name>'s Workspace".
+    const workspaceId = nanoid();
     await tx.insert(workspaceTable).values({
-      id: nanoid(),
+      id: workspaceId,
       organizationId: invite.organizationId,
       ownerId: user.id,
       name: invite.workspaceName ?? defaultWorkspaceName(user.name),
     });
+
+    // Apply the invitation's ordered set of Blueprints (ADR-0009) to the fresh
+    // Workspace, in `position` order, so it lands pre-stamped. Tier 1
+    // Attachments union; Tier 2 settings resolve last-write-wins. This shares
+    // the accept transaction — a partial-list failure rolls back the whole
+    // accept rather than stranding a half-stamped Workspace.
+    const blueprintRows = await tx
+      .select({ blueprintId: invitationBlueprintTable.blueprintId })
+      .from(invitationBlueprintTable)
+      .where(eq(invitationBlueprintTable.invitationId, invitationId))
+      .orderBy(asc(invitationBlueprintTable.position));
+    await applyBlueprintsToWorkspace(
+      tx,
+      workspaceId,
+      blueprintRows.map((r) => r.blueprintId),
+    );
 
     // Update invitation status
     await tx

--- a/apps/backend/src/services/blueprint-apply.test.ts
+++ b/apps/backend/src/services/blueprint-apply.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockDb, resetMockDb } from "../test-utils.ts";
+import { applyBlueprintsToWorkspace } from "./blueprint-apply.ts";
+
+// The service runs entirely on the executor it is handed; tests pass `mockDb`
+// directly and queue the resolved values for its two selects (Tier 2 settings,
+// then items), the attachment insert's returning(), and the workspace update.
+describe("applyBlueprintsToWorkspace", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+  });
+
+  const tier2 = (over: Record<string, unknown> = {}) => ({
+    taskModelProviderId: null,
+    memoryExtractionProviderId: null,
+    memoryEmbeddingProviderId: null,
+    context: null,
+    ...over,
+  });
+
+  it("runs no queries and returns zero counts for an empty set", async () => {
+    const result = await applyBlueprintsToWorkspace(mockDb as any, "ws-1", []);
+    expect(result).toEqual({ attached: 0, skipped: 0, total: 0 });
+    expect(mockDb.select).not.toHaveBeenCalled();
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it("attaches the deduped union across blueprints (Tier 1)", async () => {
+    mockDb.where
+      // Tier 2 settings select — nothing set on either blueprint.
+      .mockResolvedValueOnce([
+        { id: "bp-1", ...tier2() },
+        { id: "bp-2", ...tier2() },
+      ])
+      // Items select — agent-1 appears in both; skill-1 only in bp-2.
+      .mockResolvedValueOnce([
+        { resourceType: "agent", resourceId: "agent-1" },
+        { resourceType: "agent", resourceId: "agent-1" },
+        { resourceType: "skill", resourceId: "skill-1" },
+      ]);
+    // Both deduped rows are newly inserted.
+    mockDb.returning.mockResolvedValueOnce([{ id: "att-1" }, { id: "att-2" }]);
+
+    const result = await applyBlueprintsToWorkspace(mockDb as any, "ws-1", [
+      "bp-1",
+      "bp-2",
+    ]);
+
+    expect(result).toEqual({ attached: 2, skipped: 0, total: 2 });
+    // The insert received the deduped union, each pinned to the workspace.
+    const inserted = mockDb.values.mock.calls.at(-1)?.[0];
+    expect(inserted).toHaveLength(2);
+    expect(
+      inserted.map((a: { resourceId: string }) => a.resourceId).sort(),
+    ).toEqual(["agent-1", "skill-1"]);
+    expect(
+      inserted.every((a: { workspaceId: string }) => a.workspaceId === "ws-1"),
+    ).toBe(true);
+    // No Tier 2 slot set → the workspace is not updated.
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+
+  it("counts already-attached rows as skipped (idempotent re-apply)", async () => {
+    mockDb.where
+      .mockResolvedValueOnce([{ id: "bp-1", ...tier2() }])
+      .mockResolvedValueOnce([
+        { resourceType: "agent", resourceId: "agent-1" },
+        { resourceType: "skill", resourceId: "skill-1" },
+      ]);
+    // onConflictDoNothing inserts only one — the other was already attached.
+    mockDb.returning.mockResolvedValueOnce([{ id: "att-1" }]);
+
+    const result = await applyBlueprintsToWorkspace(mockDb as any, "ws-1", [
+      "bp-1",
+    ]);
+
+    expect(result).toEqual({ attached: 1, skipped: 1, total: 2 });
+  });
+
+  it("resolves Tier 2 conflicts last-write-wins by blueprint order; null never clobbers", async () => {
+    // Returned unordered (bp-2 first) to prove ordering follows blueprintIds,
+    // not the row order. bp-1 sets task=A & context; bp-2 overrides task=B and
+    // leaves context null (which must NOT wipe bp-1's context).
+    mockDb.where
+      .mockResolvedValueOnce([
+        { id: "bp-2", ...tier2({ taskModelProviderId: "prov-B" }) },
+        {
+          id: "bp-1",
+          ...tier2({ taskModelProviderId: "prov-A", context: "ctx-1" }),
+        },
+      ])
+      .mockResolvedValueOnce([]); // no items
+
+    const result = await applyBlueprintsToWorkspace(mockDb as any, "ws-1", [
+      "bp-1",
+      "bp-2",
+    ]);
+
+    expect(result).toEqual({ attached: 0, skipped: 0, total: 0 });
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockDb.update).toHaveBeenCalled();
+    const set = mockDb.set.mock.calls.at(-1)?.[0];
+    expect(set).toMatchObject({
+      taskModelProviderId: "prov-B", // later blueprint wins
+      context: "ctx-1", // earlier value survives bp-2's null
+    });
+    // Slots no blueprint set are left untouched (absent from the update).
+    expect(set).not.toHaveProperty("memoryExtractionProviderId");
+    expect(set).not.toHaveProperty("memoryEmbeddingProviderId");
+  });
+
+  it("skips a missing blueprint id without throwing", async () => {
+    mockDb.where
+      // Only bp-1 comes back; "missing" was deleted / not found.
+      .mockResolvedValueOnce([
+        { id: "bp-1", ...tier2({ taskModelProviderId: "prov-A" }) },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const result = await applyBlueprintsToWorkspace(mockDb as any, "ws-1", [
+      "bp-1",
+      "missing",
+    ]);
+
+    expect(result).toEqual({ attached: 0, skipped: 0, total: 0 });
+    const set = mockDb.set.mock.calls.at(-1)?.[0];
+    expect(set).toMatchObject({ taskModelProviderId: "prov-A" });
+  });
+});

--- a/apps/backend/src/services/blueprint-apply.ts
+++ b/apps/backend/src/services/blueprint-apply.ts
@@ -1,0 +1,134 @@
+import { eq, inArray } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { db } from "../index.ts";
+import {
+  blueprint as blueprintTable,
+  blueprintItem as blueprintItemTable,
+  attachment as attachmentTable,
+  workspace as workspaceTable,
+} from "../db/schema.ts";
+
+// Any query executor — the top-level `db` or a transaction handle. Both share
+// the query-builder surface this module uses, so callers can wrap a multi-step
+// apply in their own transaction (invite-accept does; ad-hoc apply does too).
+type Executor = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+// The Workspace pointer-settings a Blueprint can stamp (ADR-0008, Tier 2).
+const TIER2_FIELDS = [
+  "taskModelProviderId",
+  "memoryExtractionProviderId",
+  "memoryEmbeddingProviderId",
+  "context",
+] as const;
+
+export interface ApplyBlueprintsResult {
+  // Attachments actually created (Tier 1 union, minus those already present).
+  attached: number;
+  // Distinct Attachments that already existed and were skipped.
+  skipped: number;
+  // Distinct Attachments the Blueprint set spans (the union size).
+  total: number;
+}
+
+/**
+ * Apply an ordered set of Blueprints to a Workspace (ADR-0008, ADR-0009).
+ *
+ * Tier 1 Attachments compose as an idempotent **union** — duplicates across the
+ * set collapse, and `onConflictDoNothing` skips anything already attached, so
+ * re-runs only add what is missing. Tier 2 pointer-settings are single-valued,
+ * so when several Blueprints set the same slot the **later one in `blueprintIds`
+ * wins** (last-write-wins); a Blueprint that leaves a slot null never clobbers
+ * an earlier winner or the Workspace's existing value.
+ *
+ * Runs entirely on the supplied executor so the caller controls the transaction
+ * boundary — accept-time provisioning applies the whole set atomically.
+ */
+export const applyBlueprintsToWorkspace = async (
+  exec: Executor,
+  workspaceId: string,
+  blueprintIds: string[],
+): Promise<ApplyBlueprintsResult> => {
+  if (blueprintIds.length === 0) {
+    return { attached: 0, skipped: 0, total: 0 };
+  }
+
+  // Tier 2 source values, keyed by id so we can walk them in `blueprintIds`
+  // order (the select returns them unordered).
+  const blueprints = await exec
+    .select({
+      id: blueprintTable.id,
+      taskModelProviderId: blueprintTable.taskModelProviderId,
+      memoryExtractionProviderId: blueprintTable.memoryExtractionProviderId,
+      memoryEmbeddingProviderId: blueprintTable.memoryEmbeddingProviderId,
+      context: blueprintTable.context,
+    })
+    .from(blueprintTable)
+    .where(inArray(blueprintTable.id, blueprintIds));
+  const byId = new Map(blueprints.map((b) => [b.id, b]));
+
+  const itemRows = await exec
+    .select({
+      resourceType: blueprintItemTable.resourceType,
+      resourceId: blueprintItemTable.resourceId,
+    })
+    .from(blueprintItemTable)
+    .where(inArray(blueprintItemTable.blueprintId, blueprintIds));
+
+  // Tier 1 — dedupe the union across the set so the insert has no internal
+  // conflict; onConflictDoNothing then handles rows already on the Workspace.
+  const seen = new Set<string>();
+  const attachValues: {
+    id: string;
+    workspaceId: string;
+    resourceType: (typeof itemRows)[number]["resourceType"];
+    resourceId: string;
+  }[] = [];
+  for (const row of itemRows) {
+    const key = `${row.resourceType}:${row.resourceId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    attachValues.push({
+      id: nanoid(),
+      workspaceId,
+      resourceType: row.resourceType,
+      resourceId: row.resourceId,
+    });
+  }
+
+  let attached = 0;
+  if (attachValues.length > 0) {
+    const inserted = await exec
+      .insert(attachmentTable)
+      .values(attachValues)
+      .onConflictDoNothing()
+      .returning();
+    attached = inserted.length;
+  }
+
+  // Tier 2 — last-write-wins. Walk the set in order; each Blueprint's non-null
+  // slots overwrite earlier ones. Null slots are left out entirely so they
+  // never null an earlier winner or the Workspace's current value.
+  const merged: Record<string, string> = {};
+  for (const id of blueprintIds) {
+    const bp = byId.get(id);
+    if (!bp) continue;
+    for (const field of TIER2_FIELDS) {
+      const value = bp[field];
+      if (value !== null && value !== undefined) {
+        merged[field] = value;
+      }
+    }
+  }
+  if (Object.keys(merged).length > 0) {
+    await exec
+      .update(workspaceTable)
+      .set({ ...merged, updatedAt: new Date() })
+      .where(eq(workspaceTable.id, workspaceId));
+  }
+
+  return {
+    attached,
+    skipped: attachValues.length - attached,
+    total: attachValues.length,
+  };
+};

--- a/apps/backend/src/services/blueprint-guard.test.ts
+++ b/apps/backend/src/services/blueprint-guard.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { mockDb, resetMockDb } from "../test-utils.ts";
+import {
+  isResourceListedInBlueprint,
+  isBlueprintReferencedByLiveInvitation,
+} from "./blueprint-guard.ts";
+
+describe("blueprint-guard", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+    mockDb.innerJoin.mockReturnValue(mockDb);
+  });
+
+  describe("isResourceListedInBlueprint", () => {
+    it("is true when a blueprint_item references the resource", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "item-1" }]);
+      expect(await isResourceListedInBlueprint("provider", "prov-1")).toBe(
+        true,
+      );
+    });
+
+    it("is false when no blueprint lists the resource", async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+      expect(await isResourceListedInBlueprint("agent", "agent-1")).toBe(false);
+    });
+  });
+
+  describe("isBlueprintReferencedByLiveInvitation", () => {
+    const future = () => {
+      const d = new Date();
+      d.setDate(d.getDate() + 7);
+      return d.toISOString();
+    };
+    const past = () => {
+      const d = new Date();
+      d.setDate(d.getDate() - 1);
+      return d.toISOString();
+    };
+
+    it("is true when a referencing pending invitation is still live", async () => {
+      mockDb.where.mockResolvedValueOnce([{ expiresAt: future() }]);
+      expect(await isBlueprintReferencedByLiveInvitation("bp-1")).toBe(true);
+    });
+
+    // Expiry is lazy with write-back, so a row past expiresAt may still read
+    // 'pending'. The guard must exclude it in app code.
+    it("is false when the only referencing pending invite is lazily-expired", async () => {
+      mockDb.where.mockResolvedValueOnce([{ expiresAt: past() }]);
+      expect(await isBlueprintReferencedByLiveInvitation("bp-1")).toBe(false);
+    });
+
+    it("is false when no pending invitation references the blueprint", async () => {
+      mockDb.where.mockResolvedValueOnce([]);
+      expect(await isBlueprintReferencedByLiveInvitation("bp-1")).toBe(false);
+    });
+
+    it("is true when at least one of several invites is still live", async () => {
+      mockDb.where.mockResolvedValueOnce([
+        { expiresAt: past() },
+        { expiresAt: future() },
+      ]);
+      expect(await isBlueprintReferencedByLiveInvitation("bp-1")).toBe(true);
+    });
+  });
+});

--- a/apps/backend/src/services/blueprint-guard.ts
+++ b/apps/backend/src/services/blueprint-guard.ts
@@ -1,6 +1,10 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "../index.ts";
-import { blueprintItem as blueprintItemTable } from "../db/schema.ts";
+import {
+  blueprintItem as blueprintItemTable,
+  invitationBlueprint as invitationBlueprintTable,
+  invitation as invitationTable,
+} from "../db/schema.ts";
 
 type SharedResourceType = "mcp" | "provider" | "skill" | "agent";
 
@@ -24,4 +28,36 @@ export const isResourceListedInBlueprint = async (
     )
     .limit(1);
   return Boolean(row);
+};
+
+/**
+ * Whether a Blueprint is referenced by a **live pending** invitation (ADR-0009)
+ * — the literal generalization of "nothing still pointed-at is deletable"
+ * (chain: Shared resource ← Blueprint ← pending invitation). A Blueprint cannot
+ * be deleted while such an invitation exists, or accept-time provisioning would
+ * dereference a missing Blueprint.
+ *
+ * The predicate is `status = 'pending' AND expiresAt > now()`. Invitation expiry
+ * is lazy with write-back (a row stays `pending` until read, then flips to
+ * `expired`), so `status` alone is not trustworthy — we filter `expiresAt` in
+ * app code, mirroring the invitation list endpoint, rather than trust the flag.
+ */
+export const isBlueprintReferencedByLiveInvitation = async (
+  blueprintId: string,
+): Promise<boolean> => {
+  const rows = await db
+    .select({ expiresAt: invitationTable.expiresAt })
+    .from(invitationBlueprintTable)
+    .innerJoin(
+      invitationTable,
+      eq(invitationBlueprintTable.invitationId, invitationTable.id),
+    )
+    .where(
+      and(
+        eq(invitationBlueprintTable.blueprintId, blueprintId),
+        eq(invitationTable.status, "pending"),
+      ),
+    );
+  const now = new Date();
+  return rows.some((r) => new Date(r.expiresAt) > now);
 };

--- a/apps/frontend/app/[orgId]/settings/invitations/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/invitations/page.tsx
@@ -4,7 +4,11 @@ import { useParams } from "next/navigation";
 import { InvitationForm } from "@/components/invitation-form";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { useBackendUrl } from "@/app/client-context";
-import { type InvitationListItem, type Organization } from "@platypus/schemas";
+import {
+  type InvitationListItem,
+  type Organization,
+  type Blueprint,
+} from "@platypus/schemas";
 import { Button } from "@/components/ui/button";
 import { Trash2, Mail } from "lucide-react";
 import { toast } from "sonner";
@@ -43,6 +47,16 @@ const OrgInvitationsPage = () => {
       ? joinUrl(backendUrl, `/organizations/${orgId}/invitations`)
       : null,
     fetcher,
+  );
+  // Map blueprint id → name so the table can show what each invite provisions.
+  const { data: blueprintsData } = useSWR<{ results: Blueprint[] }>(
+    backendUrl && user
+      ? joinUrl(backendUrl, `/organizations/${orgId}/blueprints`)
+      : null,
+    fetcher,
+  );
+  const blueprintNameById = new Map(
+    (blueprintsData?.results ?? []).map((b) => [b.id, b.name]),
   );
 
   const [invitationToDelete, setInvitationToDelete] = useState<string | null>(
@@ -150,6 +164,7 @@ const OrgInvitationsPage = () => {
                   <TableRow>
                     <TableHead>Email</TableHead>
                     <TableHead>Workspace</TableHead>
+                    <TableHead>Blueprints</TableHead>
                     <TableHead>Status</TableHead>
                     <TableHead>Expires</TableHead>
                     <TableHead className="text-right">Actions</TableHead>
@@ -162,6 +177,16 @@ const OrgInvitationsPage = () => {
                       <TableCell className="text-muted-foreground">
                         {invite.workspaceName || (
                           <span className="italic">Member&apos;s name</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {invite.blueprintIds &&
+                        invite.blueprintIds.length > 0 ? (
+                          invite.blueprintIds
+                            .map((id) => blueprintNameById.get(id) ?? id)
+                            .join(", ")
+                        ) : (
+                          <span className="italic">None</span>
                         )}
                       </TableCell>
                       <TableCell>{getStatusBadge(invite.status)}</TableCell>

--- a/apps/frontend/components/blueprint-form.tsx
+++ b/apps/frontend/components/blueprint-form.tsx
@@ -13,6 +13,13 @@ import { ExpandableTextarea } from "@/components/expandable-textarea";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
@@ -22,6 +29,7 @@ import type {
   Blueprint,
   BlueprintItem,
   AttachmentResourceType,
+  Provider,
 } from "@platypus/schemas";
 import useSWR from "swr";
 import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
@@ -156,7 +164,25 @@ const BlueprintForm = ({
     fetcher,
   );
 
-  const [formData, setFormData] = useState({ name: "", description: "" });
+  // Org-scoped providers — the eligible set for Tier 2 pointer-settings, which
+  // may only reference Shared resources (ADR-0008).
+  const { data: providersData } = useSWR<{ results: Provider[] }>(
+    backendUrl && user
+      ? joinUrl(backendUrl, `/organizations/${orgId}/providers`)
+      : null,
+    fetcher,
+  );
+  const providers = providersData?.results || [];
+
+  const [formData, setFormData] = useState({
+    name: "",
+    description: "",
+    // Tier 2 pointer-settings stamped onto the workspace on apply (ADR-0008).
+    context: "",
+    taskModelProviderId: null as string | null,
+    memoryExtractionProviderId: null as string | null,
+    memoryEmbeddingProviderId: null as string | null,
+  });
   // Selected items as a Set of `${type}:${id}` keys for cheap toggling.
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -172,6 +198,11 @@ const BlueprintForm = ({
       setFormData({
         name: blueprint.name,
         description: blueprint.description ?? "",
+        context: blueprint.context ?? "",
+        taskModelProviderId: blueprint.taskModelProviderId ?? null,
+        memoryExtractionProviderId:
+          blueprint.memoryExtractionProviderId ?? null,
+        memoryEmbeddingProviderId: blueprint.memoryEmbeddingProviderId ?? null,
       });
       setSelected(
         new Set(
@@ -211,7 +242,39 @@ const BlueprintForm = ({
       else next.delete(key);
       return next;
     });
+    // A Tier 2 pointer-setting can only target a provider this blueprint also
+    // attaches. Removing a provider from the composer clears any Tier 2 slot
+    // pointing at it, so we never stamp a workspace with an unattached provider.
+    if (type === "provider" && !on) {
+      setFormData((prev) => ({
+        ...prev,
+        taskModelProviderId:
+          prev.taskModelProviderId === id ? null : prev.taskModelProviderId,
+        memoryExtractionProviderId:
+          prev.memoryExtractionProviderId === id
+            ? null
+            : prev.memoryExtractionProviderId,
+        memoryEmbeddingProviderId:
+          prev.memoryEmbeddingProviderId === id
+            ? null
+            : prev.memoryEmbeddingProviderId,
+      }));
+    }
   };
+
+  // Tier 2 settings may only reference a provider the blueprint attaches (a
+  // selected "provider:<id>" item). The memory slots additionally require the
+  // provider to expose the relevant model. Each select is disabled when it has
+  // no eligible provider, so an empty "Leave unset"-only dropdown never shows.
+  const attachedProviders = providers.filter((p) =>
+    selected.has(itemKey("provider", p.id)),
+  );
+  const memoryExtractionProviders = attachedProviders.filter(
+    (p) => p.memoryExtractionModelId,
+  );
+  const memoryEmbeddingProviders = attachedProviders.filter(
+    (p) => (p as { embeddingModelId?: string }).embeddingModelId,
+  );
 
   const handleSubmit = async () => {
     setIsSubmitting(true);
@@ -229,6 +292,12 @@ const BlueprintForm = ({
         name: formData.name,
         description: formData.description || undefined,
         items,
+        // Tier 2 pointer-settings (ADR-0008). Null clears the slot; on apply a
+        // null slot leaves the workspace's existing value untouched.
+        context: formData.context || null,
+        taskModelProviderId: formData.taskModelProviderId,
+        memoryExtractionProviderId: formData.memoryExtractionProviderId,
+        memoryEmbeddingProviderId: formData.memoryEmbeddingProviderId,
       };
 
       const url = blueprintId
@@ -352,6 +421,144 @@ const BlueprintForm = ({
           disabled={isSubmitting}
         />
       ))}
+
+      <h2 className="text-lg font-semibold mb-1">Workspace settings</h2>
+      <p className="text-sm text-muted-foreground mb-4">
+        Optional settings applied to the workspace when this blueprint is
+        applied. Leave a setting unset to keep the workspace&apos;s existing
+        value.
+      </p>
+
+      <FieldSet className="mb-6">
+        <FieldGroup className="gap-4">
+          <Field data-invalid={!!validationErrors.context}>
+            <ExpandableTextarea
+              id="context"
+              label="Default context"
+              placeholder="Optional context for the workspace"
+              value={formData.context}
+              onChange={handleChange}
+              disabled={isSubmitting}
+              className="!font-mono"
+              maxLength={1000}
+              aria-invalid={!!validationErrors.context}
+              error={validationErrors.context}
+            />
+            <FieldDescription>
+              Additional context included in all chats in the workspace.
+            </FieldDescription>
+          </Field>
+
+          <Field data-invalid={!!validationErrors.taskModelProviderId}>
+            <FieldLabel htmlFor="taskModelProviderId">
+              Task model provider
+            </FieldLabel>
+            <Select
+              value={formData.taskModelProviderId || "none"}
+              onValueChange={(value) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  taskModelProviderId: value === "none" ? null : value,
+                }))
+              }
+              disabled={isSubmitting || attachedProviders.length === 0}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a provider" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">Leave unset</SelectItem>
+                {attachedProviders.map((provider) => (
+                  <SelectItem key={provider.id} value={provider.id}>
+                    {provider.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FieldDescription>
+              Provider used for generating chat titles and tags. Attach a
+              provider under Shared resources to enable this.
+            </FieldDescription>
+            {validationErrors.taskModelProviderId && (
+              <FieldError>{validationErrors.taskModelProviderId}</FieldError>
+            )}
+          </Field>
+
+          <Field data-invalid={!!validationErrors.memoryExtractionProviderId}>
+            <FieldLabel htmlFor="memoryExtractionProviderId">
+              Memory extraction provider
+            </FieldLabel>
+            <Select
+              value={formData.memoryExtractionProviderId || "none"}
+              onValueChange={(value) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  memoryExtractionProviderId: value === "none" ? null : value,
+                }))
+              }
+              disabled={isSubmitting || memoryExtractionProviders.length === 0}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a provider" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">Leave unset</SelectItem>
+                {memoryExtractionProviders.map((provider) => (
+                  <SelectItem key={provider.id} value={provider.id}>
+                    {provider.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FieldDescription>
+              Provider used to extract memories from conversations. Must be
+              attached by this blueprint and expose a memory-extraction model.
+            </FieldDescription>
+            {validationErrors.memoryExtractionProviderId && (
+              <FieldError>
+                {validationErrors.memoryExtractionProviderId}
+              </FieldError>
+            )}
+          </Field>
+
+          <Field data-invalid={!!validationErrors.memoryEmbeddingProviderId}>
+            <FieldLabel htmlFor="memoryEmbeddingProviderId">
+              Memory embedding provider
+            </FieldLabel>
+            <Select
+              value={formData.memoryEmbeddingProviderId || "none"}
+              onValueChange={(value) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  memoryEmbeddingProviderId: value === "none" ? null : value,
+                }))
+              }
+              disabled={isSubmitting || memoryEmbeddingProviders.length === 0}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select a provider" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">Leave unset</SelectItem>
+                {memoryEmbeddingProviders.map((provider) => (
+                  <SelectItem key={provider.id} value={provider.id}>
+                    {provider.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FieldDescription>
+              Provider used for memory embeddings. Must be attached by this
+              blueprint and expose an embedding model.
+            </FieldDescription>
+            {validationErrors.memoryEmbeddingProviderId && (
+              <FieldError>
+                {validationErrors.memoryEmbeddingProviderId}
+              </FieldError>
+            )}
+          </Field>
+        </FieldGroup>
+      </FieldSet>
 
       {formError && <FieldError className="mb-4">{formError}</FieldError>}
 

--- a/apps/frontend/components/invitation-form.tsx
+++ b/apps/frontend/components/invitation-form.tsx
@@ -6,12 +6,19 @@ import {
   FieldGroup,
   FieldSet,
   FieldError,
+  FieldDescription,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import { useState } from "react";
-import { parseValidationErrors, joinUrl } from "@/lib/utils";
+import Link from "next/link";
+import useSWR from "swr";
+import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
 import { useBackendUrl } from "@/app/client-context";
+import { useAuth } from "@/components/auth-provider";
+import type { Blueprint } from "@platypus/schemas";
+import { ArrowDown, ArrowUp, X } from "lucide-react";
 import { toast } from "sonner";
 
 interface InvitationFormProps {
@@ -21,13 +28,43 @@ interface InvitationFormProps {
 
 export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
   const backendUrl = useBackendUrl();
+  const { user } = useAuth();
 
   const [email, setEmail] = useState("");
   const [workspaceName, setWorkspaceName] = useState("");
+  // The ordered set of blueprints applied to the provisioned workspace on
+  // accept (ADR-0009). Selection order is application order; on conflicting
+  // settings the later blueprint wins (last-write-wins).
+  const [blueprintIds, setBlueprintIds] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [validationErrors, setValidationErrors] = useState<
     Record<string, string>
   >({});
+
+  const { data: blueprintsData } = useSWR<{ results: Blueprint[] }>(
+    backendUrl && user
+      ? joinUrl(backendUrl, `/organizations/${orgId}/blueprints`)
+      : null,
+    fetcher,
+  );
+  const blueprints = blueprintsData?.results || [];
+  const blueprintsById = new Map(blueprints.map((b) => [b.id, b]));
+
+  const toggleBlueprint = (id: string, on: boolean) => {
+    setBlueprintIds((prev) =>
+      on ? [...prev, id] : prev.filter((bid) => bid !== id),
+    );
+  };
+
+  const moveBlueprint = (index: number, delta: number) => {
+    setBlueprintIds((prev) => {
+      const next = [...prev];
+      const target = index + delta;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -47,6 +84,8 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
             ...(workspaceName.trim()
               ? { workspaceName: workspaceName.trim() }
               : {}),
+            // The ordered set of blueprints applied on accept (ADR-0009).
+            ...(blueprintIds.length ? { blueprintIds } : {}),
           }),
           credentials: "include",
         },
@@ -56,6 +95,7 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
         toast.success("Invitation created");
         setEmail("");
         setWorkspaceName("");
+        setBlueprintIds([]);
         onSuccess?.();
       } else {
         const errorData = await response.json();
@@ -64,6 +104,8 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
 
         if (errorData.message) {
           toast.error(errorData.message);
+        } else if (errorData.error) {
+          toast.error(errorData.error);
         } else if (Object.keys(errors).length > 0) {
           toast.error("Please fix the errors in the form");
         } else {
@@ -136,6 +178,121 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
               )}
             </Field>
           </div>
+
+          {/* ADR-0009: the invitation carries an ordered set of blueprints,
+              applied to the provisioned workspace on accept. */}
+          <Field data-invalid={!!validationErrors.blueprintIds}>
+            <FieldLabel htmlFor="blueprints">Blueprints (optional)</FieldLabel>
+            <FieldDescription>
+              Provision the member&apos;s new workspace from one or more
+              blueprints. They apply top to bottom — when two set the same
+              workspace setting, the later one wins.
+            </FieldDescription>
+
+            {blueprints.length === 0 ? (
+              <p className="text-sm text-muted-foreground mt-2">
+                No blueprints in this organization yet.{" "}
+                <Link
+                  href={`/${orgId}/settings/blueprints`}
+                  className="underline underline-offset-2"
+                >
+                  Create one
+                </Link>{" "}
+                to pre-provision new members&apos; workspaces.
+              </p>
+            ) : (
+              <>
+                <FieldGroup className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-2">
+                  {blueprints.map((bp) => {
+                    const checked = blueprintIds.includes(bp.id);
+                    return (
+                      <Field key={bp.id} orientation="horizontal">
+                        <Switch
+                          id={`bp-${bp.id}`}
+                          className="cursor-pointer"
+                          checked={checked}
+                          onCheckedChange={(on) => toggleBlueprint(bp.id, on)}
+                          disabled={isSubmitting}
+                        />
+                        <FieldLabel htmlFor={`bp-${bp.id}`}>
+                          <div className="flex flex-col">
+                            <p>{bp.name}</p>
+                            {bp.description && (
+                              <p className="text-xs text-muted-foreground line-clamp-1">
+                                {bp.description}
+                              </p>
+                            )}
+                          </div>
+                        </FieldLabel>
+                      </Field>
+                    );
+                  })}
+                </FieldGroup>
+
+                {blueprintIds.length > 0 && (
+                  <div className="mt-4">
+                    <p className="text-xs font-medium text-muted-foreground mb-2">
+                      Application order
+                    </p>
+                    <ol className="flex flex-col gap-2">
+                      {blueprintIds.map((id, index) => (
+                        <li
+                          key={id}
+                          className="flex items-center gap-2 rounded-md border bg-background px-3 py-2"
+                        >
+                          <span className="text-xs text-muted-foreground w-4">
+                            {index + 1}.
+                          </span>
+                          <span className="flex-1 text-sm">
+                            {blueprintsById.get(id)?.name ?? id}
+                          </span>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-7"
+                            disabled={isSubmitting || index === 0}
+                            onClick={() => moveBlueprint(index, -1)}
+                            aria-label="Move earlier"
+                          >
+                            <ArrowUp className="size-4" />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-7"
+                            disabled={
+                              isSubmitting || index === blueprintIds.length - 1
+                            }
+                            onClick={() => moveBlueprint(index, 1)}
+                            aria-label="Move later"
+                          >
+                            <ArrowDown className="size-4" />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-7"
+                            disabled={isSubmitting}
+                            onClick={() => toggleBlueprint(id, false)}
+                            aria-label="Remove"
+                          >
+                            <X className="size-4" />
+                          </Button>
+                        </li>
+                      ))}
+                    </ol>
+                  </div>
+                )}
+              </>
+            )}
+
+            {validationErrors.blueprintIds && (
+              <FieldError>{validationErrors.blueprintIds}</FieldError>
+            )}
+          </Field>
         </FieldGroup>
       </FieldSet>
       <Button

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -500,6 +500,14 @@ const blueprintBaseSchema = z.object({
   // The Shared resources this Blueprint provisions. Deduped/validated by the
   // route; each must be an org-scoped resource in the same organization.
   items: z.array(blueprintItemSchema),
+  // Tier 2 pointer-settings (ADR-0008) stamped onto the Workspace on apply.
+  // The three provider references must be org-scoped (Shared) — validated by
+  // the route. `context` is the default Workspace context text. All optional;
+  // a null/omitted slot leaves the Workspace's existing value untouched.
+  taskModelProviderId: z.string().nullable().optional(),
+  memoryExtractionProviderId: z.string().nullable().optional(),
+  memoryEmbeddingProviderId: z.string().nullable().optional(),
+  context: z.string().max(1000).nullable().optional(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
@@ -511,6 +519,10 @@ export const blueprintCreateSchema = blueprintBaseSchema.pick({
   name: true,
   description: true,
   items: true,
+  taskModelProviderId: true,
+  memoryExtractionProviderId: true,
+  memoryEmbeddingProviderId: true,
+  context: true,
 });
 export type BlueprintCreateData = z.infer<typeof blueprintCreateSchema>;
 
@@ -518,6 +530,10 @@ export const blueprintUpdateSchema = blueprintBaseSchema.pick({
   name: true,
   description: true,
   items: true,
+  taskModelProviderId: true,
+  memoryExtractionProviderId: true,
+  memoryEmbeddingProviderId: true,
+  context: true,
 });
 export type BlueprintUpdateData = z.infer<typeof blueprintUpdateSchema>;
 
@@ -718,6 +734,10 @@ export const invitationSchema = z.object({
     .max(WORKSPACE_NAME_MAX_LENGTH)
     .nullable()
     .optional(),
+  // The ordered set of Blueprints applied to the provisioned Workspace on
+  // accept (ADR-0009). Stored in the invitation_blueprint junction; surfaced
+  // here in `position` order on reads.
+  blueprintIds: z.array(z.string()).optional(),
   expiresAt: z.date(),
   createdAt: z.date(),
 });
@@ -727,6 +747,7 @@ export type Invitation = z.infer<typeof invitationSchema>;
 export const invitationCreateSchema = invitationSchema.pick({
   email: true,
   workspaceName: true,
+  blueprintIds: true,
 });
 
 export const invitationListItemSchema = invitationSchema.extend({


### PR DESCRIPTION
Closes #158.

Wires Blueprints into the invitation flow as an **ordered set** (ADR-0009) and extends the Blueprint macro with **Tier 2** workspace pointer-settings (ADR-0008).

## What changed

### Data model (migration 0045)
- `blueprint` gains Tier 2 columns: `task_model_provider_id`, `memory_extraction_provider_id`, `memory_embedding_provider_id` (FK → provider, `ON DELETE SET NULL`) and `context`.
- New `invitation_blueprint` junction `(id, invitation_id, blueprint_id, position)` — both FKs `ON DELETE CASCADE` — carries the ordered set.

### Behaviour
- **`applyBlueprintsToWorkspace`** (new service): Tier 1 Attachments compose as an idempotent **union**; Tier 2 settings resolve **last-write-wins by `position`** (a null slot never clobbers an earlier winner).
- **Accept-time provisioning** applies the invitation's whole ordered set **inside the accept transaction** — atomic, per the issue.
- **Ad-hoc apply** stays single-Blueprint and now also stamps Tier 2.
- **Deletion guard**: a Blueprint can't be deleted while a *live pending* invitation references it (`status = 'pending' AND expiresAt > now()`, expiry filtered in app code to honour lazy write-back).
- **Invariants**: a Tier 2 provider must be one the Blueprint also attaches, and a memory provider must expose the model its slot needs (parity with the workspace route).

### Frontend
- **Blueprint form** — new *Workspace settings* section (default context + task/memory provider selects); selects are constrained to attached providers and disabled when none are eligible; toggling a provider off clears any Tier 2 slot pointing at it.
- **Invitation form** — ordered blueprint picker with reorder/remove controls and an empty-state linking to blueprint creation.
- **Sent Invitations table** — new Blueprints column.

### Docs
- CONTEXT.md Blueprint definition updated for Tier 2 + the attached-provider rule.

## Testing
`pnpm lint` clean; `pnpm test` green (backend **896 tests**, frontend `tsc` clean). Coverage added for ordering/union/last-write-wins, the deletion guard (incl. lazily-expired-does-not-block), Tier 2 attach + memory-model validation, and invitation list/create paths. Direct unit tests for `blueprint-apply` and `blueprint-guard`.

## Known deferrals (called out, not silently dropped)
- **Apply-time staleness**: Tier 2 memory-model validation runs at blueprint authoring, not apply (snapshots can go stale if a provider's model is later removed — same write-time-only posture as the workspace route).
- The **member-facing invite list** (`/users/me/invitations`) doesn't yet expose blueprints.
- **No explicit accept-time atomicity test** (apply runs inside the accept transaction; rollback is awkward to assert with the chained DB mock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)