### PR TITLE
feat(docs): write the Concepts section (#212)

### DIFF
--- a/apps/docs/content/concepts/_meta.ts
+++ b/apps/docs/content/concepts/_meta.ts
@@ -1,0 +1,15 @@
+// Concepts section — the Platypus domain model explained for end users.
+// Ordered as a reading sequence: the big picture first, then the nouns a user
+// meets while building, then how resources are shared across Workspaces.
+const meta = {
+  index: "The big picture",
+  agents: "Agents & sub-agents",
+  providers: "Providers & models",
+  tools: "Tools, tool sets & MCP",
+  sandboxes: "Sandboxes",
+  skills: "Skills",
+  "memory-and-context": "Memory & context",
+  sharing: "Sharing across workspaces",
+};
+
+export default meta;

--- a/apps/docs/content/concepts/agents.mdx
+++ b/apps/docs/content/concepts/agents.mdx
@@ -1,0 +1,41 @@
+---
+title: Agents & sub-agents
+description: Agents are reusable presets that pin a model, prompt, tools, and skills. Sub-agents let one agent delegate to another.
+---
+
+# Agents & sub-agents
+
+## Agent
+
+An **Agent** is a saved configuration for how the assistant should behave. Rather
+than choosing a model and writing a system prompt every time you start a
+conversation, you set it all up once on an Agent and then just pick that Agent on
+a Chat.
+
+An Agent pins together:
+
+- a **Provider** and a specific **model** to run on,
+- a **system prompt** that shapes its personality and instructions,
+- **generation parameters** (such as temperature),
+- the **tools** it's allowed to use (see [Tools, tool sets & MCP](/concepts/tools)),
+- any **[Skills](/concepts/skills)** it can draw on,
+- and any **sub-agents** it can delegate to.
+
+When you select an Agent on a Chat turn, that selection takes the place of
+choosing a Provider and model by hand — the Agent already carries those choices.
+
+**Why you'd use one:** consistency and reuse. A "Research assistant" Agent, a
+"Code reviewer" Agent, and a "Friendly support bot" Agent can each have their own
+prompt, model, and tools. Build them once, use them across many Chats, and tweak
+them in one place.
+
+## Sub-agent
+
+A **Sub-Agent** is simply an Agent that another Agent can call on. When you add an
+Agent as a sub-agent of a parent Agent, the parent gains the ability to hand off
+work to it — the sub-agent shows up to the parent as a tool it can invoke.
+
+**Why you'd use one:** to break a big job into specialists. A top-level Agent can
+stay focused on coordinating, then delegate research to one sub-agent, drafting to
+another, and fact-checking to a third. Each sub-agent is a full Agent in its own
+right, with its own model, prompt, and tools.

--- a/apps/docs/content/concepts/index.mdx
+++ b/apps/docs/content/concepts/index.mdx
@@ -1,7 +1,89 @@
 ---
-title: Concepts
+title: The big picture
+description: How Platypus is organised — Organizations, Workspaces, Chats, and Agents — and the core ideas you'll meet along the way.
 ---
+
+import { Callout } from "nextra/components";
 
 # Concepts
 
-_Content coming soon._
+Platypus is a place to build AI agents and chat with them. Before you start
+clicking around, it helps to know how the pieces fit together. This section
+explains the main ideas in plain language — what each one is, and why you'd
+reach for it.
+
+If you just want to get a chat running, head to
+[Getting Started](/getting-started). Come back here when you want to understand
+_why_ things are arranged the way they are.
+
+## The hierarchy
+
+Everything in Platypus lives inside a nesting of three things:
+
+**Organization → Workspace → Chat / Agent**
+
+### Organization
+
+An **Organization** is the top level — your company, your team, or just you.
+It's the boundary that everything else lives inside. An Organization owns its
+**Workspaces**, holds shared settings like AI **Providers**, and is where member
+roles are managed.
+
+You'll typically belong to one Organization. People who administer it (adding
+members, configuring credentials) are **Org Admins**.
+
+### Workspace
+
+A **Workspace** is your own scoped environment inside an Organization. It holds
+your **Chats**, the **Agents** you've built, and the other resources they use.
+Each Workspace is owned by exactly one person — the **Workspace Owner** — and is
+not shared with other people. Think of it as your personal project space: what
+you build in one Workspace doesn't leak into anyone else's.
+
+<Callout type="info">
+  You don't create your own Workspaces — an Org Admin sets them up, often
+  pre-loaded with everything you need via a [Blueprint](/concepts/sharing). When
+  you accept an invitation, a ready-to-use Workspace can be provisioned for you
+  automatically.
+</Callout>
+
+### Chat
+
+A **Chat** is a saved conversation. It's a sequence of messages plus the
+configuration used to produce the assistant's replies. Every back-and-forth you
+have lives in a Chat, and Chats persist so you can return to them later.
+
+Each round of the conversation — you send a message, the assistant streams a
+reply — is a **Chat turn**. A turn runs against either an **Agent** or a direct
+**Provider** + model choice.
+
+### Agent
+
+An **Agent** is a reusable preset for how the assistant should behave. Instead of
+picking a model and writing a system prompt every time, you configure an Agent
+once — its **Provider** and model, its system prompt, its tools, its **Skills**,
+and any **Sub-Agents** — and then select it on a Chat. Selecting an Agent
+replaces choosing a Provider and model by hand.
+
+Agents are the heart of building with Platypus. The
+[Agents & sub-agents](/concepts/agents) page goes deeper.
+
+## The core nouns
+
+Beyond the hierarchy, you'll meet a handful of building blocks. Each has its own
+page in this section:
+
+- **[Agents & sub-agents](/concepts/agents)** — the configurable presets that
+  drive a conversation, and how one Agent can delegate to another.
+- **[Providers & models](/concepts/providers)** — your connections to AI vendors
+  like OpenAI, Anthropic, or Google.
+- **[Tools, tool sets & MCP](/concepts/tools)** — how an Agent gets the ability
+  to _do_ things, not just talk.
+- **[Sandboxes](/concepts/sandboxes)** — isolated environments where an Agent can
+  run shell commands and work with files.
+- **[Skills](/concepts/skills)** — packaged know-how an Agent can pull in on
+  demand.
+- **[Memory & context](/concepts/memory-and-context)** — how an Agent remembers
+  past activity and the notes you give it.
+- **[Sharing across workspaces](/concepts/sharing)** — how an Organization
+  reuses one resource across many Workspaces.

--- a/apps/docs/content/concepts/memory-and-context.mdx
+++ b/apps/docs/content/concepts/memory-and-context.mdx
@@ -1,0 +1,38 @@
+---
+title: Memory & context
+description: Memory lets an agent recall past activity; Context is the free-text notes you give it. Both shape the assistant's replies.
+---
+
+# Memory & context
+
+Two related ideas control what an **Agent** knows about _you_ and your past
+activity, beyond the messages in the current Chat: **Memory** and **Context**.
+
+## Memory
+
+**Memory** is a running summary of your prior activity that an Agent can recall.
+It's kept per person, per **Workspace**, and when an Agent is configured to use
+it, that summary is folded into the Agent's instructions automatically.
+
+**Why you'd use it:** so the assistant doesn't start from scratch every time.
+With Memory, an Agent can carry forward what it learned about your preferences,
+your projects, and earlier conversations — without you repeating yourself.
+
+Memory only comes into play when the Agent's tools include the memory tool set,
+so it's something you opt an Agent into rather than something that's always on.
+
+## Context
+
+**Context** is free-text notes _you_ write and attach for the assistant to read.
+You can set Context at two levels:
+
+- **global** — notes that apply everywhere you work, or
+- **per-Workspace** — notes specific to one Workspace.
+
+Whatever you put there is rendered into the Agent's instructions, so it's a
+direct way to tell the assistant standing facts: who you are, how you like
+answers formatted, what a project is about.
+
+**Memory vs. Context:** Memory is built up automatically from your activity;
+Context is written deliberately by you. They work together — Memory remembers,
+Context instructs.

--- a/apps/docs/content/concepts/providers.mdx
+++ b/apps/docs/content/concepts/providers.mdx
@@ -1,0 +1,46 @@
+---
+title: Providers & models
+description: A Provider is a configured connection to an AI vendor, carrying credentials and the set of models you're allowed to use.
+---
+
+import { Callout } from "nextra/components";
+
+# Providers & models
+
+## Provider
+
+A **Provider** is a configured connection to an AI vendor — OpenAI, OpenRouter,
+Bedrock, Anthropic, Google, and others. It's what lets Platypus actually talk to
+a model on your behalf.
+
+A Provider carries:
+
+- the **credentials** (such as an API key) for that vendor,
+- an optional **base URL** for self-hosted or proxied endpoints,
+- the list of **models** that have been enabled for use,
+- and a default **task model** used for quick one-shot jobs (like generating a
+  title for a Chat) rather than full conversations.
+
+When you run a Chat turn, you either pick a Provider and one of its models
+directly, or you select an **[Agent](/concepts/agents)** that already points at a
+Provider and model for you.
+
+## Where Providers live
+
+A Provider lives at one of two levels:
+
+- **Organization scope** — set up once and made available across many Workspaces
+  (a [Shared resource](/concepts/sharing)).
+- **Workspace scope** — private to a single Workspace.
+
+<Callout type="info">
+  Providers carry credentials, so they're usually configured by an **Org
+  Admin**. A Workspace Owner can manage them only where an Org Admin has
+  delegated that. See [Self-Hosting → Providers & authentication](/self-hosting)
+  for setup.
+</Callout>
+
+**Why this matters to you:** the models you can pick on a Chat or an Agent come
+from the Providers available in your Workspace. If a model you expect isn't
+there, it's because no available Provider has it enabled — an Org Admin controls
+that list.

--- a/apps/docs/content/concepts/sandboxes.mdx
+++ b/apps/docs/content/concepts/sandboxes.mdx
@@ -1,0 +1,44 @@
+---
+title: Sandboxes
+description: A Sandbox is an isolated execution environment that gives an agent shell and filesystem tools, safely separated from everything else.
+---
+
+import { Callout } from "nextra/components";
+
+# Sandboxes
+
+## Sandbox
+
+A **Sandbox** is an isolated, self-contained environment where an **Agent** can
+run shell commands and work with files. It's registered in a **Workspace**, and
+when it's available, the Agent gains shell and filesystem tools that operate
+_inside_ that environment — not on the machine running Platypus.
+
+**Why you'd use one:** lots of useful work involves actually executing
+something — running a script, building a project, inspecting files. A Sandbox
+lets an Agent do that safely, because the work happens in an isolated environment
+rather than touching anything outside it.
+
+Like an MCP, a Sandbox resolves to a **[tool set](/concepts/tools)** at Chat-turn
+time — the shell and filesystem tools it provides.
+
+## Pluggable backends
+
+The Sandbox is designed to be pluggable: the same Agent-facing tools can be
+powered by different backends — a local container, a remote VM, or a hosted
+sandbox-as-a-service. Which backend a deployment offers is an Operator decision;
+contributors can add new ones (see [Extending](/extending)).
+
+## Default environment variables
+
+A Sandbox can also carry **environment variables** that are merged into every
+shell command it runs. This is handy for things like API keys or configuration a
+command needs — and importantly, those values are applied directly to the
+execution **without being sent through the model**, so secrets stay out of the
+conversation.
+
+<Callout type="info">
+  Setting up a Sandbox is an infrastructure task. See [Self-Hosting → Sandbox
+  infrastructure](/self-hosting) for how an Operator and Org Admin configure the
+  available backends.
+</Callout>

--- a/apps/docs/content/concepts/sharing.mdx
+++ b/apps/docs/content/concepts/sharing.mdx
@@ -1,0 +1,74 @@
+---
+title: Sharing across workspaces
+description: How an Organization reuses one resource across many Workspaces — Shared resources, Attachments, and Blueprints.
+---
+
+import { Callout } from "nextra/components";
+
+# Sharing across workspaces
+
+Most of the things you build — **Agents**, **Skills**, **MCP** servers, and
+**Providers** — live inside a single **Workspace**. But an Organization often
+wants _one_ of something used everywhere: a single approved Provider, a standard
+support Agent, a company-wide Skill. That's what this page is about.
+
+These four resource types — Agent, Skill, MCP, and Provider — can each live at
+either **Workspace scope** (private to one Workspace) or **Organization scope**
+(shared). A resource always lives at exactly one of those scopes, never both.
+
+## Shared resource
+
+A **Shared resource** is one of those resources defined once at the Organization
+level and _referenced_ by many Workspaces — not copied into each one. There's a
+single source of truth: only **Org Admins** edit it, and it shows up as **locked**
+to Workspace Owners, who can use it but not change it.
+
+**Why this matters:** when the Org Admin updates a Shared Agent's prompt or
+rotates a Shared Provider's credentials, every Workspace using it gets the change
+at once. No drift, no copy-paste.
+
+<Callout type="info">
+  A Shared resource may only reference other Shared resources. Sharing is always
+  explicit and per-resource — it never cascades implicitly.
+</Callout>
+
+## Attachment
+
+A Shared resource doesn't automatically appear in every Workspace. An
+**Attachment** is the explicit link that makes a Shared resource show up inside a
+particular Workspace. No Attachment, no appearance — the resource simply isn't in
+that Workspace's lists.
+
+This keeps sharing deliberate: an Org Admin attaches exactly the Shared resources
+each Workspace should see, and manages all of them from the Organization surface
+regardless of where they're attached.
+
+## Promote
+
+**Promote** is the Org Admin action that turns a Workspace-private resource into a
+Shared one. It re-scopes the resource up to the Organization, automatically
+attaches it back to the Workspace it came from, and hands governance of it to Org
+Admins.
+
+**Why you'd use it:** you built a great Agent in your own Workspace, and now the
+whole Organization should have it. Promoting it makes it shared without rebuilding
+it from scratch.
+
+## Blueprint
+
+A **Blueprint** is a named, Organization-level recipe for setting up a Workspace
+in one step. Applying a Blueprint to a Workspace does two things at once:
+
+1. **attaches a chosen set of Shared resources** to the Workspace, and
+2. **sets the Workspace's defaults** — its task and memory **Providers**, and a
+   default **[Context](/concepts/memory-and-context)**.
+
+**Why you'd use one:** onboarding. Instead of hand-configuring every new
+Workspace, an Org Admin defines a Blueprint once and applies it whenever a
+Workspace is provisioned — often automatically when someone accepts an invitation.
+
+<Callout type="warning">
+  A Blueprint runs **once**, at the moment it's applied — it isn't a live link.
+  Editing a Blueprint later only affects Workspaces provisioned _after_ the
+  edit; Workspaces already set up are left unchanged.
+</Callout>

--- a/apps/docs/content/concepts/skills.mdx
+++ b/apps/docs/content/concepts/skills.mdx
@@ -1,0 +1,32 @@
+---
+title: Skills
+description: A Skill is packaged know-how an agent can pull in on demand, keeping its instructions lean until the skill is actually needed.
+---
+
+# Skills
+
+## Skill
+
+A **Skill** is a named capability you attach to an **Agent** — a description plus
+a set of instructions for doing something well. Rather than stuffing every
+possible instruction into the Agent's system prompt, you give the Agent Skills it
+can reach for when the moment calls for it.
+
+Here's the clever part: the Agent only sees each Skill's _name and description_
+up front. When it decides a Skill is relevant, it requests that Skill's full
+instructions on demand. This keeps the Agent's everyday prompt short and focused,
+while still giving it deep know-how the instant it's needed.
+
+**Why you'd use one:** to teach an Agent how to handle specific situations
+without bloating its prompt. A "Write a release note" Skill, a "Triage a bug
+report" Skill, a "Format data as a table" Skill — each stays tucked away until the
+Agent recognises it should use it.
+
+## Where Skills live
+
+A Skill lives at **Workspace scope** (private to one Workspace) or can be shared
+at **Organization scope** as a [Shared resource](/concepts/sharing), so the same
+know-how is reused across many Workspaces.
+
+See [Building with Platypus → Skills](/building-with-platypus) for how to author
+one.

--- a/apps/docs/content/concepts/tools.mdx
+++ b/apps/docs/content/concepts/tools.mdx
@@ -1,0 +1,49 @@
+---
+title: Tools, tool sets & MCP
+description: Tools let an agent do things, not just talk. Tool sets bundle them, and MCP servers contribute tool sets from outside Platypus.
+---
+
+# Tools, tool sets & MCP
+
+An **Agent** that can only talk is limited. Tools are how an Agent _acts_ —
+searching the web, reading a file, calling an API, running a command. This page
+explains how tools are bundled and where they come from.
+
+## Tool set
+
+A **Tool set** is a named bundle of tools you can grant to an **Agent**. Instead
+of wiring up individual tools one by one, you give an Agent a whole tool set.
+
+Tool sets come from two places:
+
+- **built in** — registered in Platypus's code and available out of the box, or
+- **backed by an MCP server** — contributed from outside Platypus (see below).
+
+When an Agent runs, each tool set it's been granted is resolved into the actual
+tools the model can call.
+
+## MCP
+
+**MCP** stands for the Model Context Protocol — an open standard for exposing
+tools to AI models. An **MCP** in Platypus is a registered MCP server. At
+Chat-turn time it resolves to a **tool set**, so the tools that server offers
+become available to the Agent.
+
+**Why you'd use one:** MCP is how you connect Platypus to capabilities that don't
+ship with it — your own internal services, third-party integrations, or community
+MCP servers. Register the server once, then grant its tool set to any Agent that
+needs it.
+
+An MCP can live at **Workspace scope** (private to one Workspace) or be shared at
+**Organization scope** as a [Shared resource](/concepts/sharing). See
+[Building with Platypus → MCP servers](/building-with-platypus) for how to set one
+up.
+
+## How it fits together
+
+> An **Agent** is granted zero or more **tool sets**. Each tool set is either
+> built in or backed by an **MCP** server, and resolves to a concrete set of
+> tools the model can call during a **Chat turn**.
+
+A **[Sandbox](/concepts/sandboxes)** also resolves to a tool set — its shell and
+filesystem tools — which is why sandboxes get their own page.


### PR DESCRIPTION
Closes #212.

Replaces the **Concepts** stub (`apps/docs/content/concepts/`) with real, end-user-facing content explaining the Platypus domain model, per ADR-0011 (`CONTEXT.md` is not published; these pages are written independently for end users).

## What's here

Eight pages plus a `_meta.ts` for nav ordering, structured as a reading sequence:

- **The big picture** (`index.mdx`) — the **Organization → Workspace → Chat / Agent** hierarchy, Chat turn, and an index of the rest
- **Agents & sub-agents** — Agent & Sub-Agent
- **Providers & models** — Provider, and where Providers live
- **Tools, tool sets & MCP** — Tool set & MCP
- **Sandboxes** — Sandbox, pluggable backends, default env vars
- **Skills** — Skill (on-demand instructions)
- **Memory & context** — Memory & Context
- **Sharing across workspaces** — Shared resource, Attachment, Promote, Blueprint

## Acceptance criteria

- [x] `content/concepts` replaces the stub with real content
- [x] Covers the Org → Workspace → Agent hierarchy and the core nouns (Provider, Tool set, MCP, Skill, Sandbox, Memory, Context, Shared resource/Attachment, Blueprint)
- [x] Written for end users — does not copy `CONTEXT.md` verbatim ("what it is / why you'd use it" voice)
- [x] Uses the glossary terms consistently (no synonyms)
- [x] Renders in the nav, Pagefind indexes it, `pnpm docs-build` stays green

## Verification

`pnpm docs-build` succeeds — all 8 pages prerender and Pagefind indexes them (14 pages total). `eslint` and `prettier --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)