### PR TITLE
feat(backend): migrate Provider routes onto ScopedResource (#190)

### DIFF
--- a/apps/backend/src/routes/org-provider.test.ts
+++ b/apps/backend/src/routes/org-provider.test.ts
@@ -91,9 +91,10 @@ describe("Organization Provider Routes", () => {
         headers: { "Content-Type": "application/json" },
       });
 
+      // The unique violation flows through the central onError (ADR-0009).
       expect(res.status).toBe(409);
       expect(await res.json()).toEqual({
-        error: "A provider with this name already exists in this organization",
+        error: "A resource with that name already exists",
       });
     });
   });

--- a/apps/backend/src/routes/org-provider.ts
+++ b/apps/backend/src/routes/org-provider.ts
@@ -13,6 +13,7 @@ import { dedupeArray } from "../utils.ts";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { isResourceListedInBlueprint } from "../services/blueprint-guard.ts";
+import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
 const orgProvider = new Hono<{ Variables: Variables }>();
@@ -31,36 +32,19 @@ orgProvider.post(
       data.modelIds = dedupeArray(data.modelIds).sort();
     }
 
-    try {
-      const record = await db
-        .insert(providerTable)
-        .values({
-          id: nanoid(),
-          ...data,
-          organizationId: orgId,
-          workspaceId: null,
-        })
-        .returning();
+    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
+    // by the central onError (ADR-0009).
+    const record = await db
+      .insert(providerTable)
+      .values({
+        id: nanoid(),
+        ...data,
+        organizationId: orgId,
+        workspaceId: null,
+      })
+      .returning();
 
-      return c.json(record[0], 201);
-    } catch (error: any) {
-      const isUniqueViolation =
-        error.code === "23505" ||
-        error.cause?.code === "23505" ||
-        error.message?.includes("unique constraint") ||
-        error.cause?.message?.includes("unique constraint");
-
-      if (isUniqueViolation) {
-        return c.json(
-          {
-            error:
-              "A provider with this name already exists in this organization",
-          },
-          409,
-        );
-      }
-      throw error;
-    }
+    return c.json(record[0], 201);
   },
 );
 
@@ -92,7 +76,7 @@ orgProvider.get("/:providerId", requireAuth, requireOrgAccess(), async (c) => {
     .limit(1);
 
   if (record.length === 0) {
-    return c.json({ error: "Provider not found" }, 404);
+    throw new NotFoundError("Provider not found");
   }
 
   return c.json(record[0]);
@@ -116,44 +100,27 @@ orgProvider.put(
     // Detect and handle embedding config changes before the update
     await handleEmbeddingConfigChange(providerId, data);
 
-    try {
-      const record = await db
-        .update(providerTable)
-        .set({
-          ...data,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(providerTable.id, providerId),
-            eq(providerTable.organizationId, orgId),
-          ),
-        )
-        .returning();
+    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
+    // by the central onError (ADR-0009).
+    const record = await db
+      .update(providerTable)
+      .set({
+        ...data,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(providerTable.id, providerId),
+          eq(providerTable.organizationId, orgId),
+        ),
+      )
+      .returning();
 
-      if (record.length === 0) {
-        return c.json({ error: "Provider not found" }, 404);
-      }
-
-      return c.json(record[0], 200);
-    } catch (error: any) {
-      const isUniqueViolation =
-        error.code === "23505" ||
-        error.cause?.code === "23505" ||
-        error.message?.includes("unique constraint") ||
-        error.cause?.message?.includes("unique constraint");
-
-      if (isUniqueViolation) {
-        return c.json(
-          {
-            error:
-              "A provider with this name already exists in this organization",
-          },
-          409,
-        );
-      }
-      throw error;
+    if (record.length === 0) {
+      throw new NotFoundError("Provider not found");
     }
+
+    return c.json(record[0], 200);
   },
 );
 
@@ -211,7 +178,7 @@ orgProvider.delete(
       .returning();
 
     if (result.length === 0) {
-      return c.json({ error: "Provider not found" }, 404);
+      throw new NotFoundError("Provider not found");
     }
 
     return c.json({ message: "Provider deleted" });

--- a/apps/backend/src/routes/provider.test.ts
+++ b/apps/backend/src/routes/provider.test.ts
@@ -202,6 +202,30 @@ describe("Provider Routes", () => {
       memoryExtractionModelId: "gpt-4",
     };
 
+    it("updates a workspace-scoped provider and returns the row", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      // requireWorkspaceMutable → resolveScoped → workspace-scoped row (no
+      // attachment check needed)
+      mockDb.limit.mockResolvedValueOnce([{ id: "p1", workspaceId }]);
+
+      const updated = { id: "p1", name: "Renamed", workspaceId };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const res = await app.request(`${baseUrl}/p1`, {
+        method: "PUT",
+        body: JSON.stringify(updateBody),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(200);
+      // The single row, not the raw `.returning()` array.
+      expect(await res.json()).toEqual(updated);
+    });
+
     it("should 403 when updating an attached org-scoped provider", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess

--- a/apps/backend/src/routes/provider.test.ts
+++ b/apps/backend/src/routes/provider.test.ts
@@ -72,9 +72,10 @@ describe("Provider Routes", () => {
         headers: { "Content-Type": "application/json" },
       });
 
+      // The unique violation flows through the central onError (ADR-0009).
       expect(res.status).toBe(409);
       expect(await res.json()).toEqual({
-        error: "A provider with this name already exists in this workspace",
+        error: "A resource with that name already exists",
       });
     });
 
@@ -171,6 +172,110 @@ describe("Provider Routes", () => {
       const res = await app.request(`${baseUrl}/p1`);
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ ...mockProvider, scope: "workspace" });
+    });
+
+    it("should 404 for an org-scoped provider not attached here", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      // resolveScoped row lookup → org-scoped provider...
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "p2", name: "Org OpenAI", organizationId: orgId },
+      ]);
+      // ...attachment check → not attached here → not visible → 404
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const res = await app.request(`${baseUrl}/p2`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PUT /:providerId", () => {
+    const updateBody = {
+      name: "Renamed",
+      providerType: "OpenAI",
+      apiKey: "sk-123",
+      modelIds: ["gpt-4"],
+      taskModelId: "gpt-4",
+      memoryExtractionModelId: "gpt-4",
+    };
+
+    it("should 403 when updating an attached org-scoped provider", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      // requireWorkspaceMutable → resolveScoped row lookup → org-scoped provider...
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "p2", name: "Org OpenAI", organizationId: orgId },
+      ]);
+      // ...attachment check → attached, so it is visible but locked
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]);
+
+      const res = await app.request(`${baseUrl}/p2`, {
+        method: "PUT",
+        body: JSON.stringify(updateBody),
+        headers: { "Content-Type": "application/json" },
+      });
+      // Shared providers are edited only on the Organization surface (ADR-0007).
+      expect(res.status).toBe(403);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("DELETE /:providerId", () => {
+    it("deletes a workspace-scoped provider", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      // requireWorkspaceMutable → resolveScoped → workspace-scoped row (no
+      // attachment check needed)
+      mockDb.limit.mockResolvedValueOnce([{ id: "p1", workspaceId }]);
+
+      const res = await app.request(`${baseUrl}/p1`, { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ message: "Provider deleted" });
+    });
+
+    it("should 404 when deleting an org-scoped provider not attached here", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      // resolveScoped row lookup → org-scoped provider...
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "p2", name: "Org OpenAI", organizationId: orgId },
+      ]);
+      // ...attachment check → not attached here → 404
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const res = await app.request(`${baseUrl}/p2`, { method: "DELETE" });
+      expect(res.status).toBe(404);
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("should 403 when deleting an attached org-scoped provider", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      // resolveScoped row lookup → org-scoped provider...
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "p2", name: "Org OpenAI", organizationId: orgId },
+      ]);
+      // ...attachment check → attached, so it is visible but locked
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]);
+
+      const res = await app.request(`${baseUrl}/p2`, { method: "DELETE" });
+      expect(res.status).toBe(403);
+      expect(mockDb.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/routes/provider.ts
+++ b/apps/backend/src/routes/provider.ts
@@ -2,12 +2,9 @@ import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import {
-  provider as providerTable,
-  attachment as attachmentTable,
-} from "../db/schema.ts";
+import { provider as providerTable } from "../db/schema.ts";
 import { providerCreateSchema, providerUpdateSchema } from "@platypus/schemas";
-import { eq, and, or } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { handleEmbeddingConfigChange } from "../services/embedding-invalidation.ts";
 import { dedupeArray } from "../utils.ts";
 import { requireAuth } from "../middleware/authentication.ts";
@@ -16,6 +13,11 @@ import {
   requireWorkspaceAccess,
   requireWorkspaceConfigAccess,
 } from "../middleware/authorization.ts";
+import {
+  listScoped,
+  requireScoped,
+  requireWorkspaceMutable,
+} from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 
 const provider = new Hono<{ Variables: Variables }>();
@@ -37,36 +39,20 @@ provider.post(
     if (data.modelIds) {
       data.modelIds = dedupeArray(data.modelIds).sort();
     }
-    try {
-      const record = await db
-        .insert(providerTable)
-        .values({
-          id: nanoid(),
-          ...data,
-        })
-        .returning();
-      return c.json(record[0], 201);
-    } catch (error: any) {
-      const isUniqueViolation =
-        error.code === "23505" ||
-        error.cause?.code === "23505" ||
-        error.message?.includes("unique constraint") ||
-        error.cause?.message?.includes("unique constraint");
-
-      if (isUniqueViolation) {
-        return c.json(
-          {
-            error: "A provider with this name already exists in this workspace",
-          },
-          409,
-        );
-      }
-      throw error;
-    }
+    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
+    // by the central onError (ADR-0009).
+    const record = await db
+      .insert(providerTable)
+      .values({
+        id: nanoid(),
+        ...data,
+      })
+      .returning();
+    return c.json(record[0], 201);
   },
 );
 
-/** List all providers (workspace + org-scoped) */
+/** List providers visible in this workspace (workspace-scoped + attached org-scoped) */
 provider.get(
   "/",
   requireAuth,
@@ -76,39 +62,16 @@ provider.get(
     const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
 
-    // Get workspace-scoped providers
-    const workspaceProviders = await db
-      .select()
-      .from(providerTable)
-      .where(eq(providerTable.workspaceId, workspaceId));
-
-    // Org-scoped providers appear in a Workspace only where attached
-    // (ADR-0007 / #154) — gate by an inner join on the Attachment table.
-    const attachedOrgRows = await db
-      .select()
-      .from(providerTable)
-      .innerJoin(
-        attachmentTable,
-        and(
-          eq(attachmentTable.resourceId, providerTable.id),
-          eq(attachmentTable.resourceType, "provider"),
-          eq(attachmentTable.workspaceId, workspaceId),
-        ),
-      )
-      .where(eq(providerTable.organizationId, orgId));
-    const orgProviders = attachedOrgRows.map((r) => r.provider);
-
-    // Tag providers with their scope for frontend
-    const results = [
-      ...orgProviders.map((p) => ({ ...p, scope: "organization" as const })),
-      ...workspaceProviders.map((p) => ({ ...p, scope: "workspace" as const })),
-    ];
-
+    const scoped = await listScoped(db, "provider", {
+      orgId,
+      wsId: workspaceId,
+    });
+    const results = scoped.map(({ row, scope }) => ({ ...row, scope }));
     return c.json({ results });
   },
 );
 
-/** Get a provider by ID */
+/** Get a provider by ID (workspace-scoped, or attached org-scoped) */
 provider.get(
   "/:providerId",
   requireAuth,
@@ -119,28 +82,11 @@ provider.get(
     const workspaceId = c.req.param("workspaceId")!;
     const providerId = c.req.param("providerId");
 
-    const record = await db
-      .select()
-      .from(providerTable)
-      .where(
-        and(
-          eq(providerTable.id, providerId),
-          or(
-            eq(providerTable.workspaceId, workspaceId),
-            eq(providerTable.organizationId, orgId),
-          ),
-        ),
-      )
-      .limit(1);
-
-    if (record.length === 0) {
-      return c.json({ error: "Provider not found" }, 404);
-    }
-
-    const p = record[0];
-    const scope = p.organizationId ? "organization" : "workspace";
-
-    return c.json({ ...p, scope });
+    const found = await requireScoped(db, "provider", providerId, {
+      orgId,
+      wsId: workspaceId,
+    });
+    return c.json({ ...found.row, scope: found.scope });
   },
 );
 
@@ -153,6 +99,7 @@ provider.put(
   requireWorkspaceConfigAccess("providerSelfManagement"),
   sValidator("json", providerUpdateSchema),
   async (c) => {
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
     const providerId = c.req.param("providerId");
     const data = c.req.valid("json");
@@ -160,42 +107,35 @@ provider.put(
       data.modelIds = dedupeArray(data.modelIds).sort();
     }
 
+    // A Shared Provider is a single source of truth edited only on the
+    // Organization surface (ADR-0007); requireWorkspaceMutable throws NotFound
+    // (→404) when the Provider is not visible here, then Locked (→403) when it
+    // is org-scoped.
+    await requireWorkspaceMutable(db, "provider", providerId, {
+      orgId,
+      wsId: workspaceId,
+    });
+
     // Detect and handle embedding config changes before the update
     await handleEmbeddingConfigChange(providerId, data);
 
-    try {
-      const record = await db
-        .update(providerTable)
-        .set({
-          ...data,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(providerTable.id, providerId),
-            eq(providerTable.workspaceId, workspaceId),
-          ),
-        )
-        .returning();
+    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
+    // by the central onError (ADR-0009).
+    const record = await db
+      .update(providerTable)
+      .set({
+        ...data,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(providerTable.id, providerId),
+          eq(providerTable.workspaceId, workspaceId),
+        ),
+      )
+      .returning();
 
-      return c.json(record, 200);
-    } catch (error: any) {
-      const isUniqueViolation =
-        error.code === "23505" ||
-        error.cause?.code === "23505" ||
-        error.message?.includes("unique constraint") ||
-        error.cause?.message?.includes("unique constraint");
-
-      if (isUniqueViolation) {
-        return c.json(
-          {
-            error: "A provider with this name already exists in this workspace",
-          },
-          409,
-        );
-      }
-      throw error;
-    }
+    return c.json(record, 200);
   },
 );
 
@@ -207,8 +147,18 @@ provider.delete(
   requireWorkspaceAccess,
   requireWorkspaceConfigAccess("providerSelfManagement"),
   async (c) => {
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
     const providerId = c.req.param("providerId");
+
+    // A Shared Provider is deleted only from the Organization surface
+    // (ADR-0007): requireWorkspaceMutable throws NotFound (→404) when the
+    // Provider is not visible here, then Locked (→403) when it is org-scoped.
+    await requireWorkspaceMutable(db, "provider", providerId, {
+      orgId,
+      wsId: workspaceId,
+    });
+
     await db
       .delete(providerTable)
       .where(

--- a/apps/backend/src/routes/provider.ts
+++ b/apps/backend/src/routes/provider.ts
@@ -135,7 +135,7 @@ provider.put(
       )
       .returning();
 
-    return c.json(record, 200);
+    return c.json(record[0], 200);
   },
 );
 


### PR DESCRIPTION
Closes #190.

Moves the dual-scope **Provider** routes onto the `ScopedResource` read module and typed-error seam from #187 — following the precedent proven on Agent in #195.

## Workspace provider routes (`provider.ts`)
- `GET /` → `listScoped("provider", …)`
- `GET /:id` → `requireScoped` — an **unattached org-scoped Provider now 404s** (previously it leaked through the bare `or(workspaceId, organizationId)` lookup)
- `PUT` / `DELETE /:id` → `requireWorkspaceMutable` — not visible → 404, attached org-scoped (Shared) → 403 (previously a silent 0-row no-op)
- Provider-specific behaviour stays inline: the `requireWorkspaceConfigAccess("providerSelfManagement")` delegation-flag auth (ADR-0006) and the `modelIds` dedupe/sort
- Dropped now-unused `or` / `attachmentTable` imports

## Conflict handling
- Deleted the local `isUniqueViolation` copies in **both** `provider.ts` and `org-provider.ts`; duplicate names now flow through the central `app.onError` as a 409 (ADR-0009)
- `org-provider.ts` not-found paths throw `NotFoundError`; the attachment/blueprint delete-guard 409s stay inline

## Tests
- Added workspace GET/PUT/DELETE visibility + lock coverage: 404 for unattached org-scoped, 403 for attached org-scoped, workspace-scoped delete happy path
- Retargeted the conflict assertions at the central 409 message

## Acceptance criteria
- [x] Provider GET-by-id, list, and workspace mutation use the module's entry points
- [x] Unattached org-scoped → 404; workspace mutation of an attached org-scoped → 403; duplicate name → 409 — behaviour-preserving
- [x] Provider's local `isUniqueViolation` is deleted; conflicts flow through the central `onError`
- [x] Delegation-flag auth (ADR-0006) and `modelIds` dedupe/sort are unchanged
- [x] Provider route tests pass with redundant visibility/lock/conflict assertions consolidated

## Note on org-provider
The module's `resolveScoped`/`requireScoped` are Workspace-relative (they gate on attachment visibility), so they don't fit the org surface's pure `organizationId` lookup. I followed the exact precedent set for org-agent in #195 — adopt the typed-error seam (`NotFoundError`) and drop local conflict handling — rather than forcing an ill-fitting resolver.

## Verification
- Full backend suite: **918 passed** (incl. new cases)
- `prettier` clean, `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)