### PR TITLE
feat(docs): Extending section & Reference config pages

### DIFF
--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -2,6 +2,296 @@
 title: Extending
 ---
 
+import { Callout } from "nextra/components";
+
 # Extending
 
-_Content coming soon._
+This section is for **contributors** working in the Platypus codebase. It maps
+the in-tree extension points — places designed to be added to without forking
+the core — and points at the [Architecture Decision
+Records](https://github.com/willdady/platypus/tree/main/docs/adr) that explain
+_why_ each one is shaped the way it is.
+
+Platypus has two first-class extension points today, plus a deliberate
+non-extension point:
+
+- **[Sandbox backends](#sandbox-backends)** — implement the `SandboxBackend`
+  interface to run shell and filesystem tools on a new execution environment
+  (Modal, Daytona, E2B, a remote host…).
+- **[Tool sets](#tool-sets)** — register a named group of tools that Agents can
+  be granted.
+- **[MCP servers](#mcp-vs-static-tool-sets)** are _not_ a code extension point —
+  they're the runtime, open-ended way to add tools without touching the
+  codebase. Reach for them first; see the comparison below.
+
+<Callout type="info">
+  Both extension points are **static, in-tree registries** wired up at process
+  start — there is no plugin loader or dynamic discovery yet. Adding an
+  extension means adding code to `apps/backend` and rebuilding. The
+  [plugins](#the-plugin-direction-future) direction below is the future shape,
+  not today's.
+</Callout>
+
+## Sandbox backends
+
+A **Sandbox** is a persistent, Workspace-keyed execution environment that
+exposes a fixed set of shell and filesystem tools to Agents. The contract every
+backend implements is small and fixed on purpose: an Agent's prompt should not
+care _which_ backend it's running on, so you can swap the reference Docker
+adapter for Modal or Daytona without re-prompting.
+
+> See [ADR-0001](https://github.com/willdady/platypus/blob/main/docs/adr/0001-sandbox-as-workspace-keyed-execution-environment.md)
+> for why a Sandbox is a Workspace-keyed sibling of Provider (not a Provider
+> variant, an MCP server, or a generic plugin), and
+> [ADR-0002](https://github.com/willdady/platypus/blob/main/docs/adr/0002-sandbox-fixed-five-tool-core.md)
+> for why the interface is a fixed five-tool core.
+
+### The interface
+
+A backend is anything that implements `SandboxBackend`
+(`apps/backend/src/sandbox/types.ts`). It is exactly five tools plus an
+idempotent teardown — adapters **cannot** add, rename, or re-sign tools:
+
+```ts
+export interface SandboxBackend {
+  shellExec(
+    ctx: SandboxContext,
+    input: ShellExecInput,
+  ): Promise<ShellExecOutput>;
+  fsRead(ctx: SandboxContext, input: FsReadInput): Promise<FsReadOutput>;
+  fsWrite(ctx: SandboxContext, input: FsWriteInput): Promise<FsWriteOutput>;
+  fsEdit(ctx: SandboxContext, input: FsEditInput): Promise<FsEditOutput>;
+  fsList(ctx: SandboxContext, input: FsListInput): Promise<FsListOutput>;
+  destroy(ctx: SandboxContext): Promise<void>;
+}
+```
+
+Every method receives a `SandboxContext` — the stable identity key your adapter
+uses to find or provision the environment:
+
+```ts
+export type SandboxContext = {
+  orgId: string;
+  workspaceId: string;
+  userId: string;
+};
+```
+
+State (filesystem, environment) is expected to **persist across Chat turns**,
+keyed on `(orgId, workspaceId)`. That persistence is the whole point —
+Hermes / Claude-Code-style workflows depend on it.
+
+Contract rules your adapter must honour (all from
+[ADR-0002](https://github.com/willdady/platypus/blob/main/docs/adr/0002-sandbox-fixed-five-tool-core.md)):
+
+- **Paths are workspace-root-relative.** The root is conventionally
+  `/workspace`; reject absolute paths.
+- **`shellExec` is stateless** — a fresh shell per call with an explicit `cwd`,
+  no session state between calls. Default 60s timeout, hard cap 600s.
+- **`fsWrite` requires explicit `mode: "create" | "overwrite"`** — no silent
+  create-or-overwrite.
+- **`fsEdit` uses `oldString` / `newString` semantics** (Claude Code style), not
+  patch/diff format.
+- **Every response carries a `truncated` flag** with the Platypus-defined byte /
+  entry caps. If your backend can't honour the cap natively, truncate yourself.
+- **`destroy` must be idempotent** — it fires on row delete, on a `backend`
+  change, and best-effort on Workspace cascade.
+
+### Registering a backend
+
+Backends are registered into an in-tree registry
+(`apps/backend/src/sandbox/index.ts`) via `registerSandboxBackend`. A
+registration declares a `backend` discriminator, a display `name`, Zod schemas
+for the per-Sandbox `config` and `credentials`, and a `create` factory:
+
+```ts
+export interface SandboxBackendRegistration<
+  TConfig = unknown,
+  TCredentials = unknown,
+> {
+  backend: string;
+  name: string;
+  configSchema: z.ZodType<TConfig>;
+  credentialsSchema: z.ZodType<TCredentials>;
+  create(config: TConfig, credentials: TCredentials): SandboxBackend;
+}
+```
+
+The reference **Docker** adapter
+(`apps/backend/src/sandbox/backends/docker.ts`) shows the pattern. Its
+registration is **env-gated** so an un-runnable backend is never offered
+(`apps/backend/src/sandbox/backends/index.ts`):
+
+```ts
+if (process.env.PLATYPUS_SANDBOX_DOCKER_ENABLED === "true") {
+  registerSandboxBackend({
+    backend: "docker",
+    name: "Local Docker",
+    configSchema: dockerSandboxConfigSchema,
+    credentialsSchema: dockerSandboxCredentialsSchema,
+    create: (config, credentials) =>
+      new DockerSandboxBackend(config, credentials),
+  });
+}
+```
+
+The whole `backends/` module is imported for its side effects at boot
+(`import "./sandbox/backends/index.ts"` in `apps/backend/src/server.ts`), which
+is what populates the registry.
+
+**To add a backend:**
+
+1. Implement `SandboxBackend` in a new file under
+   `apps/backend/src/sandbox/backends/`.
+2. Define `configSchema` and `credentialsSchema` (Zod). `config` is non-secret
+   shape (e.g. region, image); `credentials` is secret material (e.g. API
+   tokens).
+3. Call `registerSandboxBackend({...})` from
+   `apps/backend/src/sandbox/backends/index.ts`, gated behind an env flag if the
+   backend needs external prerequisites.
+
+<Callout type="warning">
+  The Docker reference adapter mounts the host Docker socket and is scoped to
+  **development and single-node self-hosting only** — explicitly not for
+  multi-tenant or hostile-tenant environments. Reach / network exposure is
+  default-deny and admin-curated. See
+  [ADR-0003](https://github.com/willdady/platypus/blob/main/docs/adr/0003-docker-reference-sandbox-adapter-socket-mount.md)
+  and
+  [ADR-0005](https://github.com/willdady/platypus/blob/main/docs/adr/0005-sandbox-host-reachability-is-admin-curated-default-deny.md)
+  before shipping a backend with host reach.
+</Callout>
+
+## Tool sets
+
+A **tool set** is a named, categorised group of tools that an Agent can be
+granted. Built-in tool sets are registered statically into an in-tree registry
+(`apps/backend/src/tools/index.ts`) via `registerToolSet`:
+
+```ts
+type ToolSet = {
+  id: string;
+  name: string;
+  category: string;
+  description?: string;
+  tools:
+    | { [toolId: string]: Tool<any, any> }
+    | ((
+        context: ToolSetContext,
+      ) => Record<string, Tool> | Promise<Record<string, Tool>>);
+};
+```
+
+`tools` is either a **static map** of tools, or a **factory** that receives a
+`ToolSetContext` at Chat-turn time — use the factory form when tools need
+runtime scope:
+
+```ts
+export type ToolSetContext = {
+  workspaceId: string;
+  agentId: string;
+  orgId: string;
+  frontendUrl: string | undefined;
+  userId: string;
+};
+```
+
+Individual tools are Vercel AI SDK tools (`tool()` from the `ai` package) with a
+Zod `inputSchema` and an `execute` function. The simplest registration uses a
+static map:
+
+```ts
+registerToolSet("math-conversions", {
+  name: "Math Conversions",
+  category: "Math",
+  description: "Temperature and unit conversions",
+  tools: { convertTemperature, convertDistance, convertWeight, convertVolume },
+});
+```
+
+When tools need the Workspace / Agent context, pass a factory instead:
+
+```ts
+registerToolSet("kanban", {
+  name: "Kanban",
+  category: "Productivity",
+  description: "Manage kanban boards in this workspace",
+  tools: ({ workspaceId, agentId, orgId, frontendUrl }) =>
+    createKanbanTools(workspaceId, agentId, orgId, frontendUrl),
+});
+```
+
+**To add a tool set:**
+
+1. Define your tools with `tool({ description, inputSchema, execute })`. Put
+   them in a new file under `apps/backend/src/tools/` (see `math.ts` for a
+   stateless example, `kanban.ts` for a context-factory example).
+2. Call `registerToolSet("my-tool-set", {...})` in
+   `apps/backend/src/tools/index.ts`. Use a static `tools` map, or a factory if
+   your tools need `ToolSetContext`.
+3. Optionally export a `MY_TOOLSET_ID` constant for code that references the id.
+
+A tool set is granted to Agents like any other; if its dependencies aren't
+present at turn time it degrades gracefully (the `sandbox` tool set, for
+example, is registered unconditionally but resolves to no tools when a Workspace
+has no Sandbox configured).
+
+<Callout type="info">
+  Frontend tool / tool-set presentation (icons, custom UI) lives separately. If
+  you're wiring a new tool set end to end, see the `tools` skill in the repo for
+  the frontend icon mapping and custom-UI conventions.
+</Callout>
+
+### MCP vs static tool sets
+
+Static tool sets and MCP servers are deliberately different surfaces — pick the
+right one:
+
+- **MCP server** — the open-ended, runtime way to expose arbitrary tools
+  _without changing Platypus_. Configured per Workspace (or shared at the Org
+  level). This is the default answer to "I want my Agent to call X."
+- **Static tool set** — for tools that ship _with_ Platypus and are part of the
+  product surface (Kanban, math, sandbox…). Adding one means adding code and
+  rebuilding.
+
+If you're integrating an external service for your own use, you almost always
+want an MCP server, not a code change.
+
+## Shared resources
+
+Agents, Skills, and MCPs can be **Promoted** to Organization scope and become
+**Shared resources** that many Workspaces reference (never copy). The defining
+rule is **no implicit sharing** — a Shared resource may reference only other
+Shared resources. If you're touching the resource model (adding a new shareable
+resource type, or a reference between resources), read
+[ADR-0007](https://github.com/willdady/platypus/blob/main/docs/adr/0007-organization-scoped-shared-resources.md)
+first; the promotion-prerequisite rule has wide-reaching consequences.
+
+## The plugin direction (future)
+
+There is **no plugin system today** — both extension points above are static,
+in-tree registries compiled into the backend. That's a deliberate v1 choice, not
+an oversight:
+
+- The Sandbox interface was explicitly modelled as a fixed contract rather than
+  "a generic plugin system"
+  ([ADR-0001](https://github.com/willdady/platypus/blob/main/docs/adr/0001-sandbox-as-workspace-keyed-execution-environment.md)).
+- A "fixed core plus adapter extensions" hybrid for Sandbox was considered and
+  deferred — it can be added later **without breaking the v1 contract**
+  ([ADR-0002](https://github.com/willdady/platypus/blob/main/docs/adr/0002-sandbox-fixed-five-tool-core.md)).
+
+The registry shape is the seam a future plugin loader would plug into: dynamic
+discovery would call the same `registerSandboxBackend` / `registerToolSet`
+functions rather than replace them. Until then, contribute backends and tool
+sets in-tree and reach for MCP for everything open-ended.
+
+## Reference ADRs
+
+| ADR                                                                                                                             | Topic                                              |
+| ------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| [0001](https://github.com/willdady/platypus/blob/main/docs/adr/0001-sandbox-as-workspace-keyed-execution-environment.md)        | Sandbox is a Workspace-keyed execution environment |
+| [0002](https://github.com/willdady/platypus/blob/main/docs/adr/0002-sandbox-fixed-five-tool-core.md)                            | Fixed five-tool Sandbox interface                  |
+| [0003](https://github.com/willdady/platypus/blob/main/docs/adr/0003-docker-reference-sandbox-adapter-socket-mount.md)           | Docker reference adapter (socket mount)            |
+| [0004](https://github.com/willdady/platypus/blob/main/docs/adr/0004-sandbox-workspace-default-env-vars.md)                      | Sandbox default environment variables              |
+| [0005](https://github.com/willdady/platypus/blob/main/docs/adr/0005-sandbox-host-reachability-is-admin-curated-default-deny.md) | Host reachability is admin-curated, default-deny   |
+| [0006](https://github.com/willdady/platypus/blob/main/docs/adr/0006-credential-and-reach-bearing-config-is-admin-managed.md)    | Credential/reach config is admin-managed           |
+| [0007](https://github.com/willdady/platypus/blob/main/docs/adr/0007-organization-scoped-shared-resources.md)                    | Organization-scoped Shared resources               |

--- a/apps/docs/content/reference/_meta.ts
+++ b/apps/docs/content/reference/_meta.ts
@@ -1,0 +1,9 @@
+// Reference is the exhaustive, lookup-oriented section. The narrative "how to
+// configure" lives in Self-Hosting; these pages are the flat enumerations.
+const meta = {
+  index: "Overview",
+  "backend-configuration": "Backend configuration",
+  "frontend-configuration": "Frontend configuration",
+};
+
+export default meta;

--- a/apps/docs/content/reference/backend-configuration.mdx
+++ b/apps/docs/content/reference/backend-configuration.mdx
@@ -1,0 +1,97 @@
+---
+title: Backend configuration
+---
+
+import { Callout } from "nextra/components";
+
+# Backend configuration
+
+The exhaustive list of backend environment variables. Source of truth:
+[`apps/backend/.env.example`](https://github.com/willdady/platypus/blob/main/apps/backend/.env.example).
+For a guided walkthrough of configuring a deployment, see
+[Self-Hosting](/self-hosting); this page is the flat enumeration.
+
+<Callout type="info">
+  **"Required"** means the backend won't start correctly without an explicit
+  value. Everything else has a working default suitable for local development.
+  In Docker Compose deployments the top-level `.env` feeds these through to the
+  backend container.
+</Callout>
+
+## Core
+
+| Variable          | Purpose                                                                               | Default                                                  | Required |
+| ----------------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------- | -------- |
+| `PORT`            | Port the backend HTTP server listens on.                                              | `4001`                                                   | No       |
+| `ALLOWED_ORIGINS` | Comma-separated origins allowed by CORS. Set to your frontend's URL(s).               | `http://localhost:3001`                                  | No       |
+| `DATABASE_URL`    | Postgres 17 connection string (with pgvector).                                        | `postgres://postgres:mypassword@localhost:5432/postgres` | **Yes**  |
+| `LOG_LEVEL`       | Logging verbosity (`trace`, `debug`, `info`, `warn`, `error`, `fatal`).               | `info`                                                   | No       |
+| `TIMEZONE`        | IANA timezone (e.g. `America/New_York`, `Europe/London`). Falls back to UTC if unset. | `UTC`                                                    | No       |
+| `NODE_OPTIONS`    | Node runtime flags. Ships set to silence the experimental-feature warning.            | `--disable-warning=ExperimentalWarning`                  | No       |
+
+## Authentication
+
+| Variable                 | Purpose                                                                                                                  | Default                                                    | Required |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- | -------- |
+| `BETTER_AUTH_SECRET`     | Secret used to sign session tokens (better-auth). Must be a secure random string, 32+ characters. Treat like a password. | `your-secret-key-min-32-chars` _(placeholder — change it)_ | **Yes**  |
+| `BETTER_AUTH_URL`        | Public base URL of the backend, used by better-auth.                                                                     | `http://localhost:4001`                                    | **Yes**  |
+| `INVITATION_EXPIRY_DAYS` | Days a Workspace/Org invitation remains valid.                                                                           | `7`                                                        | No       |
+
+## Default admin
+
+Seeded only on first startup, when no matching admin exists. Changing these
+later does **not** reset an already-created account — change the password from
+within the app. See [Getting Started](/getting-started) for the first-run flow.
+
+| Variable         | Purpose                                   | Default             | Required |
+| ---------------- | ----------------------------------------- | ------------------- | -------- |
+| `ADMIN_EMAIL`    | Email of the first admin (Operator) user. | `admin@example.com` | No       |
+| `ADMIN_PASSWORD` | Password for that user.                   | `admin123`          | No       |
+
+<Callout type="warning">
+  Change `ADMIN_PASSWORD` (or set a non-default one before first startup) on any
+  network-reachable deployment.
+</Callout>
+
+## Background workers
+
+| Variable                         | Purpose                                                               | Default              | Required |
+| -------------------------------- | --------------------------------------------------------------------- | -------------------- | -------- |
+| `MEMORY_EXTRACTION_INTERVAL_MS`  | How often the memory-extraction worker runs, in milliseconds.         | `300000` (5 minutes) | No       |
+| `SCHEDULE_SCHEDULER_INTERVAL_MS` | How often the schedule scheduler polls for due runs, in milliseconds. | `60000` (1 minute)   | No       |
+| `SCHEDULE_MAX_CONCURRENT`        | Maximum parallel schedule executions.                                 | `5`                  | No       |
+
+## Tools
+
+| Variable                       | Purpose                                                                    | Default                 | Required |
+| ------------------------------ | -------------------------------------------------------------------------- | ----------------------- | -------- |
+| `FETCH_TOOL_IGNORE_ROBOTS_TXT` | Set `true` to skip `robots.txt` checks when the fetch tool retrieves URLs. | `false`                 | No       |
+| `FRONTEND_URL`                 | Frontend URL used to build resource links inside tool responses.           | `http://localhost:3001` | No       |
+
+## Storage
+
+The file-storage backend. Disk is the default; S3 (or an S3-compatible service)
+is the production option.
+
+| Variable                       | Purpose                                                                                                       | Default        | Required                  |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------- | -------------- | ------------------------- |
+| `STORAGE_BACKEND`              | Storage backend: `disk` or `s3`.                                                                              | `disk`         | No                        |
+| `STORAGE_DISK_PATH`            | Filesystem path for stored files (when `STORAGE_BACKEND=disk`).                                               | `./data/files` | No                        |
+| `STORAGE_PUBLIC_URL`           | Optional public URL for direct file access, bypassing the `/files` proxy endpoint (e.g. a CDN or bucket URL). | _(unset)_      | No                        |
+| `STORAGE_S3_BUCKET`            | S3 bucket name.                                                                                               | _(unset)_      | When `STORAGE_BACKEND=s3` |
+| `STORAGE_S3_REGION`            | S3 region.                                                                                                    | _(unset)_      | When `STORAGE_BACKEND=s3` |
+| `STORAGE_S3_ENDPOINT`          | S3 endpoint URL (for S3-compatible services).                                                                 | _(unset)_      | When `STORAGE_BACKEND=s3` |
+| `STORAGE_S3_ACCESS_KEY_ID`     | S3 access key ID.                                                                                             | _(unset)_      | When `STORAGE_BACKEND=s3` |
+| `STORAGE_S3_SECRET_ACCESS_KEY` | S3 secret access key.                                                                                         | _(unset)_      | When `STORAGE_BACKEND=s3` |
+
+## Sandbox
+
+The Docker reference Sandbox adapter. Disabled by default and scoped to
+development / single-node self-hosting only. See
+[ADR-0003](https://github.com/willdady/platypus/blob/main/docs/adr/0003-docker-reference-sandbox-adapter-socket-mount.md)
+and the [Extending](/extending#sandbox-backends) section.
+
+| Variable                                   | Purpose                                                                                                                                            | Default   | Required |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | -------- |
+| `PLATYPUS_SANDBOX_DOCKER_ENABLED`          | Set `true` to register the Docker reference adapter. Requires a reachable Docker daemon and the `compose.sandbox.yaml` overlay.                    | `false`   | No       |
+| `PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS` | Comma-separated Docker networks a Sandbox may attach to. Admins select a per-Sandbox subset; unset/empty means none are attachable (default-deny). | _(unset)_ | No       |

--- a/apps/docs/content/reference/frontend-configuration.mdx
+++ b/apps/docs/content/reference/frontend-configuration.mdx
@@ -1,0 +1,30 @@
+---
+title: Frontend configuration
+---
+
+import { Callout } from "nextra/components";
+
+# Frontend configuration
+
+The exhaustive list of frontend environment variables. Source of truth:
+[`apps/frontend/.env.example`](https://github.com/willdady/platypus/blob/main/apps/frontend/.env.example).
+For a guided walkthrough of configuring a deployment, see
+[Self-Hosting](/self-hosting); this page is the flat enumeration.
+
+The frontend is a Next.js 16 App Router app. It needs to know how to reach the
+backend — once from the browser, and (in containerised deployments) once from
+the server-side renderer.
+
+| Variable               | Purpose                                                                                                                                                                                                      | Default                   | Required               |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------- | ---------------------- |
+| `BACKEND_URL`          | Backend base URL for **client-side** requests (browser → backend).                                                                                                                                           | `http://localhost:4001`   | **Yes**                |
+| `INTERNAL_BACKEND_URL` | Backend base URL for **server-side** requests (SSR → backend) over the internal Docker network. Only needed when running in Docker; leave unset for local development, where `BACKEND_URL` is used for both. | _(unset)_                 | When running in Docker |
+| `BASE_PATH`            | Optional base path for deploying the app under a subpath (e.g. `/platypus-app`).                                                                                                                             | _(unset, served at root)_ | No                     |
+
+<Callout type="info">
+  In Docker Compose, the browser and the SSR process reach the backend by
+  different routes: the browser uses the host-published URL (`BACKEND_URL`),
+  while the SSR process talks to the backend container directly over the Docker
+  network (`INTERNAL_BACKEND_URL`, e.g. `http://backend:4000`). Outside Docker,
+  set only `BACKEND_URL`.
+</Callout>

--- a/apps/docs/content/reference/index.mdx
+++ b/apps/docs/content/reference/index.mdx
@@ -2,6 +2,31 @@
 title: Reference
 ---
 
+import { Cards } from "nextra/components";
+
 # Reference
 
-_Content coming soon._
+Exhaustive, lookup-oriented reference material. These pages enumerate every
+configuration option as flat tables — they are the source-of-truth lists, not a
+guided walkthrough.
+
+For the narrative "how do I configure this for my deployment" story — TLS,
+storage, providers, the sandbox overlay — see
+[Self-Hosting](/self-hosting). This section is what you reach for when you
+already know roughly what you want and need the exact variable name, default, or
+whether it's required.
+
+<Cards>
+  <Cards.Card
+    title="Backend configuration"
+    href="/reference/backend-configuration"
+  />
+  <Cards.Card
+    title="Frontend configuration"
+    href="/reference/frontend-configuration"
+  />
+</Cards>
+
+Both pages are derived from the `.env.example` files in the repository
+(`apps/backend/.env.example`, `apps/frontend/.env.example`) — treat those files
+as the ultimate source of truth if anything here drifts.


### PR DESCRIPTION
Closes #214, #225, #226 (sub-issues of #209).

Replaces the **Extending** and **Reference** stubs with real content.

## Extending — `content/extending/index.mdx` (#214)
Contributor-facing guide to Platypus's in-tree extension points:
- **Sandbox backends** — the `SandboxBackend` interface, the `registerSandboxBackend` registry, env-gated registration, and the contract rules adapters must honour (paths, stateless shell, `fsWrite` mode, `fsEdit` semantics, truncation, idempotent `destroy`).
- **Tool sets** — `registerToolSet` with static-map vs context-factory forms, and how to add one.
- **MCP vs static tool sets** — when to reach for which.
- **Shared resources** and the **future plugin direction**, both pointing at the relevant ADRs.

Framed for contributors; points at ADRs 0001–0007 rather than restating them.

## Reference — `content/reference/` (#225, #226)
Split into two enumeration pages plus an overview + `_meta.ts`:
- **Backend configuration** — every var from `apps/backend/.env.example` grouped (core, auth, default admin, workers, tools, storage, sandbox) with purpose / default / required.
- **Frontend configuration** — every var from `apps/frontend/.env.example`.

Kept deliberately distinct from the Self-Hosting narrative; both pages name the `.env.example` files as source of truth.

## Verification
- `pnpm build` green; Pagefind indexes all new pages (`extending`, `reference/backend-configuration`, `reference/frontend-configuration`).
- `pnpm lint` clean; Prettier-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)