### PR TITLE
fix(docs): restore og:image on doc pages

### DIFF
--- a/apps/docs/app/[[...mdxPath]]/page.tsx
+++ b/apps/docs/app/[[...mdxPath]]/page.tsx
@@ -1,5 +1,6 @@
 import { generateStaticParamsFor, importPage } from "nextra/pages";
 import type { FC } from "react";
+import { openGraph, twitter } from "../layout";
 import { useMDXComponents as getMDXComponents } from "../../mdx-components";
 
 export const generateStaticParams = generateStaticParamsFor("mdxPath");
@@ -16,10 +17,17 @@ export async function generateMetadata(props: PageProps) {
   // Nextra only sets the plain `title` from frontmatter. Mirror it into
   // openGraph/twitter so link previews show the page title (the parent
   // layout's `%s | Platypus Docs` template then applies to og:title too).
+  // Spread the layout's shared bases first: Next.js OVERWRITES (does not
+  // deep-merge) openGraph/twitter across segments, so without these the
+  // og:image and Twitter card from the layout would be dropped.
   const pageTitle = metadata.title;
   if (typeof pageTitle === "string") {
-    metadata.openGraph = { ...metadata.openGraph, title: pageTitle };
-    metadata.twitter = { ...metadata.twitter, title: pageTitle };
+    metadata.openGraph = {
+      ...openGraph,
+      ...metadata.openGraph,
+      title: pageTitle,
+    };
+    metadata.twitter = { ...twitter, ...metadata.twitter, title: pageTitle };
   }
   return metadata;
 }

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -10,6 +10,41 @@ const title = "Platypus Docs";
 const description =
   "Documentation for Platypus — build and manage AI agents with tool support and multi-provider capabilities.";
 
+// Shared OG/Twitter bases. Exported so per-page `generateMetadata`
+// (app/[[...mdxPath]]/page.tsx) can spread them when mirroring the page title:
+// Next.js OVERWRITES (does not deep-merge) openGraph/twitter across segments, so
+// a page that returns its own openGraph without these would drop `images` and
+// the Twitter `card`, and no og:image tag would render.
+export const openGraph: Metadata["openGraph"] = {
+  type: "website",
+  siteName: title,
+  title: {
+    default: title,
+    template: `%s | ${title}`,
+  },
+  description,
+  url: "/",
+  locale: "en_US",
+  images: [
+    {
+      url: "/og.png",
+      width: 1200,
+      height: 630,
+      alt: "Platypus — build and manage AI agents with tool support and multi-provider capabilities.",
+    },
+  ],
+};
+
+export const twitter: Metadata["twitter"] = {
+  card: "summary_large_image",
+  title: {
+    default: title,
+    template: `%s | ${title}`,
+  },
+  description,
+  images: ["/og.png"],
+};
+
 export const metadata: Metadata = {
   metadataBase: new URL("https://docs.platypus.chat"),
   title: {
@@ -18,34 +53,8 @@ export const metadata: Metadata = {
   },
   description,
   applicationName: title,
-  openGraph: {
-    type: "website",
-    siteName: title,
-    title: {
-      default: title,
-      template: `%s | ${title}`,
-    },
-    description,
-    url: "/",
-    locale: "en_US",
-    images: [
-      {
-        url: "/og.png",
-        width: 1200,
-        height: 630,
-        alt: "Platypus — build and manage AI agents with tool support and multi-provider capabilities.",
-      },
-    ],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: {
-      default: title,
-      template: `%s | ${title}`,
-    },
-    description,
-    images: ["/og.png"],
-  },
+  openGraph,
+  twitter,
 };
 
 const version = process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown";


### PR DESCRIPTION
## Why

`og:image` wasn't rendering for any page on docs.platypus.chat. The image file (`/og.png`) was served fine, but the `<meta property="og:image">` tag was never emitted.

## Cause

Per-page `generateMetadata` in `app/[[...mdxPath]]/page.tsx` mirrored the page title into `openGraph`/`twitter` by overwriting those objects with `{ title: pageTitle }`. Next.js **overwrites rather than deep-merges** these nested metadata objects across route segments, so the layout's `images: ["/og.png"]` and the Twitter `summary_large_image` card were dropped on every doc page. (`og:title` kept its suffix via title-template resolution and `og:description` survived via top-level fallback — images have no such fallback.)

## Fix

Export the shared `openGraph`/`twitter` bases from `app/layout.tsx` and spread them first in the page override, so the images and card survive while the title is still mirrored.

## Verification

Production build (`pnpm build`) now emits on every page:

```
og:image        → https://docs.platypus.chat/og.png
og:image:width  → 1200
og:image:height → 630
og:image:alt    → Platypus — build and manage AI agents…
twitter:card    → summary_large_image
twitter:image   → https://docs.platypus.chat/og.png
```

> Note: platforms that cache OG previews (Slack, Twitter/X, LinkedIn, iMessage) may need a manual re-scrape after deploy to drop the old cached preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)