### PR TITLE
feat(backend): surface self-hosted reasoning via @ai-sdk/openai-compatible

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -26,6 +26,7 @@
     "@ai-sdk/google": "^3.0.82",
     "@ai-sdk/mcp": "^1.0.50",
     "@ai-sdk/openai": "^3.0.71",
+    "@ai-sdk/openai-compatible": "^2.0.50",
     "@aws-sdk/client-s3": "^3.1068.0",
     "@hono/node-server": "^2.0.4",
     "@hono/standard-validator": "^0.2.2",

--- a/apps/backend/src/services/provider.test.ts
+++ b/apps/backend/src/services/provider.test.ts
@@ -115,6 +115,7 @@ describe("openProvider", () => {
       baseURL: "http://localhost:8000/v1",
       apiKey: "sk-test",
       headers: undefined,
+      includeUsage: true,
     });
     expect(mockCreateOpenAICompatible.chatModel).toHaveBeenCalledWith("qwen3");
     // OpenAI SDK is still instantiated for embeddings + native search tools.

--- a/apps/backend/src/services/provider.test.ts
+++ b/apps/backend/src/services/provider.test.ts
@@ -12,6 +12,7 @@ type ProviderInstance = Mock<
 
 const {
   mockCreateOpenAI,
+  mockCreateOpenAICompatible,
   mockCreateOpenRouter,
   mockCreateAmazonBedrock,
   mockCreateGoogleGenerativeAI,
@@ -30,8 +31,18 @@ const {
     const creator = vi.fn(() => instance);
     return { creator, instance };
   };
+  // openai-compatible exposes `chatModel(id)`, not a callable instance.
+  const compatChatModel = vi.fn((modelId: string) => ({
+    modelId,
+    _compat: true,
+  }));
+  const mockCreateOpenAICompatible = {
+    creator: vi.fn(() => ({ chatModel: compatChatModel })),
+    chatModel: compatChatModel,
+  };
   return {
     mockCreateOpenAI: makeMock(),
+    mockCreateOpenAICompatible,
     mockCreateOpenRouter: makeMock(),
     mockCreateAmazonBedrock: makeMock(),
     mockCreateGoogleGenerativeAI: makeMock(),
@@ -40,6 +51,9 @@ const {
 });
 
 vi.mock("@ai-sdk/openai", () => ({ createOpenAI: mockCreateOpenAI.creator }));
+vi.mock("@ai-sdk/openai-compatible", () => ({
+  createOpenAICompatible: mockCreateOpenAICompatible.creator,
+}));
 vi.mock("@openrouter/ai-sdk-provider", () => ({
   createOpenRouter: mockCreateOpenRouter.creator,
 }));
@@ -85,6 +99,35 @@ describe("openProvider", () => {
       organization: undefined,
       project: undefined,
     });
+  });
+
+  it("routes chat-completions language model through openai-compatible", () => {
+    // apiMode "chat" (self-hosted vLLM/SGLang/etc.) must use the compatible
+    // provider so `reasoning_content` is surfaced as reasoning parts.
+    openProvider({
+      ...baseProvider,
+      apiMode: "chat",
+      name: "vLLM Local",
+      baseUrl: "http://localhost:8000/v1",
+    }).languageModel("qwen3");
+    expect(mockCreateOpenAICompatible.creator).toHaveBeenCalledWith({
+      name: "vLLM Local",
+      baseURL: "http://localhost:8000/v1",
+      apiKey: "sk-test",
+      headers: undefined,
+    });
+    expect(mockCreateOpenAICompatible.chatModel).toHaveBeenCalledWith("qwen3");
+    // OpenAI SDK is still instantiated for embeddings + native search tools.
+    expect(mockCreateOpenAI.creator).toHaveBeenCalled();
+  });
+
+  it("uses the OpenAI Responses model when apiMode is responses", () => {
+    openProvider({
+      ...baseProvider,
+      apiMode: "responses",
+    }).languageModel("gpt-4");
+    expect(mockCreateOpenAICompatible.creator).not.toHaveBeenCalled();
+    expect(mockCreateOpenAI.instance).toHaveBeenCalledWith("gpt-4");
   });
 
   it("dispatches OpenRouter to the OpenRouter SDK", () => {

--- a/apps/backend/src/services/provider.ts
+++ b/apps/backend/src/services/provider.ts
@@ -1,4 +1,5 @@
 import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
 import { createAnthropic } from "@ai-sdk/anthropic";
@@ -23,8 +24,27 @@ export const openProvider = (provider: Provider): OpenedProvider => {
         project: provider.project ?? undefined,
       });
       const useChatCompletions = provider.apiMode === "chat";
+      // Chat-completions mode is, in practice, only used against self-hosted /
+      // company OpenAI-compatible servers (vLLM, SGLang, llama.cpp, TGI, …) —
+      // real OpenAI is driven via the Responses API. Those servers expose the
+      // model's thinking in a `reasoning_content` field that `@ai-sdk/openai`'s
+      // chat model silently drops. `@ai-sdk/openai-compatible` reads it natively
+      // and emits reasoning stream parts the UI renders as a collapsible block.
+      // Embeddings + native search tools stay on the OpenAI SDK (unaffected).
+      // NOTE: leaving `supportsStructuredOutputs` at its default (false) means a
+      // requested JSON schema is downgraded to plain `json_object` mode; the AI
+      // SDK still validates client-side. Enabling it would send strict
+      // `json_schema` (vLLM guided decoding) but breaks servers lacking support.
+      const compat = useChatCompletions
+        ? createOpenAICompatible({
+            name: provider.name,
+            baseURL: provider.baseUrl ?? "",
+            apiKey: provider.apiKey ?? undefined,
+            headers: provider.headers ?? undefined,
+          })
+        : undefined;
       return {
-        languageModel: (id) => (useChatCompletions ? sdk.chat(id) : sdk(id)),
+        languageModel: (id) => (compat ? compat.chatModel(id) : sdk(id)),
         embeddingModel: (id) => sdk.embeddingModel(id),
         searchTools: () => ({
           web_search: sdk.tools.webSearch({

--- a/apps/backend/src/services/provider.ts
+++ b/apps/backend/src/services/provider.ts
@@ -41,6 +41,11 @@ export const openProvider = (provider: Provider): OpenedProvider => {
             baseURL: provider.baseUrl ?? "",
             apiKey: provider.apiKey ?? undefined,
             headers: provider.headers ?? undefined,
+            // Request `stream_options.include_usage` so streamed responses carry
+            // token usage. Without it the compatible provider omits stream_options
+            // and servers (vLLM/SGLang/…) return no usage on the streaming path,
+            // surfacing as In:0 / Out:0 in the UI. Non-streaming already reports it.
+            includeUsage: true,
           })
         : undefined;
       return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.71
         version: 3.0.71(zod@4.4.3)
+      '@ai-sdk/openai-compatible':
+        specifier: ^2.0.50
+        version: 2.0.50(zod@4.4.3)
       '@aws-sdk/client-s3':
         specifier: ^3.1068.0
         version: 3.1068.0
@@ -511,6 +514,12 @@ packages:
 
   '@ai-sdk/mcp@1.0.50':
     resolution: {integrity: sha512-iLqDZ62ezEjBhTJgiAQ4D2tHG1q7INVhPx0uOPnxJTxxqVUzN4KqeWAd6j5hYNhsPqC7TPGRQHQqAa1Z/lu2jg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@2.0.50':
+    resolution: {integrity: sha512-HyuxddF2Yv5G8qxK/0uksAINjQ4h6TpwOqHuqzsCM0u78/JWAW2OXcIplQeB44PIAORgPjbMzrw9DhnPYHMskA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -8332,6 +8341,12 @@ snapshots:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
       pkce-challenge: 5.0.1
+      zod: 4.4.3
+
+  '@ai-sdk/openai-compatible@2.0.50(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/openai@3.0.71(zod@4.4.3)':


### PR DESCRIPTION
## Summary

Chat-completions mode (`apiMode=chat`) on an `OpenAI` provider is, in practice, only used against self-hosted / company OpenAI-compatible servers (vLLM, SGLang, llama.cpp, TGI, LM Studio) — real OpenAI is driven via the Responses API. Those servers expose the model's thinking in a `reasoning_content` field, but `@ai-sdk/openai`'s chat model only parses `role`/`content`/`tool_calls` and silently drops it. So the existing reasoning UI never received anything from them.

This routes chat-mode language models through `@ai-sdk/openai-compatible`, which reads `reasoning_content` (and `reasoning`) natively and emits reasoning stream parts — rendered by the existing collapsible "Thinking…" block. No frontend changes.

## Changes

- Add `@ai-sdk/openai-compatible` dependency (depends on the same `@ai-sdk/provider@3` as the other adapters).
- `provider.ts`: for `OpenAI` providers with `apiMode==="chat"`, build the **language model** via `createOpenAICompatible(...)`. Embeddings and native search tools stay on the OpenAI SDK. Responses mode is unchanged.
- Set `includeUsage: true` so streamed turns carry `stream_options.include_usage` — without it self-hosted servers return no token usage on the streaming path (shows as In:0 / Out:0).
- Tests covering chat→compatible routing and responses→OpenAI dispatch.

## Behavior notes

- Real OpenAI in chat mode is unaffected — it returns no `reasoning_content`, so no reasoning parts are emitted.
- `supportsStructuredOutputs` is left at its default (`false`): a requested JSON schema downgrades to `json_object` mode (the AI SDK still validates client-side), which is safe across servers that don't support `json_schema` response_format. This only affects the title/tag generation call.

## Testing

- `typecheck`, `lint`, and the `provider` unit tests pass.
- Verified end-to-end against a vLLM server (Qwen3, reasoning parser enabled): reasoning streams into the collapsible block and token usage populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)