### PR TITLE
fix(frontend): persist cleared sampling params as null (#263)

### DIFF
--- a/apps/backend/src/routes/agent.test.ts
+++ b/apps/backend/src/routes/agent.test.ts
@@ -253,6 +253,37 @@ describe("Agent Routes", () => {
       expect(await res.json()).toEqual(mockAgent);
     });
 
+    it("persists a cleared temperature as null instead of keeping the old value (#263)", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // findVisibleAgent → workspace-scoped agent
+      mockDb.limit.mockResolvedValueOnce([{ id: "agent-1", workspaceId }]);
+
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "agent-1", name: "Updated Agent", temperature: null },
+      ]);
+
+      const res = await app.request(`${baseUrl}/agent-1`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "Updated Agent",
+          description: "An updated agent",
+          providerId: "p1",
+          modelId: "m1",
+          temperature: null,
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockDb.set).toHaveBeenCalledWith(
+        expect.objectContaining({ temperature: null }),
+      );
+    });
+
     it("should lock a shared agent for a workspace owner (non-admin)", async () => {
       mockSession();
       // requireOrgAccess → member

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -318,12 +318,15 @@ const AgentForm = ({
         systemPrompt: formData.systemPrompt,
         modelId: formData.modelId,
         maxSteps: formData.maxSteps,
-        temperature: formData.temperature,
-        topP: formData.topP,
-        topK: formData.topK,
-        seed: formData.seed,
-        presencePenalty: formData.presencePenalty,
-        frequencyPenalty: formData.frequencyPenalty,
+        // Send null (not undefined) for cleared sampling params so the key
+        // survives JSON.stringify and the backend persists the cleared value
+        // instead of silently keeping the previous one (#263).
+        temperature: formData.temperature ?? null,
+        topP: formData.topP ?? null,
+        topK: formData.topK ?? null,
+        seed: formData.seed ?? null,
+        presencePenalty: formData.presencePenalty ?? null,
+        frequencyPenalty: formData.frequencyPenalty ?? null,
         toolSetIds: formData.toolSetIds,
         skillIds: formData.skillIds,
         subAgentIds: formData.subAgentIds,

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -192,12 +192,16 @@ const agentBaseSchema = z.object({
   systemPrompt: z.string().optional(),
   modelId: z.string(),
   maxSteps: z.number().optional(),
-  temperature: z.number().optional(),
-  topP: z.number().optional(),
-  topK: z.number().optional(),
-  seed: z.number().optional(),
-  presencePenalty: z.number().optional(),
-  frequencyPenalty: z.number().optional(),
+  // Sampling params are nullable so the UI can clear them back to "unset"
+  // (null) — without null, JSON.stringify drops the cleared `undefined` key
+  // and the column keeps its previous value (#263). null is treated as "unset"
+  // at run time, falling back to the provider/model default.
+  temperature: z.number().nullable().optional(),
+  topP: z.number().nullable().optional(),
+  topK: z.number().nullable().optional(),
+  seed: z.number().nullable().optional(),
+  presencePenalty: z.number().nullable().optional(),
+  frequencyPenalty: z.number().nullable().optional(),
   toolSetIds: z.array(z.string()).optional(),
   skillIds: z.array(z.string()).optional(),
   subAgentIds: z.array(z.string()).optional(),


### PR DESCRIPTION
Fixes #263

## Problem

Clearing the **temperature** field on an agent and clicking **Update** did not persist — the field reverted to its previous value. The same latent bug affected the other cleared sampling params (top-p, top-k, seed, presence/frequency penalty).

## Root cause

1. **Frontend** (`agent-form.tsx`): clearing the input set `formData.temperature = undefined`, and the payload sent `temperature: formData.temperature`. `JSON.stringify` **drops `undefined` keys**, so the key never reached the backend.
2. **Backend** (`agent.ts` PUT): the handler does `.set({ ...data, updatedAt })`. With no `temperature` key in `data`, the column was left untouched — keeping its previous value.

## Fix

A cleared field now **persists as `null`** (treated as "unset" → falls back to the provider/model default at run time, which `resolveGenerationConfig`'s `!= null` guard already handles).

- **`packages/schemas/index.ts`** — sampling params are now `z.number().nullable().optional()` so an explicit `null` passes validation.
- **`apps/frontend/components/agent-form.tsx`** — payload sends `formData.temperature ?? null` (and the same for the other sampling params), so the key survives `JSON.stringify`.
- **Backend** — no change needed: `...data` now carries `temperature: null`, which Drizzle writes as `NULL` (column already nullable). Applies to both `agent.ts` and `org-agent.ts`.
- **`apps/backend/src/routes/agent.test.ts`** — regression test asserting a cleared (`null`) temperature is passed through to `.set()`.

## Verification

- `pnpm typecheck` (CI gate) ✅
- Backend tests (952 + new regression test) ✅
- Schemas tests (37) ✅
- `pnpm lint` ✅ / Prettier ✅

## Note

A cleared sampling param persists as `null` (use provider default) rather than resetting to a hardcoded default — this matches the first option the issue listed as acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)