### PR TITLE
feat(docs): add Open Graph and Twitter Card metadata

### DIFF
--- a/apps/docs/app/[[...mdxPath]]/page.tsx
+++ b/apps/docs/app/[[...mdxPath]]/page.tsx
@@ -13,6 +13,14 @@ type PageProps = Readonly<{
 export async function generateMetadata(props: PageProps) {
   const params = await props.params;
   const { metadata } = await importPage(params.mdxPath);
+  // Nextra only sets the plain `title` from frontmatter. Mirror it into
+  // openGraph/twitter so link previews show the page title (the parent
+  // layout's `%s | Platypus Docs` template then applies to og:title too).
+  const pageTitle = metadata.title;
+  if (typeof pageTitle === "string") {
+    metadata.openGraph = { ...metadata.openGraph, title: pageTitle };
+    metadata.twitter = { ...metadata.twitter, title: pageTitle };
+  }
   return metadata;
 }
 

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -5,14 +5,37 @@ import { getPageMap } from "nextra/page-map";
 import type { FC, ReactNode } from "react";
 import "./globals.css";
 
+const title = "Platypus Docs";
+const description =
+  "Documentation for Platypus — build and manage AI agents with tool support and multi-provider capabilities.";
+
 export const metadata: Metadata = {
+  metadataBase: new URL("https://docs.platypus.chat"),
   title: {
-    default: "Platypus Docs",
-    template: "%s | Platypus Docs",
+    default: title,
+    template: `%s | ${title}`,
   },
-  description:
-    "Documentation for Platypus — build and manage AI agents with tool support and multi-provider capabilities.",
-  applicationName: "Platypus Docs",
+  description,
+  applicationName: title,
+  openGraph: {
+    type: "website",
+    siteName: title,
+    title: {
+      default: title,
+      template: `%s | ${title}`,
+    },
+    description,
+    url: "/",
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: {
+      default: title,
+      template: `%s | ${title}`,
+    },
+    description,
+  },
 };
 
 const version = process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown";

--- a/apps/docs/app/opengraph-image.tsx
+++ b/apps/docs/app/opengraph-image.tsx
@@ -1,0 +1,62 @@
+import { ImageResponse } from "next/og";
+
+// Static metadata for the generated card.
+export const alt =
+  "Platypus Docs — build and manage AI agents with tool support and multi-provider capabilities.";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// Brand green, matching apps/frontend `--primary` (ADR-0011): hsl(166 100% 26%).
+const brand = "hsl(166, 100%, 26%)";
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: "80px",
+        background: "#0a0a0a",
+        color: "#fafafa",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "20px" }}>
+        <div
+          style={{
+            width: "56px",
+            height: "56px",
+            borderRadius: "14px",
+            background: brand,
+          }}
+        />
+        <div style={{ fontSize: "32px", fontWeight: 700, color: brand }}>
+          Platypus
+        </div>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: "24px" }}>
+        <div style={{ fontSize: "84px", fontWeight: 800, lineHeight: 1.05 }}>
+          Platypus Docs
+        </div>
+        <div
+          style={{
+            fontSize: "36px",
+            color: "#a1a1aa",
+            maxWidth: "900px",
+            lineHeight: 1.3,
+          }}
+        >
+          Build and manage AI agents with tool support and multi-provider
+          capabilities.
+        </div>
+      </div>
+      <div style={{ fontSize: "28px", color: brand, fontWeight: 600 }}>
+        docs.platypus.chat
+      </div>
+    </div>,
+    { ...size },
+  );
+}


### PR DESCRIPTION
## Summary

The docs app (`apps/docs`) was missing Open Graph and Twitter Card metadata entirely — only `title`/`description` were set, so link previews on social platforms had no rich preview.

- **`app/layout.tsx`** — add `metadataBase` (`https://docs.platypus.chat`), an `openGraph` block (`type`, `siteName`, templated `title`, `description`, `url`, `locale`), and a `twitter` block (`summary_large_image`).
- **`app/opengraph-image.tsx`** (new) — generated 1200×630 OG image via Next's `ImageResponse`, brand-aligned to the frontend green (ADR-0011). Next auto-wires it into `og:image`/`twitter:image`, so there's no static asset to maintain.
- **`app/[[...mdxPath]]/page.tsx`** — Nextra only sets the plain `title` from MDX frontmatter, leaving `og:title` stuck on the site default. `generateMetadata` now mirrors the page title into `openGraph.title`/`twitter.title` so the parent `%s | Platypus Docs` template applies (e.g. `Agents & sub-agents | Platypus Docs`).

## Verification

`next build` succeeds; `/opengraph-image` prerenders as a static route. Confirmed in emitted HTML:
- Home: full `og:*` + `twitter:*`, `og:image` → `https://docs.platypus.chat/opengraph-image?...` (1200×630, `image/png`, alt text).
- Sub-page (`/building-with-platypus/agents`): `og:title`/`twitter:title` correctly read `Agents & sub-agents | Platypus Docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)