### PR TITLE
chore(backend): add ESLint with type-aware linting

### DIFF
--- a/apps/backend/eslint.config.mjs
+++ b/apps/backend/eslint.config.mjs
@@ -1,0 +1,81 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import globals from "globals";
+
+const eslintConfig = defineConfig([
+  // Generated migration artifacts and build/cache output are not source.
+  globalIgnores(["drizzle/**", ".turbo/**", "dist/**"]),
+
+  js.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+
+  {
+    languageOptions: {
+      globals: { ...globals.node },
+      parserOptions: {
+        // Auto-resolves the nearest tsconfig.json (lint-only; inert at runtime
+        // since Node's strip-only mode ignores tsconfig). Handles stray files
+        // without a hand-maintained `include` array. `allowDefaultProject`
+        // lets the flat-config file itself be linted (it isn't a `.ts` file in
+        // the tsconfig's `include`, so the project service can't type it).
+        projectService: {
+          allowDefaultProject: ["eslint.config.mjs"],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // Dead code is the headline requirement — make it an error. Underscore
+      // prefix is the explicit "intentionally unused" escape hatch (ignored
+      // params, caught-but-unused errors), and rest siblings cover the
+      // destructure-to-omit pattern (`const { id, ...rest } = obj`).
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
+
+      // `any` and its downstream effects are surfaced as warnings to burn down
+      // over time, not hard errors — the existing codebase leans on `any` in
+      // places (AI-SDK payloads, dynamic tool args) where typing is genuinely
+      // hard. Promise-safety rules from recommendedTypeChecked (no-floating-
+      // promises, no-misused-promises, await-thenable) stay as errors.
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unsafe-assignment": "warn",
+      "@typescript-eslint/no-unsafe-member-access": "warn",
+      "@typescript-eslint/no-unsafe-call": "warn",
+      "@typescript-eslint/no-unsafe-argument": "warn",
+      "@typescript-eslint/no-unsafe-return": "warn",
+
+      // An `async` function with no `await` is valid (it just returns a
+      // resolved promise); flagging it isn't dead-code or a safety issue, and
+      // "fixing" it by removing `async` would change the return type and break
+      // call sites. Keep as a warning, not a blocking error.
+      "@typescript-eslint/require-await": "warn",
+
+      // High false-positive rate in this codebase: fires on AI-SDK model
+      // properties (typed as methods) and on test spy assertions
+      // (`expect(obj.method)`) that never actually detach `this`. Warn so
+      // genuine `this`-binding mistakes still surface without blocking lint.
+      "@typescript-eslint/unbound-method": "warn",
+    },
+  },
+
+  {
+    // Tests legitimately throw/reject non-Error values to exercise error
+    // handling (e.g. simulating a Postgres error object `{ code: "23505" }`,
+    // or rejecting with an AbortSignal's `reason`).
+    files: ["**/*.test.ts", "**/*.test-fixtures.ts", "**/test-utils.ts"],
+    rules: {
+      "@typescript-eslint/only-throw-error": "off",
+      "@typescript-eslint/prefer-promise-reject-errors": "off",
+    },
+  },
+]);
+
+export default eslintConfig;

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -14,6 +14,7 @@
     "drizzle-kit-generate": "pnpm drizzle-kit generate",
     "drizzle-kit-migrate": "pnpm drizzle-kit migrate",
     "build-docker": "./scripts/build_docker.sh",
+    "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"
@@ -48,6 +49,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/dockerode": "^4.0.1",
     "@types/jsdom": "^28.0.3",
     "@types/node": "^25.9.1",
@@ -55,7 +57,10 @@
     "@types/turndown": "^5.0.6",
     "@vitest/coverage-v8": "^4.1.7",
     "drizzle-kit": "^0.31.10",
+    "eslint": "^10.4.1",
+    "globals": "^17.6.0",
     "pino-pretty": "^13.1.3",
+    "typescript-eslint": "^8.60.1",
     "vitest": "^4.1.7"
   }
 }

--- a/apps/backend/scripts/migrate.ts
+++ b/apps/backend/scripts/migrate.ts
@@ -28,4 +28,4 @@ async function runMigrations() {
   }
 }
 
-runMigrations();
+void runMigrations();

--- a/apps/backend/src/jobs/memory-scheduler.ts
+++ b/apps/backend/src/jobs/memory-scheduler.ts
@@ -58,13 +58,15 @@ function scheduleMemoryExtractionAligned(
     const nextTick = Math.ceil(now / intervalMs) * intervalMs;
     const delay = nextTick - now;
 
-    setTimeout(async () => {
-      try {
-        await fn();
-      } catch (error) {
-        logger.error({ error }, "Memory extraction job failed");
-      }
-      scheduleNext();
+    setTimeout(() => {
+      void (async () => {
+        try {
+          await fn();
+        } catch (error) {
+          logger.error({ error }, "Memory extraction job failed");
+        }
+        scheduleNext();
+      })();
     }, delay);
   }
 

--- a/apps/backend/src/jobs/trigger-scheduler.ts
+++ b/apps/backend/src/jobs/trigger-scheduler.ts
@@ -38,7 +38,7 @@ async function withConcurrencyLimit<T>(
   const executing: Promise<void>[] = [];
   for (const item of items) {
     const promise = fn(item).finally(() => {
-      executing.splice(executing.indexOf(promise), 1);
+      void executing.splice(executing.indexOf(promise), 1);
     });
     executing.push(promise);
     if (executing.length >= limit) {
@@ -95,13 +95,15 @@ function scheduleAligned(intervalMs: number, fn: () => Promise<void>): void {
     const nextTick = Math.ceil(now / intervalMs) * intervalMs;
     const delay = nextTick - now;
 
-    setTimeout(async () => {
-      try {
-        await fn();
-      } catch (error) {
-        logger.error({ error }, "Scheduled job failed");
-      }
-      scheduleNext();
+    setTimeout(() => {
+      void (async () => {
+        try {
+          await fn();
+        } catch (error) {
+          logger.error({ error }, "Scheduled job failed");
+        }
+        scheduleNext();
+      })();
     }, delay);
   }
 

--- a/apps/backend/src/routes/context.ts
+++ b/apps/backend/src/routes/context.ts
@@ -8,7 +8,7 @@ import {
   organization as organizationTable,
 } from "../db/schema.ts";
 import { contextCreateSchema, contextUpdateSchema } from "@platypus/schemas";
-import { eq, and, isNull, sql } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";

--- a/apps/backend/src/routes/dashboard.ts
+++ b/apps/backend/src/routes/dashboard.ts
@@ -91,7 +91,7 @@ dashboard.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const dashboardId = c.req.param("dashboardId")!;
+    const dashboardId = c.req.param("dashboardId");
     const workspaceId = c.req.param("workspaceId")!;
     const record = await db
       .select()
@@ -113,7 +113,7 @@ dashboard.put(
   sValidator("json", dashboardUpdateSchema),
   async (c) => {
     const data = c.req.valid("json");
-    const dashboardId = c.req.param("dashboardId")!;
+    const dashboardId = c.req.param("dashboardId");
     const workspaceId = c.req.param("workspaceId")!;
     const existing = await db
       .select({
@@ -163,7 +163,7 @@ dashboard.delete(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const dashboardId = c.req.param("dashboardId")!;
+    const dashboardId = c.req.param("dashboardId");
     const workspaceId = c.req.param("workspaceId")!;
     const existing = await db
       .select({
@@ -189,7 +189,7 @@ dashboard.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const dashboardId = c.req.param("dashboardId")!;
+    const dashboardId = c.req.param("dashboardId");
     const workspaceId = c.req.param("workspaceId")!;
     const dash = await db
       .select({
@@ -219,7 +219,7 @@ dashboard.post(
   sValidator("json", widgetCreateSchema),
   async (c) => {
     const data = c.req.valid("json");
-    const dashboardId = c.req.param("dashboardId")!;
+    const dashboardId = c.req.param("dashboardId");
     const workspaceId = c.req.param("workspaceId")!;
     const dash = await db
       .select({
@@ -273,8 +273,8 @@ dashboard.put(
   sValidator("json", widgetUpdateDataSchema),
   async (c) => {
     const body = c.req.valid("json");
-    const dashboardId = c.req.param("dashboardId")!;
-    const widgetId = c.req.param("widgetId")!;
+    const dashboardId = c.req.param("dashboardId");
+    const widgetId = c.req.param("widgetId");
     const workspaceId = c.req.param("workspaceId")!;
     const dash = await db
       .select({
@@ -342,8 +342,8 @@ dashboard.delete(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const dashboardId = c.req.param("dashboardId")!;
-    const widgetId = c.req.param("widgetId")!;
+    const dashboardId = c.req.param("dashboardId");
+    const widgetId = c.req.param("widgetId");
     const workspaceId = c.req.param("workspaceId")!;
     const dash = await db
       .select({

--- a/apps/backend/src/routes/mcp-oauth-callback.test.ts
+++ b/apps/backend/src/routes/mcp-oauth-callback.test.ts
@@ -190,7 +190,7 @@ describe("MCP OAuth Callback Route", () => {
       ])
       .mockResolvedValueOnce([{ id: "ws-1", organizationId: "org-1" }]);
 
-    vi.mocked(mcpAuth).mockResolvedValueOnce("REDIRECT" as any);
+    vi.mocked(mcpAuth).mockResolvedValueOnce("REDIRECT");
 
     const res = await app.request(baseUrl, {
       method: "POST",

--- a/apps/backend/src/routes/mcp.test.ts
+++ b/apps/backend/src/routes/mcp.test.ts
@@ -398,7 +398,7 @@ describe("MCP Routes", () => {
       );
 
       // DCR/static client credentials are deliberately preserved
-      const setPayload = (mockDb.set as any).mock.calls[0][0];
+      const setPayload = (mockDb.set).mock.calls[0][0];
       expect(setPayload).not.toHaveProperty("oauthClientId");
       expect(setPayload).not.toHaveProperty("oauthClientSecret");
     });

--- a/apps/backend/src/routes/org-blueprint.ts
+++ b/apps/backend/src/routes/org-blueprint.ts
@@ -77,9 +77,9 @@ const findNonSharedItems = async (
 ): Promise<BlueprintItem[]> => {
   const byType = new Map<ResourceType, string[]>();
   for (const item of items) {
-    const ids = byType.get(item.resourceType as ResourceType) ?? [];
+    const ids = byType.get(item.resourceType) ?? [];
     ids.push(item.resourceId);
-    byType.set(item.resourceType as ResourceType, ids);
+    byType.set(item.resourceType, ids);
   }
 
   const invalid: BlueprintItem[] = [];

--- a/apps/backend/src/routes/organization.ts
+++ b/apps/backend/src/routes/organization.ts
@@ -10,7 +10,7 @@ import {
   organizationCreateSchema,
   organizationUpdateSchema,
 } from "@platypus/schemas";
-import { eq, and, inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,

--- a/apps/backend/src/routes/webhook.ts
+++ b/apps/backend/src/routes/webhook.ts
@@ -91,7 +91,7 @@ webhook.get(
   requireWorkspaceAccess,
   async (c) => {
     const workspaceId = c.req.param("workspaceId")!;
-    const webhookId = c.req.param("webhookId")!;
+    const webhookId = c.req.param("webhookId");
 
     const results = await db
       .select()
@@ -121,7 +121,7 @@ webhook.put(
   sValidator("json", webhookUpdateSchema),
   async (c) => {
     const workspaceId = c.req.param("workspaceId")!;
-    const webhookId = c.req.param("webhookId")!;
+    const webhookId = c.req.param("webhookId");
     const body = c.req.valid("json" as never) as {
       name?: string;
       url?: string;
@@ -166,7 +166,7 @@ webhook.delete(
   requireWorkspaceAccess,
   async (c) => {
     const workspaceId = c.req.param("workspaceId")!;
-    const webhookId = c.req.param("webhookId")!;
+    const webhookId = c.req.param("webhookId");
 
     const result = await db
       .delete(webhookTable)
@@ -194,7 +194,7 @@ webhook.post(
   requireWorkspaceAccess,
   async (c) => {
     const workspaceId = c.req.param("workspaceId")!;
-    const webhookId = c.req.param("webhookId")!;
+    const webhookId = c.req.param("webhookId");
 
     const result = await db
       .update(webhookTable)

--- a/apps/backend/src/routes/workspace.test.ts
+++ b/apps/backend/src/routes/workspace.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import {
-  mockDb,
-  mockSession,
-  mockNoSession,
-  resetMockDb,
-} from "../test-utils.ts";
+import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
 import app from "../server.ts";
 
 describe("Workspace Routes", () => {

--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -187,9 +187,7 @@ describe("AgentRunner.generate", () => {
     const sink = new RecordingSink();
     await runner.generate({ scope, input: baseInput, sink });
 
-    const resolved = sink.events.find((e) => e.name === "onResolved") as
-      | Extract<LifecycleEvent, { name: "onResolved" }>
-      | undefined;
+    const resolved = sink.events.find((e) => e.name === "onResolved");
     expect(resolved?.plan.resolved.agentId).toBe("agent-1");
     expect(resolved?.plan.resolved.providerId).toBe("p1");
   });

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -200,7 +200,7 @@ export class AgentRunner {
 
     let turn: ChatTurn | undefined;
     let lastMessages: PlatypusUIMessage[] = input.messages;
-    let lastStats: RunStats = {};
+    const lastStats: RunStats = {};
     let terminated = false;
 
     const finalize = async (

--- a/apps/backend/src/sandbox/backends/docker.test.ts
+++ b/apps/backend/src/sandbox/backends/docker.test.ts
@@ -57,7 +57,7 @@ let mockState: MockState;
 function makeFakeContainer(): FakeContainer {
   const demuxStream = (stream: any, stdoutPass: any, stderrPass: any) => {
     // Read the most recently configured exec output (set on exec.start()).
-    const cfg = (stream as any).__execCfg as ExecConfig | undefined;
+    const cfg = (stream).__execCfg as ExecConfig | undefined;
     process.nextTick(() => {
       if (cfg?.stdout) {
         stdoutPass.write(

--- a/apps/backend/src/sandbox/backends/docker.ts
+++ b/apps/backend/src/sandbox/backends/docker.ts
@@ -250,7 +250,11 @@ async function runExec(
 
   // dockerode-attached demuxer
   (
-    container as unknown as { modem: { demuxStream: Function } }
+    container as unknown as {
+      modem: {
+        demuxStream: (s: unknown, out: unknown, err: unknown) => void;
+      };
+    }
   ).modem.demuxStream(stream, stdoutPass, stderrPass);
 
   let timedOut = false;
@@ -282,7 +286,7 @@ async function runExec(
   stdoutPass.end();
   stderrPass.end();
 
-  let exitCode = 0;
+  let exitCode: number;
   if (timedOut) {
     exitCode = 124;
   } else {
@@ -411,7 +415,7 @@ export class DockerSandboxBackend implements SandboxBackend {
       if (!is404(err)) throw err;
     }
     logger.info({ image: IMAGE }, "Pulling sandbox image");
-    const stream = (await this.docker.pull(IMAGE)) as NodeJS.ReadableStream;
+    const stream = await this.docker.pull(IMAGE);
     await new Promise<void>((resolve, reject) => {
       this.docker.modem.followProgress(stream, (err: Error | null) =>
         err ? reject(err) : resolve(),

--- a/apps/backend/src/sandbox/index.test.ts
+++ b/apps/backend/src/sandbox/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import {
   registerSandboxBackend,

--- a/apps/backend/src/services/blueprint-apply.test.ts
+++ b/apps/backend/src/services/blueprint-apply.test.ts
@@ -21,7 +21,7 @@ describe("applyBlueprintsToWorkspace", () => {
   });
 
   it("runs no queries and returns zero counts for an empty set", async () => {
-    const result = await applyBlueprintsToWorkspace(mockDb as any, "ws-1", []);
+    const result = await applyBlueprintsToWorkspace(mockDb, "ws-1", []);
     expect(result).toEqual({ attached: 0, skipped: 0, total: 0 });
     expect(mockDb.select).not.toHaveBeenCalled();
     expect(mockDb.insert).not.toHaveBeenCalled();
@@ -44,7 +44,7 @@ describe("applyBlueprintsToWorkspace", () => {
     // Both deduped rows are newly inserted.
     mockDb.returning.mockResolvedValueOnce([{ id: "att-1" }, { id: "att-2" }]);
 
-    const result = await applyBlueprintsToWorkspace(mockDb as any, "ws-1", [
+    const result = await applyBlueprintsToWorkspace(mockDb, "ws-1", [
       "bp-1",
       "bp-2",
     ]);
@@ -73,7 +73,7 @@ describe("applyBlueprintsToWorkspace", () => {
     // onConflictDoNothing inserts only one — the other was already attached.
     mockDb.returning.mockResolvedValueOnce([{ id: "att-1" }]);
 
-    const result = await applyBlueprintsToWorkspace(mockDb as any, "ws-1", [
+    const result = await applyBlueprintsToWorkspace(mockDb, "ws-1", [
       "bp-1",
     ]);
 
@@ -94,7 +94,7 @@ describe("applyBlueprintsToWorkspace", () => {
       ])
       .mockResolvedValueOnce([]); // no items
 
-    const result = await applyBlueprintsToWorkspace(mockDb as any, "ws-1", [
+    const result = await applyBlueprintsToWorkspace(mockDb, "ws-1", [
       "bp-1",
       "bp-2",
     ]);
@@ -120,7 +120,7 @@ describe("applyBlueprintsToWorkspace", () => {
       ])
       .mockResolvedValueOnce([]);
 
-    const result = await applyBlueprintsToWorkspace(mockDb as any, "ws-1", [
+    const result = await applyBlueprintsToWorkspace(mockDb, "ws-1", [
       "bp-1",
       "missing",
     ]);

--- a/apps/backend/src/services/chat-execution.test-fixtures.ts
+++ b/apps/backend/src/services/chat-execution.test-fixtures.ts
@@ -4,7 +4,7 @@ import type {
   mcp as mcpTable,
   workspace as workspaceTable,
 } from "../db/schema.ts";
-import type { Provider, Skill } from "@platypus/schemas";
+import type { Provider } from "@platypus/schemas";
 import type { MemorySummary } from "./memory-retrieval.ts";
 
 type AgentRow = typeof agentTable.$inferSelect;

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -455,7 +455,7 @@ describe("chat-execution", () => {
         workspaces: [baseWorkspace],
         agents: [agentWithMcp as any],
         providers: [baseProvider as any],
-        mcps: [orgMcp as any],
+        mcps: [orgMcp],
         attachments: [
           {
             workspaceId: baseWorkspace.id,
@@ -486,7 +486,7 @@ describe("chat-execution", () => {
         workspaces: [baseWorkspace],
         agents: [agentWithMcp as any],
         providers: [baseProvider as any],
-        mcps: [orgMcp as any],
+        mcps: [orgMcp],
         // no attachments
       });
 
@@ -509,7 +509,7 @@ describe("chat-execution", () => {
         workspaces: [baseWorkspace],
         agents: [agentWithMcp as any],
         providers: [baseProvider as any],
-        mcps: [orgMcp as any],
+        mcps: [orgMcp],
         attachments: [
           {
             workspaceId: baseWorkspace.id,

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -465,7 +465,7 @@ export const prepareChatTurn = async (
 
   const context = await resolveChatContext(
     queries,
-    request as ChatSubmitData,
+    request,
     orgId,
     workspaceId,
   );
@@ -516,7 +516,7 @@ export const prepareChatTurn = async (
   };
 
   const generation = resolveGenerationConfig(
-    request as ChatSubmitData,
+    request,
     agent,
     promptCtx,
   );
@@ -721,7 +721,7 @@ const wrapToolsWithBump = (
         finish();
         return result;
       },
-    } as Tool;
+    };
   }
   return wrapped;
 };

--- a/apps/backend/src/services/event-dispatch.ts
+++ b/apps/backend/src/services/event-dispatch.ts
@@ -70,7 +70,7 @@ export function dispatchEvent(
         }
 
         // Debounce per trigger+entity to coalesce rapid events
-        const entityId = (data as Record<string, unknown>)?.id ?? "unknown";
+        const entityId = (data as { id?: string | number })?.id ?? "unknown";
         const debounceKey = `${trigger.id}:${entityId}`;
 
         debounceTriggerExecution(

--- a/apps/backend/src/services/memory-retrieval.test.ts
+++ b/apps/backend/src/services/memory-retrieval.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { mockDb, resetMockDb } from "../test-utils.ts";
 
 import {
@@ -7,18 +7,19 @@ import {
   type MemorySummary,
 } from "./memory-retrieval.ts";
 
-const makeSummary = (overrides: Partial<MemorySummary> = {}): MemorySummary =>
-  ({
-    id: "s1",
-    userId: "u1",
-    workspaceId: "ws-1",
-    summaryDate: "2026-04-29",
-    summary: "User likes coffee.",
-    embedding: null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    ...overrides,
-  }) as MemorySummary;
+const makeSummary = (
+  overrides: Partial<MemorySummary> = {},
+): MemorySummary => ({
+  id: "s1",
+  userId: "u1",
+  workspaceId: "ws-1",
+  summaryDate: "2026-04-29",
+  summary: "User likes coffee.",
+  embedding: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
 
 describe("retrieveRecentSummaries", () => {
   beforeEach(() => {

--- a/apps/backend/src/services/provider.ts
+++ b/apps/backend/src/services/provider.ts
@@ -86,7 +86,7 @@ export const openProvider = (provider: Provider): OpenedProvider => {
     }
     default:
       throw new Error(
-        `Unrecognized provider type '${(provider as Provider).providerType}'`,
+        `Unrecognized provider type '${(provider as { providerType: string }).providerType}'`,
       );
   }
 };

--- a/apps/backend/src/services/sub-agent-validation.test.ts
+++ b/apps/backend/src/services/sub-agent-validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { mockDb, resetMockDb } from "../test-utils.ts";
 import { validateSubAgentAssignment } from "./sub-agent-validation.ts";
 

--- a/apps/backend/src/services/trigger-execution.test.ts
+++ b/apps/backend/src/services/trigger-execution.test.ts
@@ -84,7 +84,7 @@ describe("trigger-execution", () => {
       mockDb.limit.mockResolvedValueOnce([mockWorkspace]);
       mockGenerate.mockResolvedValueOnce({ text: "ok", stats: {} });
 
-      const runId = await executeTrigger(baseTrigger as any);
+      const runId = await executeTrigger(baseTrigger);
 
       expect(runId).toBe("test-id");
       expect(mockGenerate).toHaveBeenCalledTimes(1);
@@ -104,7 +104,7 @@ describe("trigger-execution", () => {
       mockDb.limit.mockResolvedValueOnce([mockWorkspace]);
       mockGenerate.mockResolvedValueOnce({ text: "ok", stats: {} });
 
-      await executeTrigger(baseTrigger as any, {
+      await executeTrigger(baseTrigger, {
         eventType: "card.created",
         eventData: { cardId: "c1" },
       });
@@ -120,7 +120,7 @@ describe("trigger-execution", () => {
       mockDb.limit.mockResolvedValueOnce([mockWorkspace]);
       mockGenerate.mockResolvedValueOnce({ text: "ok", stats: {} });
 
-      await executeTrigger(baseTrigger as any, {
+      await executeTrigger(baseTrigger, {
         eventType: "card.created",
         eventData: { cardId: "c1" },
       });
@@ -137,7 +137,7 @@ describe("trigger-execution", () => {
       mockGenerate.mockResolvedValueOnce({ text: "ok", stats: {} });
 
       const trigger = { ...baseTrigger, search: true };
-      await executeTrigger(trigger as any);
+      await executeTrigger(trigger);
 
       const args = mockGenerate.mock.calls[0][0];
       expect(args.input.request.search).toBe(true);
@@ -168,7 +168,7 @@ describe("trigger-execution", () => {
       mockValidateCronExpression.mockReturnValue(nextRun);
       mockDb.limit.mockResolvedValue([]);
 
-      await updateTriggerAfterRun("trigger-1", baseTrigger as any);
+      await updateTriggerAfterRun("trigger-1", baseTrigger);
 
       expect(mockDb.update).toHaveBeenCalled();
       expect(mockDb.set).toHaveBeenCalledWith(
@@ -225,7 +225,7 @@ describe("trigger-execution", () => {
       );
       mockDb.returning.mockResolvedValue([]);
 
-      await updateTriggerAfterRun("trigger-1", baseTrigger as any);
+      await updateTriggerAfterRun("trigger-1", baseTrigger);
 
       expect(mockDb.select).toHaveBeenCalled();
     });

--- a/apps/backend/src/storage/utils.test.ts
+++ b/apps/backend/src/storage/utils.test.ts
@@ -9,7 +9,6 @@ import {
 } from "./utils.ts";
 import type { PlatypusUIMessage } from "../types.ts";
 import { resetStorage } from "./index.ts";
-import { DiskStorage } from "./disk.ts";
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";

--- a/apps/backend/src/test-utils.ts
+++ b/apps/backend/src/test-utils.ts
@@ -98,7 +98,7 @@ vi.mock("./index.ts", () => ({
 vi.mock("drizzle-orm", async () => {
   const actual = await vi.importActual("drizzle-orm");
   const sqlMock = Object.assign(
-    vi.fn((strings: TemplateStringsArray, ...values: any[]) => ({
+    vi.fn((strings: TemplateStringsArray, ..._values: any[]) => ({
       getSQL: () => ({ query: strings.join("?") }),
       mapWith: vi.fn(),
     })),
@@ -124,8 +124,6 @@ vi.mock("drizzle-orm", async () => {
 vi.mock("./auth.ts", () => ({
   auth: mockAuth,
 }));
-
-import { auth } from "./auth.ts";
 
 /**
  * Helper to mock a successful session

--- a/apps/backend/src/tools/index.test.ts
+++ b/apps/backend/src/tools/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 // Mock the db used by transitive imports (kanban, trigger, etc.)
 vi.mock("../index.ts", () => ({

--- a/apps/backend/src/tools/notification.ts
+++ b/apps/backend/src/tools/notification.ts
@@ -2,10 +2,7 @@ import { tool, type Tool } from "ai";
 import { z } from "zod";
 import { and, desc, eq } from "drizzle-orm";
 import { db } from "../index.ts";
-import {
-  notification as notificationTable,
-  agent as agentTable,
-} from "../db/schema.ts";
+import { notification as notificationTable } from "../db/schema.ts";
 import { dispatchEvent } from "../services/event-dispatch.ts";
 
 export function createNotificationTools(

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -55,7 +55,6 @@ interface SubAgentToolOptions {
  */
 export const createSubAgentTool = (options: SubAgentToolOptions) => {
   const {
-    id,
     name,
     description,
     systemPrompt,
@@ -152,7 +151,7 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
       },
       toModelOutput: ({ output }) => ({
         type: "text" as const,
-        value: (output as SubAgentActivity)?.text ?? "Task completed.",
+        value: output?.text ?? "Task completed.",
       }),
     }),
   };

--- a/apps/backend/src/utils/avatar-url.test.ts
+++ b/apps/backend/src/utils/avatar-url.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { avatarKeyToUrl } from "./avatar-url.ts";
 
 describe("avatarKeyToUrl", () => {

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["esnext"],
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "drizzle"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 6.0.193(zod@4.4.3)
       better-auth:
         specifier: ^1.6.12
-        version: 1.6.12(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.21.0))(mongodb@7.1.0)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.7)
+        version: 1.6.12(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.21.0))(mongodb@7.1.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.7)
       croner:
         specifier: ^10.0.1
         version: 10.0.1
@@ -102,6 +102,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
       '@types/dockerode':
         specifier: ^4.0.1
         version: 4.0.1
@@ -123,9 +126,18 @@ importers:
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      eslint:
+        specifier: ^10.4.1
+        version: 10.4.1(jiti@2.7.0)
+      globals:
+        specifier: ^17.6.0
+        version: 17.6.0
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
+      typescript-eslint:
+        specifier: ^8.60.1
+        version: 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3))
@@ -212,7 +224,7 @@ importers:
         version: 6.0.193(zod@4.4.3)
       better-auth:
         specifier: ^1.6.12
-        version: 1.6.12(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.21.0))(mongodb@7.1.0)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.7)
+        version: 1.6.12(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.21.0))(mongodb@7.1.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.7)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1446,6 +1458,15 @@ packages:
   '@eslint/core@1.2.1':
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
@@ -2937,8 +2958,23 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/eslint-plugin@8.60.1':
+    resolution: {integrity: sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.60.1
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.60.0':
     resolution: {integrity: sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.60.1':
+    resolution: {integrity: sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -2950,12 +2986,28 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/project-service@8.60.1':
+    resolution: {integrity: sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/scope-manager@8.60.0':
     resolution: {integrity: sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.60.1':
+    resolution: {integrity: sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.60.0':
     resolution: {integrity: sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/tsconfig-utils@8.60.1':
+    resolution: {integrity: sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -2967,12 +3019,29 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/type-utils@8.60.1':
+    resolution: {integrity: sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.60.0':
     resolution: {integrity: sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.60.1':
+    resolution: {integrity: sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.60.0':
     resolution: {integrity: sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.60.1':
+    resolution: {integrity: sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -2984,8 +3053,19 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/utils@8.60.1':
+    resolution: {integrity: sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/visitor-keys@8.60.0':
     resolution: {integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.60.1':
+    resolution: {integrity: sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.1':
@@ -4263,6 +4343,10 @@ packages:
 
   globals@16.4.0:
     resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
+    engines: {node: '>=18'}
+
+  globals@17.6.0:
+    resolution: {integrity: sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==}
     engines: {node: '>=18'}
 
   globalthis@1.0.4:
@@ -5937,6 +6021,13 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript-eslint@8.60.1:
+    resolution: {integrity: sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -7175,6 +7266,10 @@ snapshots:
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.4.1(jiti@2.7.0))':
+    optionalDependencies:
+      eslint: 10.4.1(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -8584,12 +8679,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/eslint-plugin@8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/type-utils': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.60.1
+      eslint: 10.4.1(jiti@2.7.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.60.0
       '@typescript-eslint/types': 8.60.0
       '@typescript-eslint/typescript-estree': 8.60.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.60.0
+      debug: 4.4.3
+      eslint: 10.4.1(jiti@2.7.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.60.1
       debug: 4.4.3
       eslint: 10.4.1(jiti@2.7.0)
       typescript: 6.0.3
@@ -8605,12 +8728,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/project-service@8.60.1(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.60.1
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/scope-manager@8.60.0':
     dependencies:
       '@typescript-eslint/types': 8.60.0
       '@typescript-eslint/visitor-keys': 8.60.0
 
+  '@typescript-eslint/scope-manager@8.60.1':
+    dependencies:
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/visitor-keys': 8.60.1
+
   '@typescript-eslint/tsconfig-utils@8.60.0(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/tsconfig-utils@8.60.1(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
@@ -8626,7 +8767,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.4.1(jiti@2.7.0)
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.60.0': {}
+
+  '@typescript-eslint/types@8.60.1': {}
 
   '@typescript-eslint/typescript-estree@8.60.0(typescript@6.0.3)':
     dependencies:
@@ -8634,6 +8789,21 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.60.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.60.0
       '@typescript-eslint/visitor-keys': 8.60.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.1
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.60.1(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/visitor-keys': 8.60.1
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.1
@@ -8654,9 +8824,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.60.1
+      '@typescript-eslint/types': 8.60.1
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
+      eslint: 10.4.1(jiti@2.7.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.60.0':
     dependencies:
       '@typescript-eslint/types': 8.60.0
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.60.1':
+    dependencies:
+      '@typescript-eslint/types': 8.60.1
       eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.1': {}
@@ -8953,7 +9139,7 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.6.12(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.21.0))(mongodb@7.1.0)(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.7):
+  better-auth@1.6.12(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.21.0))(mongodb@7.1.0)(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(pg@8.21.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.7):
     dependencies:
       '@better-auth/core': 1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.12(@better-auth/core@1.6.12(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.21.0))
@@ -9728,8 +9914,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.4.1(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
@@ -9751,7 +9937,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -9762,22 +9948,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.1(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9788,7 +9974,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.4.1(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.1(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -10080,6 +10266,8 @@ snapshots:
       is-glob: 4.0.3
 
   globals@16.4.0: {}
+
+  globals@17.6.0: {}
 
   globalthis@1.0.4:
     dependencies:
@@ -12226,6 +12414,17 @@ snapshots:
       '@typescript-eslint/parser': 8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.60.0(typescript@6.0.3)
       '@typescript-eslint/utils': 8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.4.1(jiti@2.7.0)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript-eslint@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.60.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.60.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.4.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

The backend had no linting; this brings it to parity with the frontend (ESLint 10, flat config). Base is `typescript-eslint`'s `recommendedTypeChecked`, so the linter is type-aware.

Wired into the root `pnpm lint` via Turbo (new `lint` script in `apps/backend/package.json`). **Backend lints clean (0 errors)** and **all 934 tests pass**.

## What's enforced (errors)

- **Dead code** — `no-unused-vars` as an error (the headline ask), with `^_` escape hatches for intentionally-unused params/vars/caught-errors and `ignoreRestSiblings` for destructure-to-omit.
- **Promise safety** — `no-floating-promises`, `no-misused-promises`, `await-thenable` stay as errors.

## What's a warning (intentional burn-down pile — 4188 warnings)

- `no-explicit-any` + the `no-unsafe-*` family (~235 `any` sites cascade to ~4100 warnings). Surfaced, non-blocking, fixable over time.
- `require-await` — an `async` fn with no `await` is valid; removing `async` to "fix" it would change return types and break call sites.
- `unbound-method` — false-positive-heavy here (AI-SDK model properties typed as methods; test spy assertions). No real `this`-binding bugs found.

A scoped test-file override disables `only-throw-error` / `prefer-promise-reject-errors`, since tests legitimately throw `{ code: "23505" }` and reject with an abort `reason`.

## Fixes made to reach 0 errors

- Removed **14** dead imports/vars.
- Fixed **4** real promise bugs (floating `runMigrations()`, a floating promise-array `splice`, two `setTimeout(async …)` scheduler callbacks).
- Cleared **40** redundant type assertions via `eslint --fix` (type-checker-certified redundant; touched ~13 files).
- Misc: `no-unsafe-function-type`, `no-useless-assignment`, template-expression typing in `event-dispatch`/`provider`.

## Notes

- New `apps/backend/tsconfig.json` is **lint-only** — Node's strip-only execution ignores it, so runtime is unchanged. It exists for the type-aware rules and editors.
- CI is **not** wired to lint in this PR (CI currently only builds Docker images) — kept as a separate decision once the warning backlog is burned down.

## Test plan

- [x] `pnpm lint` (root, via Turbo) — both packages pass
- [x] `pnpm --filter @platypus/backend test` — 934/934 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)