### PR TITLE
feat(backend): add orgId to webhook event envelope and document webhooks

### DIFF
--- a/apps/backend/src/routes/kanban.ts
+++ b/apps/backend/src/routes/kanban.ts
@@ -750,7 +750,10 @@ kanban.post(
       .returning();
 
     const workspaceId = c.req.param("workspaceId")!;
-    dispatchEvent(workspaceId, "card.created", { ...record[0], boardId });
+    dispatchEvent(c.req.param("orgId")!, workspaceId, "card.created", {
+      ...record[0],
+      boardId,
+    });
 
     return c.json(record[0], 201);
   },
@@ -831,7 +834,10 @@ kanban.put(
     }
 
     const workspaceId = c.req.param("workspaceId")!;
-    dispatchEvent(workspaceId, "card.updated", { ...record[0], boardId });
+    dispatchEvent(c.req.param("orgId")!, workspaceId, "card.updated", {
+      ...record[0],
+      boardId,
+    });
 
     return c.json(record[0]);
   },
@@ -913,7 +919,10 @@ kanban.post(
 
     const workspaceId = c.req.param("workspaceId")!;
     const boardId = c.req.param("boardId");
-    dispatchEvent(workspaceId, "card.updated", { ...updated[0], boardId });
+    dispatchEvent(c.req.param("orgId")!, workspaceId, "card.updated", {
+      ...updated[0],
+      boardId,
+    });
 
     return c.json(updated[0]);
   },
@@ -951,7 +960,7 @@ kanban.delete(
     }
 
     const workspaceId = c.req.param("workspaceId")!;
-    dispatchEvent(workspaceId, "card.deleted", {
+    dispatchEvent(c.req.param("orgId")!, workspaceId, "card.deleted", {
       cardId,
       boardId,
       columnId: result[0].columnId,

--- a/apps/backend/src/routes/notification.ts
+++ b/apps/backend/src/routes/notification.ts
@@ -148,7 +148,7 @@ notification.post(
       })
       .onConflictDoNothing();
 
-    dispatchEvent(workspaceId, "notification.read", {
+    dispatchEvent(c.req.param("orgId")!, workspaceId, "notification.read", {
       notificationId,
       userId: user.id,
     });
@@ -194,7 +194,7 @@ notification.post(
         })),
       );
 
-      dispatchEvent(workspaceId, "notification.read", {
+      dispatchEvent(c.req.param("orgId")!, workspaceId, "notification.read", {
         notificationIds: unread.map((n) => n.id),
         userId: user.id,
         bulk: true,
@@ -229,9 +229,14 @@ notification.delete(
       return c.json({ error: "Notification not found" }, 404);
     }
 
-    dispatchEvent(workspaceId, "notification.dismissed", {
-      notificationId,
-    });
+    dispatchEvent(
+      c.req.param("orgId")!,
+      workspaceId,
+      "notification.dismissed",
+      {
+        notificationId,
+      },
+    );
 
     return c.json({ message: "Notification deleted" });
   },

--- a/apps/backend/src/services/event-dispatch.test.ts
+++ b/apps/backend/src/services/event-dispatch.test.ts
@@ -111,7 +111,9 @@ describe("event-dispatch", () => {
       );
 
       // The delivered envelope carries both org and workspace coordinates.
-      const body = JSON.parse(mockDeliverWebhook.mock.calls[0][1]);
+      const body = JSON.parse(
+        mockDeliverWebhook.mock.calls[0][1] as string,
+      ) as Record<string, unknown>;
       expect(body).toMatchObject({
         event: "card.created",
         orgId: "org-1",

--- a/apps/backend/src/services/event-dispatch.test.ts
+++ b/apps/backend/src/services/event-dispatch.test.ts
@@ -99,7 +99,7 @@ describe("event-dispatch", () => {
         .mockResolvedValueOnce([webhook]) // webhooks query
         .mockResolvedValueOnce([]); // event triggers query
 
-      dispatchEvent("ws-1", "card.created", { cardId: "c1" });
+      dispatchEvent("org-1", "ws-1", "card.created", { cardId: "c1" });
       await flushMicrotasks();
 
       expect(mockDeliverWebhook).toHaveBeenCalledWith(
@@ -109,13 +109,22 @@ describe("event-dispatch", () => {
         expect.any(String),
         null,
       );
+
+      // The delivered envelope carries both org and workspace coordinates.
+      const body = JSON.parse(mockDeliverWebhook.mock.calls[0][1]);
+      expect(body).toMatchObject({
+        event: "card.created",
+        orgId: "org-1",
+        workspaceId: "ws-1",
+        data: { cardId: "c1" },
+      });
     });
 
     it("should skip disabled webhooks", async () => {
       const webhook = makeWebhook({ enabled: false });
       mockDb.where.mockResolvedValueOnce([webhook]).mockResolvedValueOnce([]);
 
-      dispatchEvent("ws-1", "card.created", { cardId: "c1" });
+      dispatchEvent("org-1", "ws-1", "card.created", { cardId: "c1" });
       await flushMicrotasks();
 
       expect(mockDeliverWebhook).not.toHaveBeenCalled();
@@ -125,7 +134,7 @@ describe("event-dispatch", () => {
       const webhook = makeWebhook({ events: ["card.deleted"] });
       mockDb.where.mockResolvedValueOnce([webhook]).mockResolvedValueOnce([]);
 
-      dispatchEvent("ws-1", "card.created", { cardId: "c1" });
+      dispatchEvent("org-1", "ws-1", "card.created", { cardId: "c1" });
       await flushMicrotasks();
 
       expect(mockDeliverWebhook).not.toHaveBeenCalled();
@@ -137,7 +146,7 @@ describe("event-dispatch", () => {
         .mockResolvedValueOnce([]) // no webhooks
         .mockResolvedValueOnce([trigger]); // event triggers
 
-      dispatchEvent("ws-1", "card.created", { cardId: "c1" });
+      dispatchEvent("org-1", "ws-1", "card.created", { cardId: "c1" });
       await flushMicrotasks();
 
       expect(mockExecuteTrigger).toHaveBeenCalledWith(trigger, {
@@ -156,7 +165,7 @@ describe("event-dispatch", () => {
       });
       mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
 
-      dispatchEvent("ws-1", "card.created", { cardId: "c1" });
+      dispatchEvent("org-1", "ws-1", "card.created", { cardId: "c1" });
       await flushMicrotasks();
 
       expect(mockExecuteTrigger).not.toHaveBeenCalled();
@@ -172,7 +181,7 @@ describe("event-dispatch", () => {
       mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
 
       // Event data has a different boardId
-      dispatchEvent("ws-1", "card.created", {
+      dispatchEvent("org-1", "ws-1", "card.created", {
         cardId: "c1",
         boardId: "board-2",
       });
@@ -190,7 +199,7 @@ describe("event-dispatch", () => {
       });
       mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
 
-      dispatchEvent("ws-1", "card.created", {
+      dispatchEvent("org-1", "ws-1", "card.created", {
         cardId: "c1",
         boardId: "board-1",
       });
@@ -208,7 +217,7 @@ describe("event-dispatch", () => {
       });
       mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
 
-      dispatchEvent("ws-1", "card.created", {
+      dispatchEvent("org-1", "ws-1", "card.created", {
         cardId: "c1",
         columnId: "col-2",
       });
@@ -230,7 +239,7 @@ describe("event-dispatch", () => {
         .mockResolvedValueOnce([webhook1, webhook2])
         .mockResolvedValueOnce([trigger1, trigger2]);
 
-      dispatchEvent("ws-1", "card.created", { cardId: "c1" });
+      dispatchEvent("org-1", "ws-1", "card.created", { cardId: "c1" });
       await flushMicrotasks();
 
       expect(mockDeliverWebhook).toHaveBeenCalledTimes(2);
@@ -244,7 +253,7 @@ describe("event-dispatch", () => {
       mockExecuteTrigger.mockRejectedValue(new Error("Execution failed"));
 
       // Should not throw — errors are caught internally
-      dispatchEvent("ws-1", "card.created", { cardId: "c1" });
+      dispatchEvent("org-1", "ws-1", "card.created", { cardId: "c1" });
       await flushMicrotasks();
     });
 
@@ -253,6 +262,7 @@ describe("event-dispatch", () => {
       mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
 
       dispatchEvent(
+        "org-1",
         "ws-1",
         "card.updated",
         { id: "c1" },
@@ -269,7 +279,7 @@ describe("event-dispatch", () => {
 
       // Human write path supplies no actor, even though the card row still
       // carries a stale lastEditedByAgentId from a prior agent edit.
-      dispatchEvent("ws-1", "card.updated", {
+      dispatchEvent("org-1", "ws-1", "card.updated", {
         id: "c1",
         lastEditedByAgentId: "agent-1",
       });
@@ -283,6 +293,7 @@ describe("event-dispatch", () => {
       mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
 
       dispatchEvent(
+        "org-1",
         "ws-1",
         "card.updated",
         { id: "c1" },
@@ -298,6 +309,7 @@ describe("event-dispatch", () => {
       mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
 
       dispatchEvent(
+        "org-1",
         "ws-1",
         "card.updated",
         { id: "c1" },
@@ -315,7 +327,7 @@ describe("event-dispatch", () => {
         .mockResolvedValueOnce([webhook])
         .mockResolvedValueOnce([trigger]);
 
-      dispatchEvent("ws-1", "card.created", { cardId: "c1" });
+      dispatchEvent("org-1", "ws-1", "card.created", { cardId: "c1" });
       await flushMicrotasks();
 
       expect(mockDeliverWebhook).toHaveBeenCalledTimes(1);

--- a/apps/backend/src/services/event-dispatch.ts
+++ b/apps/backend/src/services/event-dispatch.ts
@@ -29,6 +29,7 @@ export interface DispatchEventOptions {
 }
 
 export function dispatchEvent(
+  orgId: string,
   workspaceId: string,
   event: WebhookEvent,
   data: unknown,
@@ -45,7 +46,13 @@ export function dispatchEvent(
 
       if (webhooks.length > 0) {
         const timestamp = new Date().toISOString();
-        const body = JSON.stringify({ event, timestamp, workspaceId, data });
+        const body = JSON.stringify({
+          event,
+          timestamp,
+          orgId,
+          workspaceId,
+          data,
+        });
 
         for (const webhook of webhooks) {
           if (!webhook.enabled) continue;

--- a/apps/backend/src/services/webhook-delivery.test.ts
+++ b/apps/backend/src/services/webhook-delivery.test.ts
@@ -90,7 +90,7 @@ describe("Webhook Delivery Service", () => {
     mockWebhookSelect.mockResolvedValueOnce([sampleWebhook]);
     mockFetch.mockResolvedValueOnce({ ok: true } as Response);
 
-    dispatchEvent("ws-1", "notification.created", { id: "n-1" });
+    dispatchEvent("org-1", "ws-1", "notification.created", { id: "n-1" });
 
     // Allow the async fire-and-forget to complete
     await vi.advanceTimersByTimeAsync(100);
@@ -105,10 +105,12 @@ describe("Webhook Delivery Service", () => {
 
     const body = JSON.parse(options.body) as {
       event: string;
+      orgId: string;
       workspaceId: string;
       data: unknown;
     };
     expect(body.event).toBe("notification.created");
+    expect(body.orgId).toBe("org-1");
     expect(body.workspaceId).toBe("ws-1");
     expect(body.data).toEqual({ id: "n-1" });
   });
@@ -117,7 +119,7 @@ describe("Webhook Delivery Service", () => {
     mockWebhookSelect.mockResolvedValueOnce([sampleWebhook]);
     mockFetch.mockResolvedValueOnce({ ok: true } as Response);
 
-    dispatchEvent("ws-1", "notification.created", { id: "n-1" });
+    dispatchEvent("org-1", "ws-1", "notification.created", { id: "n-1" });
 
     await vi.advanceTimersByTimeAsync(100);
 
@@ -139,7 +141,7 @@ describe("Webhook Delivery Service", () => {
     mockWebhookSelect.mockResolvedValueOnce([webhookWithHeaders]);
     mockFetch.mockResolvedValueOnce({ ok: true } as Response);
 
-    dispatchEvent("ws-1", "notification.created", {});
+    dispatchEvent("org-1", "ws-1", "notification.created", {});
 
     await vi.advanceTimersByTimeAsync(100);
 
@@ -154,7 +156,7 @@ describe("Webhook Delivery Service", () => {
       .mockRejectedValueOnce(new Error("Network error"))
       .mockResolvedValueOnce({ ok: true } as Response);
 
-    dispatchEvent("ws-1", "notification.created", {});
+    dispatchEvent("org-1", "ws-1", "notification.created", {});
 
     // First attempt fails immediately
     await vi.advanceTimersByTimeAsync(100);
@@ -172,7 +174,7 @@ describe("Webhook Delivery Service", () => {
     mockWebhookSelect.mockResolvedValueOnce([sampleWebhook]);
     mockFetch.mockRejectedValue(new Error("Network error"));
 
-    dispatchEvent("ws-1", "notification.created", {});
+    dispatchEvent("org-1", "ws-1", "notification.created", {});
 
     // Advance through all retries: initial + 1s + 2s + 4s
     await vi.advanceTimersByTimeAsync(100);
@@ -192,7 +194,7 @@ describe("Webhook Delivery Service", () => {
       { ...sampleWebhook, enabled: false },
     ]);
 
-    dispatchEvent("ws-1", "notification.created", {});
+    dispatchEvent("org-1", "ws-1", "notification.created", {});
 
     await vi.advanceTimersByTimeAsync(100);
 
@@ -202,7 +204,7 @@ describe("Webhook Delivery Service", () => {
   it("should skip when no webhook configured", async () => {
     mockWebhookSelect.mockResolvedValueOnce([]);
 
-    dispatchEvent("ws-1", "notification.created", {});
+    dispatchEvent("org-1", "ws-1", "notification.created", {});
 
     await vi.advanceTimersByTimeAsync(100);
 
@@ -214,7 +216,7 @@ describe("Webhook Delivery Service", () => {
       { ...sampleWebhook, events: ["notification.created"] },
     ]);
 
-    dispatchEvent("ws-1", "notification.dismissed", { id: "n-1" });
+    dispatchEvent("org-1", "ws-1", "notification.dismissed", { id: "n-1" });
 
     await vi.advanceTimersByTimeAsync(100);
 
@@ -232,7 +234,7 @@ describe("Webhook Delivery Service", () => {
     mockWebhookSelect.mockResolvedValueOnce([sampleWebhook, webhook2]);
     mockFetch.mockResolvedValue({ ok: true } as Response);
 
-    dispatchEvent("ws-1", "notification.created", { id: "n-1" });
+    dispatchEvent("org-1", "ws-1", "notification.created", { id: "n-1" });
 
     await vi.advanceTimersByTimeAsync(100);
 
@@ -260,7 +262,7 @@ describe("Webhook Delivery Service", () => {
     mockWebhookSelect.mockResolvedValueOnce([sampleWebhook, webhook2]);
     mockFetch.mockResolvedValue({ ok: true } as Response);
 
-    dispatchEvent("ws-1", "notification.dismissed", { id: "n-1" });
+    dispatchEvent("org-1", "ws-1", "notification.dismissed", { id: "n-1" });
 
     await vi.advanceTimersByTimeAsync(100);
 
@@ -284,7 +286,7 @@ describe("Webhook Delivery Service", () => {
       .mockRejectedValueOnce(new Error("Network error"))
       .mockResolvedValueOnce({ ok: true } as Response);
 
-    dispatchEvent("ws-1", "notification.created", { id: "n-1" });
+    dispatchEvent("org-1", "ws-1", "notification.created", { id: "n-1" });
 
     await vi.advanceTimersByTimeAsync(100);
 

--- a/apps/backend/src/tools/index.ts
+++ b/apps/backend/src/tools/index.ts
@@ -158,8 +158,8 @@ registerToolSet("notifications", {
   name: "Notifications",
   category: "Communication",
   description: "Post notifications visible to users in this workspace",
-  tools: ({ workspaceId, agentId }) =>
-    createNotificationTools(workspaceId, agentId),
+  tools: ({ workspaceId, agentId, orgId }) =>
+    createNotificationTools(workspaceId, agentId, orgId),
 });
 
 registerToolSet("memory", {

--- a/apps/backend/src/tools/kanban.ts
+++ b/apps/backend/src/tools/kanban.ts
@@ -372,6 +372,7 @@ export function createKanbanTools(
 
         const boardId = await getBoardIdForCard(cardId);
         dispatchEvent(
+          orgId,
           workspaceId,
           "card.updated",
           { ...record[0], boardId },
@@ -431,6 +432,7 @@ export function createKanbanTools(
 
       const boardId = await getBoardIdForCard(id);
       dispatchEvent(
+        orgId,
         workspaceId,
         "card.created",
         { ...record[0], boardId },
@@ -532,6 +534,7 @@ export function createKanbanTools(
 
       const boardId = await getBoardIdForCard(cardId);
       dispatchEvent(
+        orgId,
         workspaceId,
         "card.updated",
         { ...updated[0], boardId },
@@ -576,6 +579,7 @@ export function createKanbanTools(
         const columnId = cardRecord[0]?.columnId;
         await db.delete(kanbanCardTable).where(eq(kanbanCardTable.id, cardId));
         dispatchEvent(
+          orgId,
           workspaceId,
           "card.deleted",
           { cardId, boardId, columnId },
@@ -871,6 +875,7 @@ export function createKanbanTools(
 
       // 8. Dispatch event
       dispatchEvent(
+        orgId,
         workspaceId,
         "card.created",
         { ...record[0], boardId: sourceBoardId },
@@ -1070,6 +1075,7 @@ export function createKanbanTools(
           .where(eq(kanbanCardTable.id, cardId))
           .limit(1);
         dispatchEvent(
+          orgId,
           workspaceId,
           "card.updated",
           { ...updated[0], boardId },

--- a/apps/backend/src/tools/notification.test.ts
+++ b/apps/backend/src/tools/notification.test.ts
@@ -11,6 +11,7 @@ import { dispatchEvent } from "../services/event-dispatch.ts";
 const ctx = { toolCallId: "test", messages: [] };
 const workspaceId = "ws-1";
 const agentId = "agent-1";
+const orgId = "org-1";
 
 describe("createNotificationTools", () => {
   let tools: ReturnType<typeof createNotificationTools>;
@@ -18,7 +19,7 @@ describe("createNotificationTools", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetMockDb();
-    tools = createNotificationTools(workspaceId, agentId);
+    tools = createNotificationTools(workspaceId, agentId, orgId);
   });
 
   it("returns the expected tool names", () => {
@@ -48,6 +49,7 @@ describe("createNotificationTools", () => {
         ),
       ).toEqual(record);
       expect(dispatchEvent).toHaveBeenCalledWith(
+        orgId,
         workspaceId,
         "notification.created",
         record,
@@ -93,6 +95,7 @@ describe("createNotificationTools", () => {
         ),
       ).toEqual(updated);
       expect(dispatchEvent).toHaveBeenCalledWith(
+        orgId,
         workspaceId,
         "notification.updated",
         updated,
@@ -119,6 +122,7 @@ describe("createNotificationTools", () => {
         await tools.deleteNotification.execute!({ notificationId: "n1" }, ctx),
       ).toEqual({ success: true });
       expect(dispatchEvent).toHaveBeenCalledWith(
+        orgId,
         workspaceId,
         "notification.dismissed",
         { notificationId: "n1" },

--- a/apps/backend/src/tools/notification.ts
+++ b/apps/backend/src/tools/notification.ts
@@ -8,6 +8,7 @@ import { dispatchEvent } from "../services/event-dispatch.ts";
 export function createNotificationTools(
   workspaceId: string,
   agentId: string,
+  orgId: string,
 ): Record<string, Tool> {
   async function verifyNotification(notificationId: string): Promise<boolean> {
     const result = await db
@@ -58,7 +59,7 @@ export function createNotificationTools(
         })
         .returning();
 
-      dispatchEvent(workspaceId, "notification.created", record[0]);
+      dispatchEvent(orgId, workspaceId, "notification.created", record[0]);
 
       return record[0];
     },
@@ -131,7 +132,7 @@ export function createNotificationTools(
         return { error: "Notification not found" };
       }
 
-      dispatchEvent(workspaceId, "notification.updated", record[0]);
+      dispatchEvent(orgId, workspaceId, "notification.updated", record[0]);
 
       return record[0];
     },
@@ -153,7 +154,7 @@ export function createNotificationTools(
         .delete(notificationTable)
         .where(eq(notificationTable.id, notificationId));
 
-      dispatchEvent(workspaceId, "notification.dismissed", {
+      dispatchEvent(orgId, workspaceId, "notification.dismissed", {
         notificationId,
       });
 

--- a/apps/docs/content/building-with-platypus/_meta.ts
+++ b/apps/docs/content/building-with-platypus/_meta.ts
@@ -1,7 +1,7 @@
 // Building with Platypus section order. Audience: Workspace Owner (ADR-0011).
 // Ordered as a build sequence: the Agent first, then the capabilities you give
 // it (Skills, MCP), then the surfaces it works against (Triggers, Boards,
-// Dashboards).
+// Dashboards), then how to integrate with the outside world (Webhooks).
 const meta = {
   index: "Overview",
   agents: "Agents & sub-agents",
@@ -10,6 +10,7 @@ const meta = {
   triggers: "Triggers",
   boards: "Boards",
   dashboards: "Dashboards",
+  webhooks: "Webhooks",
 };
 
 export default meta;

--- a/apps/docs/content/building-with-platypus/webhooks.mdx
+++ b/apps/docs/content/building-with-platypus/webhooks.mdx
@@ -1,0 +1,225 @@
+---
+title: Webhooks
+description: Receive Workspace events in an external system with Webhooks — the events you can subscribe to, the JSON payload Platypus sends, how to verify the signature, and the delivery and retry behaviour.
+---
+
+import { Callout, Steps } from "nextra/components";
+
+# Webhooks
+
+A **Webhook** delivers Workspace events to a URL you control. Whenever something
+happens in the Workspace — a card is created, a notification is dismissed —
+Platypus sends an HTTP `POST` with a JSON body describing the event, so an
+external system can react to it.
+
+Where a [Trigger](/building-with-platypus/triggers) runs an Agent _inside_
+Platypus in response to an event, a Webhook sends that same event _out_ to your
+own service. Both subscribe to the same set of events.
+
+You'll find Webhooks under **Settings → Webhooks** in your Workspace.
+
+## Subscribable events
+
+A Webhook subscribes to one or more events. The available events are:
+
+| Event                    | Fires when                                                    |
+| ------------------------ | ------------------------------------------------------------- |
+| `card.created`           | A card is added to a [Board](/building-with-platypus/boards). |
+| `card.updated`           | A card's fields, column, or position change.                  |
+| `card.deleted`           | A card is removed.                                            |
+| `notification.created`   | An Agent posts a notification.                                |
+| `notification.updated`   | A notification is edited.                                     |
+| `notification.read`      | A notification is marked read.                                |
+| `notification.dismissed` | A notification is dismissed.                                  |
+
+If you don't pick any events when creating a Webhook, it subscribes to all of
+them.
+
+## Create a Webhook
+
+<Steps>
+
+### Open the Webhook form
+
+In your Workspace, go to **Settings → Webhooks** and click **Create**.
+
+### Configure the endpoint
+
+- **Name** — a label for the Webhook.
+- **URL** — where the `POST` is sent. **Must be HTTPS.**
+- **Events** — which events to subscribe to (defaults to all).
+- **Headers** — optional custom headers sent with every delivery (e.g. an
+  `Authorization` header your endpoint expects).
+- **Enabled** — leave on to start delivering immediately.
+
+### Save and note the signing secret
+
+On save, Platypus generates a **signing secret** for the Webhook. Every delivery
+is signed with it so you can verify the request really came from Platypus — see
+[Verifying the signature](#verifying-the-signature). You can rotate it later with
+**Regenerate secret**.
+
+</Steps>
+
+## The payload
+
+Platypus sends a `POST` request with `Content-Type: application/json`. The body
+is the same envelope for every event:
+
+```json
+{
+  "event": "card.created",
+  "timestamp": "2026-06-26T09:30:00.000Z",
+  "orgId": "g7Qw3pLm9xRt2nK5vB8dY",
+  "workspaceId": "k4Tn2pXqRf7Lm9sWvB3dY",
+  "data": {
+    "id": "V1StGXR8_Z5jdHi6B-myT",
+    "boardId": "lbfQ0p7xKmR2nT4vZ8wYs",
+    "columnId": "9zHcN3eW1qoP5rUaB7dKt",
+    "title": "Review onboarding flow",
+    "body": "Check the new sign-up steps.",
+    "labelIds": [],
+    "assignees": [],
+    "dueDate": null,
+    "priority": "none",
+    "position": 1024,
+    "createdByUserId": "x6Ym2Qp9LrT4nW8sVdB1k",
+    "createdByAgentId": null,
+    "createdAt": "2026-06-26T09:30:00.000Z",
+    "updatedAt": "2026-06-26T09:30:00.000Z"
+  }
+}
+```
+
+The envelope fields are always present:
+
+| Field         | Description                                                                       |
+| ------------- | --------------------------------------------------------------------------------- |
+| `event`       | The event name, e.g. `card.created`.                                              |
+| `timestamp`   | ISO 8601 time the event was dispatched. Matches the `X-Webhook-Timestamp` header. |
+| `orgId`       | The Organization the event belongs to.                                            |
+| `workspaceId` | The Workspace the event belongs to.                                               |
+| `data`        | The event's payload. Its shape depends on the event (see below).                  |
+
+### `data` by event
+
+The shape of `data` varies by event. For example, `notification.created` carries
+the full notification record:
+
+```json
+{
+  "event": "notification.created",
+  "timestamp": "2026-06-26T09:31:00.000Z",
+  "orgId": "g7Qw3pLm9xRt2nK5vB8dY",
+  "workspaceId": "k4Tn2pXqRf7Lm9sWvB3dY",
+  "data": {
+    "id": "Hs8dK2pQ9mRnL7wT4vYx1",
+    "workspaceId": "k4Tn2pXqRf7Lm9sWvB3dY",
+    "agentId": "Jf3kP9xR2mLqN7wT4vYsZ",
+    "title": "Daily summary ready",
+    "body": "Your daily summary has been generated.",
+    "createdAt": "2026-06-26T09:31:00.000Z",
+    "updatedAt": "2026-06-26T09:31:00.000Z"
+  }
+}
+```
+
+while lighter-weight events carry only the affected IDs. For example,
+`card.deleted`:
+
+```json
+{
+  "event": "card.deleted",
+  "timestamp": "2026-06-26T09:32:00.000Z",
+  "orgId": "g7Qw3pLm9xRt2nK5vB8dY",
+  "workspaceId": "k4Tn2pXqRf7Lm9sWvB3dY",
+  "data": {
+    "cardId": "V1StGXR8_Z5jdHi6B-myT",
+    "boardId": "lbfQ0p7xKmR2nT4vZ8wYs",
+    "columnId": "9zHcN3eW1qoP5rUaB7dKt"
+  }
+}
+```
+
+and `notification.read` / `notification.dismissed` carry the notification ID and
+the user who acted:
+
+```json
+{
+  "data": {
+    "notificationId": "Hs8dK2pQ9mRnL7wT4vYx1",
+    "userId": "x6Ym2Qp9LrT4nW8sVdB1k"
+  }
+}
+```
+
+<Callout type="info">
+  Treat `data` defensively — read the fields your integration needs rather than
+  assuming a fixed set, since the underlying records can gain fields over time.
+</Callout>
+
+## Headers
+
+Every delivery includes:
+
+| Header                | Value                                                    |
+| --------------------- | -------------------------------------------------------- |
+| `Content-Type`        | `application/json`                                       |
+| `X-Webhook-Signature` | HMAC-SHA256 of the raw request body, hex-encoded.        |
+| `X-Webhook-Timestamp` | ISO 8601 timestamp, identical to the body's `timestamp`. |
+
+Any custom **Headers** you configured on the Webhook are sent alongside these.
+
+## Verifying the signature
+
+The signature is an HMAC-SHA256 of the **exact raw request body**, keyed with the
+Webhook's signing secret and hex-encoded. Recompute it on your end and compare —
+if it doesn't match, reject the request.
+
+```js
+import crypto from "node:crypto";
+
+function verify(rawBody, signatureHeader, signingSecret) {
+  const expected = crypto
+    .createHmac("sha256", signingSecret)
+    .update(rawBody)
+    .digest("hex");
+
+  // Constant-time comparison
+  return (
+    expected.length === signatureHeader.length &&
+    crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signatureHeader))
+  );
+}
+
+// In your handler, compute over the raw body BEFORE JSON parsing:
+const ok = verify(rawBody, req.headers["x-webhook-signature"], signingSecret);
+```
+
+<Callout type="warning">
+  Compute the signature over the raw, unparsed body bytes. Re-serializing the
+  parsed JSON can change whitespace or key order and produce a different
+  signature.
+</Callout>
+
+## Delivery and retries
+
+- Deliveries are **fire-and-forget** — a slow or failing endpoint never blocks
+  the action that produced the event.
+- A delivery counts as successful on any **2xx** response. Each attempt times out
+  after **10 seconds**.
+- On failure (non-2xx, timeout, or connection error) Platypus retries up to
+  **3 times** with a backoff of **1s, 2s, then 4s**. After that the delivery is
+  given up.
+- Disabled Webhooks, and Webhooks not subscribed to the event, are skipped.
+
+<Callout type="info">
+  Your endpoint should be idempotent — a retried delivery sends the same body,
+  so process the same `data.id` / event more than once safely.
+</Callout>
+
+## Where to next
+
+- **[Triggers](/building-with-platypus/triggers)** — react to the same events by
+  running an Agent inside Platypus.
+- **[Boards](/building-with-platypus/boards)** — the source of `card.*` events.


### PR DESCRIPTION
## Summary

- Adds `orgId` to the webhook delivery envelope alongside `workspaceId`, so a receiver can call back into the org-scoped Platypus API (`/organizations/:orgId/workspaces/:workspaceId/…`) without separately resolving which org a workspace belongs to.
- Threads `orgId` through `dispatchEvent` and all 16 call sites rather than re-deriving it via a DB lookup inside the fire-and-forget dispatcher — every site already had it in scope (route params, existing tool args), keeping the dispatcher dependency-free and free of a new failure mode.
- Documents the previously-undocumented **Webhooks** feature in `apps/docs`: subscribable events, example payloads per event, signature verification, headers, and delivery/retry behaviour.

## Envelope shape

```json
{
  "event": "card.created",
  "timestamp": "2026-06-26T09:30:00.000Z",
  "orgId": "…",
  "workspaceId": "…",
  "data": { … }
}
```

## Testing

- `pnpm --filter backend typecheck` — clean
- `pnpm --filter backend test` — 974/974 pass
- Added assertions that `orgId` lands in the delivered envelope (`event-dispatch.test.ts`, `webhook-delivery.test.ts`)
- Docs JSON examples validated; Prettier-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)