### PR TITLE
fix(backend): type the shared test DB/auth mock harness

### DIFF
--- a/apps/backend/src/services/memory-extraction.test.ts
+++ b/apps/backend/src/services/memory-extraction.test.ts
@@ -61,14 +61,11 @@ const makeProvider = (overrides: Record<string, unknown> = {}) => ({
  * 4+. status update / summary update where calls (terminal, result discarded)
  */
 function setupWhere(workspaces: unknown[], providers: unknown[]) {
-  let call = 0;
-  mockDb.where.mockImplementation(() => {
-    call++;
-    if (call === 1) return Promise.resolve(workspaces);
-    if (call === 2) return mockDb; // chats query intermediate
-    if (call === 3) return Promise.resolve(providers);
-    return mockDb; // subsequent terminal awaits — discarded
-  });
+  mockDb.where
+    .mockResolvedValueOnce(workspaces) // 1. workspaces query (terminal)
+    .mockReturnValueOnce(mockDb) // 2. chats query (intermediate)
+    .mockResolvedValueOnce(providers) // 3. providers query (terminal)
+    .mockReturnValue(mockDb); // 4+. subsequent terminal awaits — discarded
 }
 
 describe("processMemoryExtractionBatch", () => {

--- a/apps/backend/src/test-utils.ts
+++ b/apps/backend/src/test-utils.ts
@@ -1,15 +1,65 @@
-import { vi } from "vitest";
+import { vi, type Mock } from "vitest";
 
 // Set environment variables for tests
 process.env.ALLOWED_ORIGINS = "http://localhost:3000";
 process.env.DATABASE_URL = "postgres://localhost:5432/test";
 process.env.STORAGE_BACKEND = "disk";
 
-const { mockDb, mockAuth } = vi.hoisted(() => {
-  // Create a mock db object that allows chaining
-  const mock: any = {};
+/**
+ * The chainable Drizzle query-builder methods exposed by the mock. Every method
+ * is a vitest `Mock` that returns the same mock instance, so a full chain like
+ * `db.select().from(...).where(...).limit(1)` resolves back to the same object.
+ */
+type BuilderMethodName =
+  | "select"
+  | "from"
+  | "where"
+  | "limit"
+  | "offset"
+  | "orderBy"
+  | "innerJoin"
+  | "leftJoin"
+  | "rightJoin"
+  | "insert"
+  | "values"
+  | "update"
+  | "set"
+  | "delete"
+  | "returning"
+  | "execute"
+  | "inArray"
+  | "groupBy"
+  | "onConflictDoNothing"
+  | "onConflictDoUpdate";
 
-  const methods = [
+/** A single chainable builder method: callable with anything, returns the mock. */
+type ChainableMethod = Mock<(...args: unknown[]) => MockDb>;
+
+/**
+ * A chainable, awaitable Drizzle query-builder mock.
+ *
+ * Every builder method returns the same typed mock so chains type-check without
+ * `any`. The mock is `PromiseLike` so `await db.select()...` resolves: the
+ * awaited result is `unknown`, which lets tests stub a terminal link with
+ * `.mockResolvedValueOnce([...])` returning arbitrary rows.
+ */
+export type MockDb = PromiseLike<unknown> & {
+  [K in BuilderMethodName]: ChainableMethod;
+} & {
+  transaction: Mock<(cb: (tx: MockDb) => unknown) => unknown>;
+};
+
+/**
+ * (Re)installs fresh chainable builder mocks on `target`. Each method returns
+ * `target` itself so the chain stays anchored to the same instance — tests stub
+ * terminal links (e.g. `mockDb.limit`) and the chain resolves through them.
+ *
+ * Declared as a hoisted function (with a function-local method list) so the
+ * `vi.hoisted` block below can call it before the module body — and its
+ * dependencies — have initialised.
+ */
+function installBuilderMethods(target: MockDb): void {
+  const methods: readonly BuilderMethodName[] = [
     "select",
     "from",
     "where",
@@ -31,13 +81,25 @@ const { mockDb, mockAuth } = vi.hoisted(() => {
     "onConflictDoNothing",
     "onConflictDoUpdate",
   ];
+  for (const method of methods) {
+    target[method] = vi.fn((..._args: unknown[]) => target);
+  }
+  target.transaction = vi.fn((cb: (tx: MockDb) => unknown) => cb(target));
+}
 
-  methods.forEach((method) => {
-    mock[method] = vi.fn().mockImplementation(() => mock);
-  });
+/**
+ * Creates a fresh, fully typed chainable query-builder mock. Use this when a
+ * test needs an isolated `db` mock; the shared `mockDb` export covers the common
+ * case where the module-level `db` is mocked.
+ */
+export function createMockDb(): MockDb {
+  const mock = {} as MockDb;
+  installBuilderMethods(mock);
+  return mock;
+}
 
-  // Transaction special handling
-  mock.transaction = vi.fn((cb) => cb(mock));
+const { mockDb, mockAuth } = vi.hoisted(() => {
+  const mock = createMockDb();
 
   // Auth mock
   const authMock = {
@@ -46,8 +108,8 @@ const { mockDb, mockAuth } = vi.hoisted(() => {
     },
     $Infer: {
       Session: {
-        user: {} as any,
-        session: {} as any,
+        user: {} as unknown,
+        session: {} as unknown,
       },
     },
   };
@@ -57,36 +119,9 @@ const { mockDb, mockAuth } = vi.hoisted(() => {
 
 export { mockDb, mockAuth };
 
+/** Resets the shared `mockDb` to fresh chainable mocks, clearing stubbed state. */
 export const resetMockDb = () => {
-  const methods = [
-    "select",
-    "from",
-    "where",
-    "limit",
-    "offset",
-    "orderBy",
-    "innerJoin",
-    "leftJoin",
-    "rightJoin",
-    "insert",
-    "values",
-    "update",
-    "set",
-    "delete",
-    "returning",
-    "execute",
-    "inArray",
-    "groupBy",
-    "onConflictDoNothing",
-    "onConflictDoUpdate",
-  ];
-
-  methods.forEach((method) => {
-    // Re-assign a fresh mock function to ensure no state leaks
-    mockDb[method] = vi.fn().mockImplementation(() => mockDb);
-  });
-
-  mockDb.transaction = vi.fn((cb: any) => cb(mockDb));
+  installBuilderMethods(mockDb);
 };
 
 // Mock the database module
@@ -98,7 +133,7 @@ vi.mock("./index.ts", () => ({
 vi.mock("drizzle-orm", async () => {
   const actual = await vi.importActual("drizzle-orm");
   const sqlMock = Object.assign(
-    vi.fn((strings: TemplateStringsArray, ..._values: any[]) => ({
+    vi.fn((strings: TemplateStringsArray, ..._values: unknown[]) => ({
       getSQL: () => ({ query: strings.join("?") }),
       mapWith: vi.fn(),
     })),
@@ -109,7 +144,7 @@ vi.mock("drizzle-orm", async () => {
   return {
     ...actual,
     eq: vi.fn(),
-    and: vi.fn((...args) => args.filter(Boolean)), // Return non-null args
+    and: vi.fn((...args: unknown[]) => args.filter(Boolean)), // Return non-null args
     or: vi.fn(),
     inArray: vi.fn(),
     asc: vi.fn(),
@@ -129,7 +164,7 @@ vi.mock("./auth.ts", () => ({
  * Helper to mock a successful session
  */
 export const mockSession = (
-  user: any = { id: "user-1", email: "test@example.com", role: "user" },
+  user: unknown = { id: "user-1", email: "test@example.com", role: "user" },
 ) => {
   mockAuth.api.getSession.mockResolvedValue({
     user,


### PR DESCRIPTION
Closes #237

## What changed

The backend's shared test harness (`src/test-utils.ts`) exposed a chainable Drizzle query-builder mock (`mockDb`) typed as `any`, so every `mockDb.select().from()...` chain emitted `no-unsafe-call` / `no-unsafe-member-access` warnings per link — the root cause of ~2/3 of the backend's lint warnings (imported by 51 test files).

- **Typed `mockDb`** as a chainable, awaitable query-builder mock: a `MockDb` type that is `PromiseLike<unknown>` intersected with the builder methods (each a `Mock<(...args: unknown[]) => MockDb>`) plus a typed `transaction`. `PromiseLike` lets `await db.select()...` resolve *and* lets tests stub terminal links with `.mockResolvedValueOnce([...])`.
- **Extracted a reusable, exported `createMockDb()` factory** (built via a hoisted helper so `vi.hoisted` can call it before module init). `resetMockDb` / `mockAuth` / `mockSession` / `mockNoSession` are preserved.
- **Fixed the latent promise misuse** surfaced by typing: `memory-extraction.test.ts`'s `setupWhere` returned a `Promise` from a chainable `mockImplementation` (only "worked" because the mock was `any`); rewritten with `mockResolvedValueOnce` / `mockReturnValueOnce` / `mockReturnValue`.

## Results

- Backend eslint warnings: **4198 → 1256, 0 errors** (target was ~1,379 or fewer)
- `src/test-utils.ts`: 0 lint warnings
- `pnpm --filter @platypus/backend test`: **952/952 pass**
- No new `any` types or `eslint-disable` suppressions

## Note for reviewers

Removing the `any` types the mock's args/results honestly as `unknown`. This surfaces ~88 **pre-existing-but-masked** `tsc` errors in ~6 *other* test files (e.g. `chat-sink`, `scoped-resource`, `blueprint-apply`) that introspect `mockDb.<method>.mock.calls[...]` or pass `mockDb` into real-Drizzle-DB-typed params. These are **not** eslint findings and **not gated** (the repo already ships 270 `tsc` errors; runtime is strip-only, no typecheck in CI/turbo), so they don't affect this issue's metrics. They're the natural adoption cost for those files (a cast or narrowing) and are kept out of scope here per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)