### PR TITLE
fix(backend): default chat-mode baseUrl to OpenAI's endpoint

### DIFF
--- a/apps/backend/src/services/provider.test.ts
+++ b/apps/backend/src/services/provider.test.ts
@@ -122,6 +122,20 @@ describe("openProvider", () => {
     expect(mockCreateOpenAI.creator).toHaveBeenCalled();
   });
 
+  it("falls back to OpenAI's endpoint for chat mode without a baseUrl", () => {
+    // baseUrl is optional, so a real-OpenAI provider in chat mode arrives with
+    // it empty. The compatible client must still target OpenAI rather than an
+    // empty URL.
+    openProvider({
+      ...baseProvider,
+      apiMode: "chat",
+      baseUrl: undefined,
+    }).languageModel("gpt-4");
+    expect(mockCreateOpenAICompatible.creator).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://api.openai.com/v1" }),
+    );
+  });
+
   it("uses the OpenAI Responses model when apiMode is responses", () => {
     openProvider({
       ...baseProvider,

--- a/apps/backend/src/services/provider.ts
+++ b/apps/backend/src/services/provider.ts
@@ -38,7 +38,12 @@ export const openProvider = (provider: Provider): OpenedProvider => {
       const compat = useChatCompletions
         ? createOpenAICompatible({
             name: provider.name,
-            baseURL: provider.baseUrl ?? "",
+            // Fall back to OpenAI's endpoint when no baseUrl is configured.
+            // `baseUrl` is optional in the schema, so a real-OpenAI provider set
+            // to chat mode arrives here with it empty/undefined — `||` (not `??`)
+            // also catches the empty-string case the form can produce. Without
+            // this the compatible client would target an empty URL and fail.
+            baseURL: provider.baseUrl || "https://api.openai.com/v1",
             apiKey: provider.apiKey ?? undefined,
             headers: provider.headers ?? undefined,
             // Request `stream_options.include_usage` so streamed responses carry


### PR DESCRIPTION
## Summary

Follow-up to #262. That PR routed `apiMode=chat` OpenAI providers through `@ai-sdk/openai-compatible`, but `baseUrl` is optional in the provider schema. A real-OpenAI provider set to chat mode (no `baseUrl`) was building the compatible client with an empty `baseURL`, so every request targeted an empty URL and failed — the OpenAI SDK had previously defaulted this to `api.openai.com`.

## Changes

- `provider.ts`: fall back to `https://api.openai.com/v1` when no `baseUrl` is configured. Uses `||` (not `??`) so the empty-string case the form can produce is also caught.
- Adds a regression test for chat mode without a `baseUrl`.

## Testing

- `provider` unit tests (62 passed), `typecheck`, and `lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)