### PR TITLE
fix(frontend): left-align attach dialog text on mobile

### DIFF
--- a/apps/frontend/components/attach-shared-resource-dialog.tsx
+++ b/apps/frontend/components/attach-shared-resource-dialog.tsx
@@ -102,7 +102,7 @@ const AttachSharedResourceDialog = ({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <DialogHeader>
+        <DialogHeader className="text-left">
           <DialogTitle>Attach a shared {label}</DialogTitle>
           <DialogDescription>
             Organization {label}s appear in this workspace only where attached.


### PR DESCRIPTION
## Summary

On mobile viewports the "Attach a shared …" dialog looked inconsistent: the title and description were centred while the body beneath them (empty-state text, the resource list, error messages) was left-aligned.

The cause is shadcn's `DialogHeader` default, `text-center sm:text-left`, which centres header content below the `sm` (640px) breakpoint. `DialogDescription` conventionally lives inside `DialogHeader`, so it inherited the centring while the dialog body did not.

## Fix

Override the header alignment locally on this one dialog:

```tsx
<DialogHeader className="text-left">
```

tailwind-merge resolves the conflict so `text-left` wins across all breakpoints. The shared `components/ui/dialog.tsx` is left untouched, so no other dialog's behaviour changes.

All four "Attach a shared MCP / provider / skill / agent" variants route through this single component, so they're all covered.

## Verification

- [ ] Visual check at a narrow (<640px) viewport — title, description, and body all left-aligned and consistent.

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)