### PR TITLE
feat(docs): write the Building with Platypus section

### DIFF
--- a/apps/docs/content/building-with-platypus/_meta.ts
+++ b/apps/docs/content/building-with-platypus/_meta.ts
@@ -1,0 +1,15 @@
+// Building with Platypus section order. Audience: Workspace Owner (ADR-0011).
+// Ordered as a build sequence: the Agent first, then the capabilities you give
+// it (Skills, MCP), then the surfaces it works against (Triggers, Boards,
+// Dashboards).
+const meta = {
+  index: "Overview",
+  agents: "Agents & sub-agents",
+  skills: "Skills",
+  mcp: "MCP servers",
+  triggers: "Triggers",
+  boards: "Boards",
+  dashboards: "Dashboards",
+};
+
+export default meta;

--- a/apps/docs/content/building-with-platypus/agents.mdx
+++ b/apps/docs/content/building-with-platypus/agents.mdx
@@ -1,0 +1,124 @@
+---
+title: Agents & sub-agents
+description: Create and configure an Agent — pin a Provider and model, write a system prompt, tune generation parameters, grant tools and Skills, and compose sub-agents.
+---
+
+import { Callout, Steps } from "nextra/components";
+
+# Agents & sub-agents
+
+An **Agent** is a reusable preset for how the assistant behaves: a Provider and
+model, a system prompt, generation settings, and the tools, Skills, and
+sub-agents it's allowed to use. Build it once, then select it on any Chat. For
+the concept, see [Agents & sub-agents](/concepts/agents); this page is the
+build.
+
+## Create an Agent
+
+<Steps>
+
+### Open the Agent form
+
+From your Workspace, go to the **Agents** section and click **Create agent**.
+
+### Name and describe it
+
+- **Name** — what to call the Agent (3–30 characters).
+- **Description** — a short summary (1–128 characters). This is also what a
+  parent Agent sees when it considers delegating to this one as a sub-agent.
+- **Input Placeholder** _(optional)_ — custom placeholder text shown in the chat
+  input when this Agent is selected.
+- **Avatar** _(optional)_ — click to upload or paste an image.
+
+### Write the system prompt
+
+The **System prompt** field shapes the Agent's personality and instructions. It's
+optional, but it's the single biggest lever on behaviour — e.g. _"You are a
+concise research assistant. Cite sources and prefer primary documents."_
+
+### Pin a Provider and model
+
+Open the **Model** dropdown and pick a model. Models are grouped under each
+**Provider** available in your Workspace. If a model you expect is missing, no
+available Provider has it enabled — that's an Org Admin setting (see
+[Providers & models](/concepts/providers)).
+
+</Steps>
+
+<Callout type="info">
+  Selecting an Agent on a Chat replaces choosing a Provider and model by hand —
+  the Agent already carries those choices.
+</Callout>
+
+## Tune generation
+
+Two levels of control over how the model generates:
+
+- **Max steps** — how many steps a tool-calling loop may run before it stops.
+  This lives in the main form (default `30`). Raise it for Agents that chain many
+  tool calls; lower it to cap runaway loops.
+- **Advanced settings** — expand this section for the optional sampling
+  parameters. Leave any blank to use the Provider's default.
+
+| Parameter             | Range    | What it does                                  |
+| --------------------- | -------- | --------------------------------------------- |
+| **Temperature**       | from `0` | Randomness — higher is more varied            |
+| **Top-p**             | `0`–`1`  | Nucleus sampling cutoff                       |
+| **Top-k**             | from `1` | Limits sampling to the _k_ most likely tokens |
+| **Seed**              | integer  | Fixes sampling for reproducible output        |
+| **Presence penalty**  | `-2`–`2` | Discourages repeating topics already present  |
+| **Frequency penalty** | `-2`–`2` | Discourages repeating the same tokens         |
+
+<Callout type="info">
+  Not every Provider or model honours every parameter — unsupported values are
+  ignored by the vendor.
+</Callout>
+
+## Grant tools and Skills
+
+An Agent that can only talk is limited. Give it the ability to _act_:
+
+- **Tools** — a card listing the **tool sets** available in your Workspace,
+  grouped by category. Flip a switch to grant a tool set. Both built-in tool sets
+  (Web Fetch, Time, Kanban, Dashboards, and more) and any
+  [MCP servers](/building-with-platypus/mcp) you've registered appear here — an
+  MCP shows up under the **MCP** category. See
+  [Tools, tool sets & MCP](/concepts/tools) for the model behind this.
+- **Skills** — a card listing the [Skills](/building-with-platypus/skills) in
+  your Workspace. Flip a switch to attach one; the Agent loads its full
+  instructions on demand at run time.
+
+<Callout type="info">
+  The **Tools** and **Skills** cards only appear when your Workspace actually
+  has tool sets or Skills to grant. A brand-new Workspace with neither won't
+  show them.
+</Callout>
+
+## Compose sub-agents
+
+A **sub-agent** is just another Agent that this one can hand work to. In the
+**Sub-Agents** card, flip a switch for each Agent you want this Agent to be able
+to delegate to.
+
+At run time each selected sub-agent is exposed to the parent as a **delegate
+tool** named `delegateTo<AgentName>` — calling it runs the sub-agent (with its
+own model, prompt, and tools) and returns the result. This lets a coordinator
+Agent stay focused while specialists do the detailed work.
+
+<Callout type="warning">
+  Delegation is **one level deep**. An Agent running _as_ a sub-agent cannot
+  delegate further — its own sub-agents are not wired up in that context. Design
+  for a coordinator plus a flat set of specialists, not deep chains.
+</Callout>
+
+Click **Save** to create the Agent. You can edit every field later from the same
+form.
+
+## Where to next
+
+- **[Skills](/building-with-platypus/skills)** — author the on-demand know-how
+  you attach above.
+- **[MCP servers](/building-with-platypus/mcp)** — add outside tools to the
+  **Tools** card.
+- **[Triggers](/building-with-platypus/triggers)** — run this Agent
+  automatically.

--- a/apps/docs/content/building-with-platypus/boards.mdx
+++ b/apps/docs/content/building-with-platypus/boards.mdx
@@ -1,0 +1,84 @@
+---
+title: Boards
+description: Kanban boards in a Workspace — create a board with columns, labels, and cards, and let Agents read and update it through the Kanban tool set.
+---
+
+import { Callout, Steps } from "nextra/components";
+
+# Boards
+
+A **Board** is a Kanban board scoped to your Workspace: columns you arrange
+left-to-right, and cards you drag between them. Boards are a shared working
+surface — both you and your Agents can read and update the same board, which
+makes them a natural place for an Agent to track tasks, triage items, or hand
+work back to you.
+
+## Create a board
+
+<Steps>
+
+### Open the board form
+
+From your Workspace, go to the **Boards** section and click **Create board**.
+
+### Name it and add labels
+
+- **Name** — what to call the board (1–100 characters).
+- **Description** _(optional)_ — up to 500 characters.
+- **Labels** _(optional)_ — add colour-coded labels (each has a name and a colour
+  from a fixed palette) that you can later apply to cards. Use **Add label** for
+  each, and the delete button to remove one.
+
+Save to create the board. You can edit the name, description, and labels anytime
+from the board's **Settings** (the gear icon).
+
+</Steps>
+
+## Work the board
+
+The board view scrolls horizontally across its **columns**. From here you:
+
+- **Add columns** with the dashed **add column** button at the end of the row;
+  rename, delete, or move a column left/right from its three-dot menu.
+- **Add cards** with **Add card** at the bottom of a column.
+- **Drag** cards between and within columns, and reorder columns.
+- **Switch boards** from the name dropdown in the header.
+
+Click a card to open its detail dialog, where you can edit:
+
+- **Title** and **Description** (the description supports Markdown).
+- **Column**, **Labels**, and **Priority** (None, Low, Medium, High, Urgent).
+- **Due Date** and a single **Assignee** — which can be a Workspace member _or an
+  Agent_.
+- **Comments** — a threaded discussion on the card (also Markdown).
+
+<Callout type="info">
+  Cards record who created and last edited them — and that can be an **Agent**,
+  not just a person. When an Agent works a board, its activity shows up in the
+  card metadata and comments just like a teammate's.
+</Callout>
+
+## Agents and boards
+
+Grant an Agent the **Kanban** tool set (in the [Agent form](/building-with-platypus/agents)'s
+**Tools** card, under _Productivity_) and it can operate boards directly. The tool
+set lets an Agent:
+
+- **list boards** and **read a board's state** (columns and card summaries),
+- **read, create, and update cards** — title, description, labels, priority, due
+  date, and assignee,
+- **move cards** between and within columns, **copy** and **delete** cards, and
+  **bulk-edit** many cards at once,
+- **read, add, and edit comments** on a card.
+
+This is what makes boards a two-way surface: you arrange the work, and an Agent —
+in a Chat or on a schedule via a [Trigger](/building-with-platypus/triggers) — can
+keep it moving. Board activity (cards created, updated, or deleted) can in turn
+fire **Event** Triggers, so a change on a board can kick off another Agent run.
+
+## Where to next
+
+- **[Triggers](/building-with-platypus/triggers)** — fire an Agent when a card
+  changes, or update a board on a schedule.
+- **[Dashboards](/building-with-platypus/dashboards)** — the other Agent-driven
+  Workspace surface, for displaying structured data.

--- a/apps/docs/content/building-with-platypus/dashboards.mdx
+++ b/apps/docs/content/building-with-platypus/dashboards.mdx
@@ -1,0 +1,104 @@
+---
+title: Dashboards
+description: Build a dashboard in a Workspace — add widgets (metric, text, image, weather, and charts), arrange them in an editable grid, and let Agents keep widget data up to date.
+---
+
+import { Callout, Steps } from "nextra/components";
+
+# Dashboards
+
+A **Dashboard** displays structured data as a grid of **widgets** in your
+Workspace. The split is deliberate: _you_ own the layout and the set of widgets,
+while an **Agent** can keep each widget's **data** current. That makes a dashboard
+a live readout — KPIs, status, charts — that an Agent updates as things change.
+
+## Create a dashboard
+
+<Steps>
+
+### Open the create form
+
+From your Workspace, go to the **Dashboards** section and click **Create
+dashboard**.
+
+### Name it
+
+- **Name** — must be unique within the Workspace (1–200 characters).
+- **Description** _(optional)_ — up to 500 characters.
+
+Save to land on the empty dashboard.
+
+</Steps>
+
+## Add and arrange widgets
+
+Click **Edit** (top right) to enter edit mode. Editing happens on desktop — the
+button is hidden on small viewports.
+
+<Steps>
+
+### Add a widget
+
+Click **Add widget**, choose a **type**, give it a **title**, and **Add**. It
+drops onto the grid with placeholder data.
+
+### Lay it out
+
+Drag widgets by their header and resize them on the grid. Switch between the
+**Desktop** and **Mobile** layout tabs to arrange each breakpoint — the mobile
+layout is edited here on desktop (it's read-only on a phone).
+
+### Edit widget data
+
+Click a widget's pencil icon to edit its data inline (the fields depend on the
+type), then save the widget.
+
+### Save the dashboard
+
+Click **Save** to persist your layout and widget changes, or **Cancel** to
+discard them and exit edit mode.
+
+</Steps>
+
+<Callout type="info">
+  In view mode a dashboard refreshes itself every few seconds, so changes —
+  yours or an Agent's — appear without a manual reload. Polling pauses while
+  you're editing.
+</Callout>
+
+## Widget types
+
+| Type                | Shows                                                            |
+| ------------------- | ---------------------------------------------------------------- |
+| **Metric**          | A single value with a label, optional unit, and change indicator |
+| **Text / Markdown** | Free-form Markdown content                                       |
+| **Image**           | An image by URL                                                  |
+| **Weather**         | A location's conditions and temperature                          |
+| **Line chart**      | One or more series over shared categories                        |
+| **Pie chart**       | A donut of labelled segments with an optional centre label       |
+| **Bar chart**       | One or more series over shared categories                        |
+
+## Agents and dashboards
+
+Grant an Agent the **Dashboards** tool set (in the [Agent form](/building-with-platypus/agents)'s
+**Tools** card, under _Productivity_) and it can keep your dashboards current. The
+tool set lets an Agent **list dashboards**, **list a dashboard's widgets**, **read
+a widget's full data**, and **update a widget's data**.
+
+<Callout type="warning">
+  Agents can change widget **data only** — never the layout, and they can't add
+  or remove widgets. You decide what's on the dashboard and where it sits; the
+  Agent fills in the numbers. (Updating a widget also requires matching its
+  type, so an Agent can't accidentally turn a chart into a metric.)
+</Callout>
+
+Pair this with a [Trigger](/building-with-platypus/triggers): a scheduled Agent
+run can refresh a dashboard's metrics or charts on a cadence, so the readout stays
+live without anyone opening a Chat.
+
+## Where to next
+
+- **[Agents & sub-agents](/building-with-platypus/agents)** — grant the
+  Dashboards tool set to an Agent.
+- **[Triggers](/building-with-platypus/triggers)** — refresh a dashboard on a
+  schedule.

--- a/apps/docs/content/building-with-platypus/index.mdx
+++ b/apps/docs/content/building-with-platypus/index.mdx
@@ -1,7 +1,35 @@
 ---
 title: Building with Platypus
+description: The Workspace Owner's guide to building agents — configuring an Agent, giving it Skills and MCP tools, and putting it to work with Triggers, Boards, and Dashboards.
 ---
 
 # Building with Platypus
 
-_Content coming soon._
+This section is for the **Workspace Owner** — the person building inside a
+Workspace. It's task-oriented: each page walks through the screens you actually
+click. If you want the _what_ and _why_ behind the nouns first, read
+[Concepts](/concepts); this section is the _how_.
+
+Everything you build lives inside your **Workspace** (your scoped environment —
+see [The big picture](/concepts)). A typical build goes in this order:
+
+1. **[Agents & sub-agents](/building-with-platypus/agents)** — create an Agent:
+   pin a Provider and model, write its system prompt, tune generation, and grant
+   it tools. Compose specialists as sub-agents.
+2. **[Skills](/building-with-platypus/skills)** — author named, on-demand
+   know-how and attach it to an Agent.
+3. **[MCP servers](/building-with-platypus/mcp)** — connect outside tools by
+   registering an MCP server and granting it to an Agent.
+4. **[Triggers](/building-with-platypus/triggers)** — run an Agent automatically
+   on a schedule (cron) or in response to an event.
+5. **[Boards](/building-with-platypus/boards)** — Kanban boards that you and
+   your Agents share as a working surface.
+6. **[Dashboards](/building-with-platypus/dashboards)** — display structured data
+   in widgets that Agents can keep up to date.
+
+<br />
+
+> Throughout this section, screens live under your Workspace at
+> `/{org}/workspace/{workspace}/…`. Resources you create are **Workspace-scoped**
+> (private to one Workspace) unless an Org Admin has shared them at Organization
+> scope — see [Sharing across workspaces](/concepts/sharing).

--- a/apps/docs/content/building-with-platypus/mcp.mdx
+++ b/apps/docs/content/building-with-platypus/mcp.mdx
@@ -1,0 +1,102 @@
+---
+title: MCP servers
+description: Register an MCP server in your Workspace (or attach a Shared one), authenticate it, and grant its tool set to an Agent. How an MCP resolves to a tool set at Chat-turn time.
+---
+
+import { Callout, Steps } from "nextra/components";
+
+# MCP servers
+
+**MCP** (the Model Context Protocol) is how you connect Platypus to tools that
+don't ship with it — your own services, third-party integrations, or community
+servers. You register an MCP server once; at run time it resolves to a **tool
+set** you can grant to any Agent. For the concept, see
+[Tools, tool sets & MCP](/concepts/tools); this page is how to set one up.
+
+<Callout type="info">
+  Platypus connects to MCP servers over **HTTP**. You point it at the server's
+  URL — there's no local command/stdio option.
+</Callout>
+
+## Register an MCP server
+
+<Steps>
+
+### Open the MCP form
+
+In your Workspace, go to **Settings → MCP** and click **Create** (the form lives
+at **Settings → MCP → Create**).
+
+### Enter the connection
+
+- **Name** — a label for this server (3–30 characters).
+- **URL** — the server's HTTP endpoint, e.g. `https://example.com/mcp`.
+
+### Choose how it authenticates
+
+The **Auth** dropdown controls the credential fields:
+
+- **None** — no authentication.
+- **Bearer** — reveals a **Bearer Token** field; sent as an `Authorization`
+  header on every request.
+- **OAuth** — reveals OAuth fields: **Client ID**, **Client Secret** (leave blank
+  if the server supports dynamic client registration), and **OAuth Scopes** (a
+  space-separated list — required by some providers, e.g. Google).
+
+### Add custom headers (optional)
+
+Under **Custom Headers**, add any extra HTTP headers to send with every request
+— use **Add header** for each name/value pair.
+
+</Steps>
+
+### Authorize and test
+
+- For **OAuth** servers, an authorization panel shows the status (**Not
+  Authorized** / **Authorized**). Click **Authorize** to complete the OAuth flow;
+  use **Re-authorize** or **Revoke** later as needed.
+- Click **Test Connection** to verify the server responds — on success it lists
+  the tools the server exposes. Then **Save**.
+
+## How an MCP resolves to a tool set
+
+An Agent's granted tools are stored as a list of **tool set IDs**. When you grant
+an MCP, its ID goes into that same list. At **Chat-turn time**, Platypus walks the
+list: anything that isn't a built-in tool set is looked up as an MCP, and — using
+the auth and headers you configured — Platypus connects to the server and fetches
+its tools live. Those tools are merged into what the model can call for that turn.
+
+<Callout type="info">
+  Resolution is **fail-soft**: if an MCP server is unreachable when a turn runs,
+  it simply contributes no tools and the turn continues, rather than failing the
+  whole Chat.
+</Callout>
+
+## Grant an MCP to an Agent
+
+Open the [Agent form](/building-with-platypus/agents) and find the **Tools** card.
+Registered MCP servers appear there grouped under the **MCP** category, alongside
+built-in tool sets. Flip a switch to grant the server's tool set to that Agent.
+
+## Workspace vs Shared scope
+
+An MCP lives at exactly one scope:
+
+- **Workspace scope** — private to your Workspace, registered as above.
+- **Organization scope** — a [Shared resource](/concepts/sharing) registered by an
+  Org Admin and attached to many Workspaces. A Shared MCP appears in your
+  Workspace with an **Organization** badge and is **read-only** here — you can
+  grant it to your Agents, but only an Org Admin can edit the server itself.
+
+<Callout type="warning">
+  Because MCP servers can carry credentials, registering them is often
+  restricted to Org Admins. A Workspace Owner can manage Workspace MCPs only
+  where that's been delegated; otherwise ask an Org Admin to register or attach
+  one.
+</Callout>
+
+## Where to next
+
+- **[Agents & sub-agents](/building-with-platypus/agents)** — grant the tool set
+  to an Agent.
+- **[Tools, tool sets & MCP](/concepts/tools)** — the underlying model.

--- a/apps/docs/content/building-with-platypus/skills.mdx
+++ b/apps/docs/content/building-with-platypus/skills.mdx
@@ -1,0 +1,92 @@
+---
+title: Skills
+description: Author a Skill — a named capability with a description and instructions — attach it to an Agent, and let the model load its full instructions on demand via the loadSkill tool.
+---
+
+import { Callout, Steps } from "nextra/components";
+
+# Skills
+
+A **Skill** is packaged know-how you attach to an Agent: a name, a description,
+and a body of instructions for doing one thing well. The Agent sees only the
+name and description up front and pulls in the full body _on demand_ — keeping
+its everyday prompt short. For the concept, see [Skills](/concepts/skills); this
+page is how to author one.
+
+## Author a Skill
+
+<Steps>
+
+### Open the Skill form
+
+From your Workspace, go to the **Skills** section and click **Create skill**.
+
+### Fill in the fields
+
+- **Name** — a kebab-case identifier, e.g. `write-release-note` (lowercase
+  letters, numbers, and hyphens; 5–64 characters). This is the name the model
+  uses to request the Skill.
+- **Description** — a brief summary of what the Skill does and when to reach for
+  it (24–1024 characters). The model reads this to decide _whether_ a request is
+  relevant, so make it specific.
+- **Body** — the full instructions, up to 50,000 characters. This is what the
+  model receives only after it loads the Skill, so be as detailed as you like:
+  step-by-step procedures, examples, formatting rules, edge cases.
+
+</Steps>
+
+<Callout type="info">
+  Write the **description** for triage and the **body** for execution. The
+  description is always in context (so keep it tight); the body is fetched only
+  when needed (so it can be long).
+</Callout>
+
+## Attach a Skill to an Agent
+
+A Skill does nothing until an Agent can use it. There are two equivalent ways to
+wire them up:
+
+- **From the Skill form** — the **Agents** section lists the Agents in your
+  Workspace. Flip a switch to enable this Skill for that Agent.
+- **From the [Agent form](/building-with-platypus/agents)** — the **Skills** card
+  lists available Skills. Flip a switch to attach one to that Agent.
+
+## How `loadSkill` surfaces a Skill
+
+When an Agent has Skills attached, Platypus injects just their names and
+descriptions into the Agent's instructions, like:
+
+```xml
+<skills>
+  <skill name="write-release-note">Draft a release note from a list of merged PRs…</skill>
+</skills>
+```
+
+along with guidance to **use the `loadSkill` tool** when a request matches one.
+The model then calls `loadSkill` with the Skill's name, and the tool returns that
+Skill's full **body** — which the model reads before responding. Nothing in the
+body costs context until the moment it's actually needed.
+
+## Workspace vs Shared scope
+
+A Skill lives at exactly one scope:
+
+- **Workspace scope** — private to your Workspace. This is what you get when you
+  create one from the Skills section above.
+- **Organization scope** — a [Shared resource](/concepts/sharing) defined once by
+  an Org Admin and attached to many Workspaces. Shared Skills appear **locked** in
+  your Workspace: you can attach them to your Agents and the Agent can `loadSkill`
+  them, but only an Org Admin can edit the Skill itself.
+
+<Callout type="info">
+  `loadSkill` resolves a Skill in your Workspace first, then falls back to a
+  Shared (Organization-scoped) Skill — but only if that Shared Skill has been
+  **attached** to your Workspace.
+</Callout>
+
+## Where to next
+
+- **[Agents & sub-agents](/building-with-platypus/agents)** — the Agent that uses
+  the Skills you author here.
+- **[Sharing across workspaces](/concepts/sharing)** — how a Skill becomes a
+  Shared resource.

--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -1,0 +1,110 @@
+---
+title: Triggers
+description: Run an Agent automatically with Triggers — scheduled (cron) runs on a cadence, or event-driven runs. How to create one, the cadence model, and what a run executes.
+---
+
+import { Callout, Steps } from "nextra/components";
+
+# Triggers
+
+A **Trigger** runs an Agent automatically, without anyone sitting in a Chat. Each
+Trigger sends a fixed instruction to a chosen Agent and records the result. There
+are two types:
+
+- **Cron** — runs on a **schedule** (a cadence you define).
+- **Event** — runs in response to something happening in the Workspace, such as a
+  card being created on a [Board](/building-with-platypus/boards).
+
+You'll find Triggers in the **Triggers** section of your Workspace —
+_"Automated agent runs configured for this workspace."_
+
+## Create a Trigger
+
+<Steps>
+
+### Open the Trigger form
+
+In your Workspace, go to the **Triggers** section and click **Create**.
+
+### Pick the type and Agent
+
+- **Trigger Type** — **Cron** or **Event**. This is fixed once the Trigger is
+  created.
+- **Name** and **Description** — label the Trigger (description optional).
+- **Agent** — which Agent to run.
+- **Instruction** — the message sent to the Agent every time the Trigger fires
+  (up to 10,000 characters). For Event triggers, the event's data is appended
+  automatically.
+
+### Set the cadence (Cron)
+
+Choose a **Schedule Mode**:
+
+- **Simple** — pick a **Frequency** (every 5 / 10 / 15 / 30 minutes, hourly,
+  daily, weekly, or monthly). Depending on the frequency you'll also set the
+  **Hour**, **Minute**, **Day of Week**, or **Day of Month**.
+- **Advanced** — enter a raw **Cron Expression** (`minute hour day-of-month month
+day-of-week`), e.g. `0 9 * * *` for "every day at 9:00 AM".
+
+Set the **Timezone** (defaults to your browser's) — the schedule is evaluated in
+that zone. A **Next Run Preview** shows when it will fire next. Toggle **One-off
+Trigger** to run once and then disable itself.
+
+### Or choose events (Event)
+
+For an Event trigger, select one or more **Events** (e.g. `card.created`,
+`card.updated`, `notification.created`). Optionally narrow with **Filter by
+Board** and **Filter by Column** so the Trigger only fires for activity on a
+specific board.
+
+### Finish
+
+Set **Max Runs to Keep** (how many run records to retain), optionally enable
+**Web Search** (native model web search, if the Provider supports it), and leave
+**Enabled** on. Click save.
+
+</Steps>
+
+<Callout type="info">
+  Simple and Advanced are two views of the same thing — your Simple choices
+  compile to a standard 5-field cron expression. Switch to Advanced to see or
+  fine-tune it.
+</Callout>
+
+## What a run does
+
+When a Trigger fires, Platypus runs its Agent against the **instruction** as a
+background job — there's no live Chat window. The run is captured as a
+**trigger run** record: it starts as _running_, accrues stats (steps, tool calls,
+token counts), and ends _success_ or _failed_.
+
+A few details worth knowing:
+
+- **Scheduled (cron) runs** are checked about once a minute; a due Trigger is
+  claimed and executed, then its next run time is recomputed from the cadence
+  (one-off Triggers disable themselves instead).
+- **Event runs** fire when a matching event occurs, with a short debounce so a
+  burst of rapid events coalesces into one run.
+- Older run records beyond **Max Runs to Keep** are pruned automatically.
+
+## Review run history
+
+Open a Trigger and go to its **Runs** view to see the history: each run's status
+(Success / Failed / Running / Pending), when it ran and how long it took, the
+event type for Event triggers, per-run stats, and any error message. It's the
+place to confirm a schedule is actually firing and to debug a Trigger that's
+failing.
+
+<Callout type="info">
+  Anything an Agent does in a run uses that Agent's own tools — so a Trigger
+  can, for example, update a [Board](/building-with-platypus/boards) or a
+  [Dashboard](/building-with-platypus/dashboards) on a schedule, as long as the
+  Agent has those tool sets granted.
+</Callout>
+
+## Where to next
+
+- **[Agents & sub-agents](/building-with-platypus/agents)** — the Agent a Trigger
+  runs.
+- **[Boards](/building-with-platypus/boards)** — a common source of Trigger
+  events and a common target for scheduled runs.

--- a/apps/docs/content/concepts/skills.mdx
+++ b/apps/docs/content/concepts/skills.mdx
@@ -28,5 +28,5 @@ A Skill lives at **Workspace scope** (private to one Workspace) or can be shared
 at **Organization scope** as a [Shared resource](/concepts/sharing), so the same
 know-how is reused across many Workspaces.
 
-See [Building with Platypus → Skills](/building-with-platypus) for how to author
-one.
+See [Building with Platypus → Skills](/building-with-platypus/skills) for how to
+author one.

--- a/apps/docs/content/concepts/tools.mdx
+++ b/apps/docs/content/concepts/tools.mdx
@@ -36,8 +36,8 @@ needs it.
 
 An MCP can live at **Workspace scope** (private to one Workspace) or be shared at
 **Organization scope** as a [Shared resource](/concepts/sharing). See
-[Building with Platypus → MCP servers](/building-with-platypus) for how to set one
-up.
+[Building with Platypus → MCP servers](/building-with-platypus/mcp) for how to set
+one up.
 
 ## How it fits together
 


### PR DESCRIPTION
Fills in the **Building with Platypus** section of the docs site (`apps/docs`) — the Workspace Owner's task-oriented build guide, per ADR-0011 and the parent tracking issue #209.

Mirrors the approach of the Self-Hosting (#228) and Concepts (#229) PRs: one PR for the whole section, with the pages filed as per-page issues.

## Pages added

| Issue | Page | Covers |
| --- | --- | --- |
| #219 | Agents & sub-agents | Provider/model, system prompt, generation params (max steps + advanced sampling), granting Tools/Skills, and composing sub-agents as `delegateTo<Name>` delegate tools (one level deep) |
| #220 | Skills | Authoring (name/description/body + limits), attaching to Agents, on-demand `loadSkill`, Workspace vs Shared scope |
| #221 | MCP servers | HTTP registration, None/Bearer/OAuth auth, custom headers, MCP → tool set resolution at chat-turn time (fail-soft), granting to an Agent, scope |
| #222 | Triggers | Cron **schedules** (simple/advanced cadence, timezone, one-off) + event triggers, what a run executes, run history |
| #223 | Boards | Kanban boards (columns, cards, labels, assignees incl. Agents) and the `kanban` agent tool set |
| #224 | Dashboards | The 7 implemented widget types, edit-mode/grid UX, polling, and the `dashboards` tool set (data-only) |

Also adds `building-with-platypus/_meta.ts`, fleshes out the section overview `index.mdx`, and repoints the Concepts → Skills/MCP forward links at their new pages.

## Grounding

All pages were written against the actual implementation (frontend forms, `packages/schemas`, and backend tool sets / runners) rather than invented. Notable: the "Schedules" feature is named **Triggers** in-app, so the page is titled accordingly while leading with the cron/schedule use case.

## Verification

- `pnpm --filter @platypus/docs build` — green; 26 static pages generated, all six new pages + index rendered
- Pagefind postbuild indexed the new pages
- `pnpm --filter @platypus/docs lint` — clean
- `prettier --check` — clean

Closes #219, closes #220, closes #221, closes #222, closes #223, closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)