### PR TITLE
chore(backend): extend Scoped resource module with a deletion seam

### DIFF
--- a/apps/backend/src/routes/attachment.ts
+++ b/apps/backend/src/routes/attachment.ts
@@ -16,6 +16,7 @@ import {
   requireOrgAccess,
   requireWorkspaceAccess,
 } from "../middleware/authorization.ts";
+import { isUniqueViolation } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
 // Attachment is the explicit reference that surfaces an org-scoped Shared
@@ -23,13 +24,6 @@ import type { Variables } from "../server.ts";
 // action — `requireOrgAccess(["admin"])` rejects non-admins with 403 — scoped
 // to a specific Workspace via `requireWorkspaceAccess`.
 const attachment = new Hono<{ Variables: Variables }>();
-
-/** Detects a Postgres unique-constraint violation across driver shapes. */
-const isUniqueViolation = (error: any): boolean =>
-  error.code === "23505" ||
-  error.cause?.code === "23505" ||
-  error.message?.includes("unique constraint") ||
-  error.cause?.message?.includes("unique constraint");
 
 /** List attachments for this workspace (admin only) */
 attachment.get(

--- a/apps/backend/src/routes/org-agent.ts
+++ b/apps/backend/src/routes/org-agent.ts
@@ -1,10 +1,7 @@
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { db } from "../index.ts";
-import {
-  agent as agentTable,
-  attachment as attachmentTable,
-} from "../db/schema.ts";
+import { agent as agentTable } from "../db/schema.ts";
 import { agentUpdateSchema } from "@platypus/schemas";
 import { eq, and } from "drizzle-orm";
 import { dedupeArray } from "../utils.ts";
@@ -12,7 +9,7 @@ import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { findNonSharedReferences } from "../services/agent-scope-validation.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
-import { isResourceListedInBlueprint } from "../services/blueprint-guard.ts";
+import { requireSharedDeletable } from "../services/scoped-resource.ts";
 import { storeAvatar, deleteAvatar } from "../services/avatar.ts";
 import { avatarKeyToUrl } from "../utils/avatar-url.ts";
 import { getOrigin } from "../utils/get-origin.ts";
@@ -203,39 +200,10 @@ orgAgent.delete(
     const orgId = c.req.param("orgId")!;
     const agentId = c.req.param("agentId");
 
-    // A Shared resource cannot be deleted while any Attachment references it
-    // (ADR-0007) — detach it from every Workspace first.
-    const [attached] = await db
-      .select()
-      .from(attachmentTable)
-      .where(
-        and(
-          eq(attachmentTable.resourceType, "agent"),
-          eq(attachmentTable.resourceId, agentId),
-        ),
-      )
-      .limit(1);
-    if (attached) {
-      return c.json(
-        {
-          error:
-            "Cannot delete: this agent is attached to one or more workspaces. Detach it first.",
-        },
-        409,
-      );
-    }
-
-    // Nor while it is listed in a Blueprint (ADR-0008) — remove it from every
-    // Blueprint first, so nothing still points at it.
-    if (await isResourceListedInBlueprint("agent", agentId)) {
-      return c.json(
-        {
-          error:
-            "Cannot delete: this agent is listed in one or more blueprints. Remove it from them first.",
-        },
-        409,
-      );
-    }
+    // A Shared resource cannot be deleted while anything still points at it —
+    // an Attachment (ADR-0007) or a Blueprint (ADR-0008). Throws ConflictError
+    // → 409 via the central onError (ADR-0009).
+    await requireSharedDeletable(db, "agent", agentId);
 
     // Delete the Agent and scrub its (now-dead) id from any Agent's subAgentIds
     // in the same transaction, so deletion never leaves dangling references.

--- a/apps/backend/src/routes/org-attachment.ts
+++ b/apps/backend/src/routes/org-attachment.ts
@@ -12,6 +12,7 @@ import {
 import { and, eq } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
+import { isUniqueViolation } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
 // Org-surface management of where a Shared resource is attached (ADR-0007).
@@ -32,13 +33,6 @@ type ResourceType = keyof typeof RESOURCE_TABLES;
 
 const isResourceType = (v: string | undefined): v is ResourceType =>
   v === "mcp" || v === "provider" || v === "skill" || v === "agent";
-
-/** Detects a Postgres unique-constraint violation across driver shapes. */
-const isUniqueViolation = (error: any): boolean =>
-  error.code === "23505" ||
-  error.cause?.code === "23505" ||
-  error.message?.includes("unique constraint") ||
-  error.cause?.message?.includes("unique constraint");
 
 /**
  * Confirms a resource is org-scoped and belongs to this organization — you can

--- a/apps/backend/src/routes/org-mcp.ts
+++ b/apps/backend/src/routes/org-mcp.ts
@@ -6,10 +6,7 @@ import {
   auth as mcpAuth,
 } from "@ai-sdk/mcp";
 import { db } from "../index.ts";
-import {
-  mcp as mcpTable,
-  attachment as attachmentTable,
-} from "../db/schema.ts";
+import { mcp as mcpTable } from "../db/schema.ts";
 import {
   mcpCreateSchema,
   mcpUpdateSchema,
@@ -19,7 +16,7 @@ import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
-import { isResourceListedInBlueprint } from "../services/blueprint-guard.ts";
+import { requireSharedDeletable } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
 import {
@@ -137,39 +134,10 @@ orgMcp.delete(
     const orgId = c.req.param("orgId")!;
     const mcpId = c.req.param("mcpId");
 
-    // A Shared resource cannot be deleted while any Attachment references it
-    // (ADR-0007) — detach it from every Workspace first.
-    const [attached] = await db
-      .select()
-      .from(attachmentTable)
-      .where(
-        and(
-          eq(attachmentTable.resourceType, "mcp"),
-          eq(attachmentTable.resourceId, mcpId),
-        ),
-      )
-      .limit(1);
-    if (attached) {
-      return c.json(
-        {
-          error:
-            "Cannot delete: this MCP is attached to one or more workspaces. Detach it first.",
-        },
-        409,
-      );
-    }
-
-    // Nor while it is listed in a Blueprint (ADR-0008) — remove it from every
-    // Blueprint first, so nothing still points at it.
-    if (await isResourceListedInBlueprint("mcp", mcpId)) {
-      return c.json(
-        {
-          error:
-            "Cannot delete: this MCP is listed in one or more blueprints. Remove it from them first.",
-        },
-        409,
-      );
-    }
+    // A Shared resource cannot be deleted while anything still points at it —
+    // an Attachment (ADR-0007) or a Blueprint (ADR-0008). Throws ConflictError
+    // → 409 via the central onError (ADR-0009).
+    await requireSharedDeletable(db, "mcp", mcpId);
 
     // Delete the MCP and scrub its (now-dead) id from any Agent's toolSetIds in
     // the same transaction, so deletion never leaves dangling references.

--- a/apps/backend/src/routes/org-provider.ts
+++ b/apps/backend/src/routes/org-provider.ts
@@ -2,17 +2,14 @@ import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import {
-  provider as providerTable,
-  attachment as attachmentTable,
-} from "../db/schema.ts";
+import { provider as providerTable } from "../db/schema.ts";
 import { providerCreateSchema, providerUpdateSchema } from "@platypus/schemas";
 import { eq, and } from "drizzle-orm";
 import { handleEmbeddingConfigChange } from "../services/embedding-invalidation.ts";
 import { dedupeArray } from "../utils.ts";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
-import { isResourceListedInBlueprint } from "../services/blueprint-guard.ts";
+import { requireSharedDeletable } from "../services/scoped-resource.ts";
 import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
@@ -133,39 +130,10 @@ orgProvider.delete(
     const orgId = c.req.param("orgId")!;
     const providerId = c.req.param("providerId");
 
-    // A Shared resource cannot be deleted while any Attachment references it
-    // (ADR-0007) — detach it from every Workspace first.
-    const [attached] = await db
-      .select()
-      .from(attachmentTable)
-      .where(
-        and(
-          eq(attachmentTable.resourceType, "provider"),
-          eq(attachmentTable.resourceId, providerId),
-        ),
-      )
-      .limit(1);
-    if (attached) {
-      return c.json(
-        {
-          error:
-            "Cannot delete: this provider is attached to one or more workspaces. Detach it first.",
-        },
-        409,
-      );
-    }
-
-    // Nor while it is listed in a Blueprint (ADR-0008) — remove it from every
-    // Blueprint first, so nothing still points at it.
-    if (await isResourceListedInBlueprint("provider", providerId)) {
-      return c.json(
-        {
-          error:
-            "Cannot delete: this provider is listed in one or more blueprints. Remove it from them first.",
-        },
-        409,
-      );
-    }
+    // A Shared resource cannot be deleted while anything still points at it —
+    // an Attachment (ADR-0007) or a Blueprint (ADR-0008). Throws ConflictError
+    // → 409 via the central onError (ADR-0009).
+    await requireSharedDeletable(db, "provider", providerId);
 
     const result = await db
       .delete(providerTable)

--- a/apps/backend/src/routes/org-skill.ts
+++ b/apps/backend/src/routes/org-skill.ts
@@ -2,16 +2,13 @@ import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import {
-  skill as skillTable,
-  attachment as attachmentTable,
-} from "../db/schema.ts";
+import { skill as skillTable } from "../db/schema.ts";
 import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
 import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
-import { isResourceListedInBlueprint } from "../services/blueprint-guard.ts";
+import { requireSharedDeletable } from "../services/scoped-resource.ts";
 import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
@@ -117,39 +114,10 @@ orgSkill.delete(
     const orgId = c.req.param("orgId")!;
     const skillId = c.req.param("skillId");
 
-    // A Shared resource cannot be deleted while any Attachment references it
-    // (ADR-0007) — detach it from every Workspace first.
-    const [attached] = await db
-      .select()
-      .from(attachmentTable)
-      .where(
-        and(
-          eq(attachmentTable.resourceType, "skill"),
-          eq(attachmentTable.resourceId, skillId),
-        ),
-      )
-      .limit(1);
-    if (attached) {
-      return c.json(
-        {
-          error:
-            "Cannot delete: this skill is attached to one or more workspaces. Detach it first.",
-        },
-        409,
-      );
-    }
-
-    // Nor while it is listed in a Blueprint (ADR-0008) — remove it from every
-    // Blueprint first, so nothing still points at it.
-    if (await isResourceListedInBlueprint("skill", skillId)) {
-      return c.json(
-        {
-          error:
-            "Cannot delete: this skill is listed in one or more blueprints. Remove it from them first.",
-        },
-        409,
-      );
-    }
+    // A Shared resource cannot be deleted while anything still points at it —
+    // an Attachment (ADR-0007) or a Blueprint (ADR-0008). Throws ConflictError
+    // → 409 via the central onError (ADR-0009).
+    await requireSharedDeletable(db, "skill", skillId);
 
     // Delete the Skill and scrub its (now-dead) id from any Agent's skillIds in
     // the same transaction, so deletion never leaves dangling references.

--- a/apps/backend/src/services/scoped-resource.test.ts
+++ b/apps/backend/src/services/scoped-resource.test.ts
@@ -5,8 +5,9 @@ import {
   listScoped,
   requireScoped,
   requireWorkspaceMutable,
+  requireSharedDeletable,
 } from "./scoped-resource.ts";
-import { NotFoundError, LockedError } from "../errors.ts";
+import { NotFoundError, LockedError, ConflictError } from "../errors.ts";
 
 const ctx = { orgId: "org-1", wsId: "ws-1" };
 
@@ -122,6 +123,40 @@ describe("ScopedResource read module", () => {
       await expect(
         requireWorkspaceMutable(mockDb, "agent", "a1", ctx),
       ).rejects.toBeInstanceOf(NotFoundError);
+    });
+  });
+
+  describe("requireSharedDeletable", () => {
+    it("throws ConflictError while an Attachment references it", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]); // attachment lookup
+      await expect(
+        requireSharedDeletable(mockDb, "agent", "a1"),
+      ).rejects.toBeInstanceOf(ConflictError);
+    });
+
+    it("throws ConflictError while a Blueprint lists it", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([]) // attachment lookup → none
+        .mockResolvedValueOnce([{ id: "item-1" }]); // blueprint lookup → listed
+      await expect(
+        requireSharedDeletable(mockDb, "agent", "a1"),
+      ).rejects.toBeInstanceOf(ConflictError);
+    });
+
+    it("resolves when nothing points at it", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([]) // attachment lookup → none
+        .mockResolvedValueOnce([]); // blueprint lookup → none
+      await expect(
+        requireSharedDeletable(mockDb, "agent", "a1"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("uses the uppercase MCP acronym in the conflict message", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]);
+      await expect(requireSharedDeletable(mockDb, "mcp", "m1")).rejects.toThrow(
+        /this MCP is attached/,
+      );
     });
   });
 });

--- a/apps/backend/src/services/scoped-resource.ts
+++ b/apps/backend/src/services/scoped-resource.ts
@@ -7,7 +7,8 @@ import {
   attachment as attachmentTable,
 } from "../db/schema.ts";
 import { db } from "../index.ts";
-import { LockedError, NotFoundError } from "../errors.ts";
+import { ConflictError, LockedError, NotFoundError } from "../errors.ts";
+import { isResourceListedInBlueprint } from "./blueprint-guard.ts";
 
 /**
  * The read side of the **Scoped resource** (CONTEXT.md): an Agent, Skill, MCP,
@@ -20,8 +21,9 @@ import { LockedError, NotFoundError } from "../errors.ts";
  * Collapses the "resolve → null-check → org-scope-403" branch that the
  * dual-scope resource routes each re-implemented. `resolveScoped`/`listScoped`
  * are exception-free for callers that tolerate absence (e.g. the Chat-turn
- * attachment check); `requireScoped`/`requireWorkspaceMutable` throw the typed
- * errors mapped centrally by `app.onError` (ADR-0009).
+ * attachment check); `requireScoped`/`requireWorkspaceMutable`/
+ * `requireSharedDeletable` throw the typed errors mapped centrally by
+ * `app.onError` (ADR-0009).
  */
 
 /** `"workspace"` for a directly-owned row, `"organization"` for a Shared one. */
@@ -54,14 +56,20 @@ type RegistryEntry = {
   table: ScopedTable;
   /** Human label used in the `NotFoundError` message ("Agent not found"). */
   label: string;
+  /**
+   * The resource as it reads mid-sentence in a conflict message ("this agent
+   * is attached…"). Distinct from `label` because `mcp` stays the uppercase
+   * acronym "MCP" rather than lowercasing to "mcp".
+   */
+  noun: string;
 };
 
 // Typed registry keyed by the `attachment.resourceType` enum.
 const REGISTRY: Record<ScopedResourceType, RegistryEntry> = {
-  agent: { table: agentTable, label: "Agent" },
-  skill: { table: skillTable, label: "Skill" },
-  mcp: { table: mcpTable, label: "MCP" },
-  provider: { table: providerTable, label: "Provider" },
+  agent: { table: agentTable, label: "Agent", noun: "agent" },
+  skill: { table: skillTable, label: "Skill", noun: "skill" },
+  mcp: { table: mcpTable, label: "MCP", noun: "MCP" },
+  provider: { table: providerTable, label: "Provider", noun: "provider" },
 };
 
 /** The Workspace a Scoped resource is resolved relative to. */
@@ -206,4 +214,40 @@ export const requireWorkspaceMutable = async <T extends ScopedResourceType>(
     );
   }
   return { row: found.row, scope: "workspace" };
+};
+
+/**
+ * Guards deletion of an Organization-scoped (Shared) resource: throws
+ * `ConflictError` while anything still points at it — an Attachment in any
+ * Workspace (ADR-0007) or a Blueprint that would re-provision it (ADR-0008).
+ * The single home for the "can this Shared resource be deleted?" rule the four
+ * org-resource delete routes each re-implemented inline; the `ConflictError` is
+ * mapped to 409 at `app.onError` (ADR-0009). Returns when deletion may proceed.
+ */
+export const requireSharedDeletable = async (
+  database: Database,
+  type: ScopedResourceType,
+  id: string,
+): Promise<void> => {
+  const [attached] = await database
+    .select({ id: attachmentTable.id })
+    .from(attachmentTable)
+    .where(
+      and(
+        eq(attachmentTable.resourceType, type),
+        eq(attachmentTable.resourceId, id),
+      ),
+    )
+    .limit(1);
+  if (attached) {
+    throw new ConflictError(
+      `Cannot delete: this ${REGISTRY[type].noun} is attached to one or more workspaces. Detach it first.`,
+    );
+  }
+
+  if (await isResourceListedInBlueprint(type, id)) {
+    throw new ConflictError(
+      `Cannot delete: this ${REGISTRY[type].noun} is listed in one or more blueprints. Remove it from them first.`,
+    );
+  }
 };


### PR DESCRIPTION
## Summary

Candidate 2 from the 8 Jun architecture review — extends the deep **Scoped resource** module with a deletion seam, following candidates 1 (#202) and 3 (#201).

The *"can this Shared resource be deleted?"* rule (ADR-0007 + ADR-0008) was re-implemented inline in four org-resource delete routes: a byte-similar `attached?` / `in-blueprint?` guard returning `c.json(…, 409)`, differing only by `resourceType` and the noun in the message.

## Changes

- **`services/scoped-resource.ts`** — new `requireSharedDeletable(db, type, id)` entry point on the module that already owns dual-scope reads. Throws `ConflictError`, mapped to 409 by the existing `app.onError` (ADR-0009). Adds a `noun` registry field so `mcp` keeps the uppercase acronym "MCP" mid-sentence.
- **`org-agent.ts` / `org-mcp.ts` / `org-skill.ts` / `org-provider.ts`** — each two-stage gate collapses to a single call (~136 lines of duplicated guard removed).
- **`attachment.ts` / `org-attachment.ts`** — the two inline `isUniqueViolation` copies fold back to the shared `errors.ts`.

Behaviour and response shape are unchanged: 409 with `{ error: message }`, same messages.

## Verification

- Full backend suite: **952 tests pass** (84 files), incl. 4 new `requireSharedDeletable` cases.
- Lint: **0 errors** (warnings 4215 → 4199 from removing two `any`-typed dupes).
- `tsc`: no new errors (the lone `org-mcp.ts` type error is pre-existing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)