### PR TITLE
chore: add aggregate gate job as the single required CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,8 @@ concurrency:
 jobs:
   # Skip on release-please's release PR: it only bumps the version and
   # changelog (no source changes), so lint/test would re-run on code that
-  # already passed. A job skipped via `if:` is reported as skipped, which
-  # branch protection counts as a passing required check — so the release PR
-  # stays mergeable without doing redundant work.
+  # already passed. Skipped jobs feed the `gate` job below — the single required
+  # check — so the release PR stays mergeable without doing redundant work.
   lint:
     if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     uses: ./.github/workflows/lint.yml
@@ -47,3 +46,24 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  # Single required status check. Runs always (even when lint/test are skipped
+  # on release PRs), so the required context is always reported. Passes when
+  # both jobs succeeded or were skipped; fails otherwise. Branch protection
+  # requires only this `gate` context — keying it to the reusable `lint` job's
+  # nested name (`lint / lint`) breaks when that job is skipped, since the
+  # context collapses to `lint` and the required check never reports.
+  gate:
+    needs: [lint, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify lint & test passed (or were skipped)
+        run: |
+          echo "lint=${{ needs.lint.result }} test=${{ needs.test.result }}"
+          if [[ "${{ needs.lint.result }}" == "failure" || "${{ needs.lint.result }}" == "cancelled" || \
+                "${{ needs.test.result }}" == "failure" || "${{ needs.test.result }}" == "cancelled" ]]; then
+            echo "CI gate failed"
+            exit 1
+          fi
+          echo "CI gate passed"


### PR DESCRIPTION
## Summary

Restores the `gate` job that should have shipped with #254. A lagging push meant the squash merge of #254 captured only the skip commit, not the gate commit — so `main` ended up requiring a `gate` status check that didn't exist, which would block every PR (and the release PR).

The `gate` job:
- `needs: [lint, test]`, `if: always()` — always runs and reports, even when lint/test are skipped on release PRs.
- Fails only if lint or test `failure`/`cancelled`; passes on `success` or `skipped`.

Branch protection already requires only `gate` (immune to the reusable `lint` job's context collapsing from `lint / lint` to `lint` when skipped).

## Verification

- This is a normal PR (not `release-please--`), so lint + test **run**, then gate runs — exercising the run-path of the gate (the case not yet observed live).
- A `release-please--`-prefixed probe (PR #255) already confirmed the skip-path: lint/test skipped, `gate: success`, PR `MERGEABLE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)