### PR TITLE
chore: skip CI on release-please release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Skip on release-please's release PR: it only bumps the version and
+  # changelog (no source changes), so lint/test would re-run on code that
+  # already passed. A job skipped via `if:` is reported as skipped, which
+  # branch protection counts as a passing required check — so the release PR
+  # stays mergeable without doing redundant work.
   lint:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     uses: ./.github/workflows/lint.yml
 
   test:
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Skips the `lint` and `test` jobs when the PR is release-please's release PR (head branch prefixed `release-please--`), via a job-level `if:`.

The release PR only changes `CHANGELOG.md` and `package.json` — verified zero `.ts` files — so lint/test were re-running on code that already passed on its feature PRs. Worse, release-please refreshes that PR on every qualifying push to `main`, so the redundant run fired on essentially every merge.

A job skipped via `if:` reports as **skipped**, which branch protection counts as a **passing** required check, so the release PR stays mergeable without the work.

## Verification

- This PR (normal branch) should run both jobs → proves real PRs are unaffected.
- Separately verifying that a `release-please--`-prefixed branch skips both jobs **and stays mergeable** (skipped checks satisfy the required-check protection, including the reusable `lint / lint` context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)