### PR TITLE
fix(backend): type ScopedResource registry as the real table union

### DIFF
--- a/apps/backend/src/services/scoped-resource.ts
+++ b/apps/backend/src/services/scoped-resource.ts
@@ -38,22 +38,30 @@ export type RowOf = {
   provider: typeof providerTable.$inferSelect;
 };
 
+/**
+ * The four dual-scope tables, each at its real type. They share the `id` /
+ * `organizationId` / `workspaceId` columns this module relies on; the
+ * per-resource row type is recovered via the `RowOf` cast at each return.
+ */
+type ScopedTable =
+  | typeof agentTable
+  | typeof skillTable
+  | typeof mcpTable
+  | typeof providerTable;
+
 type RegistryEntry = {
   /** The Drizzle table backing this resource type. */
-  table: typeof agentTable;
+  table: ScopedTable;
   /** Human label used in the `NotFoundError` message ("Agent not found"). */
   label: string;
 };
 
-// Typed registry keyed by the `attachment.resourceType` enum. The tables share
-// the `id` / `organizationId` / `workspaceId` columns this module relies on, so
-// they are addressed through a single common shape (`typeof agentTable`); the
-// per-resource row type is recovered via the `RowOf` cast at each return.
+// Typed registry keyed by the `attachment.resourceType` enum.
 const REGISTRY: Record<ScopedResourceType, RegistryEntry> = {
   agent: { table: agentTable, label: "Agent" },
-  skill: { table: skillTable as typeof agentTable, label: "Skill" },
-  mcp: { table: mcpTable as typeof agentTable, label: "MCP" },
-  provider: { table: providerTable as typeof agentTable, label: "Provider" },
+  skill: { table: skillTable, label: "Skill" },
+  mcp: { table: mcpTable, label: "MCP" },
+  provider: { table: providerTable, label: "Provider" },
 };
 
 /** The Workspace a Scoped resource is resolved relative to. */
@@ -146,8 +154,9 @@ export const listScoped = async <T extends ScopedResourceType>(
 
   // The inner-join rows are keyed by the table's name, which matches the
   // resource type for every dual-scope table (`agent`, `skill`, `mcp`,
-  // `provider`).
-  const orgRows = (attachedRows as Record<string, RowOf[T]>[]).map(
+  // `provider`). The key is dynamic over the union table, so bridge through
+  // `unknown` to recover the per-resource row shape.
+  const orgRows = (attachedRows as unknown as Record<string, RowOf[T]>[]).map(
     (r) => r[type],
   );
 


### PR DESCRIPTION
## Problem
`scoped-resource.ts` coerced each dual-scope table to `typeof agentTable` (`skillTable as typeof agentTable`, etc.) so they could be addressed through a single common shape. TypeScript rejects these casts (TS2352 — "neither type sufficiently overlaps"), surfacing as **four editor errors** (one per non-agent table, plus the dynamic join-result cast). The backend has no `tsc` step in CI, so these never broke the build/tests — but they're genuinely unsound and noisy in the editor.

## Fix
- Type the registry `table` field as the real union of the four tables (`agent | skill | mcp | provider`) instead of coercing to `typeof agentTable`. Drizzle's query-builder calls (`.select().from(table)`, `eq(table.id, …)`, the inner join) all accept the union, so the three registry casts disappear.
- The inner-join result is keyed by the table's *runtime* name, which the union type can't know statically — bridge that one spot through `unknown` (as TS itself suggests) with a comment explaining why.

No runtime/behavior change — the public return types (`{ row: RowOf[T]; scope }`) are identical.

## Verification
- `tsc --noEmit --strict --skipLibCheck` on `scoped-resource.ts` and all four consumer routes (`provider`/`agent`/`skill`/`mcp`): **clean** (the unrelated pre-existing `mcp.ts:376` URL-typing error is untouched and out of scope).
- Full backend suite: **934 passed**.
- `prettier` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)