### PR TITLE
chore(backend): lift Agent avatar handling into a module

### DIFF
--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -23,20 +23,9 @@ import {
   requireWorkspaceMutable,
 } from "../services/scoped-resource.ts";
 import { NotFoundError } from "../errors.ts";
-import { getStorage } from "../storage/index.ts";
-import sharp from "sharp";
+import { storeAvatar, deleteAvatar } from "../services/avatar.ts";
 import { avatarKeyToUrl } from "../utils/avatar-url.ts";
 import { getOrigin } from "../utils/get-origin.ts";
-
-const ALLOWED_AVATAR_TYPES = [
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-  "image/gif",
-];
-const MAX_AVATAR_SIZE = 5 * 1024 * 1024;
-const MIN_AVATAR_DIMENSION = 64;
-const AVATAR_SIZE = 512;
 
 function agentWithAvatarUrl(
   agent: Record<string, unknown>,
@@ -225,68 +214,18 @@ agent.post(
     });
 
     const body = await c.req.parseBody();
-    const file = body["file"];
-    if (!file || !(file instanceof File)) {
-      return c.json({ error: "No file provided" }, 400);
+    const result = await storeAvatar(
+      body["file"],
+      agentId,
+      found.row.avatarKey,
+    );
+    if (!result.ok) {
+      return c.json({ error: result.error }, 400);
     }
-
-    if (!ALLOWED_AVATAR_TYPES.includes(file.type)) {
-      return c.json({ error: "Invalid file type" }, 400);
-    }
-
-    if (file.size > MAX_AVATAR_SIZE) {
-      return c.json({ error: "File too large (max 5MB)" }, 400);
-    }
-
-    const buffer = Buffer.from(await file.arrayBuffer());
-
-    let metadata: sharp.Metadata;
-    try {
-      metadata = await sharp(buffer).metadata();
-    } catch {
-      return c.json({ error: "Invalid image" }, 400);
-    }
-
-    if (metadata.width && metadata.height) {
-      if (
-        metadata.width < MIN_AVATAR_DIMENSION ||
-        metadata.height < MIN_AVATAR_DIMENSION
-      ) {
-        return c.json(
-          {
-            error: `Image must be at least ${MIN_AVATAR_DIMENSION}x${MIN_AVATAR_DIMENSION} pixels`,
-          },
-          400,
-        );
-      }
-    }
-
-    const processedBuffer = await sharp(buffer)
-      .resize(AVATAR_SIZE, AVATAR_SIZE, { fit: "cover" })
-      .webp()
-      .toBuffer();
-
-    // Avatars are keyed by the Agent's (globally unique) id, independent of
-    // scope — so the path never goes stale when a workspace Agent is Promoted
-    // to the Organization (ADR-0007). The exact key is stored on the row, so
-    // deletion never needs to reconstruct it.
-    const key = `agents/${agentId}/avatar-${nanoid()}.webp`;
-
-    if (found.row.avatarKey) {
-      try {
-        const storage = getStorage();
-        await storage.delete(found.row.avatarKey);
-      } catch {
-        // Ignore deletion errors
-      }
-    }
-
-    const storage = getStorage();
-    await storage.put(key, processedBuffer, "image/webp");
 
     const record = await db
       .update(agentTable)
-      .set({ avatarKey: key, updatedAt: new Date() })
+      .set({ avatarKey: result.key, updatedAt: new Date() })
       .where(
         and(
           eq(agentTable.id, agentId),
@@ -317,14 +256,7 @@ agent.delete(
       wsId: workspaceId,
     });
 
-    if (found.row.avatarKey) {
-      try {
-        const storage = getStorage();
-        await storage.delete(found.row.avatarKey);
-      } catch {
-        // Ignore deletion errors
-      }
-    }
+    await deleteAvatar(found.row.avatarKey);
 
     const record = await db
       .update(agentTable)
@@ -360,14 +292,7 @@ agent.delete(
       wsId: workspaceId,
     });
 
-    if (found.row.avatarKey) {
-      try {
-        const storage = getStorage();
-        await storage.delete(found.row.avatarKey);
-      } catch {
-        // Ignore deletion errors
-      }
-    }
+    await deleteAvatar(found.row.avatarKey);
 
     await db
       .delete(agentTable)

--- a/apps/backend/src/routes/org-agent.test.ts
+++ b/apps/backend/src/routes/org-agent.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
 import app from "../server.ts";
+import { deleteAvatar } from "../services/avatar.ts";
+
+vi.mock("../services/avatar.ts", () => ({
+  storeAvatar: vi.fn(),
+  deleteAvatar: vi.fn(),
+}));
 
 describe("Organization Agent Routes", () => {
   beforeEach(() => {
@@ -144,6 +150,21 @@ describe("Organization Agent Routes", () => {
       const res = await app.request(`${baseUrl}/agent-1`, { method: "DELETE" });
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ message: "Agent deleted" });
+    });
+
+    it("removes the deleted agent's avatar from storage", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]) // attachment guard: none
+        .mockResolvedValueOnce([]); // blueprint guard: none
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "agent-1", avatarKey: "agents/agent-1/avatar-x.webp" },
+      ]);
+
+      const res = await app.request(`${baseUrl}/agent-1`, { method: "DELETE" });
+      expect(res.status).toBe(200);
+      expect(deleteAvatar).toHaveBeenCalledWith("agents/agent-1/avatar-x.webp");
     });
 
     it("returns 409 when the agent is attached to a workspace", async () => {

--- a/apps/backend/src/routes/org-agent.ts
+++ b/apps/backend/src/routes/org-agent.ts
@@ -1,7 +1,5 @@
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
-import { nanoid } from "nanoid";
-import sharp from "sharp";
 import { db } from "../index.ts";
 import {
   agent as agentTable,
@@ -15,21 +13,11 @@ import { requireOrgAccess } from "../middleware/authorization.ts";
 import { findNonSharedReferences } from "../services/agent-scope-validation.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
 import { isResourceListedInBlueprint } from "../services/blueprint-guard.ts";
-import { getStorage } from "../storage/index.ts";
+import { storeAvatar, deleteAvatar } from "../services/avatar.ts";
 import { avatarKeyToUrl } from "../utils/avatar-url.ts";
 import { getOrigin } from "../utils/get-origin.ts";
 import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
-
-const ALLOWED_AVATAR_TYPES = [
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-  "image/gif",
-];
-const MAX_AVATAR_SIZE = 5 * 1024 * 1024;
-const MIN_AVATAR_DIMENSION = 64;
-const AVATAR_SIZE = 512;
 
 // Org-scoped Agents are Shared resources (ADR-0007): a single source of truth
 // defined once at Organization scope (via Promote) and referenced by Workspaces
@@ -156,59 +144,14 @@ orgAgent.post(
     }
 
     const body = await c.req.parseBody();
-    const file = body["file"];
-    if (!file || !(file instanceof File)) {
-      return c.json({ error: "No file provided" }, 400);
+    const result = await storeAvatar(body["file"], agentId, existing.avatarKey);
+    if (!result.ok) {
+      return c.json({ error: result.error }, 400);
     }
-    if (!ALLOWED_AVATAR_TYPES.includes(file.type)) {
-      return c.json({ error: "Invalid file type" }, 400);
-    }
-    if (file.size > MAX_AVATAR_SIZE) {
-      return c.json({ error: "File too large (max 5MB)" }, 400);
-    }
-
-    const buffer = Buffer.from(await file.arrayBuffer());
-    let metadata: sharp.Metadata;
-    try {
-      metadata = await sharp(buffer).metadata();
-    } catch {
-      return c.json({ error: "Invalid image" }, 400);
-    }
-    if (
-      metadata.width &&
-      metadata.height &&
-      (metadata.width < MIN_AVATAR_DIMENSION ||
-        metadata.height < MIN_AVATAR_DIMENSION)
-    ) {
-      return c.json(
-        {
-          error: `Image must be at least ${MIN_AVATAR_DIMENSION}x${MIN_AVATAR_DIMENSION} pixels`,
-        },
-        400,
-      );
-    }
-
-    const processedBuffer = await sharp(buffer)
-      .resize(AVATAR_SIZE, AVATAR_SIZE, { fit: "cover" })
-      .webp()
-      .toBuffer();
-
-    // Avatars are keyed by the Agent's globally-unique id, independent of scope.
-    const key = `agents/${agentId}/avatar-${nanoid()}.webp`;
-
-    if (existing.avatarKey) {
-      try {
-        await getStorage().delete(existing.avatarKey);
-      } catch {
-        // Ignore deletion errors
-      }
-    }
-
-    await getStorage().put(key, processedBuffer, "image/webp");
 
     const record = await db
       .update(agentTable)
-      .set({ avatarKey: key, updatedAt: new Date() })
+      .set({ avatarKey: result.key, updatedAt: new Date() })
       .where(
         and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
       )
@@ -238,13 +181,7 @@ orgAgent.delete(
       throw new NotFoundError("Agent not found");
     }
 
-    if (existing.avatarKey) {
-      try {
-        await getStorage().delete(existing.avatarKey);
-      } catch {
-        // Ignore deletion errors
-      }
-    }
+    await deleteAvatar(existing.avatarKey);
 
     const record = await db
       .update(agentTable)
@@ -317,6 +254,13 @@ orgAgent.delete(
     if (result.length === 0) {
       throw new NotFoundError("Agent not found");
     }
+
+    // Clean up the (now-orphaned) avatar, matching the Workspace surface — the
+    // avatar is keyed by the Agent id alone, so nothing else can reference it
+    // once the row is gone. Best-effort: a storage miss must not fail the
+    // delete that already committed.
+    await deleteAvatar(result[0].avatarKey);
+
     return c.json({ message: "Agent deleted" });
   },
 );

--- a/apps/backend/src/services/avatar.test.ts
+++ b/apps/backend/src/services/avatar.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("../storage/index.ts", () => ({
+  getStorage: vi.fn(),
+}));
+
+const metadataMock = vi.fn();
+const toBufferMock = vi.fn();
+const resizeMock = vi.fn().mockReturnThis();
+const webpMock = vi.fn().mockReturnThis();
+
+vi.mock("sharp", () => ({
+  default: vi.fn(() => ({
+    metadata: metadataMock,
+    resize: resizeMock,
+    webp: webpMock,
+    toBuffer: toBufferMock,
+  })),
+}));
+
+import { storeAvatar, deleteAvatar } from "./avatar.ts";
+import { getStorage } from "../storage/index.ts";
+
+const putMock = vi.fn();
+const deleteMock = vi.fn();
+const mockStorage = { get: vi.fn(), put: putMock, delete: deleteMock };
+
+/** A real File so `instanceof File`, `.type`, `.size`, and `.arrayBuffer()` behave. */
+function makeFile(bytes: number, type: string): File {
+  return new File([Buffer.alloc(bytes)], "avatar", { type });
+}
+
+describe("storeAvatar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getStorage as ReturnType<typeof vi.fn>).mockReturnValue(mockStorage);
+    resizeMock.mockReturnThis();
+    webpMock.mockReturnThis();
+    metadataMock.mockResolvedValue({ width: 512, height: 512 });
+    toBufferMock.mockResolvedValue(Buffer.from("processed"));
+  });
+
+  it("rejects a missing or non-File value without touching storage", async () => {
+    const result = await storeAvatar(undefined, "agent-1", null);
+    expect(result).toEqual({ ok: false, error: "No file provided" });
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported content type", async () => {
+    const result = await storeAvatar(
+      makeFile(10, "image/svg+xml"),
+      "agent-1",
+      null,
+    );
+    expect(result).toEqual({ ok: false, error: "Invalid file type" });
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a file over the 5MB limit", async () => {
+    const result = await storeAvatar(
+      makeFile(5 * 1024 * 1024 + 1, "image/png"),
+      "agent-1",
+      null,
+    );
+    expect(result).toEqual({ ok: false, error: "File too large (max 5MB)" });
+  });
+
+  it("rejects a file sharp cannot decode as an image", async () => {
+    metadataMock.mockRejectedValueOnce(new Error("bad"));
+    const result = await storeAvatar(
+      makeFile(10, "image/png"),
+      "agent-1",
+      null,
+    );
+    expect(result).toEqual({ ok: false, error: "Invalid image" });
+    expect(putMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an image smaller than the minimum dimension", async () => {
+    metadataMock.mockResolvedValueOnce({ width: 32, height: 32 });
+    const result = await storeAvatar(
+      makeFile(10, "image/png"),
+      "agent-1",
+      null,
+    );
+    expect(result).toEqual({
+      ok: false,
+      error: "Image must be at least 64x64 pixels",
+    });
+  });
+
+  it("stores a processed webp under an agent-scoped key and returns it", async () => {
+    const result = await storeAvatar(
+      makeFile(10, "image/png"),
+      "agent-1",
+      null,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected ok");
+    expect(result.key).toMatch(/^agents\/agent-1\/avatar-.+\.webp$/);
+    expect(resizeMock).toHaveBeenCalledWith(512, 512, { fit: "cover" });
+    expect(putMock).toHaveBeenCalledWith(
+      result.key,
+      expect.any(Buffer),
+      "image/webp",
+    );
+  });
+
+  it("deletes the previous avatar before storing the replacement", async () => {
+    const result = await storeAvatar(
+      makeFile(10, "image/png"),
+      "agent-1",
+      "agents/agent-1/avatar-old.webp",
+    );
+    expect(result.ok).toBe(true);
+    expect(deleteMock).toHaveBeenCalledWith("agents/agent-1/avatar-old.webp");
+    expect(putMock).toHaveBeenCalled();
+  });
+});
+
+describe("deleteAvatar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getStorage as ReturnType<typeof vi.fn>).mockReturnValue(mockStorage);
+  });
+
+  it("is a no-op when no key is present", async () => {
+    await deleteAvatar(null);
+    await deleteAvatar(undefined);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("deletes the keyed object from storage", async () => {
+    await deleteAvatar("agents/agent-1/avatar-x.webp");
+    expect(deleteMock).toHaveBeenCalledWith("agents/agent-1/avatar-x.webp");
+  });
+
+  it("swallows storage errors so the surrounding request still succeeds", async () => {
+    deleteMock.mockRejectedValueOnce(new Error("gone"));
+    await expect(
+      deleteAvatar("agents/agent-1/avatar-x.webp"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/backend/src/services/avatar.ts
+++ b/apps/backend/src/services/avatar.ts
@@ -1,0 +1,110 @@
+import { nanoid } from "nanoid";
+import sharp from "sharp";
+import { getStorage } from "../storage/index.ts";
+
+/**
+ * Agent avatar handling — validation, resizing, and storage — in one place.
+ *
+ * The Workspace and Organization Agent surfaces upload and clear avatars
+ * identically; only the row lookup and the scope column on the persisting
+ * update differ, and those stay in the route. The image rules (allowed types,
+ * size/dimension limits, the resize target) and the storage key scheme live
+ * here so they cannot drift apart.
+ */
+
+const ALLOWED_AVATAR_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+];
+const MAX_AVATAR_SIZE = 5 * 1024 * 1024;
+const MIN_AVATAR_DIMENSION = 64;
+const AVATAR_SIZE = 512;
+
+/**
+ * Outcome of {@link storeAvatar}. A rejected upload carries a human-readable
+ * message the route returns as a 400 — validation 4xx stay inline at the route
+ * rather than going through the central `onError` (ADR-0009).
+ */
+export type StoreAvatarResult =
+  | { ok: true; key: string }
+  | { ok: false; error: string };
+
+/**
+ * Validate, resize, and store an uploaded avatar for an Agent, deleting the
+ * previous avatar (if any) once the new one is stored.
+ *
+ * The returned key is keyed by the Agent's globally-unique id and is
+ * independent of scope, so it never goes stale when a Workspace Agent is
+ * Promoted to the Organization (ADR-0007). The caller persists the key on the
+ * Agent row with its own scope-specific update.
+ *
+ * @param file - The raw value pulled from `parseBody()` — validated here.
+ * @param agentId - The Agent the avatar belongs to (used in the storage key).
+ * @param previousKey - The Agent's current avatar key, deleted on success.
+ */
+export async function storeAvatar(
+  file: unknown,
+  agentId: string,
+  previousKey: string | null | undefined,
+): Promise<StoreAvatarResult> {
+  if (!file || !(file instanceof File)) {
+    return { ok: false, error: "No file provided" };
+  }
+  if (!ALLOWED_AVATAR_TYPES.includes(file.type)) {
+    return { ok: false, error: "Invalid file type" };
+  }
+  if (file.size > MAX_AVATAR_SIZE) {
+    return { ok: false, error: "File too large (max 5MB)" };
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  let metadata: sharp.Metadata;
+  try {
+    metadata = await sharp(buffer).metadata();
+  } catch {
+    return { ok: false, error: "Invalid image" };
+  }
+
+  if (
+    metadata.width &&
+    metadata.height &&
+    (metadata.width < MIN_AVATAR_DIMENSION ||
+      metadata.height < MIN_AVATAR_DIMENSION)
+  ) {
+    return {
+      ok: false,
+      error: `Image must be at least ${MIN_AVATAR_DIMENSION}x${MIN_AVATAR_DIMENSION} pixels`,
+    };
+  }
+
+  const processedBuffer = await sharp(buffer)
+    .resize(AVATAR_SIZE, AVATAR_SIZE, { fit: "cover" })
+    .webp()
+    .toBuffer();
+
+  const key = `agents/${agentId}/avatar-${nanoid()}.webp`;
+
+  await deleteAvatar(previousKey);
+  await getStorage().put(key, processedBuffer, "image/webp");
+
+  return { ok: true, key };
+}
+
+/**
+ * Delete an avatar from storage if a key is present. Storage errors are
+ * swallowed: an avatar that is missing or already gone must not fail the
+ * request that is clearing or replacing it.
+ */
+export async function deleteAvatar(
+  key: string | null | undefined,
+): Promise<void> {
+  if (!key) return;
+  try {
+    await getStorage().delete(key);
+  } catch {
+    // Ignore deletion errors
+  }
+}


### PR DESCRIPTION
## What

Implements **Candidate 3** from the backend architecture review — lifting Agent avatar handling out of the route files into a dedicated module.

Both the Workspace (`routes/agent.ts`) and Organization (`routes/org-agent.ts`) Agent surfaces implemented avatar validation, resizing, and storage inline and near-identically, with the size/type constants duplicated across both files (~260 lines).

## Changes

- **New `services/avatar.ts`** behind two functions:
  - `storeAvatar(file, agentId, previousKey)` — validates (type, 5MB size, decodability, min 64px dimension), resizes to 512×512 webp, deletes the previous avatar, stores the new one, returns the key. Returns a `{ ok, key } | { ok: false, error }` result so validation 4xx stay inline at the route (ADR-0009).
  - `deleteAvatar(key)` — best-effort storage delete, swallows errors.
  - Image rules (allowed types, size/dimension limits, resize target) and the `agents/{id}/avatar-*.webp` key scheme now live in one place.
- **Routes thinned** — they keep their scope-specific row lookup and persisting update and just call the module. Removed the duplicated constants and now-unused `sharp`/`getStorage`/`nanoid` imports. **Net −138 lines** across the two routes.
- **Fixes a latent storage leak** — deleting an org-scoped Agent left its avatar orphaned in storage (the Workspace surface already cleaned up). The org delete route now removes the avatar after the delete commits, matching the Workspace surface.

## Tests

- New `services/avatar.test.ts` (10 cases) covering validation / resize / store / replace-and-delete / error-swallowing — paths the HTTP tests never exercised.
- New test covering avatar cleanup on org-agent delete (the previous delete tests passed silently only because they deleted Agents with no `avatarKey`).
- Full suite green: **945 tests passing**, lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)