### PR TITLE
feat(backend): manifest-driven plugin loader + @platypuschat/plugin-sdk + first core Tool set plugin

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -12,6 +12,9 @@ LOG_LEVEL=info
 # Defaults to UTC if not set
 TIMEZONE=UTC
 
+# Comma-separated plugins to load and enable at boot (fail-loud). Empty = no plugin tools.
+PLATYPUS_PLUGINS=@platypus/tools-basic
+
 # Memory extraction configuration
 MEMORY_EXTRACTION_INTERVAL_MS=300000  # 5 minutes
 

--- a/apps/backend/index.ts
+++ b/apps/backend/index.ts
@@ -13,6 +13,7 @@ import { auth } from "./src/auth.ts";
 import { logger } from "./src/logger.ts";
 import { startMemoryScheduler } from "./src/jobs/memory-scheduler.ts";
 import { startTriggerScheduler } from "./src/jobs/trigger-scheduler.ts";
+import { loadPlugins } from "./src/plugins/loader.ts";
 
 const PORT = process.env.PORT || "4001";
 
@@ -100,6 +101,15 @@ const main = async () => {
       }
     }
   });
+
+  // Load plugins before the HTTP server accepts traffic so their Tool set
+  // contributions are registered by the time Chat turns resolve tools. Fail-loud
+  // and all-or-nothing: a bad plugin aborts startup (ADR-0013).
+  const loadedPlugins = await loadPlugins();
+  logger.info(
+    { plugins: loadedPlugins },
+    `Loaded ${loadedPlugins.length} plugin(s)`,
+  );
 
   serve({
     fetch: app.fetch,

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -33,6 +33,7 @@
     "@mozilla/readability": "^0.6.0",
     "@openrouter/ai-sdk-provider": "^2.10.0",
     "@platypus/schemas": "workspace:*",
+    "@platypuschat/plugin-sdk": "workspace:*",
     "ai": "^6.0.217",
     "better-auth": "^1.6.23",
     "croner": "^10.0.1",

--- a/apps/backend/src/plugins/builtin.ts
+++ b/apps/backend/src/plugins/builtin.ts
@@ -1,0 +1,15 @@
+import type { PlatypusPlugin } from "@platypuschat/plugin-sdk";
+
+// The static built-in map IS the core allowlist (ADR-0013): membership here —
+// resolved from the trusted bundle, not the package-scope string — decides which
+// plugin names are treated as core. Core plugins are internal backend modules
+// under `apps/backend/src/plugins/<name>/`, reached through these loader thunks,
+// mirroring today's `import "./sandbox/backends/index.ts"`. Their `@platypus/*`
+// names are logical ids, not published packages. Third-party plugins are absent
+// from this map and resolve via dynamic `import()` in the loader.
+export const BUILTIN_PLUGINS: Record<
+  string,
+  () => Promise<{ plugin: PlatypusPlugin }>
+> = {
+  "@platypus/tools-basic": () => import("./tools-basic/index.ts"),
+};

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -86,9 +86,11 @@ describe("loadPlugins", () => {
 
   it("resolves a third-party plugin via dynamic import", async () => {
     const { register, calls } = makeRegister();
-    const importPlugin = vi.fn(async (_name: string) => ({
-      plugin: manifest("@third/party", [toolSet("custom")]),
-    }));
+    const importPlugin = vi.fn((_name: string) =>
+      Promise.resolve({
+        plugin: manifest("@third/party", [toolSet("custom")]),
+      }),
+    );
 
     const loaded = await loadPlugins({
       pluginNames: ["@third/party"],
@@ -110,9 +112,11 @@ describe("loadPlugins", () => {
           plugin: manifest("@platypus/tools-basic", [toolSet("time")]),
         }),
     };
-    const importPlugin = vi.fn(async (_name: string) => ({
-      plugin: manifest("@third/party", [toolSet("custom")]),
-    }));
+    const importPlugin = vi.fn((_name: string) =>
+      Promise.resolve({
+        plugin: manifest("@third/party", [toolSet("custom")]),
+      }),
+    );
 
     const loaded = await loadPlugins({
       pluginNames: ["@platypus/tools-basic", "@third/party"],
@@ -129,7 +133,7 @@ describe("loadPlugins", () => {
 
   it("aborts (fail-loud) when a plugin cannot be resolved", async () => {
     const { register } = makeRegister();
-    const importPlugin = vi.fn(async () => {
+    const importPlugin = vi.fn(() => {
       throw new Error("Cannot find module");
     });
 
@@ -149,9 +153,10 @@ describe("loadPlugins", () => {
       loadPlugins({
         pluginNames: ["@bad/plugin"],
         builtinPlugins: {},
-        importPlugin: async () => ({
-          plugin: { name: "@bad/plugin", version: "0.1.0", apiVersion: 1 },
-        }),
+        importPlugin: () =>
+          Promise.resolve({
+            plugin: { name: "@bad/plugin", version: "0.1.0", apiVersion: 1 },
+          }),
         register,
       }),
     ).rejects.toThrow(/@bad\/plugin.*contributes/s);
@@ -163,14 +168,15 @@ describe("loadPlugins", () => {
       loadPlugins({
         pluginNames: ["@bad/plugin"],
         builtinPlugins: {},
-        importPlugin: async () => ({
-          plugin: {
-            name: "@bad/plugin",
-            version: "0.1.0",
-            apiVersion: "1",
-            contributes: {},
-          },
-        }),
+        importPlugin: () =>
+          Promise.resolve({
+            plugin: {
+              name: "@bad/plugin",
+              version: "0.1.0",
+              apiVersion: "1",
+              contributes: {},
+            },
+          }),
         register,
       }),
     ).rejects.toThrow(/@bad\/plugin.*apiVersion/s);
@@ -182,7 +188,7 @@ describe("loadPlugins", () => {
       loadPlugins({
         pluginNames: ["@empty/plugin"],
         builtinPlugins: {},
-        importPlugin: async () => ({}),
+        importPlugin: () => Promise.resolve({}),
         register,
       }),
     ).rejects.toThrow(/@empty\/plugin.*manifest/s);
@@ -190,9 +196,11 @@ describe("loadPlugins", () => {
 
   it("aborts (fail-loud) on a duplicate id, naming both owning plugins", async () => {
     const { register } = makeRegister();
-    const importPlugin = vi.fn(async (name: string) => ({
-      plugin: manifest(name, [toolSet("time")]),
-    }));
+    const importPlugin = vi.fn((name: string) =>
+      Promise.resolve({
+        plugin: manifest(name, [toolSet("time")]),
+      }),
+    );
 
     await expect(
       loadPlugins({
@@ -214,9 +222,10 @@ describe("loadPlugins", () => {
       loadPlugins({
         pluginNames: ["@collides/plugin"],
         builtinPlugins: {},
-        importPlugin: async () => ({
-          plugin: manifest("@collides/plugin", [toolSet("kanban")]),
-        }),
+        importPlugin: () =>
+          Promise.resolve({
+            plugin: manifest("@collides/plugin", [toolSet("kanban")]),
+          }),
         register,
       }),
     ).rejects.toThrow(/@collides\/plugin.*"kanban".*already been registered/s);

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi } from "vitest";
+import type {
+  PlatypusPlugin,
+  ToolSetContribution,
+} from "@platypuschat/plugin-sdk";
+import { loadPlugins, parsePluginList } from "./loader.ts";
+
+// A capturing `register` and the builtin/import module shapes the loader expects.
+const makeRegister = () => {
+  const calls: Array<{ id: string; def: Omit<ToolSetContribution, "id"> }> = [];
+  const register = (id: string, def: Omit<ToolSetContribution, "id">) => {
+    calls.push({ id, def });
+  };
+  return { register, calls };
+};
+
+const manifest = (
+  name: string,
+  toolSets: ToolSetContribution[],
+): PlatypusPlugin => ({
+  name,
+  version: "0.1.0",
+  apiVersion: 1,
+  contributes: { toolSets },
+});
+
+const toolSet = (id: string): ToolSetContribution => ({
+  id,
+  name: id,
+  category: "Test",
+  tools: {},
+});
+
+describe("parsePluginList", () => {
+  it("splits, trims, and drops blank entries", () => {
+    expect(parsePluginList("a, b ,, c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns an empty list for unset or empty input", () => {
+    expect(parsePluginList(undefined)).toEqual([]);
+    expect(parsePluginList("")).toEqual([]);
+    expect(parsePluginList("  ")).toEqual([]);
+  });
+});
+
+describe("loadPlugins", () => {
+  it("loads a core plugin via the static built-in map", async () => {
+    const { register, calls } = makeRegister();
+    const builtinPlugins = {
+      "@platypus/tools-basic": () =>
+        Promise.resolve({
+          plugin: manifest("@platypus/tools-basic", [
+            toolSet("math-conversions"),
+            toolSet("time"),
+          ]),
+        }),
+    };
+
+    const loaded = await loadPlugins({
+      pluginNames: ["@platypus/tools-basic"],
+      builtinPlugins,
+      register,
+    });
+
+    expect(calls.map((c) => c.id)).toEqual(["math-conversions", "time"]);
+    expect(loaded).toEqual([
+      {
+        name: "@platypus/tools-basic",
+        version: "0.1.0",
+        origin: "core",
+        toolSetIds: ["math-conversions", "time"],
+      },
+    ]);
+  });
+
+  it("registers nothing for an empty list and does not crash", async () => {
+    const { register, calls } = makeRegister();
+    const loaded = await loadPlugins({
+      pluginNames: [],
+      builtinPlugins: {},
+      register,
+    });
+    expect(loaded).toEqual([]);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("resolves a third-party plugin via dynamic import", async () => {
+    const { register, calls } = makeRegister();
+    const importPlugin = vi.fn(async (_name: string) => ({
+      plugin: manifest("@third/party", [toolSet("custom")]),
+    }));
+
+    const loaded = await loadPlugins({
+      pluginNames: ["@third/party"],
+      builtinPlugins: {},
+      importPlugin,
+      register,
+    });
+
+    expect(importPlugin).toHaveBeenCalledWith("@third/party");
+    expect(calls.map((c) => c.id)).toEqual(["custom"]);
+    expect(loaded[0].origin).toBe("third-party");
+  });
+
+  it("exercises both resolution paths in one load", async () => {
+    const { register, calls } = makeRegister();
+    const builtinPlugins = {
+      "@platypus/tools-basic": () =>
+        Promise.resolve({
+          plugin: manifest("@platypus/tools-basic", [toolSet("time")]),
+        }),
+    };
+    const importPlugin = vi.fn(async (_name: string) => ({
+      plugin: manifest("@third/party", [toolSet("custom")]),
+    }));
+
+    const loaded = await loadPlugins({
+      pluginNames: ["@platypus/tools-basic", "@third/party"],
+      builtinPlugins,
+      importPlugin,
+      register,
+    });
+
+    expect(importPlugin).toHaveBeenCalledTimes(1);
+    expect(importPlugin).toHaveBeenCalledWith("@third/party");
+    expect(calls.map((c) => c.id)).toEqual(["time", "custom"]);
+    expect(loaded.map((p) => p.origin)).toEqual(["core", "third-party"]);
+  });
+
+  it("aborts (fail-loud) when a plugin cannot be resolved", async () => {
+    const { register } = makeRegister();
+    const importPlugin = vi.fn(async () => {
+      throw new Error("Cannot find module");
+    });
+
+    await expect(
+      loadPlugins({
+        pluginNames: ["@missing/plugin"],
+        builtinPlugins: {},
+        importPlugin,
+        register,
+      }),
+    ).rejects.toThrow(/@missing\/plugin.*failed to resolve/s);
+  });
+
+  it("aborts (fail-loud) on a manifest missing contributes", async () => {
+    const { register } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@bad/plugin"],
+        builtinPlugins: {},
+        importPlugin: async () => ({
+          plugin: { name: "@bad/plugin", version: "0.1.0", apiVersion: 1 },
+        }),
+        register,
+      }),
+    ).rejects.toThrow(/@bad\/plugin.*contributes/s);
+  });
+
+  it("aborts (fail-loud) on a non-numeric apiVersion", async () => {
+    const { register } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@bad/plugin"],
+        builtinPlugins: {},
+        importPlugin: async () => ({
+          plugin: {
+            name: "@bad/plugin",
+            version: "0.1.0",
+            apiVersion: "1",
+            contributes: {},
+          },
+        }),
+        register,
+      }),
+    ).rejects.toThrow(/@bad\/plugin.*apiVersion/s);
+  });
+
+  it("aborts (fail-loud) when a module exports no manifest", async () => {
+    const { register } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@empty/plugin"],
+        builtinPlugins: {},
+        importPlugin: async () => ({}),
+        register,
+      }),
+    ).rejects.toThrow(/@empty\/plugin.*manifest/s);
+  });
+
+  it("aborts (fail-loud) on a duplicate id, naming both owning plugins", async () => {
+    const { register } = makeRegister();
+    const importPlugin = vi.fn(async (name: string) => ({
+      plugin: manifest(name, [toolSet("time")]),
+    }));
+
+    await expect(
+      loadPlugins({
+        pluginNames: ["@a/plugin", "@b/plugin"],
+        builtinPlugins: {},
+        importPlugin,
+        register,
+      }),
+    ).rejects.toThrow(/"time".*"@a\/plugin".*"@b\/plugin"/s);
+  });
+
+  it("re-throws a legacy-registry collision with plugin attribution", async () => {
+    // A `register` that rejects the id (as the real registry does for an
+    // already-registered legacy tool set) surfaces with plugin attribution.
+    const register = () => {
+      throw new Error("Tool set with id 'kanban' has already been registered.");
+    };
+    await expect(
+      loadPlugins({
+        pluginNames: ["@collides/plugin"],
+        builtinPlugins: {},
+        importPlugin: async () => ({
+          plugin: manifest("@collides/plugin", [toolSet("kanban")]),
+        }),
+        register,
+      }),
+    ).rejects.toThrow(/@collides\/plugin.*"kanban".*already been registered/s);
+  });
+});

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -116,7 +116,7 @@ export async function loadPlugins(
         `Plugin "${name}": failed to resolve (${
           cause instanceof Error ? cause.message : String(cause)
         }).`,
-        { cause: cause instanceof Error ? cause : undefined },
+        { cause },
       );
     }
 
@@ -142,7 +142,7 @@ export async function loadPlugins(
           `Plugin "${manifest.name}": failed to register tool set "${id}" (${
             cause instanceof Error ? cause.message : String(cause)
           }).`,
-          { cause: cause instanceof Error ? cause : undefined },
+          { cause },
         );
       }
 

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -1,0 +1,162 @@
+import type {
+  PlatypusPlugin,
+  ToolSetContribution,
+} from "@platypuschat/plugin-sdk";
+import { BUILTIN_PLUGINS } from "./builtin.ts";
+import { registerToolSet } from "../tools/index.ts";
+
+// Summary of one loaded plugin, for the boot log line and observability.
+export interface LoadedPlugin {
+  name: string;
+  version: string;
+  origin: "core" | "third-party";
+  toolSetIds: string[];
+}
+
+// A module that exports a plugin manifest. Values are `unknown` until validated.
+type PluginModule = { plugin?: unknown };
+
+export interface LoadPluginsOptions {
+  /** Plugin names to load. Defaults to parsing `PLATYPUS_PLUGINS`. */
+  pluginNames?: string[];
+  /** The core allowlist / static built-in map. Defaults to {@link BUILTIN_PLUGINS}. */
+  builtinPlugins?: Record<string, () => Promise<PluginModule>>;
+  /** Resolves a third-party plugin. Defaults to dynamic `import()`. */
+  importPlugin?: (name: string) => Promise<PluginModule>;
+  /** Registers one Tool set contribution. Defaults to the core `registerToolSet`. */
+  register?: (id: string, def: Omit<ToolSetContribution, "id">) => void;
+}
+
+/**
+ * Parse the comma-separated `PLATYPUS_PLUGINS` value into a clean name list.
+ * Trims whitespace and drops empty entries; an unset/empty value yields `[]`.
+ */
+export const parsePluginList = (raw: string | undefined): string[] =>
+  (raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+// Validate an imported module's `plugin` export into a typed manifest, or throw
+// a plugin-named error explaining why. Shape-only for this slice — apiVersion
+// compatibility windowing lands in a follow-up.
+const validateManifest = (name: string, mod: PluginModule): PlatypusPlugin => {
+  const p = mod.plugin;
+  if (!p || typeof p !== "object") {
+    throw new Error(
+      `Plugin "${name}": module does not export a "plugin" manifest object.`,
+    );
+  }
+  const m = p as Record<string, unknown>;
+  if (typeof m.name !== "string" || m.name.length === 0) {
+    throw new Error(`Plugin "${name}": manifest is missing a "name".`);
+  }
+  if (typeof m.version !== "string" || m.version.length === 0) {
+    throw new Error(`Plugin "${name}": manifest is missing a "version".`);
+  }
+  if (typeof m.apiVersion !== "number" || !Number.isFinite(m.apiVersion)) {
+    throw new Error(
+      `Plugin "${name}": manifest "apiVersion" must be a number.`,
+    );
+  }
+  if (!m.contributes || typeof m.contributes !== "object") {
+    throw new Error(
+      `Plugin "${name}": manifest is missing a "contributes" object.`,
+    );
+  }
+  const contributes = m.contributes as Record<string, unknown>;
+  if (
+    contributes.toolSets !== undefined &&
+    !Array.isArray(contributes.toolSets)
+  ) {
+    throw new Error(
+      `Plugin "${name}": "contributes.toolSets" must be an array.`,
+    );
+  }
+  return p as PlatypusPlugin;
+};
+
+/**
+ * Load and register every plugin in the list. Runs before the HTTP server so
+ * registries are populated by the time Chat turns resolve tools.
+ *
+ * Boot is fail-loud and all-or-nothing (ADR-0013): a plugin that can't resolve,
+ * has an invalid manifest, or collides with another aborts startup. Runtime
+ * Chat-turn resolution stays graceful and is unaffected.
+ *
+ * Resolution differs by origin: core plugins (present in the built-in map) load
+ * via their static thunk; third-party plugins load via dynamic `import()`.
+ * "Loaded identically" means an identical manifest → register flow, not
+ * identical module resolution.
+ */
+export async function loadPlugins(
+  opts: LoadPluginsOptions = {},
+): Promise<LoadedPlugin[]> {
+  const names =
+    opts.pluginNames ?? parsePluginList(process.env.PLATYPUS_PLUGINS);
+  const builtins = opts.builtinPlugins ?? BUILTIN_PLUGINS;
+  const importPlugin =
+    opts.importPlugin ??
+    ((name: string) => import(name) as Promise<PluginModule>);
+  const register = opts.register ?? registerToolSet;
+
+  // Tracks contribution id -> owning plugin name for owner-attributed collisions.
+  const owners = new Map<string, string>();
+  const loaded: LoadedPlugin[] = [];
+
+  for (const name of names) {
+    const isCore = Object.prototype.hasOwnProperty.call(builtins, name);
+    const origin: LoadedPlugin["origin"] = isCore ? "core" : "third-party";
+
+    let mod: PluginModule;
+    try {
+      mod = isCore ? await builtins[name]() : await importPlugin(name);
+    } catch (cause) {
+      throw new Error(
+        `Plugin "${name}": failed to resolve (${
+          cause instanceof Error ? cause.message : String(cause)
+        }).`,
+        { cause: cause instanceof Error ? cause : undefined },
+      );
+    }
+
+    const manifest = validateManifest(name, mod);
+    const toolSetIds: string[] = [];
+
+    for (const contribution of manifest.contributes.toolSets ?? []) {
+      const { id, name: tsName, category, description, tools } = contribution;
+
+      const existingOwner = owners.get(id);
+      if (existingOwner) {
+        throw new Error(
+          `Tool set id "${id}" is contributed by both "${existingOwner}" and "${manifest.name}".`,
+        );
+      }
+
+      try {
+        register(id, { name: tsName, category, description, tools });
+      } catch (cause) {
+        // A collision with a Tool set registered outside the loader (a legacy
+        // static registration) surfaces here — re-throw with plugin attribution.
+        throw new Error(
+          `Plugin "${manifest.name}": failed to register tool set "${id}" (${
+            cause instanceof Error ? cause.message : String(cause)
+          }).`,
+          { cause: cause instanceof Error ? cause : undefined },
+        );
+      }
+
+      owners.set(id, manifest.name);
+      toolSetIds.push(id);
+    }
+
+    loaded.push({
+      name: manifest.name,
+      version: manifest.version,
+      origin,
+      toolSetIds,
+    });
+  }
+
+  return loaded;
+}

--- a/apps/backend/src/plugins/tools-basic/index.test.ts
+++ b/apps/backend/src/plugins/tools-basic/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import { plugin } from "./index.ts";
+
+describe("@platypus/tools-basic plugin manifest", () => {
+  it("declares its identity and API version", () => {
+    expect(plugin.name).toBe("@platypus/tools-basic");
+    expect(plugin.version).toBe("0.1.0");
+    expect(plugin.apiVersion).toBe(PLUGIN_API_VERSION);
+  });
+
+  it("contributes the math-conversions and time tool sets with unprefixed ids", () => {
+    const ids = (plugin.contributes.toolSets ?? []).map((t) => t.id);
+    expect(ids).toEqual(["math-conversions", "time"]);
+  });
+
+  it("exposes the expected tools as static maps", () => {
+    const [math, time] = plugin.contributes.toolSets ?? [];
+
+    expect(typeof math.tools).not.toBe("function");
+    expect(Object.keys(math.tools as Record<string, unknown>)).toEqual([
+      "convertTemperature",
+      "convertDistance",
+      "convertWeight",
+      "convertVolume",
+    ]);
+
+    expect(typeof time.tools).not.toBe("function");
+    expect(Object.keys(time.tools as Record<string, unknown>)).toEqual([
+      "getCurrentTime",
+      "convertTimezone",
+    ]);
+  });
+});

--- a/apps/backend/src/plugins/tools-basic/index.ts
+++ b/apps/backend/src/plugins/tools-basic/index.ts
@@ -1,0 +1,46 @@
+import type { PlatypusPlugin } from "@platypuschat/plugin-sdk";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import {
+  convertTemperature,
+  convertDistance,
+  convertWeight,
+  convertVolume,
+} from "../../tools/math.ts";
+import { getCurrentTime, convertTimezone } from "../../tools/time.ts";
+
+// First core plugin: pure utility Tool sets (math, time). Grouped by cohesion
+// per ADR-0013 (a capability gets its own plugin when an Operator would
+// plausibly want to deny it in isolation — utilities don't). Core ids stay
+// unprefixed, so every persisted `agent.toolSetIds` reference keeps working.
+export const plugin: PlatypusPlugin = {
+  name: "@platypus/tools-basic",
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  contributes: {
+    toolSets: [
+      {
+        id: "math-conversions",
+        name: "Math Conversions",
+        category: "Math",
+        description: "Temperature and unit conversions",
+        tools: {
+          convertTemperature,
+          convertDistance,
+          convertWeight,
+          convertVolume,
+        },
+      },
+      {
+        id: "time",
+        name: "Time",
+        category: "Utilities",
+        description:
+          "Tools for getting current time and converting between timezones",
+        tools: {
+          getCurrentTime,
+          convertTimezone,
+        },
+      },
+    ],
+  },
+};

--- a/apps/backend/src/tools/index.test.ts
+++ b/apps/backend/src/tools/index.test.ts
@@ -32,8 +32,11 @@ describe("Tool Set Registry", () => {
 
     it("includes the expected built-in tool sets", () => {
       const sets = getToolSets();
-      expect(sets).toHaveProperty("math-conversions");
-      expect(sets).toHaveProperty("time");
+      // `math-conversions` and `time` now ship as the @platypus/tools-basic
+      // plugin (loaded via the plugin loader), so they are absent from this
+      // statically-registered set. See apps/backend/src/plugins/tools-basic.
+      expect(sets).not.toHaveProperty("math-conversions");
+      expect(sets).not.toHaveProperty("time");
       expect(sets).toHaveProperty("web-fetch");
       expect(sets).toHaveProperty("kanban");
       expect(sets).toHaveProperty("triggers");
@@ -46,10 +49,10 @@ describe("Tool Set Registry", () => {
 
   describe("getToolSet", () => {
     it("returns a tool set by id", () => {
-      const set = getToolSet("math-conversions");
+      const set = getToolSet("web-fetch");
       expect(set).toBeDefined();
-      expect(set.name).toBe("Math Conversions");
-      expect(set.category).toBe("Math");
+      expect(set.name).toBe("Web Fetch");
+      expect(set.category).toBe("Web");
     });
 
     it("throws for an unregistered id", () => {
@@ -62,34 +65,16 @@ describe("Tool Set Registry", () => {
   describe("registerToolSet", () => {
     it("throws when registering a duplicate id", () => {
       expect(() =>
-        registerToolSet("math-conversions", {
+        registerToolSet("web-fetch", {
           name: "Duplicate",
           category: "Test",
           tools: {},
         }),
-      ).toThrow(
-        "Tool set with id 'math-conversions' has already been registered.",
-      );
+      ).toThrow("Tool set with id 'web-fetch' has already been registered.");
     });
   });
 
   describe("tool set metadata", () => {
-    it("math-conversions has static tools object", () => {
-      const set = getToolSet("math-conversions");
-      expect(typeof set.tools).toBe("object");
-      expect(set.tools).toHaveProperty("convertTemperature");
-      expect(set.tools).toHaveProperty("convertDistance");
-      expect(set.tools).toHaveProperty("convertWeight");
-      expect(set.tools).toHaveProperty("convertVolume");
-    });
-
-    it("time has static tools object", () => {
-      const set = getToolSet("time");
-      expect(typeof set.tools).toBe("object");
-      expect(set.tools).toHaveProperty("getCurrentTime");
-      expect(set.tools).toHaveProperty("convertTimezone");
-    });
-
     it("web-fetch has static tools object", () => {
       const set = getToolSet("web-fetch");
       expect(typeof set.tools).toBe("object");

--- a/apps/backend/src/tools/index.ts
+++ b/apps/backend/src/tools/index.ts
@@ -1,12 +1,5 @@
 import { type Tool } from "ai";
 import { eq } from "drizzle-orm";
-import {
-  convertTemperature,
-  convertDistance,
-  convertWeight,
-  convertVolume,
-} from "./math.ts";
-import { getCurrentTime, convertTimezone } from "./time.ts";
 import { fetchUrl } from "./fetch.ts";
 import { createKanbanTools } from "./kanban.ts";
 import { createDashboardTools } from "./dashboard.ts";
@@ -22,13 +15,10 @@ import { getSandboxBackend } from "../sandbox/index.ts";
 import { createSandboxTools } from "../sandbox/tools.ts";
 import { logger } from "../logger.ts";
 
-export type ToolSetContext = {
-  workspaceId: string;
-  agentId: string;
-  orgId: string;
-  frontendUrl: string | undefined;
-  userId: string;
-};
+// The Extension-point surface lives in the published SDK; re-export the context
+// type so core's internal callers keep importing it from here.
+export type { ToolSetContext } from "@platypuschat/plugin-sdk";
+import type { ToolSetContext } from "@platypuschat/plugin-sdk";
 
 type ToolSet = {
   id: string;
@@ -72,29 +62,10 @@ export const getToolSets = (): typeof TOOL_SETS_REGISTRY => TOOL_SETS_REGISTRY;
 export const MEMORY_TOOLSET_ID = "memory";
 
 // REGISTER TOOL SETS HERE!
-registerToolSet("math-conversions", {
-  name: "Math Conversions",
-  category: "Math",
-  description: "Temperature and unit conversions",
-  tools: {
-    convertTemperature,
-    convertDistance,
-    convertWeight,
-    convertVolume,
-  },
-});
-
-registerToolSet("time", {
-  name: "Time",
-  category: "Utilities",
-  description:
-    "Tools for getting current time and converting between timezones",
-  tools: {
-    getCurrentTime,
-    convertTimezone,
-  },
-});
-
+// Note: the `math-conversions` and `time` tool sets now ship as the
+// `@platypus/tools-basic` plugin (apps/backend/src/plugins/tools-basic), loaded
+// via the plugin loader from `PLATYPUS_PLUGINS`. See ADR-0013. The tool sets
+// below remain statically registered pending migration in later slices.
 registerToolSet("web-fetch", {
   name: "Web Fetch",
   category: "Web",

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -6,31 +6,85 @@ import { Callout } from "nextra/components";
 
 # Extending
 
-This section is for **contributors** working in the Platypus codebase. It maps
-the in-tree extension points — places designed to be added to without forking
-the core — and points at the [Architecture Decision
+This section is for **contributors** working in the Platypus codebase and for
+**plugin authors** extending Platypus without forking it. It maps the
+extension points — the core-owned seams a plugin's manifest fills — and points
+at the [Architecture Decision
 Records](https://github.com/willdady/platypus/tree/main/docs/adr) that explain
 _why_ each one is shaped the way it is.
 
-Platypus has two first-class extension points today, plus a deliberate
-non-extension point:
+Platypus extends itself through **plugins** (see
+[the plugin model](#the-plugin-model) below). A plugin exports a typed
+**manifest** whose `contributes` block declares one or more **Contributions** to
+a fixed set of core-owned **Extension points**:
 
+- **[Tool sets](#tool-sets)** — a named group of tools that Agents can be
+  granted.
 - **[Sandbox backends](#sandbox-backends)** — implement the `SandboxBackend`
   interface to run shell and filesystem tools on a new execution environment
   (Modal, Daytona, E2B, a remote host…).
-- **[Tool sets](#tool-sets)** — register a named group of tools that Agents can
-  be granted.
-- **[MCP servers](#mcp-vs-static-tool-sets)** are _not_ a code extension point —
-  they're the runtime, open-ended way to add tools without touching the
+- **[MCP servers](#mcp-vs-static-tool-sets)** are _not_ a plugin extension point
+  — they're the runtime, open-ended way to add tools without touching the
   codebase. Reach for them first; see the comparison below.
 
 <Callout type="info">
-  Both extension points are **static, in-tree registries** wired up at process
-  start — there is no plugin loader or dynamic discovery yet. Adding an
-  extension means adding code to `apps/backend` and rebuilding. The
-  [plugins](#the-plugin-direction-future) direction below is the future shape,
-  not today's.
+  The plugin loader is being rolled out incrementally (see
+  [ADR-0013](https://github.com/willdady/platypus/blob/main/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md)).
+  The first core plugin — `@platypus/tools-basic` (math, time) — ships through
+  it today; the remaining built-in Tool sets and the Docker Sandbox backend are
+  still registered in-tree pending migration. Either way the underlying
+  `registerToolSet` / `registerSandboxBackend` functions are the same — they are
+  now **core-internal**, driven by the loader rather than called by plugin
+  authors.
 </Callout>
+
+## The plugin model
+
+A **plugin** is a distributable bundle — one version, one config namespace, one
+enable/disable switch — that an Operator installs at deploy time and that core
+loads **in-process** (no isolation). Each plugin exports a typed manifest from
+its package entry:
+
+```ts
+import type { PlatypusPlugin } from "@platypuschat/plugin-sdk";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+
+export const plugin: PlatypusPlugin = {
+  name: "@example/my-plugin",
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  contributes: {
+    toolSets: [/* Tool set contributions — see below */],
+  },
+};
+```
+
+The compile-time contract — the manifest type, the Contribution types, and
+`PLUGIN_API_VERSION` — lives in the published
+[`@platypuschat/plugin-sdk`](https://www.npmjs.com/package/@platypuschat/plugin-sdk)
+package. Third-party authors depend on it from npm; core plugins consume the
+same types via a workspace link.
+
+**Loading.** Before the HTTP server starts, core reads the Operator-supplied
+[`PLATYPUS_PLUGINS`](/self-hosting/configuration#plugins) list, resolves each
+plugin, reads its manifest, and drives registration by calling the internal
+`register*()` per `contributes` entry. Resolution differs by origin:
+
+- **Core plugins** are internal backend modules under
+  `apps/backend/src/plugins/<name>/`, reached through a **static built-in map**
+  (`apps/backend/src/plugins/builtin.ts`) — which _is_ the core allowlist. Their
+  `@platypus/*` names are logical ids, not published packages.
+- **Third-party plugins** are installed npm packages reached via dynamic
+  `import()`.
+
+"Loaded identically" means an identical manifest → register flow, not identical
+module resolution.
+
+**Boot is fail-loud and all-or-nothing.** A listed plugin that can't resolve,
+exports an invalid manifest, or whose Contribution ids collide with another
+plugin's aborts startup with a plugin-named error. Runtime Chat-turn resolution
+stays graceful (a Workspace pointing at a since-removed Tool set degrades to no
+tools, as before) — strict at boot, forgiving at runtime.
 
 ## Sandbox backends
 
@@ -164,21 +218,26 @@ is what populates the registry.
 ## Tool sets
 
 A **tool set** is a named, categorised group of tools that an Agent can be
-granted. Built-in tool sets are registered statically into an in-tree registry
-(`apps/backend/src/tools/index.ts`) via `registerToolSet`:
+granted. A plugin contributes tool sets through the `contributes.toolSets` array
+in its manifest; each entry is a `ToolSetContribution` from the SDK:
 
 ```ts
-type ToolSet = {
+import type {
+  ToolSetContribution,
+  ToolSetContext,
+} from "@platypuschat/plugin-sdk";
+
+interface ToolSetContribution {
   id: string;
   name: string;
   category: string;
   description?: string;
   tools:
-    | { [toolId: string]: Tool<any, any> }
+    | { [toolId: string]: Tool }
     | ((
-        context: ToolSetContext,
+        ctx: ToolSetContext,
       ) => Record<string, Tool> | Promise<Record<string, Tool>>);
-};
+}
 ```
 
 `tools` is either a **static map** of tools, or a **factory** that receives a
@@ -186,54 +245,78 @@ type ToolSet = {
 runtime scope:
 
 ```ts
-export type ToolSetContext = {
+export interface ToolSetContext {
   workspaceId: string;
   agentId: string;
   orgId: string;
   frontendUrl: string | undefined;
   userId: string;
-};
+}
 ```
 
 Individual tools are Vercel AI SDK tools (`tool()` from the `ai` package) with a
-Zod `inputSchema` and an `execute` function. The simplest registration uses a
-static map:
+Zod `inputSchema` and an `execute` function. The simplest contribution uses a
+static map; the `@platypus/tools-basic` core plugin
+(`apps/backend/src/plugins/tools-basic/`) is the reference:
 
 ```ts
-registerToolSet("math-conversions", {
-  name: "Math Conversions",
-  category: "Math",
-  description: "Temperature and unit conversions",
-  tools: { convertTemperature, convertDistance, convertWeight, convertVolume },
-});
+export const plugin: PlatypusPlugin = {
+  name: "@platypus/tools-basic",
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  contributes: {
+    toolSets: [
+      {
+        id: "math-conversions",
+        name: "Math Conversions",
+        category: "Math",
+        description: "Temperature and unit conversions",
+        tools: {
+          convertTemperature,
+          convertDistance,
+          convertWeight,
+          convertVolume,
+        },
+      },
+    ],
+  },
+};
 ```
 
-When tools need the Workspace / Agent context, pass a factory instead:
+When tools need the Workspace / Agent context, use a factory for the `tools`
+field instead:
 
 ```ts
-registerToolSet("kanban", {
+{
+  id: "kanban",
   name: "Kanban",
   category: "Productivity",
   description: "Manage kanban boards in this workspace",
   tools: ({ workspaceId, agentId, orgId, frontendUrl }) =>
     createKanbanTools(workspaceId, agentId, orgId, frontendUrl),
-});
+}
 ```
 
-**To add a tool set:**
+**To add a core tool set (in-tree plugin):**
 
 1. Define your tools with `tool({ description, inputSchema, execute })`. Put
    them in a new file under `apps/backend/src/tools/` (see `math.ts` for a
    stateless example, `kanban.ts` for a context-factory example).
-2. Call `registerToolSet("my-tool-set", {...})` in
-   `apps/backend/src/tools/index.ts`. Use a static `tools` map, or a factory if
-   your tools need `ToolSetContext`.
-3. Optionally export a `MY_TOOLSET_ID` constant for code that references the id.
+2. Add the contribution to an existing core plugin's manifest, or create a new
+   plugin under `apps/backend/src/plugins/<name>/index.ts` and register its
+   logical `@platypus/*` name in
+   `apps/backend/src/plugins/builtin.ts` (the built-in map / core allowlist).
+3. Add the plugin name to the deployment's `PLATYPUS_PLUGINS` list so it loads.
 
-A tool set is granted to Agents like any other; if its dependencies aren't
-present at turn time it degrades gracefully (the `sandbox` tool set, for
-example, is registered unconditionally but resolves to no tools when a Workspace
-has no Sandbox configured).
+**To ship a third-party tool set:** publish a package that depends on
+`@platypuschat/plugin-sdk` and exports a `plugin` manifest; the Operator adds
+its package name to `PLATYPUS_PLUGINS`.
+
+Core Contribution ids stay unprefixed (`math-conversions`, `time`) so persisted
+`agent.toolSetIds` references keep working. A tool set is granted to Agents like
+any other; if its dependencies aren't present at turn time it degrades
+gracefully (the `sandbox` tool set, for example, resolves to no tools when a
+Workspace has no Sandbox configured).
 
 <Callout type="info">
   Frontend tool / tool-set presentation (icons, custom UI) lives separately. If
@@ -266,32 +349,33 @@ resource type, or a reference between resources), read
 [ADR-0007](https://github.com/willdady/platypus/blob/main/docs/adr/0007-organization-scoped-shared-resources.md)
 first; the promotion-prerequisite rule has wide-reaching consequences.
 
-## The plugin direction (future)
+## Migration status
 
-There is **no plugin system today** — both extension points above are static,
-in-tree registries compiled into the backend. That's a deliberate v1 choice, not
-an oversight:
+The plugin loader is landing incrementally
+([ADR-0013](https://github.com/willdady/platypus/blob/main/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md)).
+What's live and what's still in-tree today:
 
-- The Sandbox interface was explicitly modelled as a fixed contract rather than
-  "a generic plugin system"
-  ([ADR-0001](https://github.com/willdady/platypus/blob/main/docs/adr/0001-sandbox-as-workspace-keyed-execution-environment.md)).
-- A "fixed core plus adapter extensions" hybrid for Sandbox was considered and
-  deferred — it can be added later **without breaking the v1 contract**
-  ([ADR-0002](https://github.com/willdady/platypus/blob/main/docs/adr/0002-sandbox-fixed-five-tool-core.md)).
-
-The registry shape is the seam a future plugin loader would plug into: dynamic
-discovery would call the same `registerSandboxBackend` / `registerToolSet`
-functions rather than replace them. Until then, contribute backends and tool
-sets in-tree and reach for MCP for everything open-ended.
+- **Live:** the `@platypuschat/plugin-sdk` surface, the boot-time loader, the
+  built-in map / core allowlist, and the first core plugin
+  `@platypus/tools-basic` (math, time), which flows manifest → loader →
+  registry → tools in a Chat turn.
+- **Still in-tree, pending migration:** the remaining built-in Tool sets
+  (`kanban`, `triggers`, `sandbox`, …) and the Docker Sandbox backend still call
+  `registerToolSet` / `registerSandboxBackend` directly at boot. They keep
+  working unchanged; the same registration functions are what the loader drives.
+- **Follow-up slices:** Sandbox-backend contributions, third-party id
+  namespacing, deploy-time plugin config/credentials, `apiVersion` compatibility
+  windowing, and a read-only `GET /plugins` catalog.
 
 ## Reference ADRs
 
-| ADR                                                                                                                             | Topic                                              |
-| ------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| [0001](https://github.com/willdady/platypus/blob/main/docs/adr/0001-sandbox-as-workspace-keyed-execution-environment.md)        | Sandbox is a Workspace-keyed execution environment |
-| [0002](https://github.com/willdady/platypus/blob/main/docs/adr/0002-sandbox-fixed-five-tool-core.md)                            | Fixed five-tool Sandbox interface                  |
-| [0003](https://github.com/willdady/platypus/blob/main/docs/adr/0003-docker-reference-sandbox-adapter-socket-mount.md)           | Docker reference adapter (socket mount)            |
-| [0004](https://github.com/willdady/platypus/blob/main/docs/adr/0004-sandbox-workspace-default-env-vars.md)                      | Sandbox default environment variables              |
-| [0005](https://github.com/willdady/platypus/blob/main/docs/adr/0005-sandbox-host-reachability-is-admin-curated-default-deny.md) | Host reachability is admin-curated, default-deny   |
-| [0006](https://github.com/willdady/platypus/blob/main/docs/adr/0006-credential-and-reach-bearing-config-is-admin-managed.md)    | Credential/reach config is admin-managed           |
-| [0007](https://github.com/willdady/platypus/blob/main/docs/adr/0007-organization-scoped-shared-resources.md)                    | Organization-scoped Shared resources               |
+| ADR                                                                                                                               | Topic                                              |
+| --------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| [0001](https://github.com/willdady/platypus/blob/main/docs/adr/0001-sandbox-as-workspace-keyed-execution-environment.md)          | Sandbox is a Workspace-keyed execution environment |
+| [0002](https://github.com/willdady/platypus/blob/main/docs/adr/0002-sandbox-fixed-five-tool-core.md)                              | Fixed five-tool Sandbox interface                  |
+| [0003](https://github.com/willdady/platypus/blob/main/docs/adr/0003-docker-reference-sandbox-adapter-socket-mount.md)             | Docker reference adapter (socket mount)            |
+| [0004](https://github.com/willdady/platypus/blob/main/docs/adr/0004-sandbox-workspace-default-env-vars.md)                        | Sandbox default environment variables              |
+| [0005](https://github.com/willdady/platypus/blob/main/docs/adr/0005-sandbox-host-reachability-is-admin-curated-default-deny.md)   | Host reachability is admin-curated, default-deny   |
+| [0006](https://github.com/willdady/platypus/blob/main/docs/adr/0006-credential-and-reach-bearing-config-is-admin-managed.md)      | Credential/reach config is admin-managed           |
+| [0007](https://github.com/willdady/platypus/blob/main/docs/adr/0007-organization-scoped-shared-resources.md)                      | Organization-scoped Shared resources               |
+| [0013](https://github.com/willdady/platypus/blob/main/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md) | Manifest-driven plugin system                      |

--- a/apps/docs/content/reference/backend-configuration.mdx
+++ b/apps/docs/content/reference/backend-configuration.mdx
@@ -29,6 +29,15 @@ For a guided walkthrough of configuring a deployment, see
 | `TIMEZONE`        | IANA timezone (e.g. `America/New_York`, `Europe/London`). Falls back to UTC if unset. | `UTC`                                                    | No       |
 | `NODE_OPTIONS`    | Node runtime flags. Ships set to silence the experimental-feature warning.            | `--disable-warning=ExperimentalWarning`                  | No       |
 
+## Plugins
+
+| Variable           | Purpose                                                                                                                                                                                       | Default                 | Required |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | -------- |
+| `PLATYPUS_PLUGINS` | Comma-separated list of plugins to load and enable at boot (core built-ins included). List membership both loads _and_ enables a plugin. Empty ⇒ no plugin-provided tools. Fail-loud at boot. | `@platypus/tools-basic` | No       |
+
+See [Extending → the plugin model](/extending#the-plugin-model) and
+[Configuration → Plugins](/self-hosting/configuration#plugins).
+
 ## Authentication
 
 | Variable                 | Purpose                                                                                                                  | Default                                                    | Required |
@@ -70,9 +79,9 @@ the same result). Headless runs aren't user-facing, so the defaults are generous
 — raise them for long multi-step research or MCP work, lower them to fail a stuck
 run sooner.
 
-| Variable                      | Purpose                                                                              | Default              | Required |
-| ----------------------------- | ------------------------------------------------------------------------------------ | -------------------- | -------- |
-| `TRIGGER_PER_STEP_TIMEOUT_MS` | Idle timeout between steps of a Trigger run; a step that makes no progress aborts it. | `600000` (10 minutes) | No       |
+| Variable                      | Purpose                                                                               | Default                | Required |
+| ----------------------------- | ------------------------------------------------------------------------------------- | ---------------------- | -------- |
+| `TRIGGER_PER_STEP_TIMEOUT_MS` | Idle timeout between steps of a Trigger run; a step that makes no progress aborts it. | `600000` (10 minutes)  | No       |
 | `TRIGGER_PER_RUN_TIMEOUT_MS`  | Wall-clock timeout for an entire Trigger run.                                         | `3600000` (60 minutes) | No       |
 
 ## Tools

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -69,6 +69,29 @@ at `/auth/*` on the backend. The essentials:
 The deeper model — Providers, the role ladder, and the default admin — lives in
 [Providers & authentication](/self-hosting/providers-and-auth).
 
+## Plugins
+
+Platypus loads its extensions — starting with Tool sets — as **plugins**, and
+`PLATYPUS_PLUGINS` is the single, auditable statement of what runs. It's a
+comma-separated list of plugin names; core built-ins are listed too (e.g.
+`@platypus/tools-basic`).
+
+- **List membership both loads and enables a plugin.** There is no separate
+  enable switch — adding a name turns a plugin on, removing it turns it off.
+  Both take effect on the next backend restart (this is a deploy-time trust
+  boundary — there is no in-app install button).
+- **An empty list yields a deployment with no plugin-provided tools** (the
+  `@platypus/tools-basic` math/time tools disappear, for example). That's
+  accepted and self-documenting.
+- **Boot is fail-loud.** A listed plugin that can't be resolved or exports an
+  invalid manifest, or two plugins whose tool-set ids collide, aborts startup
+  with a plugin-named error — a misconfigured plugin never silently drops tools.
+- **New core plugins in a later release are not auto-enabled** — add them to your
+  pinned list to opt in.
+
+See [Extending → the plugin model](/extending#the-plugin-model) for how a
+manifest's `contributes` block fills extension points.
+
 ## Sandbox
 
 The [Sandbox](/concepts) (agent shell/filesystem access) is **off by default**.
@@ -98,9 +121,9 @@ These rarely need changing but exist when you need them — see the
 
 ## Where the exhaustive lists live
 
-| You want…                                   | Go to                                         |
-| ------------------------------------------- | --------------------------------------------- |
-| Why a setting exists and how it relates     | **This page**                                 |
-| Every backend variable + default            | [Reference](/reference) — backend config      |
-| Every frontend variable + default           | [Reference](/reference) — frontend config     |
-| The sandbox security model                  | [Sandbox infrastructure](/self-hosting/sandbox) |
+| You want…                               | Go to                                           |
+| --------------------------------------- | ----------------------------------------------- |
+| Why a setting exists and how it relates | **This page**                                   |
+| Every backend variable + default        | [Reference](/reference) — backend config        |
+| Every frontend variable + default       | [Reference](/reference) — frontend config       |
+| The sandbox security model              | [Sandbox infrastructure](/self-hosting/sandbox) |

--- a/packages/plugin-sdk/index.test.ts
+++ b/packages/plugin-sdk/index.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { tool } from "ai";
+import {
+  PLUGIN_API_VERSION,
+  type PlatypusPlugin,
+  type ToolSetContribution,
+} from "./index.ts";
+
+describe("@platypuschat/plugin-sdk", () => {
+  it("pins the plugin API version", () => {
+    expect(PLUGIN_API_VERSION).toBe(1);
+  });
+
+  it("accepts a well-formed manifest with a static-map tool set", () => {
+    const staticSet: ToolSetContribution = {
+      id: "example",
+      name: "Example",
+      category: "Utilities",
+      tools: {
+        echo: tool({
+          description: "Echo the input",
+          inputSchema: z.object({ text: z.string() }),
+          execute: ({ text }) => text,
+        }),
+      },
+    };
+
+    const plugin: PlatypusPlugin = {
+      name: "@example/plugin",
+      version: "0.1.0",
+      apiVersion: PLUGIN_API_VERSION,
+      contributes: { toolSets: [staticSet] },
+    };
+
+    expect(plugin.name).toBe("@example/plugin");
+    expect(plugin.contributes.toolSets).toHaveLength(1);
+    expect(plugin.contributes.toolSets?.[0].id).toBe("example");
+  });
+
+  it("accepts a manifest with a factory tool set and config schemas", () => {
+    const plugin: PlatypusPlugin = {
+      name: "@example/scoped",
+      version: "0.1.0",
+      apiVersion: PLUGIN_API_VERSION,
+      configSchema: z.object({ region: z.string() }),
+      credentialsSchema: z.object({ token: z.string() }),
+      contributes: {
+        toolSets: [
+          {
+            id: "scoped",
+            name: "Scoped",
+            category: "Productivity",
+            description: "Needs runtime scope",
+            tools: (ctx) => {
+              expect(ctx.workspaceId).toBeDefined();
+              return {};
+            },
+          },
+        ],
+      },
+    };
+
+    expect(typeof plugin.contributes.toolSets?.[0].tools).toBe("function");
+    expect(plugin.configSchema).toBeDefined();
+  });
+});

--- a/packages/plugin-sdk/index.ts
+++ b/packages/plugin-sdk/index.ts
@@ -1,0 +1,79 @@
+import type { Tool } from "ai";
+import type { z } from "zod";
+
+/**
+ * Minimum core API a plugin declares it needs, via its manifest `apiVersion`.
+ *
+ * Compatibility is forward-compatible and append-only: contracts grow only by
+ * optional members, and core supports the current major and one previous (N and
+ * N−1). This slice publishes the surface and the constant; the boot-time
+ * compatibility window (rejecting plugins that need a newer or dropped major) is
+ * enforced in a follow-up. See ADR-0013.
+ */
+export const PLUGIN_API_VERSION = 1 as const;
+
+/**
+ * Runtime scope handed to a Tool set factory at Chat-turn time. This SDK is the
+ * single home of the type; core re-exports it for its internal callers.
+ */
+export interface ToolSetContext {
+  workspaceId: string;
+  agentId: string;
+  orgId: string;
+  frontendUrl: string | undefined;
+  userId: string;
+}
+
+/**
+ * The tools a Tool set contributes: either a static map keyed by tool id, or a
+ * factory resolved with the {@link ToolSetContext} at Chat-turn time (use the
+ * factory when tools need Workspace/Agent scope). Tools are Vercel AI SDK tools.
+ */
+export type ToolSetTools =
+  | Record<string, Tool>
+  | ((
+      ctx: ToolSetContext,
+    ) => Record<string, Tool> | Promise<Record<string, Tool>>);
+
+/**
+ * A single Tool set contribution — a named, categorised group of tools an Agent
+ * can be granted. This is the payload core's internal `registerToolSet` accepts,
+ * with the `id` it takes as its first argument folded in.
+ */
+export interface ToolSetContribution {
+  id: string;
+  name: string;
+  category: string;
+  description?: string;
+  tools: ToolSetTools;
+}
+
+/**
+ * The `contributes` block: keyed by Extension-point type (core-owned, fixed).
+ * Adding an Extension point (e.g. Sandbox backends, a messaging gateway) is a
+ * purely additive, minor API bump — a new optional key here.
+ */
+export interface PluginContributions {
+  toolSets?: ToolSetContribution[];
+  // sandboxBackends?: SandboxBackendContribution[]; // follow-up slice
+}
+
+/**
+ * A Platypus plugin manifest. A plugin is a distributable bundle — one version,
+ * one config namespace, one enable/disable switch — whose `contributes` block
+ * fills core-owned Extension points. Core reads this manifest and drives
+ * registration itself; plugin authors never call the internal `register*()`.
+ *
+ * `configSchema` / `credentialsSchema` describe deploy-time, Operator-owned
+ * config keyed by plugin name; they are part of the locked manifest shape but
+ * are not consumed until the plugin-config follow-up slice.
+ */
+export interface PlatypusPlugin {
+  name: string;
+  version: string;
+  /** Minimum core API this plugin needs. */
+  apiVersion: number;
+  configSchema?: z.ZodType;
+  credentialsSchema?: z.ZodType;
+  contributes: PluginContributions;
+}

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@platypuschat/plugin-sdk",
+  "version": "0.1.0",
+  "description": "Plugin SDK for Platypus — the manifest type and extension-point surface third-party plugins depend on.",
+  "license": "MIT",
+  "author": "Will Dady",
+  "type": "module",
+  "main": "index.ts",
+  "types": "index.ts",
+  "files": ["index.ts", "dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit",
+    "test": "vitest run"
+  },
+  "publishConfig": {
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  },
+  "dependencies": {
+    "ai": "^6.0.217",
+    "zod": "^4.4.3"
+  },
+  "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa",
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/plugin-sdk/tsconfig.build.json
+++ b/packages/plugin-sdk/tsconfig.build.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/plugin-sdk/turbo.json
+++ b/packages/plugin-sdk/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@platypus/schemas':
         specifier: workspace:*
         version: link:../../packages/schemas
+      '@platypuschat/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
       ai:
         specifier: ^6.0.217
         version: 6.0.217(zod@4.4.3)
@@ -475,6 +478,22 @@ importers:
       wrangler:
         specifier: ^4.106.0
         version: 4.106.0
+
+  packages/plugin-sdk:
+    dependencies:
+      ai:
+        specifier: ^6.0.217
+        version: 6.0.217(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/schemas:
     dependencies:


### PR DESCRIPTION
Closes #288. Implements the walking skeleton for the plugin system ([ADR-0013](docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md)).

## What this is

A tracer bullet — a complete path from **manifest → loader → registry → usable tools in a Chat turn**, carrying only Tool set contributions and migrating one core plugin (`@platypus/tools-basic`: math + time). Sandbox backends, third-party id namespacing, plugin config, versioning, and observability are explicit follow-up slices.

> **HITL:** this slice fixes the SDK/manifest type, the loader contract, and the static built-in map (= core allowlist) that later slices build on. Please review the API surface (`packages/plugin-sdk/index.ts`, `apps/backend/src/plugins/loader.ts`).

## Changes

**New package `@platypuschat/plugin-sdk`** (`packages/plugin-sdk/`) — the one published contract: `PlatypusPlugin` manifest type, `PLUGIN_API_VERSION`, and `ToolSetContribution` / `ToolSetContext`. Ships raw `.ts` for workspace consumption (like `@platypus/schemas`) plus a `tsc` build emitting `dist/` + `.d.ts`, with `publishConfig` overriding entry points for npm. The manifest type includes optional `configSchema` / `credentialsSchema` (shape locked now; consumed in the config follow-up).

**Loader** (`apps/backend/src/plugins/loader.ts`) — runs before the HTTP server:
- Reads `PLATYPUS_PLUGINS`; empty list ⇒ no plugin tools (no crash).
- Resolves **core** plugins via a static built-in map (`builtin.ts`, which *is* the core allowlist) and **third-party** via dynamic `import()` — both paths exercised.
- Validates each manifest and drives the now core-internal `registerToolSet` per `contributes.toolSets` entry.
- **Fail-loud / all-or-nothing:** an unresolvable, invalid, or colliding plugin aborts boot with a plugin-named error (collisions attribute both owning plugins).

**First core plugin `@platypus/tools-basic`** (`plugins/tools-basic/`) — math + time migrated to a manifest; ids stay unprefixed (`math-conversions`, `time`) so persisted `agent.toolSetIds` keep working. Removed their static registrations from `tools/index.ts`, which now re-exports `ToolSetContext` from the SDK. `loadPlugins()` wired into boot before `serve()`.

**Docs** — reframed `extending/index.mdx` around the plugin model (with a migration-status note that the remaining Tool sets and the Docker Sandbox backend are still in-tree pending migration), and documented `PLATYPUS_PLUGINS` in `self-hosting/configuration.mdx` and `reference/backend-configuration.mdx`.

## Acceptance criteria

- [x] SDK exports `PlatypusPlugin`, `PLUGIN_API_VERSION`, and the Tool set contribution type; builds and is publishable.
- [x] `PLATYPUS_PLUGINS=@platypus/tools-basic` ⇒ math/time resolve and work in a Chat turn.
- [x] Empty `PLATYPUS_PLUGINS` ⇒ those tools absent, no crash.
- [x] Invalid/duplicate manifest aborts boot with an error naming the plugin and reason.
- [x] Core ids remain unprefixed and unchanged.
- [x] Loader resolves core via the static built-in map and third-party via dynamic import (both paths exercised).
- [x] Tests cover: successful core load, empty list, invalid manifest, duplicate id (fail-loud with owner attribution).
- [x] Extending + config docs describe `PLATYPUS_PLUGINS` and the plugin model; docs build passes.

## Verification

- `pnpm --filter @platypuschat/plugin-sdk build` → emits `dist/index.js` + `dist/index.d.ts`.
- Plugin tests: 15 pass; full backend suite: **987 pass**.
- `pnpm typecheck` green across all 6 packages; `pnpm docs-build` passes.
- End-to-end against the real code path: built-in map dynamically imports the real plugin, registers `math-conversions` + `time` with their actual tools; a missing plugin aborts with a plugin-named error.

## Follow-ups (out of scope, per the issue)

Sandbox-backend contributions (migrating `@platypus/docker` + retiring `PLATYPUS_SANDBOX_DOCKER_ENABLED`), third-party id auto-namespacing, deploy-time plugin config/credentials, `apiVersion` compatibility windowing, and a read-only `GET /plugins` catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)