### PR TITLE
feat(backend): enforce plugin apiVersion compatibility gate (N and N-1)

### DIFF
--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { z } from "zod";
-import type {
-  PlatypusPlugin,
-  SandboxBackend,
-  SandboxBackendContribution,
-  ToolSetContribution,
+import {
+  OLDEST_SUPPORTED_API_VERSION,
+  PLUGIN_API_VERSION,
+  type PlatypusPlugin,
+  type SandboxBackend,
+  type SandboxBackendContribution,
+  type ToolSetContribution,
 } from "@platypuschat/plugin-sdk";
 import { loadPlugins, parsePluginList } from "./loader.ts";
 
@@ -29,10 +31,11 @@ const makeSandboxRegister = () => {
 const manifest = (
   name: string,
   toolSets: ToolSetContribution[],
+  apiVersion: number = PLUGIN_API_VERSION,
 ): PlatypusPlugin => ({
   name,
   version: "0.1.0",
-  apiVersion: 1,
+  apiVersion,
   contributes: { toolSets },
 });
 
@@ -71,6 +74,94 @@ describe("parsePluginList", () => {
     expect(parsePluginList(undefined)).toEqual([]);
     expect(parsePluginList("")).toEqual([]);
     expect(parsePluginList("  ")).toEqual([]);
+  });
+});
+
+describe("loadPlugins — apiVersion compatibility window (N and N−1)", () => {
+  it("accepts a plugin declaring exactly core's apiVersion", async () => {
+    const { register, calls } = makeRegister();
+    const loaded = await loadPlugins({
+      pluginNames: ["@exact/plugin"],
+      builtinPlugins: {},
+      importPlugin: () =>
+        Promise.resolve({
+          plugin: manifest(
+            "@exact/plugin",
+            [toolSet("exact")],
+            PLUGIN_API_VERSION,
+          ),
+        }),
+      register,
+    });
+    expect(calls.map((c) => c.id)).toEqual(["exact"]);
+    expect(loaded[0].name).toBe("@exact/plugin");
+  });
+
+  it("accepts a plugin on the previous major (N−1)", async () => {
+    const { register, calls } = makeRegister();
+    const loaded = await loadPlugins({
+      pluginNames: ["@nminus1/plugin"],
+      builtinPlugins: {},
+      importPlugin: () =>
+        Promise.resolve({
+          plugin: manifest(
+            "@nminus1/plugin",
+            [toolSet("older")],
+            OLDEST_SUPPORTED_API_VERSION,
+          ),
+        }),
+      register,
+    });
+    expect(calls.map((c) => c.id)).toEqual(["older"]);
+    expect(loaded[0].name).toBe("@nminus1/plugin");
+  });
+
+  it("rejects (fail-loud) a plugin needing a newer API than core provides", async () => {
+    const { register } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@future/plugin"],
+        builtinPlugins: {},
+        importPlugin: () =>
+          Promise.resolve({
+            plugin: manifest(
+              "@future/plugin",
+              [toolSet("future")],
+              PLUGIN_API_VERSION + 1,
+            ),
+          }),
+        register,
+      }),
+    ).rejects.toThrow(
+      new RegExp(
+        `@future/plugin.*needs API v${PLUGIN_API_VERSION + 1}.*core supports up to v${PLUGIN_API_VERSION}`,
+        "s",
+      ),
+    );
+  });
+
+  it("rejects (fail-loud) a plugin targeting a dropped, older major", async () => {
+    const { register } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@ancient/plugin"],
+        builtinPlugins: {},
+        importPlugin: () =>
+          Promise.resolve({
+            plugin: manifest(
+              "@ancient/plugin",
+              [toolSet("ancient")],
+              OLDEST_SUPPORTED_API_VERSION - 1,
+            ),
+          }),
+        register,
+      }),
+    ).rejects.toThrow(
+      new RegExp(
+        `@ancient/plugin.*targets API v${OLDEST_SUPPORTED_API_VERSION - 1}.*below the oldest`,
+        "s",
+      ),
+    );
   });
 });
 

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -1,7 +1,9 @@
-import type {
-  PlatypusPlugin,
-  SandboxBackendContribution,
-  ToolSetContribution,
+import {
+  OLDEST_SUPPORTED_API_VERSION,
+  PLUGIN_API_VERSION,
+  type PlatypusPlugin,
+  type SandboxBackendContribution,
+  type ToolSetContribution,
 } from "@platypuschat/plugin-sdk";
 import { BUILTIN_PLUGINS } from "./builtin.ts";
 import { registerToolSet } from "../tools/index.ts";
@@ -43,8 +45,9 @@ export const parsePluginList = (raw: string | undefined): string[] =>
     .filter(Boolean);
 
 // Validate an imported module's `plugin` export into a typed manifest, or throw
-// a plugin-named error explaining why. Shape-only for this slice — apiVersion
-// compatibility windowing lands in a follow-up.
+// a plugin-named error explaining why. Covers manifest shape and the ADR-0013
+// apiVersion compatibility window (N and N−1): a plugin needing a newer API than
+// core provides, or targeting a dropped major, is rejected fail-loud at boot.
 const validateManifest = (name: string, mod: PluginModule): PlatypusPlugin => {
   const p = mod.plugin;
   if (!p || typeof p !== "object") {
@@ -62,6 +65,18 @@ const validateManifest = (name: string, mod: PluginModule): PlatypusPlugin => {
   if (typeof m.apiVersion !== "number" || !Number.isFinite(m.apiVersion)) {
     throw new Error(
       `Plugin "${name}": manifest "apiVersion" must be a number.`,
+    );
+  }
+  // Compatibility window (ADR-0013): apiVersion is a *minimum*. Core supports the
+  // current major and one previous (N and N−1). Reject only outside that window.
+  if (m.apiVersion > PLUGIN_API_VERSION) {
+    throw new Error(
+      `Plugin "${name}": needs API v${m.apiVersion}, but core supports up to v${PLUGIN_API_VERSION}. Upgrade core.`,
+    );
+  }
+  if (m.apiVersion < OLDEST_SUPPORTED_API_VERSION) {
+    throw new Error(
+      `Plugin "${name}": targets API v${m.apiVersion}, below the oldest core supports (v${OLDEST_SUPPORTED_API_VERSION}). Core supports v${OLDEST_SUPPORTED_API_VERSION}–v${PLUGIN_API_VERSION} (N and N−1).`,
     );
   }
   if (!m.contributes || typeof m.contributes !== "object") {

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -65,6 +65,34 @@ The compile-time contract — the manifest type, the Contribution types, and
 package. Third-party authors depend on it from npm; core plugins consume the
 same types via a workspace link.
 
+### API versioning & compatibility
+
+Set `apiVersion` from the SDK's `PLUGIN_API_VERSION` constant. It declares the
+**minimum** core API major your plugin needs — not an exact match. The policy is
+**forward-compatible with minimum-version semantics**: a core upgrade must never
+break a plugin already in the wild.
+
+Core supports the **current major and one previous — N and N−1** — at the same
+time. At boot, core rejects a listed plugin only when its `apiVersion` is:
+
+- **newer than core** (needs a capability this core doesn't provide yet) — the
+  Operator fixes it by upgrading core, which they control; or
+- **below core's oldest supported major** (targets a dropped, long-deprecated
+  major).
+
+Anything inside the `[N−1, N]` window loads. Rejection is
+[fail-loud](#the-plugin-model): the boot error names the plugin and both
+versions (`plugin X needs API vY, core supports vZ`).
+
+**Contracts evolve append-only.** Within a major, every extension-point contract
+grows only by **optional** members — a new capability is an optional method or
+field, never a new required one. That is what lets a plugin built against an
+older minor keep working after a core bump: it simply doesn't use members it
+never knew about. Adding a whole extension point (a new `contributes` key) is
+likewise additive. A genuinely breaking change — removing or re-signing a
+required member — is a **windowed major bump**: the major increments and core
+runs both N and N−1 for a release so authors can migrate.
+
 **Loading.** Before the HTTP server starts, core reads the Operator-supplied
 [`PLATYPUS_PLUGINS`](/self-hosting/configuration#plugins) list, resolves each
 plugin, reads its manifest, and drives registration by calling the internal
@@ -367,17 +395,18 @@ The plugin loader is landing incrementally
 What's live and what's still in-tree today:
 
 - **Live:** the `@platypuschat/plugin-sdk` surface (Tool sets _and_
-  Sandbox-backend contributions), the boot-time loader, the built-in map / core
-  allowlist, the first core plugin `@platypus/tools-basic` (math, time), and the
-  Docker Sandbox backend as the core plugin `@platypus/docker` — each flowing
-  manifest → loader → registry in a Chat turn.
+  Sandbox-backend contributions), the boot-time loader with the
+  [`apiVersion` compatibility window](#api-versioning--compatibility) (N and
+  N−1), the built-in map / core allowlist, the first core plugin
+  `@platypus/tools-basic` (math, time), and the Docker Sandbox backend as the
+  core plugin `@platypus/docker` — each flowing manifest → loader → registry in a
+  Chat turn.
 - **Still in-tree, pending migration:** the remaining built-in Tool sets
   (`kanban`, `triggers`, `sandbox`, …) still call `registerToolSet` directly at
   boot. They keep working unchanged; the same registration functions are what the
   loader drives.
 - **Follow-up slices:** third-party id namespacing, deploy-time plugin
-  config/credentials, `apiVersion` compatibility windowing, and a read-only
-  `GET /plugins` catalog.
+  config/credentials, and a read-only `GET /plugins` catalog.
 
 ## Reference ADRs
 

--- a/packages/plugin-sdk/index.test.ts
+++ b/packages/plugin-sdk/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { tool } from "ai";
 import {
+  OLDEST_SUPPORTED_API_VERSION,
   PLUGIN_API_VERSION,
   type PlatypusPlugin,
   type ToolSetContribution,
@@ -10,6 +11,10 @@ import {
 describe("@platypuschat/plugin-sdk", () => {
   it("pins the plugin API version", () => {
     expect(PLUGIN_API_VERSION).toBe(1);
+  });
+
+  it("supports exactly one previous major (N and N−1)", () => {
+    expect(OLDEST_SUPPORTED_API_VERSION).toBe(PLUGIN_API_VERSION - 1);
   });
 
   it("accepts a well-formed manifest with a static-map tool set", () => {

--- a/packages/plugin-sdk/index.ts
+++ b/packages/plugin-sdk/index.ts
@@ -2,15 +2,46 @@ import type { Tool } from "ai";
 import type { z } from "zod";
 
 /**
- * Minimum core API a plugin declares it needs, via its manifest `apiVersion`.
+ * The current major of the plugin API surface. A plugin's manifest `apiVersion`
+ * states the **minimum** core API it needs, not an exact match.
  *
- * Compatibility is forward-compatible and append-only: contracts grow only by
- * optional members, and core supports the current major and one previous (N and
- * N−1). This slice publishes the surface and the constant; the boot-time
- * compatibility window (rejecting plugins that need a newer or dropped major) is
- * enforced in a follow-up. See ADR-0013.
+ * ## Compatibility policy (enforced at boot; see ADR-0013)
+ *
+ * Compatibility is **forward-compatible with minimum-version semantics** — a
+ * core upgrade must never break an in-the-wild plugin. Core supports the current
+ * major **and one previous (N and N−1)** simultaneously, so the accepted window
+ * is `[OLDEST_SUPPORTED_API_VERSION, PLUGIN_API_VERSION]`. At boot core rejects a
+ * plugin only when its `apiVersion` is:
+ *
+ * - **newer than core** (`apiVersion > PLUGIN_API_VERSION`) — the plugin needs a
+ *   capability this core does not yet provide; the Operator fixes it by
+ *   upgrading core, which they control; or
+ * - **below core's oldest supported major** (`apiVersion <
+ *   OLDEST_SUPPORTED_API_VERSION`) — the plugin targets a dropped, long-
+ *   deprecated major.
+ *
+ * ## The append-only contract policy
+ *
+ * Within a major, every Extension-point contract in this SDK evolves
+ * **append-only**: a new capability arrives as an **optional** member (an
+ * optional method or field), never as a new required member. That is what lets a
+ * plugin built against an older minor keep working after a core bump — the older
+ * plugin simply doesn't use the members it never knew about. Adding a whole
+ * Extension point (e.g. a messaging gateway) is likewise additive: a new optional
+ * key on {@link PluginContributions}.
+ *
+ * A genuinely **breaking** change — removing or re-signing a required member — is
+ * a **windowed major bump**: the major increments, and during the window core
+ * runs both N and N−1 so authors have a release to migrate.
  */
 export const PLUGIN_API_VERSION = 1 as const;
+
+/**
+ * The oldest plugin API major core still accepts — one below the current major
+ * (the "N−1" of the N-and-N−1 window). A plugin whose `apiVersion` is below this
+ * targets a dropped major and is rejected at boot. See {@link PLUGIN_API_VERSION}.
+ */
+export const OLDEST_SUPPORTED_API_VERSION = PLUGIN_API_VERSION - 1;
 
 /**
  * Runtime scope handed to a Tool set factory at Chat-turn time. This SDK is the
@@ -179,7 +210,11 @@ export interface PluginContributions {
 export interface PlatypusPlugin {
   name: string;
   version: string;
-  /** Minimum core API this plugin needs. */
+  /**
+   * The **minimum** core API major this plugin needs. Core accepts it when it
+   * falls in the N-and-N−1 window `[OLDEST_SUPPORTED_API_VERSION,
+   * PLUGIN_API_VERSION]`; see {@link PLUGIN_API_VERSION} for the policy.
+   */
   apiVersion: number;
   configSchema?: z.ZodType;
   credentialsSchema?: z.ZodType;


### PR DESCRIPTION
## What & why

Enforces the [ADR-0013](docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md) compatibility policy at boot: **forward-compatible, minimum-version semantics** — a core upgrade must never break an in-the-wild plugin.

A plugin's manifest `apiVersion` states the **minimum** core API major it needs. Core supports the current major **and one previous (N and N−1)**, so the accepted window is `[OLDEST_SUPPORTED_API_VERSION, PLUGIN_API_VERSION]`. At boot core rejects a plugin only when its `apiVersion` is:

- **newer than core** — needs a capability this core doesn't provide yet (Operator upgrades core); or
- **below core's oldest supported major** — targets a dropped, long-deprecated major.

Rejection is **fail-loud**, naming the plugin and both versions (`plugin X needs API vY, core supports vZ`).

## Changes

- **`@platypuschat/plugin-sdk`**: add `OLDEST_SUPPORTED_API_VERSION` (= `PLUGIN_API_VERSION − 1`); document the N/N−1 window and the **append-only contract policy** (new capabilities are optional members; breaking changes are windowed major bumps).
- **Loader**: gate `apiVersion` in manifest validation with clear, plugin-named errors.
- **Tests**: accept (equal, N−1) and reject (too new, dropped major) for both SDK and loader.
- **Docs**: new "API versioning & compatibility" section in `apps/docs/content/extending`; migration status updated (windowing is now live).

## Acceptance criteria

- [x] A plugin declaring a higher `apiVersion` than core is rejected at boot with a clear message.
- [x] A plugin on major N−1 loads; a plugin on an older, dropped major is rejected.
- [x] `PLUGIN_API_VERSION` and the compatibility policy are documented in the SDK.
- [x] Tests cover accept (equal, N−1) and reject (too new, too old).
- [x] The versioning/compatibility policy is documented for plugin authors; the docs build passes.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- SDK tests: 4 passed; loader tests: 20 passed
- `pnpm --filter docs build` — passes

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)