### PR TITLE
fix(backend): resolve source-level tsc errors in apps/backend

### DIFF
--- a/apps/backend/src/routes/mcp.ts
+++ b/apps/backend/src/routes/mcp.ts
@@ -336,6 +336,9 @@ mcp.post(
     if (!mcpRecord[0].url) {
       return c.json({ error: "MCP URL is not configured" }, 400);
     }
+    // Capture the narrowed URL before the `force` block reassigns
+    // `mcpRecord[0]`, which widens the property back to `string | null`.
+    const serverUrl = mcpRecord[0].url;
 
     // `force=true` clears stored tokens before running the OAuth flow so
     // mcpAuth always returns REDIRECT. Lets the UI offer a single-click
@@ -373,7 +376,7 @@ mcp.post(
       );
 
       const result = await mcpAuth(provider, {
-        serverUrl: mcpRecord[0].url,
+        serverUrl,
         fetchFn: oauthFetchFn,
       });
 

--- a/apps/backend/src/routes/org-mcp.ts
+++ b/apps/backend/src/routes/org-mcp.ts
@@ -269,6 +269,9 @@ orgMcp.post(
     if (!mcpRecord[0].url) {
       return c.json({ error: "MCP URL is not configured" }, 400);
     }
+    // Capture the narrowed URL before the `force` block reassigns
+    // `mcpRecord[0]`, which widens the property back to `string | null`.
+    const serverUrl = mcpRecord[0].url;
 
     // `force=true` clears stored tokens before the OAuth flow so mcpAuth always
     // returns REDIRECT (see mcp.ts for the full rationale). DCR/static client
@@ -290,7 +293,7 @@ orgMcp.post(
       );
 
       const result = await mcpAuth(provider, {
-        serverUrl: mcpRecord[0].url,
+        serverUrl,
         fetchFn: oauthFetchFn,
       });
 

--- a/apps/backend/src/runs/types.ts
+++ b/apps/backend/src/runs/types.ts
@@ -1,5 +1,5 @@
 import type { PlatypusUIMessage } from "../types.ts";
-import type { ChatSubmitData, ChatTurn } from "../services/chat-execution.ts";
+import type { ChatTurnRequest, ChatTurn } from "../services/chat-execution.ts";
 
 export type RunId = string;
 
@@ -19,7 +19,7 @@ export type RunStats = {
  */
 export type RunInput = {
   runId: RunId;
-  request: ChatSubmitData;
+  request: ChatTurnRequest;
   messages: PlatypusUIMessage[];
 };
 

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -23,11 +23,7 @@ import {
   retrieveRecentSummaries,
   type MemorySummary,
 } from "./memory-retrieval.ts";
-import type {
-  ChatSubmitData as ChatSubmitDataSchema,
-  Provider,
-  Skill,
-} from "@platypus/schemas";
+import type { Provider, Skill } from "@platypus/schemas";
 import type { Tool } from "ai";
 import { logger } from "../logger.ts";
 import { buildMcpTransportConfig } from "./mcp-oauth-provider.ts";
@@ -85,7 +81,7 @@ type GenerationConfig = {
   skills?: Array<Pick<Skill, "name" | "description">>;
 };
 
-type ChatSubmitData = {
+export type ChatSubmitData = {
   agentId?: string;
   providerId?: string;
   modelId?: string;
@@ -132,7 +128,7 @@ export type PrepareChatTurnInput = {
   orgId: string;
   workspaceId: string;
   user: { id: string; name: string };
-  request: ChatSubmitDataSchema;
+  request: ChatSubmitData;
   messages: PlatypusUIMessage[];
   /**
    * Used to rewrite `storage://` URLs in messages to absolute HTTP URLs so
@@ -515,11 +511,7 @@ export const prepareChatTurn = async (
     runMode,
   };
 
-  const generation = resolveGenerationConfig(
-    request,
-    agent,
-    promptCtx,
-  );
+  const generation = resolveGenerationConfig(request, agent, promptCtx);
 
   if (skills.length > 0) {
     tools.loadSkill = createLoadSkillTool(orgId, workspaceId);

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -81,7 +81,13 @@ type GenerationConfig = {
   skills?: Array<Pick<Skill, "name" | "description">>;
 };
 
-export type ChatSubmitData = {
+/**
+ * The slim request shape `prepareChatTurn` actually consumes: agent/provider
+ * selection plus generation overrides. Distinct from `@platypus/schemas`'
+ * `ChatSubmitData` (the HTTP payload, which also carries id/workspaceId/
+ * messages) — those arrive as separate `PrepareChatTurnInput` fields.
+ */
+export type ChatTurnRequest = {
   agentId?: string;
   providerId?: string;
   modelId?: string;
@@ -128,7 +134,7 @@ export type PrepareChatTurnInput = {
   orgId: string;
   workspaceId: string;
   user: { id: string; name: string };
-  request: ChatSubmitData;
+  request: ChatTurnRequest;
   messages: PlatypusUIMessage[];
   /**
    * Used to rewrite `storage://` URLs in messages to absolute HTTP URLs so
@@ -720,7 +726,7 @@ const wrapToolsWithBump = (
 
 const resolveChatContext = async (
   queries: ChatTurnQueries,
-  data: ChatSubmitData,
+  data: ChatTurnRequest,
   orgId: string,
   workspaceId: string,
 ): Promise<ChatContext> => {
@@ -841,7 +847,7 @@ const loadTools = async (
 };
 
 const resolveGenerationConfig = (
-  data: ChatSubmitData,
+  data: ChatTurnRequest,
   agent: AgentRow | undefined,
   promptCtx: SystemPromptContext,
 ): GenerationConfig => {


### PR DESCRIPTION
## Summary

`apps/backend` ships a strict `tsconfig`, but CI gates on ESLint only — so source-level `tsc --noEmit` errors can land on `main` unnoticed. This PR fixes the four source-level type errors currently present and removes a type-name collision that made one of them dangerous.

After this change: `tsc -p apps/backend/tsconfig.json --noEmit` reports **0 source errors** (down from 4). Remaining diagnostics are all pre-existing `.test.ts` warnings, untouched here. ESLint: 0 errors. Backend tests: **952 pass**.

## Changes

### 1. `chat-execution.ts` / `runs/types.ts` — fix masked type degradation (TS2459)

`runs/types.ts` imported `ChatSubmitData` from `chat-execution.ts`, but that type was declared **locally and never exported** → `TS2459`. The unresolved import silently degraded to `any`, which in turn masked a second mismatch:

- `PrepareChatTurnInput.request` was typed as the full `@platypus/schemas` `ChatSubmitData` (requires `id` / `workspaceId` / `messages`)…
- …while every caller and every internal reader (`resolveChatContext`, `resolveGenerationConfig`) used the **slim local shape** (agent/provider selection + generation overrides only).

Fix: export the local type and use it for the public input; drop the now-unused schema alias. This matches runtime — `prepareChatTurn` reads only generation/selection fields from `request`; `orgId`, `workspaceId`, and `messages` arrive as separate `PrepareChatTurnInput` fields.

### 2. `mcp.ts` / `org-mcp.ts` — preserve URL narrowing (TS error: `string | null` → `string`)

Both routes passed `mcpRecord[0].url` (`string | null`) to `mcpAuth`'s `serverUrl: string | URL`. A guard already returns `400` on a null URL — but the later `force` block reassigns `mcpRecord[0]` via object spread, which **widens the property back to `string | null`** and drops the narrowing.

Fix: capture the narrowed URL into a `const serverUrl` right after the guard, before the `force` block runs.

### 3. `chat-execution.ts` / `runs/types.ts` — rename slim type to `ChatTurnRequest` (collision removal)

After change #1, the backend exported a type named `ChatSubmitData` that **shadowed** `@platypus/schemas`' `ChatSubmitData` — same name, different shape (the local one omits `id` / `workspaceId` / `messages`). Importing the wrong one would compile but silently accept/reject the wrong fields.

Fix: rename the backend type to `ChatTurnRequest` and document the distinction inline. No behavior change.

## Testing

- `tsc -p apps/backend/tsconfig.json --noEmit` — 0 source errors (4 → 0)
- `pnpm --filter @platypus/backend test` — 952 passed
- ESLint — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
