### PR TITLE
chore: add pre-merge CI running lint and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+# Pre-merge gate: lint and tests must pass on every PR into main (and on main
+# itself). This catches problems at the merge boundary, before release-please
+# and the release/deploy workflows ever see the code.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Cancel superseded runs for the same ref (e.g. a new push to a PR branch).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test
+        run: pnpm test


### PR DESCRIPTION
## Summary

Closes the gap we discussed: lint previously ran **only at deploy time**, so problems were caught after code had already merged to main. This adds a pre-merge CI gate.

- **New `ci.yml`** triggered on `pull_request` → main and `push` → main.
- Runs two jobs in parallel:
  - `lint` — calls the existing reusable `lint.yml` (`pnpm lint`).
  - `test` — `pnpm test` (full monorepo: backend, frontend, schemas).
- `concurrency` cancels superseded runs for the same ref (e.g. new pushes to a PR branch).
- Uses `node-version-file: .nvmrc`, consistent with the other workflows.

Tests need no Postgres (the backend suite mocks the DB) — verified the full suite is green locally (952 backend tests + frontend + schemas).

## Follow-up (not in this PR)

To make these blocking, enable them as **required status checks** on `main` in branch protection: Settings → Branches → branch protection rule for `main` → "Require status checks to pass before merging" → add `lint` and `test`. (That's a repo setting I can't change from here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)