### PR TITLE
fix(backend): stop event triggers from re-firing on their own agent's writes

### DIFF
--- a/apps/backend/src/services/event-dispatch.test.ts
+++ b/apps/backend/src/services/event-dispatch.test.ts
@@ -248,6 +248,66 @@ describe("event-dispatch", () => {
       await flushMicrotasks();
     });
 
+    it("should skip a trigger when its own agent caused the event", async () => {
+      const trigger = makeEventTrigger({ agentId: "agent-1" });
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
+
+      dispatchEvent(
+        "ws-1",
+        "card.updated",
+        { id: "c1" },
+        { actorAgentId: "agent-1" },
+      );
+      await flushMicrotasks();
+
+      expect(mockExecuteTrigger).not.toHaveBeenCalled();
+    });
+
+    it("should fire on a human event even when the trigger's agent previously touched the card", async () => {
+      const trigger = makeEventTrigger({ agentId: "agent-1" });
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
+
+      // Human write path supplies no actor, even though the card row still
+      // carries a stale lastEditedByAgentId from a prior agent edit.
+      dispatchEvent("ws-1", "card.updated", {
+        id: "c1",
+        lastEditedByAgentId: "agent-1",
+      });
+      await flushMicrotasks();
+
+      expect(mockExecuteTrigger).toHaveBeenCalled();
+    });
+
+    it("should fire when a different agent caused the event", async () => {
+      const trigger = makeEventTrigger({ agentId: "agent-1" });
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
+
+      dispatchEvent(
+        "ws-1",
+        "card.updated",
+        { id: "c1" },
+        { actorAgentId: "agent-2" },
+      );
+      await flushMicrotasks();
+
+      expect(mockExecuteTrigger).toHaveBeenCalled();
+    });
+
+    it("should not apply the self-actor guard to triggers without an agentId", async () => {
+      const trigger = makeEventTrigger({ agentId: null });
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
+
+      dispatchEvent(
+        "ws-1",
+        "card.updated",
+        { id: "c1" },
+        { actorAgentId: "agent-1" },
+      );
+      await flushMicrotasks();
+
+      expect(mockExecuteTrigger).toHaveBeenCalled();
+    });
+
     it("should dispatch to both webhooks and triggers for the same event", async () => {
       const webhook = makeWebhook();
       const trigger = makeEventTrigger();

--- a/apps/backend/src/services/event-dispatch.ts
+++ b/apps/backend/src/services/event-dispatch.ts
@@ -11,10 +11,28 @@ import { debounceTriggerExecution } from "./event-trigger-debounce.ts";
 import { logger } from "../logger.ts";
 import type { WebhookEvent, EventTriggerConfig } from "@platypus/schemas";
 
+/**
+ * Optional context about who caused the event being dispatched.
+ *
+ * `actorAgentId` is the agent that performed the write. It is supplied by
+ * agent-facing tool write paths and is absent for human-originated (HTTP
+ * route) writes. The dispatcher uses it to skip an event trigger when the
+ * trigger's own agent caused the event — preventing an agent's writes from
+ * re-firing the very trigger that started it (see #267).
+ *
+ * This is keyed off the actor of *this specific event*, not a persisted
+ * attribution column (e.g. `lastEditedByAgentId`), which is sticky and would
+ * cause false-negatives on later human edits.
+ */
+export interface DispatchEventOptions {
+  actorAgentId?: string;
+}
+
 export function dispatchEvent(
   workspaceId: string,
   event: WebhookEvent,
   data: unknown,
+  options?: DispatchEventOptions,
 ): void {
   // Fire-and-forget — never awaited by the caller
   void (async () => {
@@ -58,6 +76,18 @@ export function dispatchEvent(
       for (const trigger of eventTriggers) {
         const triggerConfig = trigger.config as EventTriggerConfig;
         if (!triggerConfig.events.includes(event)) continue;
+
+        // Self-actor guard: skip when the agent that caused this event is the
+        // very same agent this trigger would run. This stops an agent's own
+        // card writes from re-firing the trigger that started it (#267).
+        // Human-originated events carry no actor, so they always pass.
+        if (
+          options?.actorAgentId &&
+          trigger.agentId &&
+          trigger.agentId === options.actorAgentId
+        ) {
+          continue;
+        }
 
         // Apply event filters
         if (triggerConfig.filters?.boardId) {

--- a/apps/backend/src/tools/kanban.ts
+++ b/apps/backend/src/tools/kanban.ts
@@ -371,10 +371,12 @@ export function createKanbanTools(
         }
 
         const boardId = await getBoardIdForCard(cardId);
-        dispatchEvent(workspaceId, "card.updated", {
-          ...record[0],
-          boardId,
-        });
+        dispatchEvent(
+          workspaceId,
+          "card.updated",
+          { ...record[0], boardId },
+          { actorAgentId: agentId },
+        );
         const url = boardId
           ? buildResourceUrl(
               frontendUrl,
@@ -428,7 +430,12 @@ export function createKanbanTools(
         .returning();
 
       const boardId = await getBoardIdForCard(id);
-      dispatchEvent(workspaceId, "card.created", { ...record[0], boardId });
+      dispatchEvent(
+        workspaceId,
+        "card.created",
+        { ...record[0], boardId },
+        { actorAgentId: agentId },
+      );
       const url = boardId
         ? buildResourceUrl(
             frontendUrl,
@@ -524,7 +531,12 @@ export function createKanbanTools(
         .limit(1);
 
       const boardId = await getBoardIdForCard(cardId);
-      dispatchEvent(workspaceId, "card.updated", { ...updated[0], boardId });
+      dispatchEvent(
+        workspaceId,
+        "card.updated",
+        { ...updated[0], boardId },
+        { actorAgentId: agentId },
+      );
       const url = boardId
         ? buildResourceUrl(
             frontendUrl,
@@ -563,11 +575,12 @@ export function createKanbanTools(
           .limit(1);
         const columnId = cardRecord[0]?.columnId;
         await db.delete(kanbanCardTable).where(eq(kanbanCardTable.id, cardId));
-        dispatchEvent(workspaceId, "card.deleted", {
-          cardId,
-          boardId,
-          columnId,
-        });
+        dispatchEvent(
+          workspaceId,
+          "card.deleted",
+          { cardId, boardId, columnId },
+          { actorAgentId: agentId },
+        );
       }
 
       return { success: true };
@@ -857,10 +870,12 @@ export function createKanbanTools(
       }
 
       // 8. Dispatch event
-      dispatchEvent(workspaceId, "card.created", {
-        ...record[0],
-        boardId: sourceBoardId,
-      });
+      dispatchEvent(
+        workspaceId,
+        "card.created",
+        { ...record[0], boardId: sourceBoardId },
+        { actorAgentId: agentId },
+      );
 
       const url = sourceBoardId
         ? buildResourceUrl(
@@ -1054,10 +1069,12 @@ export function createKanbanTools(
           .from(kanbanCardTable)
           .where(eq(kanbanCardTable.id, cardId))
           .limit(1);
-        dispatchEvent(workspaceId, "card.updated", {
-          ...updated[0],
-          boardId,
-        });
+        dispatchEvent(
+          workspaceId,
+          "card.updated",
+          { ...updated[0], boardId },
+          { actorAgentId: agentId },
+        );
       }
 
       const succeededResults = validCardIds.map((cardId) => ({


### PR DESCRIPTION
## Problem

An event trigger on `card.updated` (or `card.created`) whose agent edits the firing card re-fired itself forever. `dispatchEvent` applied board/column filters but had no notion of *who* caused an event, so it could not tell an agent's own write from a human's. The 5s debounce only spaced iterations; it didn't stop them. (#267)

## Fix

Carry the event's actor on dispatch via a new optional `DispatchEventOptions { actorAgentId }`:

- **Agent-facing kanban write paths** (`upsertCard`, `moveCard`, `copyCard`, `bulkEditCards`, `deleteCard`) pass their `agentId`.
- **Human HTTP routes** pass nothing.
- The dispatcher skips a trigger when `trigger.agentId === options.actorAgentId`.

Keying off the **per-event actor** rather than the sticky `lastEditedByAgentId` / `createdByAgentId` columns avoids the false-negatives called out in the agent brief: a human edit still fires the trigger even on a card the trigger's own agent previously touched, and an edit by a *different* agent still fires.

## Acceptance criteria

- [x] An agent-trigger run that edits the firing card does not re-trigger the same trigger.
- [x] A `card.created` trigger whose agent creates a card does not re-trigger itself.
- [x] A human edit still fires a matching trigger, even on an agent-touched card.
- [x] An edit by agent A still fires a trigger bound to agent B.
- [x] Triggers with no `agentId` are unaffected.
- [x] No DB schema change or migration.
- [x] Dispatcher tests cover: same-agent → skipped; human-on-agent-touched-card → fires; different-agent → fires; no-`agentId` → fires.

## Out of scope

- Mutual loops between two *different* agents (A→B→A) — needs a depth limit (tracked with the run-termination work, #268).
- Non-convergence / step-ceiling termination (#268), debounce changes, webhook behavior.

## Testing

`pnpm --filter backend test` (event-dispatch + kanban) and `pnpm --filter backend typecheck` pass.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)