### PR TITLE
fix(backend): eliminate any/unsafe lint warnings in source code

### DIFF
--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -23,7 +23,7 @@ const unboundVector = customType<{
   },
   fromDriver(value: unknown): number[] {
     if (typeof value === "string") {
-      return JSON.parse(value);
+      return JSON.parse(value) as number[];
     }
     return value as number[];
   },

--- a/apps/backend/src/middleware/authorization.ts
+++ b/apps/backend/src/middleware/authorization.ts
@@ -4,8 +4,16 @@ import {
   organizationMember,
   workspace as workspaceTable,
 } from "../db/schema.ts";
-import type { SuperAdminOrgMembership, OrgRole } from "../server.ts";
+import type {
+  SuperAdminOrgMembership,
+  OrgRole,
+  OrganizationMembership,
+  Variables,
+} from "../server.ts";
 import { orgScope, userScope, workspaceScope } from "../scope.ts";
+
+/** Hono environment for these middleware: carries the request-scoped Variables. */
+type Env = { Variables: Variables };
 
 /**
  * Checks if a user is a super admin based on their role field.
@@ -21,8 +29,8 @@ import { orgScope, userScope, workspaceScope } from "../scope.ts";
  * }
  * ```
  */
-const isSuperAdmin = (user: { role: string }): boolean => {
-  return user.role === "admin";
+const isSuperAdmin = (user: { role?: string | null } | undefined): boolean => {
+  return user?.role === "admin";
 };
 
 /**
@@ -45,9 +53,13 @@ const isSuperAdmin = (user: { role: string }): boolean => {
  * ```
  */
 const isSuperAdminMembership = (
-  membership: any,
+  membership: OrganizationMembership | SuperAdminOrgMembership | undefined,
 ): membership is SuperAdminOrgMembership => {
-  return membership?.isSuperAdmin === true;
+  return (
+    membership != null &&
+    "isSuperAdmin" in membership &&
+    membership.isSuperAdmin === true
+  );
 };
 
 /**
@@ -79,8 +91,9 @@ const isSuperAdminMembership = (
  * ```
  */
 export const requireOrgAccess = (requiredRoles?: OrgRole[]) =>
-  createMiddleware(async (c, next) => {
-    const user = c.get("user");
+  createMiddleware<Env>(async (c, next) => {
+    // requireAuth runs first, so user is always set here.
+    const user = c.get("user")!;
     const db = c.get("db");
 
     const parentScope = c.get("userScope") ?? userScope(user);
@@ -154,10 +167,11 @@ export const requireOrgAccess = (requiredRoles?: OrgRole[]) =>
  * app.get("/chats", requireAuth, requireOrgAccess(), requireWorkspaceAccess, handler);
  * ```
  */
-export const requireWorkspaceAccess = createMiddleware(async (c, next) => {
-  const user = c.get("user");
+export const requireWorkspaceAccess = createMiddleware<Env>(async (c, next) => {
+  // requireAuth and requireOrgAccess run first, so user and orgMembership are set.
+  const user = c.get("user")!;
   const db = c.get("db");
-  const orgMembership = c.get("orgMembership");
+  const orgMembership = c.get("orgMembership")!;
 
   const workspaceId = c.req.param("workspaceId");
   const orgId = c.req.param("orgId");
@@ -252,7 +266,7 @@ export const requireWorkspaceAccess = createMiddleware(async (c, next) => {
 export const requireWorkspaceConfigAccess = (
   delegationFlag?: "providerSelfManagement" | "mcpSelfManagement",
 ) =>
-  createMiddleware(async (c, next) => {
+  createMiddleware<Env>(async (c, next) => {
     const user = c.get("user");
     const orgMembership = c.get("orgMembership");
 
@@ -321,7 +335,7 @@ export const requireWorkspaceConfigAccess = (
  * app.put("/system/settings", requireAuth, requireSuperAdmin, handler);
  * ```
  */
-export const requireSuperAdmin = createMiddleware(async (c, next) => {
+export const requireSuperAdmin = createMiddleware<Env>(async (c, next) => {
   const user = c.get("user");
 
   if (!isSuperAdmin(user)) {
@@ -360,7 +374,7 @@ export const requireSuperAdmin = createMiddleware(async (c, next) => {
  * app.post("/chats/:id/messages", requireAuth, requireOrgAccess(), requireWorkspaceAccess, requireWorkspaceOwner, handler);
  * ```
  */
-export const requireWorkspaceOwner = createMiddleware(async (c, next) => {
+export const requireWorkspaceOwner = createMiddleware<Env>(async (c, next) => {
   const isWorkspaceOwner = c.get("isWorkspaceOwner");
 
   if (!isWorkspaceOwner) {

--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -406,8 +406,8 @@ agent.post(
         { ...agentWithAvatarUrl(promoted, baseUrl), scope: "organization" },
         200,
       );
-    } catch (error: any) {
-      if (error?.message === PROMOTE_RACE) {
+    } catch (error) {
+      if (error instanceof Error && error.message === PROMOTE_RACE) {
         throw new NotFoundError("Agent not found");
       }
       // A duplicate Shared-Agent name surfaces as a Postgres unique violation,

--- a/apps/backend/src/routes/attachment.ts
+++ b/apps/backend/src/routes/attachment.ts
@@ -81,7 +81,7 @@ attachment.post(
         .values({ id: nanoid(), workspaceId, resourceType, resourceId })
         .returning();
       return c.json(record[0], 201);
-    } catch (error: any) {
+    } catch (error) {
       if (isUniqueViolation(error)) {
         return c.json(
           { error: "This resource is already attached to this workspace" },

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -146,7 +146,7 @@ chat.post(
     const input: RunInput = {
       runId: data.id,
       request: data,
-      messages: data.messages ?? [],
+      messages: (data.messages as PlatypusUIMessage[] | undefined) ?? [],
     };
 
     const sink = new ChatSink({
@@ -384,7 +384,7 @@ chat.post(
     promptParts.push(`Conversation:\n${conversationText}`);
 
     const { output } = await generateText({
-      model: model as any,
+      model,
       output: Output.object({
         schema: z.object({
           title: z.string(),

--- a/apps/backend/src/routes/context.ts
+++ b/apps/backend/src/routes/context.ts
@@ -97,9 +97,9 @@ context.post(
         .returning();
 
       return c.json(record[0], 201);
-    } catch (error: any) {
+    } catch (error) {
       // Handle unique constraint violation
-      if (error.code === "23505") {
+      if ((error as { code?: string }).code === "23505") {
         return c.json(
           { error: "You already have a context for this scope" },
           409,

--- a/apps/backend/src/routes/files.ts
+++ b/apps/backend/src/routes/files.ts
@@ -59,7 +59,7 @@ files.get("/*", requireAuth, async (c) => {
 
   // Authorization check
   // Super admins bypass all checks
-  if (user.role && isSuperAdmin(user as { role: string })) {
+  if (user.role && isSuperAdmin(user)) {
     // Continue to serve file
   } else {
     // Check org membership

--- a/apps/backend/src/routes/invitation.ts
+++ b/apps/backend/src/routes/invitation.ts
@@ -95,13 +95,20 @@ invitation.post(
       });
 
       return c.json({ ...record, blueprintIds }, 201);
-    } catch (error: any) {
+    } catch (error) {
+      const e = error as {
+        code?: string;
+        constraint?: string;
+        message?: string;
+        detail?: string;
+        cause?: { code?: string };
+      };
       const isDuplicate =
-        error.code === "23505" ||
-        error.cause?.code === "23505" ||
-        error.constraint === "unique_invitation_org_email" ||
-        error.message?.includes("unique_invitation_org_email") ||
-        error.detail?.includes("already exists");
+        e.code === "23505" ||
+        e.cause?.code === "23505" ||
+        e.constraint === "unique_invitation_org_email" ||
+        !!e.message?.includes("unique_invitation_org_email") ||
+        !!e.detail?.includes("already exists");
 
       if (isDuplicate) {
         return c.json(

--- a/apps/backend/src/routes/kanban.ts
+++ b/apps/backend/src/routes/kanban.ts
@@ -1133,8 +1133,7 @@ kanban.put(
 
     // Check ownership: super admins, org admins can moderate; others must own the comment
     const canModerate =
-      isSuperAdmin(currentUser as { role: string }) ||
-      orgMembership?.role === "admin";
+      isSuperAdmin(currentUser) || orgMembership?.role === "admin";
     if (!canModerate && existingComment.createdByUserId !== currentUser.id) {
       return c.json({ error: "You can only edit your own comments" }, 403);
     }
@@ -1185,8 +1184,7 @@ kanban.delete(
 
     // Check ownership: super admins, org admins can moderate; others must own the comment
     const canModerate =
-      isSuperAdmin(currentUser as { role: string }) ||
-      orgMembership?.role === "admin";
+      isSuperAdmin(currentUser) || orgMembership?.role === "admin";
     if (!canModerate && existingComment.createdByUserId !== currentUser.id) {
       return c.json({ error: "You can only delete your own comments" }, 403);
     }

--- a/apps/backend/src/routes/org-attachment.ts
+++ b/apps/backend/src/routes/org-attachment.ts
@@ -138,7 +138,7 @@ orgAttachment.post("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
       .values({ id: nanoid(), workspaceId, resourceType, resourceId })
       .returning();
     return c.json(record[0], 201);
-  } catch (error: any) {
+  } catch (error) {
     if (isUniqueViolation(error)) {
       return c.json(
         { error: "This resource is already attached to that workspace" },

--- a/apps/backend/src/routes/org-blueprint.ts
+++ b/apps/backend/src/routes/org-blueprint.ts
@@ -23,6 +23,7 @@ import { requireOrgAccess } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { applyBlueprintsToWorkspace } from "../services/blueprint-apply.ts";
 import { isBlueprintReferencedByLiveInvitation } from "../services/blueprint-guard.ts";
+import { isUniqueViolation } from "../errors.ts";
 
 // Blueprint — a named, Organization-scoped macro that, applied to a Workspace,
 // creates the Attachments for a chosen set of Shared resources in one step
@@ -40,13 +41,6 @@ const RESOURCE_TABLES = {
 } as const;
 
 type ResourceType = keyof typeof RESOURCE_TABLES;
-
-/** Detects a Postgres unique-constraint violation across driver shapes. */
-const isUniqueViolation = (error: any): boolean =>
-  error.code === "23505" ||
-  error.cause?.code === "23505" ||
-  error.message?.includes("unique constraint") ||
-  error.cause?.message?.includes("unique constraint");
 
 const NAME_CONFLICT = {
   error: "A blueprint with this name already exists in this organization",
@@ -311,7 +305,7 @@ orgBlueprint.post(
           );
         }
       });
-    } catch (error: any) {
+    } catch (error) {
       if (isUniqueViolation(error)) {
         return c.json(NAME_CONFLICT, 409);
       }
@@ -478,7 +472,7 @@ orgBlueprint.put(
           );
         }
       });
-    } catch (error: any) {
+    } catch (error) {
       if (isUniqueViolation(error)) {
         return c.json(NAME_CONFLICT, 409);
       }

--- a/apps/backend/src/routes/organization.ts
+++ b/apps/backend/src/routes/organization.ts
@@ -45,7 +45,7 @@ organization.get("/", requireAuth, async (c) => {
   const user = c.get("user")!;
 
   // Super admins see all organizations
-  if (isSuperAdmin(user as { role: string })) {
+  if (isSuperAdmin(user)) {
     const results = await db.select().from(organizationTable);
     return c.json({ results });
   }
@@ -118,13 +118,8 @@ organization.delete(
 );
 
 /** Get user's membership for an organization */
-organization.get(
-  "/:orgId/membership",
-  requireAuth,
-  requireOrgAccess(),
-  async (c) => {
-    return c.json(c.get("orgMembership"));
-  },
-);
+organization.get("/:orgId/membership", requireAuth, requireOrgAccess(), (c) => {
+  return c.json(c.get("orgMembership"));
+});
 
 export { organization };

--- a/apps/backend/src/routes/sandbox.ts
+++ b/apps/backend/src/routes/sandbox.ts
@@ -76,7 +76,7 @@ sandbox.get(
   requireAuth,
   requireOrgAccess(),
   requireWorkspaceAccess,
-  async (c) => {
+  (c) => {
     const results = getSandboxBackends().map((r) => ({
       backend: r.backend,
       name: r.name,
@@ -94,7 +94,7 @@ sandbox.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   requireSandboxAdmin,
-  async (c) => {
+  (c) => {
     return c.json({ results: readAllowedDockerNetworks() });
   },
 );

--- a/apps/backend/src/routes/skill.ts
+++ b/apps/backend/src/routes/skill.ts
@@ -341,8 +341,8 @@ skill.post(
       });
 
       return c.json({ ...promoted, scope: "organization" }, 200);
-    } catch (error: any) {
-      if (error?.message === PROMOTE_RACE) {
+    } catch (error) {
+      if (error instanceof Error && error.message === PROMOTE_RACE) {
         throw new NotFoundError("Skill not found");
       }
       // A duplicate Shared-Skill name surfaces as a Postgres unique violation,

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -8,7 +8,6 @@ import {
   readUIMessageStream,
   stepCountIs,
   streamText,
-  type LanguageModel,
 } from "ai";
 import {
   prepareChatTurn,
@@ -323,7 +322,7 @@ export class AgentRunner {
     // an `undefined` value identically, and the streaming path has always
     // passed them this way in production.
     const modelArgs = {
-      model: state.turn.stream.model as LanguageModel,
+      model: state.turn.stream.model,
       messages: await convertToModelMessages(state.turn.stream.messages),
       system: state.turn.stream.system,
       tools: state.turn.stream.tools,
@@ -382,7 +381,7 @@ export class AgentRunner {
         let status: RunStatus = "succeeded";
         let err: Error | undefined;
         if (handle.signal.aborted) {
-          const reason = handle.signal.reason;
+          const reason: unknown = handle.signal.reason;
           if (reason instanceof TimeoutError) {
             status = "failed";
             err = reason;

--- a/apps/backend/src/runs/sinks/chat-sink.ts
+++ b/apps/backend/src/runs/sinks/chat-sink.ts
@@ -94,10 +94,8 @@ export class ChatSink implements RunSink {
     }
   }
 
-  async onResolved(ctx: {
-    runId: RunId;
-    plan: ResolvedRunPlan;
-  }): Promise<void> {
+  // Synchronous work; returns a resolved promise to satisfy the async RunSink contract.
+  onResolved(ctx: { runId: RunId; plan: ResolvedRunPlan }): Promise<void> {
     this.plan = ctx.plan;
 
     // Lazily create the FlushScheduler now that we have a plan to write.
@@ -108,15 +106,18 @@ export class ChatSink implements RunSink {
         messages: this.latestMessages,
       });
     });
+    return Promise.resolve();
   }
 
-  async onProgress(ctx: {
+  // Synchronous work; returns a resolved promise to satisfy the async RunSink contract.
+  onProgress(ctx: {
     runId: RunId;
     messages: PlatypusUIMessage[];
     stats: RunStats;
   }): Promise<void> {
     this.latestMessages = ctx.messages;
     this.flusher?.bump();
+    return Promise.resolve();
   }
 
   async onFinish(ctx: {

--- a/apps/backend/src/runs/sinks/trigger-sink.ts
+++ b/apps/backend/src/runs/sinks/trigger-sink.ts
@@ -91,13 +91,15 @@ export class TriggerSink implements RunSink {
     // triggerRun schema persists today.
   }
 
-  async onProgress(ctx: {
+  // Synchronous work; returns a resolved promise to satisfy the async RunSink contract.
+  onProgress(ctx: {
     runId: RunId;
     messages: PlatypusUIMessage[];
     stats: RunStats;
   }): Promise<void> {
     this.latestStats = ctx.stats;
     this.flusher?.bump();
+    return Promise.resolve();
   }
 
   async onFinish(ctx: {

--- a/apps/backend/src/sandbox/index.ts
+++ b/apps/backend/src/sandbox/index.ts
@@ -17,10 +17,9 @@ export const MAX_SHELL_TIMEOUT_MS = 600_000;
 // is the user-visible root.
 export const SANDBOX_WORKSPACE_ROOT = "/workspace";
 
-const SANDBOX_BACKEND_REGISTRY: Record<
-  string,
-  SandboxBackendRegistration<any, any>
-> = {};
+// Stored at the erased (default `unknown`) parameterisation: the registry is
+// heterogeneous and lookups hand back this same erased shape.
+const SANDBOX_BACKEND_REGISTRY: Record<string, SandboxBackendRegistration> = {};
 
 export const registerSandboxBackend = <TConfig, TCredentials>(
   registration: SandboxBackendRegistration<TConfig, TCredentials>,

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -1,4 +1,7 @@
-import { experimental_createMCPClient as createMCPClient } from "@ai-sdk/mcp";
+import {
+  experimental_createMCPClient as createMCPClient,
+  type MCPClient,
+} from "@ai-sdk/mcp";
 import { openProvider } from "./provider.ts";
 import { and, eq, or, inArray } from "drizzle-orm";
 import { db } from "../index.ts";
@@ -24,7 +27,7 @@ import {
   type MemorySummary,
 } from "./memory-retrieval.ts";
 import type { Provider, Skill } from "@platypus/schemas";
-import type { Tool } from "ai";
+import type { LanguageModel, Tool } from "ai";
 import { logger } from "../logger.ts";
 import { buildMcpTransportConfig } from "./mcp-oauth-provider.ts";
 import { inlineFileUrls } from "../storage/utils.ts";
@@ -103,7 +106,7 @@ export type ChatTurnRequest = {
 
 export type ChatTurn = {
   stream: {
-    model: any;
+    model: LanguageModel;
     tools: Record<string, Tool>;
     system: string;
     messages: PlatypusUIMessage[];
@@ -670,14 +673,15 @@ const wrapToolsWithBump = (
 ): Record<string, Tool> => {
   const wrapped: Record<string, Tool> = {};
   for (const [name, t] of Object.entries(tools)) {
-    const execute = (t as any).execute;
+    const execute = (t as { execute?: unknown }).execute;
     if (typeof execute !== "function") {
       wrapped[name] = t;
       continue;
     }
+    const runExecute = execute as (args: unknown, options: unknown) => unknown;
     wrapped[name] = {
       ...t,
-      execute: function (args: any, options: any) {
+      execute: (args: unknown, options: unknown) => {
         const startedAt = Date.now();
         onToolStart();
         onActivity({ phase: "start", toolName: name });
@@ -691,19 +695,23 @@ const wrapToolsWithBump = (
         };
         let result: unknown;
         try {
-          result = execute.call(t, args, options);
+          result = runExecute.call(t, args, options);
         } catch (err) {
           finish();
           throw err;
         }
-        if (result && typeof (result as any).then === "function") {
-          return (result as Promise<any>).finally(finish);
+        if (
+          result != null &&
+          typeof (result as { then?: unknown }).then === "function"
+        ) {
+          return (result as Promise<unknown>).finally(finish);
         }
         // Async iterable / generator path (sub-agent tools). Wrap it so the
         // counter decrements once the consumer drains the iterator.
         if (
-          result &&
-          typeof (result as any)[Symbol.asyncIterator] === "function"
+          result != null &&
+          typeof (result as Record<symbol, unknown>)[Symbol.asyncIterator] ===
+            "function"
         ) {
           const inner = result as AsyncIterable<unknown>;
           return (async function* () {
@@ -785,14 +793,14 @@ const resolveChatContext = async (
 
 const loadTools = async (
   queries: ChatTurnQueries,
-  agent: AgentRow | undefined,
+  agent: Pick<AgentRow, "id" | "toolSetIds"> | undefined,
   workspaceId: string,
   orgId: string,
   frontendUrl: string | undefined,
   userId?: string,
-): Promise<{ tools: Record<string, Tool>; mcpClients: any[] }> => {
+): Promise<{ tools: Record<string, Tool>; mcpClients: MCPClient[] }> => {
   const tools: Record<string, Tool> = {};
-  const mcpClients: any[] = [];
+  const mcpClients: MCPClient[] = [];
 
   if (!agent || !agent.toolSetIds || agent.toolSetIds.length === 0) {
     return { tools, mcpClients };
@@ -891,7 +899,7 @@ const loadSubAgents = async (
 ): Promise<{
   subAgents: Array<{ id: string; name: string; description?: string | null }>;
   subAgentTools: Record<string, Tool>;
-  subAgentMcpClients: any[];
+  subAgentMcpClients: MCPClient[];
 }> => {
   if (!agent?.subAgentIds || agent.subAgentIds.length === 0) {
     return { subAgents: [], subAgentTools: {}, subAgentMcpClients: [] };
@@ -905,7 +913,7 @@ const loadSubAgents = async (
     description: sa.description,
   }));
 
-  const subAgentMcpClients: any[] = [];
+  const subAgentMcpClients: MCPClient[] = [];
 
   const subAgentTools = await createSubAgentTools(
     subAgentRecords,
@@ -924,7 +932,7 @@ const loadSubAgents = async (
       const subAgentRecord = subAgentRecords.find((sa) => sa.id === subAgentId);
       const { tools: subTools, mcpClients } = await loadTools(
         queries,
-        subAgentRecord ?? ({ id: subAgentId, toolSetIds } as any),
+        subAgentRecord ?? { id: subAgentId, toolSetIds },
         workspaceId,
         orgId,
         frontendUrl,

--- a/apps/backend/src/services/embedding.ts
+++ b/apps/backend/src/services/embedding.ts
@@ -11,14 +11,14 @@ export const generateEmbedding = async (
   embeddingModelId: string,
   text: string,
 ): Promise<number[]> => {
-  const embeddingModel = openProvider(provider).embeddingModel;
-  if (!embeddingModel) {
+  const opened = openProvider(provider);
+  if (!opened.embeddingModel) {
     throw new Error(
       `Provider type '${provider.providerType}' does not support text embeddings.`,
     );
   }
   const { embedding } = await embed({
-    model: embeddingModel(embeddingModelId),
+    model: opened.embeddingModel(embeddingModelId),
     value: text,
   });
   return embedding;

--- a/apps/backend/src/services/mcp-oauth-provider.ts
+++ b/apps/backend/src/services/mcp-oauth-provider.ts
@@ -195,11 +195,14 @@ export class DatabaseOAuthClientProvider implements OAuthClientProvider {
       .where(eq(mcpTable.id, this.mcpRecord.id));
   }
 
-  async redirectToAuthorization(authorizationUrl: URL) {
+  redirectToAuthorization(authorizationUrl: URL) {
     // Google requires access_type=offline to return a refresh token.
     // prompt=consent forces re-consent even if the user previously authorized,
     // which is required when requesting offline access for the first time.
-    if (authorizationUrl.hostname.endsWith(".google.com") || authorizationUrl.hostname === "google.com") {
+    if (
+      authorizationUrl.hostname.endsWith(".google.com") ||
+      authorizationUrl.hostname === "google.com"
+    ) {
       authorizationUrl.searchParams.set("access_type", "offline");
       authorizationUrl.searchParams.set("prompt", "consent");
     }
@@ -237,7 +240,7 @@ export class DatabaseOAuthClientProvider implements OAuthClientProvider {
     throw new Error("No code verifier found");
   }
 
-  async state(): Promise<string> {
+  state(): string {
     if (!this._generatedState) this._generatedState = nanoid();
     return this._generatedState;
   }
@@ -255,7 +258,7 @@ export class DatabaseOAuthClientProvider implements OAuthClientProvider {
     });
   }
 
-  async storedState(): Promise<string | undefined> {
+  storedState(): string | undefined {
     return this._stateForLookup;
   }
 

--- a/apps/backend/src/services/memory-extraction.ts
+++ b/apps/backend/src/services/memory-extraction.ts
@@ -148,14 +148,15 @@ const processChat = async (
       prompt: summaryPrompt,
       temperature: 0.3,
     });
-  } catch (error: any) {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     logger.error(
       {
         err: error,
         chatId: chat.id,
         modelId: extractionProvider.memoryExtractionModelId,
       },
-      `Memory summary extraction LLM call failed: ${error.message ?? error}`,
+      `Memory summary extraction LLM call failed: ${message}`,
     );
     await updateChatExtractionStatus(chat.id, "failed");
     return;
@@ -178,10 +179,11 @@ const processChat = async (
         embeddingProvider.embeddingModelId,
         updatedSummary,
       );
-    } catch (error: any) {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       logger.error(
         { err: error, chatId: chat.id },
-        `Failed to generate embedding for daily summary: ${error.message ?? error}`,
+        `Failed to generate embedding for daily summary: ${message}`,
       );
     }
   }

--- a/apps/backend/src/services/trigger-execution.ts
+++ b/apps/backend/src/services/trigger-execution.ts
@@ -104,7 +104,7 @@ export const executeTrigger = async (
       id: nanoid(),
       role: "user",
       parts: [{ type: "text", text: effectiveInstruction }],
-    } as PlatypusUIMessage,
+    },
   ];
 
   const input: RunInput = {

--- a/apps/backend/src/storage/disk.ts
+++ b/apps/backend/src/storage/disk.ts
@@ -73,7 +73,7 @@ export class DiskStorage implements StorageBackend {
         fs.readFile(metaPath, "utf-8"),
       ]);
 
-      const meta = JSON.parse(metaContent);
+      const meta = JSON.parse(metaContent) as { contentType: string };
       return { data, contentType: meta.contentType };
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {

--- a/apps/backend/src/storage/s3.ts
+++ b/apps/backend/src/storage/s3.ts
@@ -91,10 +91,8 @@ export class S3Storage implements StorageBackend {
 
       return { data, contentType };
     } catch (error) {
-      if (
-        (error as any).name === "NoSuchKey" ||
-        (error as any).Code === "NoSuchKey"
-      ) {
+      const e = error as { name?: string; Code?: string };
+      if (e.name === "NoSuchKey" || e.Code === "NoSuchKey") {
         return null;
       }
       throw error;

--- a/apps/backend/src/tools/index.ts
+++ b/apps/backend/src/tools/index.ts
@@ -36,7 +36,7 @@ type ToolSet = {
   category: string;
   description?: string;
   tools:
-    | { [toolId: string]: Tool<any, any> }
+    | { [toolId: string]: Tool }
     | ((
         context: ToolSetContext,
       ) => Record<string, Tool> | Promise<Record<string, Tool>>);

--- a/apps/backend/src/tools/kanban.ts
+++ b/apps/backend/src/tools/kanban.ts
@@ -795,12 +795,10 @@ export function createKanbanTools(
         const { position: calcPos, needsRebalance, afterIndex } = result;
 
         if (needsRebalance) {
-          // Rebalance existing cards and place new card at the right spot
-          const reorderedCards = [...cardsInColumn];
-          reorderedCards.splice(afterIndex + 1, 0, {
-            id: "__placeholder__",
-            position: 0,
-          } as any);
+          // Rebalance existing cards and place new card at the right spot.
+          // Only `.id` is read below, so a minimal {id} shape is enough.
+          const reorderedCards: Array<{ id: string }> = [...cardsInColumn];
+          reorderedCards.splice(afterIndex + 1, 0, { id: "__placeholder__" });
           for (let i = 0; i < reorderedCards.length; i++) {
             if (reorderedCards[i].id !== "__placeholder__") {
               await db

--- a/apps/backend/src/tools/math.ts
+++ b/apps/backend/src/tools/math.ts
@@ -13,7 +13,7 @@ export const convertTemperature = tool({
       .enum(["fahrenheit", "celsius", "kelvin"])
       .describe("The unit to convert to"),
   }),
-  execute: async ({ value, from, to }) => {
+  execute: ({ value, from, to }) => {
     let celsius: number;
     if (from === "celsius") celsius = value;
     else if (from === "fahrenheit") celsius = (value - 32) * (5 / 9);
@@ -49,7 +49,7 @@ export const convertDistance = tool({
       .enum(["meters", "centimeters", "kilometers", "miles", "feet", "inches"])
       .describe("The unit to convert to"),
   }),
-  execute: async ({ value, from, to }) => {
+  execute: ({ value, from, to }) => {
     if (from === to) return { result: value, unit: to };
     const meters = value * DISTANCE_TO_METERS[from];
     const result = meters / DISTANCE_TO_METERS[to];
@@ -65,7 +65,7 @@ export const convertWeight = tool({
     from: z.enum(["kilograms", "pounds"]).describe("The unit to convert from"),
     to: z.enum(["kilograms", "pounds"]).describe("The unit to convert to"),
   }),
-  execute: async ({ value, from, to }) => {
+  execute: ({ value, from, to }) => {
     if (from === to) return { result: value, unit: to };
     const result = from === "kilograms" ? value * 2.20462 : value / 2.20462;
     return { result: Math.round(result * 100) / 100, unit: to };
@@ -80,7 +80,7 @@ export const convertVolume = tool({
     from: z.enum(["liters", "gallons"]).describe("The unit to convert from"),
     to: z.enum(["liters", "gallons"]).describe("The unit to convert to"),
   }),
-  execute: async ({ value, from, to }) => {
+  execute: ({ value, from, to }) => {
     if (from === to) return { result: value, unit: to };
     const result = from === "liters" ? value * 0.264172 : value / 0.264172;
     return { result: Math.round(result * 100) / 100, unit: to };

--- a/apps/backend/src/tools/memory.ts
+++ b/apps/backend/src/tools/memory.ts
@@ -89,16 +89,22 @@ export const createMemoryTools = (
           LIMIT ${limit}
         `);
 
+        const rows = results.rows as Array<{
+          summary_date: string;
+          summary: string;
+          relevance: number;
+        }>;
         return {
-          results: results.rows.map((row: any) => ({
+          results: rows.map((row) => ({
             date: row.summary_date,
             summary: row.summary,
             relevance: Math.round(Number(row.relevance) * 1000) / 1000,
           })),
         };
-      } catch (error: any) {
+      } catch (error) {
         logger.error({ error }, "memorySearch tool failed");
-        return { error: `Memory search failed: ${error.message}` };
+        const message = error instanceof Error ? error.message : String(error);
+        return { error: `Memory search failed: ${message}` };
       }
     },
   });
@@ -133,9 +139,10 @@ export const createMemoryTools = (
           date: result.summaryDate,
           summary: result.summary,
         };
-      } catch (error: any) {
+      } catch (error) {
         logger.error({ error }, "memoryGet tool failed");
-        return { error: `Memory get failed: ${error.message}` };
+        const message = error instanceof Error ? error.message : String(error);
+        return { error: `Memory get failed: ${message}` };
       }
     },
   });

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -1,4 +1,10 @@
-import { stepCountIs, tool, ToolLoopAgent, type Tool } from "ai";
+import {
+  stepCountIs,
+  tool,
+  ToolLoopAgent,
+  type LanguageModel,
+  type Tool,
+} from "ai";
 import { z } from "zod";
 import { logger } from "../logger.ts";
 
@@ -8,7 +14,7 @@ import { logger } from "../logger.ts";
  */
 export const subAgentToolName = (subAgent: { name: string }): string =>
   `delegateTo${subAgent.name
-    .replace(/[^a-zA-Z0-9]+(.)/g, (_, c) => c.toUpperCase())
+    .replace(/[^a-zA-Z0-9]+(.)/g, (_, c: string) => c.toUpperCase())
     .replace(/[^a-zA-Z0-9]/g, "")
     .replace(/^./, (c) => c.toUpperCase())}`;
 
@@ -38,7 +44,7 @@ interface SubAgentToolOptions {
   name: string;
   description?: string;
   systemPrompt?: string;
-  model: any; // LanguageModel from AI SDK
+  model: LanguageModel;
   tools: Record<string, Tool>;
   maxSteps?: number;
   /** Called on each activity update from the sub-agent. Used to reset the parent run's per-step timeout. */
@@ -177,7 +183,10 @@ export const createSubAgentTools = async (
     toolSetIds?: string[] | null;
     maxSteps?: number | null;
   }>,
-  createModelFn: (providerId: string, modelId: string) => Promise<any>,
+  createModelFn: (
+    providerId: string,
+    modelId: string,
+  ) => Promise<LanguageModel>,
   loadToolsFn: (
     subAgentId: string,
     toolSetIds: string[],

--- a/apps/backend/src/tools/time.test.ts
+++ b/apps/backend/src/tools/time.test.ts
@@ -48,8 +48,8 @@ describe("convertTimezone", () => {
     );
   });
 
-  it("throws for invalid date string", async () => {
-    await expect(
+  it("throws for invalid date string", () => {
+    expect(() =>
       convertTimezone.execute(
         {
           dateTime: "not-a-date",
@@ -58,6 +58,6 @@ describe("convertTimezone", () => {
         },
         ctx,
       ),
-    ).rejects.toThrow("Invalid date format");
+    ).toThrow("Invalid date format");
   });
 });

--- a/apps/backend/src/tools/time.ts
+++ b/apps/backend/src/tools/time.ts
@@ -8,7 +8,7 @@ export const getCurrentTime = tool({
   description:
     "Get the current date and time. Use this when the user asks what time it is, what day it is, or needs to know the current date.",
   inputSchema: z.object({}),
-  execute: async () => {
+  execute: () => {
     const now = new Date();
     const formatted = formatInTimeZone(
       now,
@@ -45,7 +45,7 @@ export const convertTimezone = tool({
         'Target IANA timezone name (e.g., "Europe/London", "Asia/Tokyo").',
       ),
   }),
-  execute: async ({ dateTime, fromTimezone, toTimezone }) => {
+  execute: ({ dateTime, fromTimezone, toTimezone }) => {
     // Parse the input date
     const date = new Date(dateTime);
 

--- a/apps/backend/src/types.ts
+++ b/apps/backend/src/types.ts
@@ -30,4 +30,4 @@ export type PlatypusTools = MathTools &
   SkillTools &
   TriggerTools;
 
-export type PlatypusUIMessage = UIMessage<any, UIDataTypes, PlatypusTools>;
+export type PlatypusUIMessage = UIMessage<unknown, UIDataTypes, PlatypusTools>;


### PR DESCRIPTION
## What & why

Removes the ~171 `any`/unsafe-family and `require-await` lint warnings in the backend's non-test source (issue #238). Each cluster traced back to one or two root `any` values, so the fix annotates the root type once and lets the downstream member-access/call/assignment warnings clear.

## Changes

- **`middleware/authorization.ts` (62 warnings → 0)** — the root was `createMiddleware(...)` called without its env generic, so every `c.get(...)` returned `any`. Parameterised all five as `createMiddleware<Env>` (carrying the existing `Variables` type), typed the `isSuperAdminMembership` guard, and relaxed `isSuperAdmin` to the real session-user shape.
- **`services/chat-execution.ts`** — typed MCP client arrays as `MCPClient[]`, the stream model as `LanguageModel`, narrowed `loadTools`' param to drop a synthetic-agent `as any`, and rewrote the tool-wrapper internals with `unknown`.
- **Postgres error handling** — replaced the duplicate local `isUniqueViolation(error: any)` in `org-blueprint.ts` with the shared `errors.ts` helper; converted per-route `catch (error: any)` blocks to typed narrowing or the existing `error instanceof Error` convention.
- **`require-await`** — dropped unnecessary `async` from sync tool executes and route handlers; returned `Promise.resolve()` from sink methods bound by the async `RunSink` contract; made the MCP OAuth provider's sync methods sync.
- Removed now-redundant type assertions exposed by the tighter types.

## Acceptance criteria

- [x] All non-test `.ts` files under `apps/backend/src` produce 0 lint warnings
- [x] `authorization.ts` warnings (62) eliminated by typing the root auth-context value, not by suppression
- [x] Source-side `require-await` warnings resolved
- [x] `pnpm --filter @platypus/backend test` passes (952 tests)
- [x] No new `any` types or `eslint-disable` suppressions introduced

## Notes

One tool unit test (`time.test.ts`) was updated to assert a synchronous throw after `convertTimezone` became sync. Remaining tsc deltas are confined to the separate test-mock slice (out of scope per the issue); 3 pre-existing Prettier warnings live in untouched test files.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)