### PR TITLE
chore: run CI only on pull requests, not pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,11 @@
 name: CI
 
-# Pre-merge gate: lint and tests must pass on every PR into main (and on main
-# itself). This catches problems at the merge boundary, before release-please
-# and the release/deploy workflows ever see the code.
+# Pre-merge gate: lint and tests must pass on every PR into main. This catches
+# problems at the merge boundary, before release-please and the release/deploy
+# workflows ever see the code. Enforced as required status checks on main, so
+# nothing merges without it.
 on:
   pull_request:
-    branches: [main]
-  push:
     branches: [main]
 
 permissions:


### PR DESCRIPTION
## Summary

Drops the `push: main` trigger from `ci.yml`, leaving only `pull_request` → main.

## Why

With the branch protection now in place — required `lint / lint` + `test` checks and `strict` ("require branches to be up to date before merging") — integration drift is caught on the PR *before* it merges. The post-merge `push: main` run was re-testing essentially the same content, so it was redundant.

Trade-off accepted: a direct push to `main` (possible because `enforce_admins` is off) won't be CI-checked. If that ever matters, the cleaner fix is to flip `enforce_admins` on so everything goes through PRs.

## Verification

- Opening this PR triggers CI via `pull_request` (proving the remaining trigger works); it will no longer run on the subsequent merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)