### PR TITLE
chore(backend): enforce any/unsafe lint rules as errors

### DIFF
--- a/apps/backend/eslint.config.mjs
+++ b/apps/backend/eslint.config.mjs
@@ -40,29 +40,31 @@ const eslintConfig = defineConfig([
         },
       ],
 
-      // `any` and its downstream effects are surfaced as warnings to burn down
-      // over time, not hard errors — the existing codebase leans on `any` in
-      // places (AI-SDK payloads, dynamic tool args) where typing is genuinely
-      // hard. Promise-safety rules from recommendedTypeChecked (no-floating-
-      // promises, no-misused-promises, await-thenable) stay as errors.
-      "@typescript-eslint/no-explicit-any": "warn",
-      "@typescript-eslint/no-unsafe-assignment": "warn",
-      "@typescript-eslint/no-unsafe-member-access": "warn",
-      "@typescript-eslint/no-unsafe-call": "warn",
-      "@typescript-eslint/no-unsafe-argument": "warn",
-      "@typescript-eslint/no-unsafe-return": "warn",
+      // `any` and its downstream effects were warnings while the codebase was
+      // burned down from ~4.2k violations to zero (incl. the typed test-mock
+      // harness). Now enforced as errors — uniformly, tests included — so the
+      // `any` that dominated the old test mocks can't creep back. Promise-
+      // safety rules from recommendedTypeChecked (no-floating-promises,
+      // no-misused-promises, await-thenable) are likewise errors.
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-unsafe-assignment": "error",
+      "@typescript-eslint/no-unsafe-member-access": "error",
+      "@typescript-eslint/no-unsafe-call": "error",
+      "@typescript-eslint/no-unsafe-argument": "error",
+      "@typescript-eslint/no-unsafe-return": "error",
 
       // An `async` function with no `await` is valid (it just returns a
-      // resolved promise); flagging it isn't dead-code or a safety issue, and
-      // "fixing" it by removing `async` would change the return type and break
-      // call sites. Keep as a warning, not a blocking error.
-      "@typescript-eslint/require-await": "warn",
+      // resolved promise), but the codebase is now clean of unnecessary ones —
+      // enforce as an error so new ones get an explicit decision (drop `async`
+      // or add a scoped disable with a reason) rather than silently landing.
+      "@typescript-eslint/require-await": "error",
 
-      // High false-positive rate in this codebase: fires on AI-SDK model
-      // properties (typed as methods) and on test spy assertions
-      // (`expect(obj.method)`) that never actually detach `this`. Warn so
-      // genuine `this`-binding mistakes still surface without blocking lint.
-      "@typescript-eslint/unbound-method": "warn",
+      // Previously a warning for its false-positive rate on AI-SDK model
+      // properties (typed as methods) and test spy assertions
+      // (`expect(obj.method)`). The remaining genuine cases were resolved, so
+      // enforce as an error; suppress with a scoped disable where a known
+      // false positive recurs.
+      "@typescript-eslint/unbound-method": "error",
     },
   },
 


### PR DESCRIPTION
## Summary

Capstone for the backend lint burn-down (#237–#242). With the backend now reporting **0 warnings / 0 errors**, this makes zero the enforced contract so warnings can't silently re-accumulate.

Flips the deliberately-downgraded rules in `apps/backend/eslint.config.mjs` from `warn` to `error`:
- `no-explicit-any`, `no-unsafe-assignment`, `no-unsafe-member-access`, `no-unsafe-call`, `no-unsafe-argument`, `no-unsafe-return`
- `require-await`, `unbound-method`

**Decision: uniform enforcement, tests included.** The whole point of #237–#242 was to purge `any` from the test mocks; a `**/*.test.ts` carve-out would let exactly that regress. The existing test-file override block keeps only its `only-throw-error` / `prefer-promise-reject-errors` relaxations. Rule comments updated to reflect the enforced policy. Scoped `eslint-disable` with a reason remains the escape hatch for genuine false positives.

## Verification

- `pnpm --filter @platypus/backend lint` exits clean (0 warnings, 0 errors)

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)