### PR TITLE
feat(backend): migrate Skill routes onto ScopedResource (#188)

### DIFF
--- a/apps/backend/src/routes/org-skill.ts
+++ b/apps/backend/src/routes/org-skill.ts
@@ -12,6 +12,7 @@ import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
 import { isResourceListedInBlueprint } from "../services/blueprint-guard.ts";
+import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
 // Org-scoped Skills are Shared resources (ADR-0007): a single source of truth
@@ -19,17 +20,6 @@ import type { Variables } from "../server.ts";
 // Attachment. They are managed only by Org Admins on the Organization surface,
 // so all mutations are org-admin-only; any member may read them.
 const orgSkill = new Hono<{ Variables: Variables }>();
-
-/** Detects a Postgres unique-constraint violation across driver shapes. */
-const isUniqueViolation = (error: any): boolean =>
-  error.code === "23505" ||
-  error.cause?.code === "23505" ||
-  error.message?.includes("unique constraint") ||
-  error.cause?.message?.includes("unique constraint");
-
-const NAME_CONFLICT = {
-  error: "A skill with this name already exists in this organization",
-} as const;
 
 /** Create an org-scoped Skill (admin only) */
 orgSkill.post(
@@ -42,25 +32,20 @@ orgSkill.post(
     // Agent associations are a workspace concern; org-scoped Skills carry none.
     const { agentIds: _agentIds, ...data } = c.req.valid("json");
 
-    try {
-      const record = await db
-        .insert(skillTable)
-        .values({
-          id: nanoid(),
-          name: data.name,
-          description: data.description,
-          body: data.body,
-          organizationId: orgId,
-          workspaceId: null,
-        })
-        .returning();
-      return c.json(record[0], 201);
-    } catch (error: any) {
-      if (isUniqueViolation(error)) {
-        return c.json(NAME_CONFLICT, 409);
-      }
-      throw error;
-    }
+    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
+    // by the central onError (ADR-0009).
+    const record = await db
+      .insert(skillTable)
+      .values({
+        id: nanoid(),
+        name: data.name,
+        description: data.description,
+        body: data.body,
+        organizationId: orgId,
+        workspaceId: null,
+      })
+      .returning();
+    return c.json(record[0], 201);
   },
 );
 
@@ -86,7 +71,7 @@ orgSkill.get("/:skillId", requireAuth, requireOrgAccess(), async (c) => {
     )
     .limit(1);
   if (record.length === 0) {
-    return c.json({ error: "Skill not found" }, 404);
+    throw new NotFoundError("Skill not found");
   }
   return c.json(record[0]);
 });
@@ -102,29 +87,24 @@ orgSkill.put(
     const skillId = c.req.param("skillId");
     const { agentIds: _agentIds, ...data } = c.req.valid("json");
 
-    try {
-      const record = await db
-        .update(skillTable)
-        .set({
-          name: data.name,
-          description: data.description,
-          body: data.body,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(eq(skillTable.id, skillId), eq(skillTable.organizationId, orgId)),
-        )
-        .returning();
-      if (record.length === 0) {
-        return c.json({ error: "Skill not found" }, 404);
-      }
-      return c.json(record[0], 200);
-    } catch (error: any) {
-      if (isUniqueViolation(error)) {
-        return c.json(NAME_CONFLICT, 409);
-      }
-      throw error;
+    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
+    // by the central onError (ADR-0009).
+    const record = await db
+      .update(skillTable)
+      .set({
+        name: data.name,
+        description: data.description,
+        body: data.body,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(eq(skillTable.id, skillId), eq(skillTable.organizationId, orgId)),
+      )
+      .returning();
+    if (record.length === 0) {
+      throw new NotFoundError("Skill not found");
     }
+    return c.json(record[0], 200);
   },
 );
 
@@ -186,7 +166,7 @@ orgSkill.delete(
       return rows;
     });
     if (result.length === 0) {
-      return c.json({ error: "Skill not found" }, 404);
+      throw new NotFoundError("Skill not found");
     }
     return c.json({ message: "Skill deleted" });
   },

--- a/apps/backend/src/routes/skill.test.ts
+++ b/apps/backend/src/routes/skill.test.ts
@@ -137,12 +137,112 @@ describe("Skill Routes", () => {
 
       const res = await app.request(baseUrl);
       expect(res.status).toBe(200);
+      // listScoped returns Workspace rows first, then attached org rows; the
+      // frontend regroups by scope, so order is not observable behaviour.
       expect(await res.json()).toEqual({
         results: [
-          { id: "org-skill-1", name: "org-skill-1", scope: "organization" },
           { id: "skill-1", name: "skill-1", scope: "workspace" },
+          { id: "org-skill-1", name: "org-skill-1", scope: "organization" },
         ],
       });
+    });
+  });
+
+  describe("GET /:skillId", () => {
+    it("returns a workspace skill tagged scope workspace with its agentIds", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      // resolveScoped row lookup → workspace-scoped skill
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "skill-1", name: "my-skill", workspaceId },
+      ]);
+      mockDb.where
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // requireWorkspaceAccess
+        .mockReturnValueOnce(mockDb) // resolveScoped row lookup
+        .mockResolvedValueOnce([{ id: "agent-1" }]); // agents referencing the skill
+
+      const res = await app.request(`${baseUrl}/skill-1`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        id: "skill-1",
+        name: "my-skill",
+        workspaceId,
+        scope: "workspace",
+        agentIds: ["agent-1"],
+      });
+    });
+
+    it("404s an org skill that is not attached here", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      // resolveScoped row lookup → org-scoped skill
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "org-skill-1", name: "shared", organizationId: orgId },
+      ]);
+      // attachment check → not attached
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const res = await app.request(`${baseUrl}/org-skill-1`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("PUT /:skillId", () => {
+    const updateBody = {
+      name: "renamed-skill",
+      description: "This is a long enough description for the skill.",
+      body: "This is a long enough body for the skill to pass the validation requirements.",
+    };
+
+    it("updates a workspace skill if user is editor", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      // requireWorkspaceMutable → resolveScoped row lookup (workspace-scoped)
+      mockDb.limit.mockResolvedValueOnce([{ id: "skill-1", workspaceId }]);
+
+      const updated = { id: "skill-1", name: "renamed-skill", workspaceId };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const res = await app.request(`${baseUrl}/skill-1`, {
+        method: "PUT",
+        body: JSON.stringify(updateBody),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual(updated);
+    });
+
+    it("locks a shared skill in the workspace (edit on org surface)", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      // resolveScoped lookup → org-scoped skill
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "org-skill-1", name: "shared", organizationId: orgId },
+      ]);
+      // attachment check → attached here, so it is visible but locked
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]);
+
+      const res = await app.request(`${baseUrl}/org-skill-1`, {
+        method: "PUT",
+        body: JSON.stringify(updateBody),
+        headers: { "Content-Type": "application/json" },
+      });
+      // Shared skills are edited only on the Organization surface (ADR-0007).
+      expect(res.status).toBe(403);
+      expect(mockDb.update).not.toHaveBeenCalled();
     });
   });
 
@@ -224,6 +324,8 @@ describe("Skill Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
+      // requireWorkspaceMutable → resolveScoped row lookup (workspace-scoped)
+      mockDb.limit.mockResolvedValueOnce([{ id: "skill-1", workspaceId }]);
       // check referencing agents
       mockDb.limit.mockResolvedValueOnce([{ id: "agent-1" }]);
 
@@ -235,6 +337,7 @@ describe("Skill Routes", () => {
         error:
           "Cannot delete skill because it is referenced by one or more agents",
       });
+      expect(mockDb.delete).not.toHaveBeenCalled();
     });
 
     it("should delete skill if not referenced", async () => {
@@ -245,16 +348,53 @@ describe("Skill Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
+      // requireWorkspaceMutable → resolveScoped row lookup (workspace-scoped)
+      mockDb.limit.mockResolvedValueOnce([{ id: "skill-1", workspaceId }]);
       // check referencing agents (none)
       mockDb.limit.mockResolvedValueOnce([]);
-      // delete skill
-      mockDb.returning.mockResolvedValueOnce([{ id: "skill-1" }]);
 
       const res = await app.request(`${baseUrl}/skill-1`, {
         method: "DELETE",
       });
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ message: "Skill deleted" });
+    });
+
+    it("should 404 when deleting a shared skill not attached here", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // resolveScoped lookup → none visible here → 404
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const res = await app.request(`${baseUrl}/org-skill-1`, {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(404);
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("should 403 (locked) when deleting an attached shared skill", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // resolveScoped lookup → org-scoped skill
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "org-skill-1", name: "shared", organizationId: orgId },
+      ]);
+      // attachment check → attached here, so it is visible but locked
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]);
+
+      const res = await app.request(`${baseUrl}/org-skill-1`, {
+        method: "DELETE",
+      });
+      // Shared skills are deleted only on the Organization surface (ADR-0007).
+      expect(res.status).toBe(403);
+      expect(mockDb.delete).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/routes/skill.ts
+++ b/apps/backend/src/routes/skill.ts
@@ -8,12 +8,18 @@ import {
   attachment as attachmentTable,
 } from "../db/schema.ts";
 import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
-import { eq, and, or, sql, inArray, notInArray } from "drizzle-orm";
+import { eq, and, sql, inArray, notInArray } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
   requireWorkspaceAccess,
 } from "../middleware/authorization.ts";
+import {
+  listScoped,
+  requireScoped,
+  requireWorkspaceMutable,
+} from "../services/scoped-resource.ts";
+import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
 const skill = new Hono<{ Variables: Variables }>();
@@ -28,33 +34,10 @@ skill.get(
     const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
 
-    // Workspace-scoped Skills
-    const workspaceSkills = await db
-      .select()
-      .from(skillTable)
-      .where(eq(skillTable.workspaceId, workspaceId));
-
-    // Org-scoped (Shared) Skills appear in a Workspace only where attached
-    // (ADR-0007 / #154) — gate by an inner join on the Attachment table.
-    const attachedOrgRows = await db
-      .select()
-      .from(skillTable)
-      .innerJoin(
-        attachmentTable,
-        and(
-          eq(attachmentTable.resourceId, skillTable.id),
-          eq(attachmentTable.resourceType, "skill"),
-          eq(attachmentTable.workspaceId, workspaceId),
-        ),
-      )
-      .where(eq(skillTable.organizationId, orgId));
-    const orgSkills = attachedOrgRows.map((r) => r.skill);
-
-    // Tag each Skill with its scope for the frontend (locked cards for org).
-    const results = [
-      ...orgSkills.map((s) => ({ ...s, scope: "organization" as const })),
-      ...workspaceSkills.map((s) => ({ ...s, scope: "workspace" as const })),
-    ];
+    // Workspace-scoped Skills plus the attached org-scoped (Shared) ones, each
+    // tagged with its scope for the frontend (locked cards for org).
+    const scoped = await listScoped(db, "skill", { orgId, wsId: workspaceId });
+    const results = scoped.map(({ row, scope }) => ({ ...row, scope }));
 
     return c.json({ results });
   },
@@ -71,44 +54,12 @@ skill.get(
     const workspaceId = c.req.param("workspaceId")!;
     const skillId = c.req.param("skillId");
 
-    // Resolve a Skill at either scope: the invoking workspace, or the
-    // organization (a Shared Skill — ADR-0007).
-    const record = await db
-      .select()
-      .from(skillTable)
-      .where(
-        and(
-          eq(skillTable.id, skillId),
-          or(
-            eq(skillTable.workspaceId, workspaceId),
-            eq(skillTable.organizationId, orgId),
-          ),
-        ),
-      )
-      .limit(1);
-
-    if (record.length === 0) {
-      return c.json({ error: "Skill not found" }, 404);
-    }
-
-    // An org-scoped (Shared) Skill is only visible here where attached.
-    const isOrgScoped = !!record[0].organizationId && !record[0].workspaceId;
-    if (isOrgScoped) {
-      const [attached] = await db
-        .select({ id: attachmentTable.id })
-        .from(attachmentTable)
-        .where(
-          and(
-            eq(attachmentTable.workspaceId, workspaceId),
-            eq(attachmentTable.resourceType, "skill"),
-            eq(attachmentTable.resourceId, skillId),
-          ),
-        )
-        .limit(1);
-      if (!attached) {
-        return c.json({ error: "Skill not found" }, 404);
-      }
-    }
+    // Resolve the Skill visible here — Workspace-scoped, or an attached
+    // org-scoped (Shared) one (ADR-0007); not visible → 404 via onError.
+    const found = await requireScoped(db, "skill", skillId, {
+      orgId,
+      wsId: workspaceId,
+    });
 
     // Find workspace agents that have this skill assigned
     const agentsWithSkill = await db
@@ -122,8 +73,8 @@ skill.get(
       );
 
     return c.json({
-      ...record[0],
-      scope: isOrgScoped ? "organization" : "workspace",
+      ...found.row,
+      scope: found.scope,
       agentIds: agentsWithSkill.map((a) => a.id),
     });
   },
@@ -139,59 +90,43 @@ skill.post(
   async (c) => {
     const workspaceId = c.req.param("workspaceId")!;
     const { agentIds, ...data } = c.req.valid("json");
-    try {
-      const newId = nanoid();
-      // The workspace route only ever creates workspace-scoped Skills; the
-      // scope is taken from the route, never the body (org-scoped Skills are
-      // created via the Organization surface or by Promote).
-      const record = await db
-        .insert(skillTable)
-        .values({
-          id: newId,
-          name: data.name,
-          description: data.description,
-          body: data.body,
-          workspaceId,
-          organizationId: null,
+
+    const newId = nanoid();
+    // The workspace route only ever creates workspace-scoped Skills; the scope
+    // is taken from the route, never the body (org-scoped Skills are created via
+    // the Organization surface or by Promote). A duplicate name surfaces as a
+    // Postgres unique violation, mapped to 409 by the central onError (ADR-0009).
+    const record = await db
+      .insert(skillTable)
+      .values({
+        id: newId,
+        name: data.name,
+        description: data.description,
+        body: data.body,
+        workspaceId,
+        organizationId: null,
+      })
+      .returning();
+
+    // Add skill to specified agents
+    if (agentIds && agentIds.length > 0) {
+      const newIdJson = JSON.stringify([newId]);
+      await db
+        .update(agentTable)
+        .set({
+          skillIds: sql`${agentTable.skillIds} || ${newIdJson}::jsonb`,
+          updatedAt: new Date(),
         })
-        .returning();
-
-      // Add skill to specified agents
-      if (agentIds && agentIds.length > 0) {
-        const newIdJson = JSON.stringify([newId]);
-        await db
-          .update(agentTable)
-          .set({
-            skillIds: sql`${agentTable.skillIds} || ${newIdJson}::jsonb`,
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(agentTable.workspaceId, workspaceId),
-              inArray(agentTable.id, agentIds),
-              sql`NOT ${agentTable.skillIds} @> ${newIdJson}::jsonb`,
-            ),
-          );
-      }
-
-      return c.json(record[0], 201);
-    } catch (error: any) {
-      const isUniqueViolation =
-        error.code === "23505" ||
-        error.cause?.code === "23505" ||
-        error.message?.includes("unique constraint") ||
-        error.cause?.message?.includes("unique constraint");
-
-      if (isUniqueViolation) {
-        return c.json(
-          {
-            error: "A skill with this name already exists in this workspace",
-          },
-          409,
+        .where(
+          and(
+            eq(agentTable.workspaceId, workspaceId),
+            inArray(agentTable.id, agentIds),
+            sql`NOT ${agentTable.skillIds} @> ${newIdJson}::jsonb`,
+          ),
         );
-      }
-      throw error;
     }
+
+    return c.json(record[0], 201);
   },
 );
 
@@ -203,86 +138,75 @@ skill.put(
   requireWorkspaceAccess,
   sValidator("json", skillUpdateSchema),
   async (c) => {
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
     const skillId = c.req.param("skillId");
     const { agentIds, ...data } = c.req.valid("json");
 
-    try {
-      const record = await db
-        .update(skillTable)
-        .set({
-          ...data,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(skillTable.id, skillId),
-            eq(skillTable.workspaceId, workspaceId),
-          ),
-        )
-        .returning();
+    // A Shared Skill is a single source of truth edited only on the Organization
+    // surface (ADR-0007); requireWorkspaceMutable throws NotFound (→404) when the
+    // Skill is not visible here, then Locked (→403) when it is org-scoped.
+    await requireWorkspaceMutable(db, "skill", skillId, {
+      orgId,
+      wsId: workspaceId,
+    });
 
-      if (record.length === 0) {
-        return c.json({ error: "Skill not found" }, 404);
+    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
+    // by the central onError (ADR-0009).
+    const record = await db
+      .update(skillTable)
+      .set({
+        ...data,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(skillTable.id, skillId),
+          eq(skillTable.workspaceId, workspaceId),
+        ),
+      )
+      .returning();
+
+    // Update agent associations if agentIds was provided
+    if (agentIds !== undefined) {
+      const now = new Date();
+      const skillIdJson = JSON.stringify([skillId]);
+
+      // Remove skill from agents not in the new list
+      const removeWhere = [
+        eq(agentTable.workspaceId, workspaceId),
+        sql`${agentTable.skillIds} @> ${skillIdJson}::jsonb`,
+      ];
+      if (agentIds.length > 0) {
+        removeWhere.push(notInArray(agentTable.id, agentIds));
       }
+      await db
+        .update(agentTable)
+        .set({
+          skillIds: sql`(${agentTable.skillIds})::jsonb - ${skillId}::text`,
+          updatedAt: now,
+        })
+        .where(and(...removeWhere));
 
-      // Update agent associations if agentIds was provided
-      if (agentIds !== undefined) {
-        const now = new Date();
-        const skillIdJson = JSON.stringify([skillId]);
-
-        // Remove skill from agents not in the new list
-        const removeWhere = [
-          eq(agentTable.workspaceId, workspaceId),
-          sql`${agentTable.skillIds} @> ${skillIdJson}::jsonb`,
-        ];
-        if (agentIds.length > 0) {
-          removeWhere.push(notInArray(agentTable.id, agentIds));
-        }
+      // Add skill to agents in the new list that don't already have it
+      if (agentIds.length > 0) {
         await db
           .update(agentTable)
           .set({
-            skillIds: sql`(${agentTable.skillIds})::jsonb - ${skillId}::text`,
+            skillIds: sql`${agentTable.skillIds} || ${skillIdJson}::jsonb`,
             updatedAt: now,
           })
-          .where(and(...removeWhere));
-
-        // Add skill to agents in the new list that don't already have it
-        if (agentIds.length > 0) {
-          await db
-            .update(agentTable)
-            .set({
-              skillIds: sql`${agentTable.skillIds} || ${skillIdJson}::jsonb`,
-              updatedAt: now,
-            })
-            .where(
-              and(
-                eq(agentTable.workspaceId, workspaceId),
-                inArray(agentTable.id, agentIds),
-                sql`NOT ${agentTable.skillIds} @> ${skillIdJson}::jsonb`,
-              ),
-            );
-        }
+          .where(
+            and(
+              eq(agentTable.workspaceId, workspaceId),
+              inArray(agentTable.id, agentIds),
+              sql`NOT ${agentTable.skillIds} @> ${skillIdJson}::jsonb`,
+            ),
+          );
       }
-
-      return c.json(record[0], 200);
-    } catch (error: any) {
-      const isUniqueViolation =
-        error.code === "23505" ||
-        error.cause?.code === "23505" ||
-        error.message?.includes("unique constraint") ||
-        error.cause?.message?.includes("unique constraint");
-
-      if (isUniqueViolation) {
-        return c.json(
-          {
-            error: "A skill with this name already exists in this workspace",
-          },
-          409,
-        );
-      }
-      throw error;
     }
+
+    return c.json(record[0], 200);
   },
 );
 
@@ -293,8 +217,17 @@ skill.delete(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
     const skillId = c.req.param("skillId");
+
+    // A Shared Skill is deleted only from the Organization surface (ADR-0007):
+    // requireWorkspaceMutable throws NotFound (→404) when the Skill is not
+    // visible here, then Locked (→403) when it is org-scoped.
+    await requireWorkspaceMutable(db, "skill", skillId, {
+      orgId,
+      wsId: workspaceId,
+    });
 
     // Check if skill is referenced by any agent
     const referencingAgents = await db
@@ -318,19 +251,14 @@ skill.delete(
       );
     }
 
-    const result = await db
+    await db
       .delete(skillTable)
       .where(
         and(
           eq(skillTable.id, skillId),
           eq(skillTable.workspaceId, workspaceId),
         ),
-      )
-      .returning();
-
-    if (result.length === 0) {
-      return c.json({ error: "Skill not found" }, 404);
-    }
+      );
 
     return c.json({ message: "Skill deleted" });
   },
@@ -369,7 +297,7 @@ skill.post(
       )
       .limit(1);
     if (!existing) {
-      return c.json({ error: "Skill not found" }, 404);
+      throw new NotFoundError("Skill not found");
     }
 
     // Sentinel for a lost TOCTOU race: the Skill was re-scoped or deleted
@@ -415,22 +343,10 @@ skill.post(
       return c.json({ ...promoted, scope: "organization" }, 200);
     } catch (error: any) {
       if (error?.message === PROMOTE_RACE) {
-        return c.json({ error: "Skill not found" }, 404);
+        throw new NotFoundError("Skill not found");
       }
-      const isUniqueViolation =
-        error.code === "23505" ||
-        error.cause?.code === "23505" ||
-        error.message?.includes("unique constraint") ||
-        error.cause?.message?.includes("unique constraint");
-
-      if (isUniqueViolation) {
-        return c.json(
-          {
-            error: "A skill with this name already exists in this organization",
-          },
-          409,
-        );
-      }
+      // A duplicate Shared-Skill name surfaces as a Postgres unique violation,
+      // mapped to 409 by the central onError (ADR-0009).
       throw error;
     }
   },


### PR DESCRIPTION
Closes #188. Builds on #187 (ScopedResource read module + typed-error seam, proven on Agent).

## What changed

**`skill.ts`** (workspace surface)
- `GET /` → `listScoped("skill", …)`
- `GET /:skillId` → `requireScoped` (the skill-specific `agentIds` lookup stays inline)
- `PUT`/`DELETE /:skillId` → `requireWorkspaceMutable`: org-scoped Skill not visible here → **404**, attached org-scoped Skill → **403 (locked)**
- Deleted both local `isUniqueViolation` blocks — duplicate names flow to the central `onError` **409**
- Promote throws `NotFoundError` (not-found + lost-race) and re-throws unique violations to the central seam
- `agentIds` association side-effect on create/update unchanged

**`org-skill.ts`** (org surface)
- Removed local `isUniqueViolation` + `NAME_CONFLICT`; conflicts map centrally
- 404s now `throw new NotFoundError(...)`
- `agentIds` still stripped here

**`skill.test.ts`**
- Flipped GET-list order (workspace rows first, per `listScoped`)
- Added `GET /:skillId` (scope + `agentIds`, not-attached → 404), `PUT /:skillId` (update + lock → 403), DELETE lock/not-attached cases — mirroring the Agent suite; redundant visibility/lock mechanics live in the module's own tests from #187

## Acceptance criteria
- [x] GET-by-id, list, workspace mutation use the module's entry points
- [x] Unattached org-scoped → 404; attached org-scoped workspace mutation → 403; duplicate name → 409 (behaviour-preserving)
- [x] Skill's local `isUniqueViolation` deleted; conflicts via central `onError`
- [x] `agentIds` side-effect unchanged and still stripped on the org route
- [x] Skill route tests pass with redundant assertions consolidated

## Testing
- Full backend suite: **919 passed**
- Changed files Prettier-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)