### PR TITLE
feat(docs): add Self-Hosting section pages

### DIFF
--- a/apps/docs/content/self-hosting/_meta.ts
+++ b/apps/docs/content/self-hosting/_meta.ts
@@ -1,0 +1,10 @@
+// Self-Hosting section order. Audience: Operator / Org Admin (ADR-0011).
+const meta = {
+  index: "Overview",
+  "docker-compose": "Deploy with Docker Compose",
+  configuration: "Configuration & environment",
+  "providers-and-auth": "Providers & authentication",
+  sandbox: "Sandbox infrastructure",
+};
+
+export default meta;

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -1,0 +1,107 @@
+---
+title: Configuration & environment
+description: How the meaningful configuration areas of a Platypus deployment fit together.
+---
+
+import { Callout } from "nextra/components";
+
+# Configuration & environment
+
+This page is the **narrative** guide to configuring a deployment — the
+configuration areas that matter and how they relate to one another. It is not an
+exhaustive variable list; for every supported variable and its default, see the
+[Reference](/reference) (split into backend and frontend tables). Where this page
+names a variable, treat it as an illustration of the _area_, not the complete
+set.
+
+<Callout type="info">
+  Both services read the same root `.env` (via compose `env_file`). Keep the
+  narrative here in sync with how your deployment is actually wired, and rely on
+  the [Reference](/reference) for the precise names and defaults so the two
+  don't drift.
+</Callout>
+
+## Service URLs
+
+The most common source of first-deploy confusion is URL wiring, because the
+frontend reaches the backend by two different paths:
+
+- **`BACKEND_URL`** — the **browser-facing** backend URL. The browser uses this
+  to call the API and the `/auth/*` endpoints, so it must be reachable from the
+  user's machine (e.g. `http://localhost:4000` locally, or
+  `https://api.your-host` in production).
+- **`INTERNAL_BACKEND_URL`** — the **server-to-server** URL the frontend uses
+  during server-side rendering. In compose this is `http://backend:4000` (the
+  service name on the private network); it never leaves the cluster.
+- **`BETTER_AUTH_URL`** — the canonical base URL of the auth server. In compose
+  it is derived from `BACKEND_URL`; auth cookies and redirects are issued
+  against it, so it must match the URL the browser actually uses.
+- **`FRONTEND_URL`** — used by the backend to build links back into the web app
+  (e.g. resource links in tool output and MCP OAuth redirects).
+
+These have to agree. If the browser loads the app from one origin but
+`BETTER_AUTH_URL` points somewhere else, sign-in cookies won't stick.
+
+### CORS / trusted origins
+
+`ALLOWED_ORIGINS` is a comma-separated list of origins permitted to call the
+backend. It feeds both the API's CORS policy and better-auth's trusted-origins
+list. Include every origin the browser loads the frontend from; a missing entry
+shows up as blocked cross-origin requests or failed sign-in.
+
+## Database
+
+`DATABASE_URL` is the PostgreSQL connection string. In compose it points at the
+bundled `database` service. The database must be PostgreSQL 17 with the
+`pgvector` extension available (the backend enables the extension on startup);
+embeddings for [Memory](/concepts) are stored as vectors, so `pgvector` is not
+optional. PostgreSQL 18 is not supported.
+
+## Authentication
+
+Authentication is handled by [better-auth](https://www.better-auth.com/), mounted
+at `/auth/*` on the backend. The essentials:
+
+- **`BETTER_AUTH_SECRET`** — the signing secret for sessions and tokens. Set a
+  strong, unique value; rotating it invalidates existing sessions.
+- **`ADMIN_EMAIL` / `ADMIN_PASSWORD`** — used only to seed the first admin user
+  on an empty database (see [Deploy with Docker Compose](/self-hosting/docker-compose)).
+
+The deeper model — Providers, the role ladder, and the default admin — lives in
+[Providers & authentication](/self-hosting/providers-and-auth).
+
+## Sandbox
+
+The [Sandbox](/concepts) (agent shell/filesystem access) is **off by default**.
+Enabling the Docker reference backend and curating what it can reach is an
+Operator concern with its own page:
+
+- **`PLATYPUS_SANDBOX_DOCKER_ENABLED`** — registers the Docker backend; without
+  it, sandbox configuration is inert.
+- **`PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS`** — the Operator's allowlist that
+  bounds which Docker networks an Org Admin may attach a sandbox to
+  (default-deny).
+
+See [Sandbox infrastructure](/self-hosting/sandbox) for the security model and
+the opt-in `compose.sandbox.yaml` overlay.
+
+## Other operational areas
+
+These rarely need changing but exist when you need them — see the
+[Reference](/reference) for names and defaults:
+
+- **Storage** — uploaded files go to local disk by default; an S3-compatible
+  backend can be selected instead.
+- **Logging** — log verbosity is configurable.
+- **Time** — a deployment-wide IANA timezone for time-aware tools and schedules.
+- **Schedulers & runs** — concurrency caps and per-run / per-step timeouts for
+  scheduled and triggered agent executions.
+
+## Where the exhaustive lists live
+
+| You want…                                   | Go to                                         |
+| ------------------------------------------- | --------------------------------------------- |
+| Why a setting exists and how it relates     | **This page**                                 |
+| Every backend variable + default            | [Reference](/reference) — backend config      |
+| Every frontend variable + default           | [Reference](/reference) — frontend config     |
+| The sandbox security model                  | [Sandbox infrastructure](/self-hosting/sandbox) |

--- a/apps/docs/content/self-hosting/docker-compose.mdx
+++ b/apps/docs/content/self-hosting/docker-compose.mdx
@@ -1,0 +1,157 @@
+---
+title: Deploy with Docker Compose
+description: Stand up Platypus from the published images using compose.yaml.
+---
+
+import { Callout, Steps } from "nextra/components";
+
+# Deploy with Docker Compose
+
+The fastest way to run Platypus is the `compose.yaml` that ships in the
+repository. It pulls the published images, wires the services together on a
+private network, and seeds an initial organization, workspace, and admin user on
+first boot.
+
+## The stack
+
+`compose.yaml` defines three services on a private bridge network
+(`platypus-network`):
+
+| Service    | Image                              | Port (host:container) | Purpose                                          |
+| ---------- | ---------------------------------- | --------------------- | ------------------------------------------------ |
+| `database` | `pgvector/pgvector:pg17`           | _internal only_       | PostgreSQL 17 with the `pgvector` extension      |
+| `backend`  | `willdady/platypus-backend:latest` | `4000:4000`           | Hono REST API, auth, run lifecycle, schedulers   |
+| `frontend` | `willdady/platypus-frontend:latest`| `3000:3000`           | Next.js web app                                  |
+
+The services start in dependency order: the backend waits for the database to
+become healthy, and the frontend waits for the backend. Both the backend and the
+database publish Docker health checks so `docker compose` can gate startup and
+report status.
+
+<Callout type="info">
+  Postgres 18 is **not supported** (a Drizzle ORM incompatibility). Stay on the
+  `pg17` image tag.
+</Callout>
+
+### Image tags
+
+The compose file pins `:latest` for both application images. The docs track the
+latest release only — if you are running an older release, check out the
+matching git tag and use the `compose.yaml` from that checkout, which references
+the images for that version.
+
+### Ports
+
+- **Frontend** — `http://localhost:3000` (the URL you sign in at).
+- **Backend** — `http://localhost:4000` (the REST API and `/auth/*` endpoints).
+
+The frontend reaches the backend over the private network at
+`http://backend:4000` (set via `INTERNAL_BACKEND_URL`) for server-side rendering,
+while the browser talks to the backend at its public URL. See
+[Configuration & environment](/self-hosting/configuration) for how these URLs fit
+together.
+
+### Volumes
+
+- `postgres_data` — a named volume holding the database. Your data lives here;
+  don't delete it unless you mean to start over.
+- `./data` — a bind mount into the backend at `/data`, used by the default
+  disk storage backend for uploaded files.
+
+## First boot
+
+<Steps>
+
+### Clone and configure
+
+```bash
+git clone https://github.com/willdady/platypus.git
+cd platypus
+cp .env.example .env
+```
+
+Edit `.env`. At minimum set:
+
+- `BETTER_AUTH_SECRET` — a secure random string (32+ characters).
+- `ADMIN_EMAIL` / `ADMIN_PASSWORD` — credentials for the initial admin user.
+- `BACKEND_URL` — the URL the browser uses to reach the backend (e.g.
+  `http://localhost:4000`).
+
+Both services read the same root `.env` via `env_file`. The full set of
+variables is documented in [Configuration & environment](/self-hosting/configuration)
+and the [Reference](/reference).
+
+### Start the stack
+
+```bash
+docker compose up -d
+```
+
+Compose pulls the images, starts PostgreSQL, runs the backend (which seeds the
+database on first boot), then starts the frontend.
+
+### Sign in
+
+Open `http://localhost:3000` and sign in with the `ADMIN_EMAIL` /
+`ADMIN_PASSWORD` you configured.
+
+</Steps>
+
+### What first boot creates
+
+When the backend starts against an empty database it bootstraps:
+
+- a **Default Organization**,
+- an **admin user** from `ADMIN_EMAIL` / `ADMIN_PASSWORD` (granted the platform
+  `admin` role — the **Operator**), and
+- a **Default Workspace** owned by that user.
+
+<Callout type="warning">
+  The backend **refuses to seed** if `ADMIN_EMAIL` and `ADMIN_PASSWORD` are
+  unset — it logs an error and exits rather than creating a credential-less
+  admin. Set both before the first `docker compose up`.
+</Callout>
+
+### The default admin
+
+The shipped `.env.example` defaults to `admin@example.com` / `admin123`.
+**Override these** by editing `.env` before first boot — seeding happens exactly
+once against an empty database, so the values you set then are the ones that
+stick. Change the password from the in-app account settings after you first sign
+in.
+
+To change the admin _after_ the database is already seeded, use the in-app user
+management — editing `ADMIN_EMAIL` / `ADMIN_PASSWORD` later has no effect because
+the seed only runs when no organization exists.
+
+## Health checks
+
+The backend exposes `GET /health`; its compose health check polls that endpoint,
+and the database health check runs `pg_isready`. Inspect status with:
+
+```bash
+docker compose ps
+docker compose logs -f backend
+```
+
+A backend stuck in `starting`/`unhealthy` is almost always a database connection
+or a missing required env var — check `docker compose logs backend`.
+
+## Upgrading
+
+```bash
+docker compose pull      # fetch the latest images
+docker compose up -d     # recreate containers with the new images
+```
+
+The backend applies any pending schema changes on startup. Your data persists in
+the `postgres_data` volume across upgrades. To roll back, check out the previous
+git tag and `docker compose up -d` from there.
+
+## Next steps
+
+- [Configuration & environment](/self-hosting/configuration) — the meaningful
+  config areas and how they relate.
+- [Providers & authentication](/self-hosting/providers-and-auth) — connect an AI
+  vendor and understand the role ladder.
+- [Reference](/reference) — the exhaustive backend and frontend variable tables.

--- a/apps/docs/content/self-hosting/index.mdx
+++ b/apps/docs/content/self-hosting/index.mdx
@@ -1,7 +1,40 @@
 ---
 title: Self-Hosting
+description: Stand up and operate your own Platypus deployment.
 ---
+
+import { Cards } from "nextra/components";
 
 # Self-Hosting
 
-_Content coming soon._
+This section is for the **Operator** — the person who controls a Platypus
+deployment: its process environment, compose files, and infrastructure. It also
+covers the **Org Admin** tasks that bootstrap a usable installation, such as
+connecting AI providers and curating sandbox infrastructure.
+
+Platypus runs as two services (a backend API and a frontend web app) backed by a
+PostgreSQL database with the `pgvector` extension. The published Docker images
+let you stand the whole stack up with a single `docker compose up`.
+
+<Cards>
+  <Cards.Card
+    title="Deploy with Docker Compose"
+    href="/self-hosting/docker-compose"
+  />
+  <Cards.Card
+    title="Configuration & environment"
+    href="/self-hosting/configuration"
+  />
+  <Cards.Card
+    title="Providers & authentication"
+    href="/self-hosting/providers-and-auth"
+  />
+  <Cards.Card
+    title="Sandbox infrastructure"
+    href="/self-hosting/sandbox"
+  />
+</Cards>
+
+Once you can sign in and reach a workspace, head to
+[Building with Platypus](/building-with-platypus) to start creating agents, or
+the [Reference](/reference) for the exhaustive list of configuration variables.

--- a/apps/docs/content/self-hosting/providers-and-auth.mdx
+++ b/apps/docs/content/self-hosting/providers-and-auth.mdx
@@ -1,0 +1,114 @@
+---
+title: Providers & authentication
+description: Connect AI vendors and understand the Platypus role ladder.
+---
+
+import { Callout } from "nextra/components";
+
+# Providers & authentication
+
+A fresh installation can sign in but can't yet run an agent — it has no
+**Provider**. This page covers the two setup tasks an **Org Admin** performs to
+make a deployment usable: connecting an AI vendor, and understanding the
+authentication model and roles that govern who may do so.
+
+## Providers
+
+A **Provider** is a configured connection to an AI vendor. It carries the
+credentials and settings Platypus needs to call that vendor's models, and it is
+referenced by an [Agent](/concepts) (or selected directly on a chat turn).
+
+### Supported vendors
+
+Platypus speaks to OpenAI, OpenRouter, Amazon Bedrock, Google, and Anthropic.
+OpenAI-compatible endpoints (e.g. vLLM) are reachable through the OpenAI
+provider type by overriding the base URL.
+
+### What a Provider holds
+
+| Field           | Meaning                                                                                   |
+| --------------- | ----------------------------------------------------------------------------------------- |
+| `name`          | A human label for the connection.                                                         |
+| `providerType`  | The vendor (`OpenAI`, `OpenRouter`, `Bedrock`, `Google`, `Anthropic`).                    |
+| `apiKey`        | The vendor credential.                                                                    |
+| `baseUrl`       | Optional override for OpenAI-compatible / self-hosted endpoints.                          |
+| `region`        | Required for Bedrock (AWS region).                                                         |
+| `modelIds`      | The set of models this Provider exposes for selection (at least one).                     |
+| `taskModelId`   | The model used for one-shot internal tasks (e.g. generating a chat title), not chat turns.|
+
+A Provider also carries the models used for **Memory** (extraction and
+embeddings), so background memory features have a model to call.
+
+<Callout type="info">
+  The distinction between a **chat turn** (running the selected Agent/model to
+  reply to a user) and a **one-shot Provider execution** (like title generation,
+  which uses `taskModelId`) is part of the domain vocabulary — see
+  [Concepts](/concepts).
+</Callout>
+
+### Scope: Organization vs Workspace
+
+A Provider is a **Scoped resource**: its row lives at exactly one scope.
+
+- An **Organization-scoped** Provider is a **Shared resource** — defined once by
+  an Org Admin and referenced (not copied) by any Workspace it's attached to. A
+  single source of truth for a vendor connection across the Organization.
+- A **Workspace-scoped** Provider is private to one Workspace.
+
+Because Providers are credential-bearing, **creating and editing them is an Org
+Admin task by default**. An Org Admin may delegate self-management of
+*workspace-scoped* Providers to a Workspace Owner per-Workspace (for legitimate
+personal-credential cases), but the default is admin-managed. See
+[Concepts](/concepts) for the Scoped/Shared resource model.
+
+## Authentication
+
+Authentication runs on [better-auth](https://www.better-auth.com/), mounted at
+`/auth/*` on the backend. Out of the box Platypus uses email-and-password sign
+in. Sessions are cookie-based and signed with `BETTER_AUTH_SECRET`; the auth
+server's canonical URL is `BETTER_AUTH_URL`, and browser origins must appear in
+`ALLOWED_ORIGINS` (see [Configuration & environment](/self-hosting/configuration)).
+
+<Callout type="warning">
+  Email verification is disabled by default — appropriate for a single-operator
+  deployment, but consider enabling it before exposing sign-up more broadly.
+</Callout>
+
+## The role ladder
+
+Authority over configuration runs top-down, each tier bounded by the one above
+it:
+
+**Operator → Org Admin → Workspace Owner**
+
+- **Operator** — controls the deployment itself: process environment, compose
+  files, infrastructure. Equivalent to the platform super-admin (the
+  `admin`-role user), who bypasses all in-app authorization. The Operator
+  declares deployment-time allowlists (such as the eligible sandbox networks)
+  that *bound* what an Org Admin may configure in-app.
+- **Org Admin** — a User with the `admin` role in an Organization. Configures
+  the credential- and reach-bearing resources — **Providers, Sandboxes, MCPs** —
+  and may delegate self-management of some of them to a Workspace Owner.
+- **Workspace Owner** — the single User who owns a Workspace. Always manages
+  *composition* (Agents, Skills, Chats); manages credential- and reach-bearing
+  resources only where an Org Admin has delegated it.
+
+The split is deliberate: resources that introduce credentials, external reach,
+or code execution default to admin-managed, while resources that merely compose
+already-sanctioned capabilities stay owner-managed.
+
+## The default admin
+
+On first boot against an empty database, the backend seeds a Default
+Organization, a Default Workspace, and an admin user from `ADMIN_EMAIL` /
+`ADMIN_PASSWORD`. That user is the platform `admin` — your **Operator** and first
+**Org Admin**. The seed runs exactly once, so set those values before the first
+start and change the password from account settings after you sign in. Full
+mechanics are in [Deploy with Docker Compose](/self-hosting/docker-compose).
+
+## Next steps
+
+- [Sandbox infrastructure](/self-hosting/sandbox) — the other credential- and
+  reach-bearing resource an Org Admin curates.
+- [Concepts](/concepts) — the domain model: Organizations, Workspaces, Agents,
+  Providers, and Scoped/Shared resources.

--- a/apps/docs/content/self-hosting/sandbox.mdx
+++ b/apps/docs/content/self-hosting/sandbox.mdx
@@ -1,0 +1,160 @@
+---
+title: Sandbox infrastructure
+description: Curate the Sandbox execution environment — Docker reference adapter, env vars, and network allowlists.
+---
+
+import { Callout } from "nextra/components";
+
+# Sandbox infrastructure
+
+A **Sandbox** is a configured, isolated execution environment registered on a
+[Workspace](/concepts), giving agents shell and filesystem tools that run inside
+it. The Sandbox interface is pluggable so different backends — local container,
+remote VM, hosted sandbox-as-a-service — can be contributed. Platypus ships one
+reference backend: **Docker**.
+
+This page is for the **Operator** and **Org Admin** who stand up and curate that
+infrastructure. The architectural rationale lives in the Sandbox ADRs, linked
+throughout rather than restated here.
+
+## Sandbox backends
+
+The Sandbox is modelled as a sibling of Provider: one Sandbox row per Workspace,
+with a `backend` discriminator and a JSON config, resolved by an in-tree adapter
+registry at chat-turn time. Filesystem and environment state persist across chat
+turns — that's what makes longer-lived, build-something workflows possible.
+
+Adding a new backend (Modal, E2B, Daytona, a custom VM) means implementing the
+fixed `SandboxBackend` interface; see the [Extending](/extending) section for
+custom backends.
+
+<Callout type="info">
+  Background and trade-offs:
+  [ADR-0001 — Sandbox as a workspace-keyed execution environment](https://github.com/willdady/platypus/blob/main/docs/adr/0001-sandbox-as-workspace-keyed-execution-environment.md)
+  and
+  [ADR-0002 — the fixed five-tool core](https://github.com/willdady/platypus/blob/main/docs/adr/0002-sandbox-fixed-five-tool-core.md).
+</Callout>
+
+## The Docker reference adapter
+
+The Docker adapter (`backend: "docker"`) spawns one container per Workspace via
+the host's Docker daemon, accessed by **bind-mounting `/var/run/docker.sock`**
+into the backend container.
+
+<Callout type="error">
+  Mounting the Docker socket grants the backend container **effective root on the
+  host**. Use the Docker adapter only on single-node, single-operator
+  deployments (your laptop, a personal VPS). Do **not** enable it on a host you
+  share with anyone you don't trust, and never in a multi-tenant or
+  hostile-tenant environment.
+</Callout>
+
+Because of that, the adapter is **off by default** and gated two ways:
+
+1. An env flag, `PLATYPUS_SANDBOX_DOCKER_ENABLED`. If it's unset or false, the
+   `"docker"` backend type isn't registered at all (so you can't create
+   un-runnable Sandbox rows).
+2. An opt-in compose overlay, `compose.sandbox.yaml`, which adds the socket mount
+   and sets the flag.
+
+Enable it by composing the overlay alongside the default stack:
+
+```bash
+docker compose -f compose.yaml -f compose.sandbox.yaml up
+```
+
+Horizontally-scaled deployments **cannot** use this adapter: sandbox state lives
+on a single host's Docker daemon, so each backend replica would have its own.
+Pick a remote backend instead.
+
+<Callout type="info">
+  Details, including the hardcoded container resource/security limits
+  (`PidsLimit`, memory caps, `no-new-privileges`) and why DinD was rejected:
+  [ADR-0003 — Docker reference adapter mounts the host socket](https://github.com/willdady/platypus/blob/main/docs/adr/0003-docker-reference-sandbox-adapter-socket-mount.md).
+</Callout>
+
+## Workspace-default environment variables
+
+A Sandbox carries workspace-default environment variables that are merged into
+every shell execution **on the server, without transiting the model**. The
+motivating case is API keys (`OPENAI_API_KEY`, `GITHUB_TOKEN`, …): agent-written
+code can call third-party services without the secret values ever appearing in
+the prompt, tool-call transcripts, or logs. The model is shown the key *names*
+only.
+
+The env is split into two tiers to match the authorization model:
+
+- **`adminEnv`** — Org-Admin-managed. Secrets the Workspace Owner can read the
+  names of but cannot change or override.
+- **`userEnv`** — Workspace-Owner-managed. The Owner's own secrets, set without
+  an admin round-trip.
+
+At execution time, precedence is `adminEnv` ▸ `userEnv` ▸ the model's per-call
+`env` (highest wins) — so an Owner can never override an admin-pinned key, and
+the model's values stay lowest. Changing env takes effect on the next shell
+execution; the container is not recreated.
+
+<Callout type="info">
+  The merge semantics and validation rules:
+  [ADR-0004 — workspace-default env vars](https://github.com/willdady/platypus/blob/main/docs/adr/0004-sandbox-workspace-default-env-vars.md).
+</Callout>
+
+## Host reachability: default-deny + admin-curated allowlists
+
+A new Sandbox can reach **no host service** until reachability is explicitly
+granted — the safe, default-deny posture. Reachability is expressed as two
+per-Sandbox fields on the Docker adapter, both defaulting to empty:
+
+- **`networks`** — Docker networks the sandbox container attaches to (reaches
+  other *containers*).
+- **`extraHosts`** — host-gateway aliases (reaches non-containerized *host*
+  processes, e.g. a bare-metal Ollama or internal proxy).
+
+The authority chain is honest and runs top-down:
+
+- The **Operator** declares the eligible set at deployment time via
+  `PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS` — a deployment env var, *not* an
+  in-app screen.
+- An **Org Admin** selects a per-Sandbox subset of that allowlist. Submissions
+  are validated server-side against the allowlist; out-of-allowlist entries are
+  rejected.
+- A **Workspace Owner** cannot change reachability at all (a non-admin Owner gets
+  a 403).
+
+Reach changes are pending until the container is recreated — consistent with the
+frozen-container rule — surfaced in-app as a "Pending — applies on recreate"
+badge with a "Recreate now" action.
+
+<Callout type="warning">
+  The "Platypus database stays unreachable from sandboxes" property holds only as
+  long as the database's network is **not** in the allowlist. It's an outcome of
+  your allowlist configuration, not a structural guarantee — don't add the
+  database network.
+</Callout>
+
+<Callout type="info">
+  The reachability design:
+  [ADR-0005 — host reachability is admin-curated, default-deny](https://github.com/willdady/platypus/blob/main/docs/adr/0005-sandbox-host-reachability-is-admin-curated-default-deny.md).
+</Callout>
+
+## Who can configure what
+
+Sandboxes are credential- and reach-bearing, so configuration is **Org
+Admin-managed and never delegatable** to a Workspace Owner. Within a Sandbox the
+gate is field-level: `backend`, `credentials`, `networks`, `extraHosts`,
+`adminEnv`, and creation are admin-only, while `name` and `userEnv` stay
+Owner-editable.
+
+<Callout type="info">
+  The field-level authorization model:
+  [ADR-0006 — credential- and reach-bearing config is admin-managed](https://github.com/willdady/platypus/blob/main/docs/adr/0006-credential-and-reach-bearing-config-is-admin-managed.md).
+</Callout>
+
+## Next steps
+
+- [Extending](/extending) — implement a custom Sandbox backend against the
+  `SandboxBackend` interface.
+- [Configuration & environment](/self-hosting/configuration) — where the sandbox
+  env vars sit among the rest of the deployment config.
+- [Providers & authentication](/self-hosting/providers-and-auth) — the role
+  ladder these admin-only gates rest on.


### PR DESCRIPTION
Fills in the **Self-Hosting** section of the docs site (`apps/docs/content/self-hosting/`), covering the four sub-issues of #209 for the Operator / Org Admin audience.

## Pages added

| Page | Issue | Covers |
| --- | --- | --- |
| Deploy with Docker Compose | #215 | The three compose services, image tags, ports, volumes, first-boot seeding, default admin + override, health checks, upgrading |
| Configuration & environment | #216 | Narrative config areas (service URLs, DB, auth, sandbox) and how they relate; defers exhaustive lists to Reference to avoid drift |
| Providers & authentication | #217 | Provider config (scope, credentials, `modelIds`, `taskModelId`), the better-auth model, and the Operator → Org Admin → Workspace Owner ladder + default admin |
| Sandbox infrastructure | #218 | Docker reference adapter (socket mount), two-tier `adminEnv`/`userEnv`, default-deny host reachability + admin-curated allowlists; links the Sandbox ADRs |

Also adds a section `_meta.ts` for ordering and turns the placeholder `index.mdx` into a real overview with cards.

## Notes
- Uses the glossary vocabulary from `CONTEXT.md` (Operator, Org Admin, Workspace Owner, Provider, Scoped/Shared resource, Sandbox).
- Sandbox page links the Sandbox ADRs (0001–0006) as GitHub blob links and points to the Extending section for custom backends, rather than restating the rationale.
- `.env` / `.env.example` content is described from `README.md`, `compose.yaml`, and the backend seed logic.

## Verification
- `pnpm build` green — 13 static pages, all four new pages exported under `out/self-hosting/`.
- Pagefind indexed the new pages.
- `pnpm lint` clean.

Closes #215, closes #216, closes #217, closes #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)