### PR TITLE
feat(backend): deploy-time plugin config & shared credentials

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -15,6 +15,14 @@ TIMEZONE=UTC
 # Comma-separated plugins to load and enable at boot (fail-loud). Empty = no plugin tools.
 PLATYPUS_PLUGINS=@platypus/tools-basic
 
+# Deploy-time, Operator-owned plugin config/credentials (ADR-0013). A JSON object
+# keyed by plugin name; each value is an optional { "config": {..}, "credentials":
+# {..} }. Validated at boot against the plugin manifest's schemas (fail-loud). One
+# block is shared across all of a plugin's contributions and all tenants. Distinct
+# from per-Workspace Sandbox config. Only plugins that declare plugin-level schemas
+# consume it (@platypus/tools-basic and @platypus/docker need no entry).
+# PLATYPUS_PLUGIN_CONFIG={"@acme/cloud-sandbox":{"config":{"region":"eu"},"credentials":{"apiToken":"dtn_live_..."}}}
+
 # Memory extraction configuration
 MEMORY_EXTRACTION_INTERVAL_MS=300000  # 5 minutes
 

--- a/apps/backend/src/plugins/example/index.ts
+++ b/apps/backend/src/plugins/example/index.ts
@@ -55,28 +55,30 @@ class ExampleSandboxBackend implements SandboxBackend {
     this.region = plugin.config.region;
   }
 
-  async shellExec() {
-    return {
+  shellExec() {
+    return Promise.resolve({
       stdout: "",
       stderr: "",
       exitCode: 0,
       truncated: false,
       durationMs: 0,
-    };
+    });
   }
-  async fsRead() {
-    return { content: "", lineCount: 0, truncated: false };
+  fsRead() {
+    return Promise.resolve({ content: "", lineCount: 0, truncated: false });
   }
-  async fsWrite() {
-    return { bytesWritten: 0 };
+  fsWrite() {
+    return Promise.resolve({ bytesWritten: 0 });
   }
-  async fsEdit() {
-    return { replacements: 1 as const };
+  fsEdit() {
+    return Promise.resolve({ replacements: 1 as const });
   }
-  async fsList() {
-    return { entries: [], truncated: false };
+  fsList() {
+    return Promise.resolve({ entries: [], truncated: false });
   }
-  async destroy() {}
+  destroy() {
+    return Promise.resolve();
+  }
 }
 
 // Contribution 1 — a Sandbox backend. Its create() ignores the per-Workspace
@@ -105,8 +107,10 @@ const exampleManagementToolSet: ToolSetContribution = {
         description: "List sandboxes in the configured region",
         inputSchema: z.object({}),
         // A real tool would call the vendor API with `credentials.apiToken`.
-        execute: async () =>
-          `Listing sandboxes in ${config.region} (token ${credentials.apiToken.slice(0, 3)}…)`,
+        execute: () =>
+          Promise.resolve(
+            `Listing sandboxes in ${config.region} (token ${credentials.apiToken.slice(0, 3)}…)`,
+          ),
       }),
     };
   },

--- a/apps/backend/src/plugins/example/index.ts
+++ b/apps/backend/src/plugins/example/index.ts
@@ -1,0 +1,125 @@
+import type {
+  PlatypusPlugin,
+  PluginConfigContext,
+  SandboxBackend,
+  SandboxBackendContribution,
+  ToolSetContribution,
+} from "@platypuschat/plugin-sdk";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import { tool } from "ai";
+import { z } from "zod";
+
+// Example third-party plugin, kept as an in-repo reference for the deploy-time
+// plugin-config + shared-credential mechanics of ADR-0013. It is NOT in the
+// core allowlist (`builtin.ts`) and is NOT listed in any default
+// `PLATYPUS_PLUGINS`, so it never loads in a real deployment — it exists to
+// document the pattern and to exercise the loader's config injection in tests.
+//
+// It mimics a hosted-sandbox vendor ("Daytona"-style): the Operator supplies
+// one deploy-time credential block (an API token) plus non-secret config (a
+// region). Core validates them at boot against the plugin-level schemas below
+// and injects the single resolved block into BOTH contributions — the Sandbox
+// backend and the management Tool set — proving one credential block is shared
+// across every contribution and every tenant (deployment-wide).
+
+// Plugin-level deploy-time schemas (separate from the per-Workspace Sandbox
+// config/credentials the SandboxBackendContribution declares). `config` is
+// non-secret shape; `credentials` is secret material shared across tenants.
+export const examplePluginConfigSchema = z
+  .object({ region: z.string().min(1).default("us") })
+  .strict();
+export const examplePluginCredentialsSchema = z
+  .object({ apiToken: z.string().min(1) })
+  .strict();
+
+export type ExamplePluginConfig = z.infer<typeof examplePluginConfigSchema>;
+export type ExamplePluginCredentials = z.infer<
+  typeof examplePluginCredentialsSchema
+>;
+
+type ExamplePluginContext = PluginConfigContext<
+  ExamplePluginConfig,
+  ExamplePluginCredentials
+>;
+
+// A stub Sandbox backend that closes over the shared deploy-time credentials.
+// A real adapter would use `apiToken` to authenticate every provisioning call
+// to the vendor API; here it only records what it was handed so tests can
+// assert the shared block reached it.
+class ExampleSandboxBackend implements SandboxBackend {
+  readonly apiToken: string;
+  readonly region: string;
+
+  constructor(plugin: ExamplePluginContext) {
+    this.apiToken = plugin.credentials.apiToken;
+    this.region = plugin.config.region;
+  }
+
+  async shellExec() {
+    return {
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+      truncated: false,
+      durationMs: 0,
+    };
+  }
+  async fsRead() {
+    return { content: "", lineCount: 0, truncated: false };
+  }
+  async fsWrite() {
+    return { bytesWritten: 0 };
+  }
+  async fsEdit() {
+    return { replacements: 1 as const };
+  }
+  async fsList() {
+    return { entries: [], truncated: false };
+  }
+  async destroy() {}
+}
+
+// Contribution 1 — a Sandbox backend. Its create() ignores the per-Workspace
+// config/credentials (an empty schema here) and instead authenticates with the
+// deploy-time plugin credentials handed in as the third argument.
+const exampleSandboxBackend: SandboxBackendContribution = {
+  backend: "sandbox",
+  name: "Example Cloud Sandbox",
+  configSchema: z.object({}).strict(),
+  credentialsSchema: z.object({}).strict(),
+  create: (_config, _credentials, plugin) =>
+    new ExampleSandboxBackend(plugin as ExamplePluginContext),
+};
+
+// Contribution 2 — a management Tool set. Its factory reads the SAME shared
+// credential block (the second argument) to talk to the vendor's control API.
+const exampleManagementToolSet: ToolSetContribution = {
+  id: "management",
+  name: "Example Management",
+  category: "Sandbox",
+  description: "Manage Example Cloud sandboxes for this workspace",
+  tools: (_ctx, plugin) => {
+    const { credentials, config } = plugin as ExamplePluginContext;
+    return {
+      listSandboxes: tool({
+        description: "List sandboxes in the configured region",
+        inputSchema: z.object({}),
+        // A real tool would call the vendor API with `credentials.apiToken`.
+        execute: async () =>
+          `Listing sandboxes in ${config.region} (token ${credentials.apiToken.slice(0, 3)}…)`,
+      }),
+    };
+  },
+};
+
+export const plugin: PlatypusPlugin = {
+  name: "@example/cloud-sandbox",
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  configSchema: examplePluginConfigSchema,
+  credentialsSchema: examplePluginCredentialsSchema,
+  contributes: {
+    sandboxBackends: [exampleSandboxBackend],
+    toolSets: [exampleManagementToolSet],
+  },
+};

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect, vi } from "vitest";
 import { z } from "zod";
 import type {
   PlatypusPlugin,
+  PluginConfigContext,
   SandboxBackend,
   SandboxBackendContribution,
   ToolSetContribution,
 } from "@platypuschat/plugin-sdk";
-import { loadPlugins, parsePluginList } from "./loader.ts";
+import { loadPlugins, parsePluginConfig, parsePluginList } from "./loader.ts";
+import { plugin as examplePlugin } from "./example/index.ts";
 
 // A capturing `register` and the builtin/import module shapes the loader expects.
 const makeRegister = () => {
@@ -354,5 +356,347 @@ describe("loadPlugins — sandbox backends", () => {
         registerSandbox: () => {},
       }),
     ).rejects.toThrow(/@bad\/plugin.*sandboxBackends.*array/s);
+  });
+});
+
+describe("parsePluginConfig", () => {
+  it("returns an empty map for unset or empty input", () => {
+    expect(parsePluginConfig(undefined)).toEqual({});
+    expect(parsePluginConfig("")).toEqual({});
+    expect(parsePluginConfig("   ")).toEqual({});
+  });
+
+  it("parses a JSON object keyed by plugin name", () => {
+    const raw = JSON.stringify({
+      "@acme/daytona": {
+        config: { region: "eu" },
+        credentials: { apiToken: "secret" },
+      },
+    });
+    expect(parsePluginConfig(raw)).toEqual({
+      "@acme/daytona": {
+        config: { region: "eu" },
+        credentials: { apiToken: "secret" },
+      },
+    });
+  });
+
+  it("tolerates entries that omit config or credentials", () => {
+    const raw = JSON.stringify({ "@acme/one": { config: { a: 1 } } });
+    expect(parsePluginConfig(raw)).toEqual({
+      "@acme/one": { config: { a: 1 }, credentials: undefined },
+    });
+  });
+
+  it("throws (fail-loud) on malformed JSON", () => {
+    expect(() => parsePluginConfig("{not json")).toThrow(
+      /PLATYPUS_PLUGIN_CONFIG is not valid JSON/,
+    );
+  });
+
+  it("throws (fail-loud) when the root is not an object", () => {
+    expect(() => parsePluginConfig("[]")).toThrow(
+      /must be a JSON object keyed by plugin name/,
+    );
+    expect(() => parsePluginConfig('"x"')).toThrow(
+      /must be a JSON object keyed by plugin name/,
+    );
+  });
+
+  it("throws (fail-loud) when an entry is not an object", () => {
+    expect(() =>
+      parsePluginConfig(JSON.stringify({ "@acme/bad": "token" })),
+    ).toThrow(/@acme\/bad.*must be an object/s);
+  });
+});
+
+describe("loadPlugins — deploy-time plugin config injection", () => {
+  // A plugin declaring plugin-level schemas plus one factory tool set and one
+  // sandbox backend, both of which record the injected PluginConfigContext.
+  const configuredManifest = (
+    name: string,
+    seen: { toolSet?: PluginConfigContext; sandbox?: PluginConfigContext },
+  ): PlatypusPlugin => ({
+    name,
+    version: "0.1.0",
+    apiVersion: 1,
+    configSchema: z.object({ region: z.string() }),
+    credentialsSchema: z.object({ apiToken: z.string() }),
+    contributes: {
+      toolSets: [
+        {
+          id: "managed",
+          name: "Managed",
+          category: "Test",
+          tools: (_ctx, plugin) => {
+            seen.toolSet = plugin;
+            return {};
+          },
+        },
+      ],
+      sandboxBackends: [
+        {
+          backend: "cloud",
+          name: "Cloud",
+          configSchema: z.object({}),
+          credentialsSchema: z.object({}),
+          create: (_config, _credentials, plugin) => {
+            seen.sandbox = plugin;
+            return {} as unknown as SandboxBackend;
+          },
+        },
+      ],
+    },
+  });
+
+  it("validates and injects resolved config/credentials into every factory", async () => {
+    const seen: {
+      toolSet?: PluginConfigContext;
+      sandbox?: PluginConfigContext;
+    } = {};
+    const registered: Record<string, Omit<ToolSetContribution, "id">> = {};
+    const register = (id: string, def: Omit<ToolSetContribution, "id">) => {
+      registered[id] = def;
+    };
+    const sandboxCalls: SandboxBackendContribution[] = [];
+    const registerSandbox = (c: SandboxBackendContribution) => {
+      sandboxCalls.push(c);
+    };
+
+    await loadPlugins({
+      pluginNames: ["@acme/cloud"],
+      builtinPlugins: {},
+      importPlugin: () =>
+        Promise.resolve({ plugin: configuredManifest("@acme/cloud", seen) }),
+      register,
+      registerSandbox,
+      pluginConfig: {
+        "@acme/cloud": {
+          config: { region: "eu" },
+          credentials: { apiToken: "tok_123" },
+        },
+      },
+    });
+
+    // Tool-set factory: invoked as core would at Chat-turn time, with ctx only.
+    const toolsFactory = registered.managed.tools;
+    expect(typeof toolsFactory).toBe("function");
+    await (toolsFactory as (ctx: unknown) => unknown)({
+      workspaceId: "w",
+      agentId: "a",
+      orgId: "o",
+      frontendUrl: undefined,
+      userId: "u",
+    });
+
+    // Sandbox create(): invoked as core would, with the per-Workspace values.
+    sandboxCalls[0].create({}, {}, undefined as unknown as PluginConfigContext);
+
+    expect(seen.toolSet).toEqual({
+      config: { region: "eu" },
+      credentials: { apiToken: "tok_123" },
+    });
+    expect(seen.sandbox).toEqual({
+      config: { region: "eu" },
+      credentials: { apiToken: "tok_123" },
+    });
+  });
+
+  it("shares one credential block across contributions (same object identity)", async () => {
+    const seen: {
+      toolSet?: PluginConfigContext;
+      sandbox?: PluginConfigContext;
+    } = {};
+    const registered: Record<string, Omit<ToolSetContribution, "id">> = {};
+    const register = (id: string, def: Omit<ToolSetContribution, "id">) => {
+      registered[id] = def;
+    };
+    const sandboxCalls: SandboxBackendContribution[] = [];
+
+    await loadPlugins({
+      pluginNames: ["@acme/cloud"],
+      builtinPlugins: {},
+      importPlugin: () =>
+        Promise.resolve({ plugin: configuredManifest("@acme/cloud", seen) }),
+      register,
+      registerSandbox: (c) => sandboxCalls.push(c),
+      pluginConfig: {
+        "@acme/cloud": {
+          config: { region: "eu" },
+          credentials: { apiToken: "tok_123" },
+        },
+      },
+    });
+
+    await (registered.managed.tools as (ctx: unknown) => unknown)({
+      workspaceId: "w",
+      agentId: "a",
+      orgId: "o",
+      frontendUrl: undefined,
+      userId: "u",
+    });
+    sandboxCalls[0].create({}, {}, undefined as unknown as PluginConfigContext);
+
+    // The two contributions must be handed the *same* resolved block — one
+    // credential block per plugin, shared deployment-wide (ADR-0013).
+    expect(seen.toolSet).toBe(seen.sandbox);
+  });
+
+  it("aborts (fail-loud) when deploy-time credentials fail validation", async () => {
+    await expect(
+      loadPlugins({
+        pluginNames: ["@acme/cloud"],
+        builtinPlugins: {},
+        importPlugin: () =>
+          Promise.resolve({ plugin: configuredManifest("@acme/cloud", {}) }),
+        register: () => {},
+        registerSandbox: () => {},
+        pluginConfig: {
+          "@acme/cloud": {
+            config: { region: "eu" },
+            // apiToken missing → credentialsSchema rejects.
+            credentials: {},
+          },
+        },
+      }),
+    ).rejects.toThrow(/@acme\/cloud.*credentials failed validation/s);
+  });
+
+  it("aborts (fail-loud) when deploy-time config fails validation", async () => {
+    await expect(
+      loadPlugins({
+        pluginNames: ["@acme/cloud"],
+        builtinPlugins: {},
+        importPlugin: () =>
+          Promise.resolve({ plugin: configuredManifest("@acme/cloud", {}) }),
+        register: () => {},
+        registerSandbox: () => {},
+        pluginConfig: {
+          "@acme/cloud": {
+            // region missing → configSchema rejects.
+            config: {},
+            credentials: { apiToken: "tok_123" },
+          },
+        },
+      }),
+    ).rejects.toThrow(/@acme\/cloud.*config failed validation/s);
+  });
+
+  it("passes undefined config/credentials to plugins declaring no schemas", async () => {
+    let seenPlugin: PluginConfigContext | undefined;
+    const registered: Record<string, Omit<ToolSetContribution, "id">> = {};
+
+    await loadPlugins({
+      pluginNames: ["@no/schema"],
+      builtinPlugins: {},
+      importPlugin: () =>
+        Promise.resolve({
+          plugin: {
+            name: "@no/schema",
+            version: "0.1.0",
+            apiVersion: 1,
+            contributes: {
+              toolSets: [
+                {
+                  id: "plain",
+                  name: "Plain",
+                  category: "Test",
+                  tools: (_ctx, plugin) => {
+                    seenPlugin = plugin;
+                    return {};
+                  },
+                },
+              ],
+            },
+          } satisfies PlatypusPlugin,
+        }),
+      register: (id, def) => {
+        registered[id] = def;
+      },
+    });
+
+    await (registered.plain.tools as (ctx: unknown) => unknown)({
+      workspaceId: "w",
+      agentId: "a",
+      orgId: "o",
+      frontendUrl: undefined,
+      userId: "u",
+    });
+
+    expect(seenPlugin).toEqual({ config: undefined, credentials: undefined });
+  });
+});
+
+describe("loadPlugins — example third-party plugin", () => {
+  // Proves the documented example plugin wires one shared credential block into
+  // BOTH its Sandbox backend and its management Tool set (ADR-0013).
+  it("shares one credential block across its two contributions", async () => {
+    const registered: Record<string, Omit<ToolSetContribution, "id">> = {};
+    const sandboxCalls: SandboxBackendContribution[] = [];
+
+    const loaded = await loadPlugins({
+      pluginNames: ["@example/cloud-sandbox"],
+      builtinPlugins: {},
+      importPlugin: () => Promise.resolve({ plugin: examplePlugin }),
+      register: (id, def) => {
+        registered[id] = def;
+      },
+      registerSandbox: (c) => sandboxCalls.push(c),
+      pluginConfig: {
+        "@example/cloud-sandbox": {
+          config: { region: "ap" },
+          credentials: { apiToken: "dtn_shared_token" },
+        },
+      },
+    });
+
+    expect(loaded[0]).toMatchObject({
+      name: "@example/cloud-sandbox",
+      origin: "third-party",
+      toolSetIds: ["management"],
+      sandboxBackendIds: ["sandbox"],
+    });
+
+    // Sandbox backend: create() with per-Workspace values; the adapter reads
+    // the deploy-time token/region injected as the third argument.
+    const backend = sandboxCalls[0].create(
+      {},
+      {},
+      undefined as unknown as PluginConfigContext,
+    ) as unknown as { apiToken: string; region: string };
+    expect(backend.apiToken).toBe("dtn_shared_token");
+    expect(backend.region).toBe("ap");
+
+    // Management tool set: its tool description reflects the SAME token/region.
+    const toolsFactory = registered.management.tools as unknown as (
+      ctx: unknown,
+    ) => Promise<Record<string, { execute: (i: unknown) => Promise<string> }>>;
+    const tools = await toolsFactory({
+      workspaceId: "w",
+      agentId: "a",
+      orgId: "o",
+      frontendUrl: undefined,
+      userId: "u",
+    });
+    const msg = await tools.listSandboxes.execute({});
+    expect(msg).toContain("ap");
+    expect(msg).toContain("dtn");
+  });
+
+  it("aborts (fail-loud) when the example plugin's token is missing", async () => {
+    await expect(
+      loadPlugins({
+        pluginNames: ["@example/cloud-sandbox"],
+        builtinPlugins: {},
+        importPlugin: () => Promise.resolve({ plugin: examplePlugin }),
+        register: () => {},
+        registerSandbox: () => {},
+        pluginConfig: {
+          "@example/cloud-sandbox": { config: { region: "ap" } },
+        },
+      }),
+    ).rejects.toThrow(
+      /@example\/cloud-sandbox.*credentials failed validation/s,
+    );
   });
 });

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -490,7 +490,7 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
     });
 
     // Sandbox create(): invoked as core would, with the per-Workspace values.
-    sandboxCalls[0].create({}, {}, undefined as unknown as PluginConfigContext);
+    sandboxCalls[0].create({}, {});
 
     expect(seen.toolSet).toEqual({
       config: { region: "eu" },
@@ -535,7 +535,7 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
       frontendUrl: undefined,
       userId: "u",
     });
-    sandboxCalls[0].create({}, {}, undefined as unknown as PluginConfigContext);
+    sandboxCalls[0].create({}, {});
 
     // The two contributions must be handed the *same* resolved block — one
     // credential block per plugin, shared deployment-wide (ADR-0013).
@@ -659,11 +659,10 @@ describe("loadPlugins — example third-party plugin", () => {
 
     // Sandbox backend: create() with per-Workspace values; the adapter reads
     // the deploy-time token/region injected as the third argument.
-    const backend = sandboxCalls[0].create(
-      {},
-      {},
-      undefined as unknown as PluginConfigContext,
-    ) as unknown as { apiToken: string; region: string };
+    const backend = sandboxCalls[0].create({}, {}) as unknown as {
+      apiToken: string;
+      region: string;
+    };
     expect(backend.apiToken).toBe("dtn_shared_token");
     expect(backend.region).toBe("ap");
 

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -1,5 +1,6 @@
 import type {
   PlatypusPlugin,
+  PluginConfigContext,
   SandboxBackendContribution,
   ToolSetContribution,
 } from "@platypuschat/plugin-sdk";
@@ -19,6 +20,18 @@ export interface LoadedPlugin {
 // A module that exports a plugin manifest. Values are `unknown` until validated.
 type PluginModule = { plugin?: unknown };
 
+// Deploy-time config/credentials the Operator supplies for one plugin. Both
+// halves are optional and opaque until validated against the manifest's
+// plugin-level schemas at boot.
+export interface RawPluginConfig {
+  config?: unknown;
+  credentials?: unknown;
+}
+
+// The full Operator-supplied config map, keyed by plugin name (`manifest.name`).
+// Parsed from `PLATYPUS_PLUGIN_CONFIG` (see {@link parsePluginConfig}).
+export type PluginConfigMap = Record<string, RawPluginConfig>;
+
 export interface LoadPluginsOptions {
   /** Plugin names to load. Defaults to parsing `PLATYPUS_PLUGINS`. */
   pluginNames?: string[];
@@ -30,6 +43,11 @@ export interface LoadPluginsOptions {
   register?: (id: string, def: Omit<ToolSetContribution, "id">) => void;
   /** Registers one Sandbox-backend contribution. Defaults to core `registerSandboxBackend`. */
   registerSandbox?: (contribution: SandboxBackendContribution) => void;
+  /**
+   * Deploy-time plugin config/credentials keyed by plugin name. Defaults to
+   * parsing `PLATYPUS_PLUGIN_CONFIG` (see {@link parsePluginConfig}).
+   */
+  pluginConfig?: PluginConfigMap;
 }
 
 /**
@@ -41,6 +59,86 @@ export const parsePluginList = (raw: string | undefined): string[] =>
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
+
+/**
+ * Parse the `PLATYPUS_PLUGIN_CONFIG` value — a JSON object keyed by plugin name,
+ * each value an optional `{ config?, credentials? }` — into a {@link
+ * PluginConfigMap}. Plugin names carry `@scope/name` slashes, so a single JSON
+ * blob keyed by name is the one config namespace (ADR-0013), not per-plugin env
+ * vars. An unset/empty value yields `{}`. Fail-loud: malformed JSON, a non-object
+ * root, or a non-object entry aborts boot.
+ */
+export const parsePluginConfig = (raw: string | undefined): PluginConfigMap => {
+  const trimmed = (raw ?? "").trim();
+  if (trimmed.length === 0) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (cause) {
+    throw new Error(
+      `PLATYPUS_PLUGIN_CONFIG is not valid JSON (${
+        cause instanceof Error ? cause.message : String(cause)
+      }).`,
+      { cause },
+    );
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `PLATYPUS_PLUGIN_CONFIG must be a JSON object keyed by plugin name.`,
+    );
+  }
+
+  const map: PluginConfigMap = {};
+  for (const [pluginName, entry] of Object.entries(parsed)) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(
+        `PLATYPUS_PLUGIN_CONFIG["${pluginName}"] must be an object with optional "config" / "credentials".`,
+      );
+    }
+    const { config, credentials } = entry as RawPluginConfig;
+    map[pluginName] = { config, credentials };
+  }
+  return map;
+};
+
+/**
+ * Resolve one plugin's deploy-time config/credentials into the {@link
+ * PluginConfigContext} injected into its contribution factories. Each half is
+ * validated against the manifest's plugin-level schema when declared (fail-loud,
+ * plugin-named); when no schema is declared the raw Operator value passes
+ * through untouched (`undefined` when absent — nothing to validate against).
+ */
+const resolvePluginConfig = (
+  manifest: PlatypusPlugin,
+  raw: RawPluginConfig,
+): PluginConfigContext => {
+  const resolveOne = (
+    kind: "config" | "credentials",
+    schema: PlatypusPlugin["configSchema"],
+    value: unknown,
+  ): unknown => {
+    if (!schema) return value;
+    const result = schema.safeParse(value ?? {});
+    if (!result.success) {
+      throw new Error(
+        `Plugin "${manifest.name}": deploy-time ${kind} failed validation (${result.error.message}).`,
+        { cause: result.error },
+      );
+    }
+    return result.data;
+  };
+
+  return {
+    config: resolveOne("config", manifest.configSchema, raw.config),
+    credentials: resolveOne(
+      "credentials",
+      manifest.credentialsSchema,
+      raw.credentials,
+    ),
+  };
+};
 
 // Validate an imported module's `plugin` export into a typed manifest, or throw
 // a plugin-named error explaining why. Shape-only for this slice — apiVersion
@@ -94,8 +192,13 @@ const validateManifest = (name: string, mod: PluginModule): PlatypusPlugin => {
  * registries are populated by the time Chat turns resolve tools.
  *
  * Boot is fail-loud and all-or-nothing (ADR-0013): a plugin that can't resolve,
- * has an invalid manifest, or collides with another aborts startup. Runtime
- * Chat-turn resolution stays graceful and is unaffected.
+ * has an invalid manifest, whose deploy-time config/credentials fail schema
+ * validation, or collides with another aborts startup. Runtime Chat-turn
+ * resolution stays graceful and is unaffected.
+ *
+ * Deploy-time plugin config/credentials (keyed by plugin name) are resolved once
+ * per plugin and the single shared block is injected into every one of that
+ * plugin's contribution factories, alongside the existing per-Workspace config.
  *
  * Resolution differs by origin: core plugins (present in the built-in map) load
  * via their static thunk; third-party plugins load via dynamic `import()`.
@@ -113,6 +216,8 @@ export async function loadPlugins(
     ((name: string) => import(name) as Promise<PluginModule>);
   const register = opts.register ?? registerToolSet;
   const registerSandbox = opts.registerSandbox ?? registerSandboxBackend;
+  const pluginConfig =
+    opts.pluginConfig ?? parsePluginConfig(process.env.PLATYPUS_PLUGIN_CONFIG);
 
   // Tracks contribution id -> owning plugin name for owner-attributed collisions.
   // Tool sets and Sandbox backends live in separate registries, so each keeps
@@ -138,6 +243,15 @@ export async function loadPlugins(
     }
 
     const manifest = validateManifest(name, mod);
+
+    // Resolve the plugin's deploy-time config/credentials once (fail-loud) and
+    // share the single block across every contribution factory below — this
+    // object identity IS the "one credential block per plugin" of ADR-0013.
+    const pluginCtx = resolvePluginConfig(
+      manifest,
+      pluginConfig[manifest.name] ?? {},
+    );
+
     const toolSetIds: string[] = [];
 
     for (const contribution of manifest.contributes.toolSets ?? []) {
@@ -150,8 +264,22 @@ export async function loadPlugins(
         );
       }
 
+      // Bind the shared plugin config into the factory so core's registry and
+      // its Chat-turn callers stay ignorant of it: they invoke the stored
+      // factory with only the ToolSetContext, as before. A static-map tool set
+      // has no factory to inject into and is registered untouched.
+      const boundTools =
+        typeof tools === "function"
+          ? (ctx: Parameters<typeof tools>[0]) => tools(ctx, pluginCtx)
+          : tools;
+
       try {
-        register(id, { name: tsName, category, description, tools });
+        register(id, {
+          name: tsName,
+          category,
+          description,
+          tools: boundTools,
+        });
       } catch (cause) {
         // A collision with a Tool set registered outside the loader (a legacy
         // static registration) surfaces here — re-throw with plugin attribution.
@@ -179,8 +307,17 @@ export async function loadPlugins(
         );
       }
 
+      // Bind the same shared plugin config into create() so core's per-turn
+      // callers (chat resolution, teardown) keep calling create(config,
+      // credentials) with the per-Workspace values only.
+      const boundContribution: SandboxBackendContribution = {
+        ...contribution,
+        create: (config, credentials) =>
+          contribution.create(config, credentials, pluginCtx),
+      };
+
       try {
-        registerSandbox(contribution);
+        registerSandbox(boundContribution);
       } catch (cause) {
         // A collision with a backend registered outside the loader surfaces
         // here — re-throw with plugin attribution.

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -81,10 +81,71 @@ plugin, reads its manifest, and drives registration by calling the internal
 module resolution.
 
 **Boot is fail-loud and all-or-nothing.** A listed plugin that can't resolve,
-exports an invalid manifest, or whose Contribution ids collide with another
-plugin's aborts startup with a plugin-named error. Runtime Chat-turn resolution
-stays graceful (a Workspace pointing at a since-removed Tool set degrades to no
-tools, as before) — strict at boot, forgiving at runtime.
+exports an invalid manifest, whose deploy-time config/credentials fail schema
+validation, or whose Contribution ids collide with another plugin's aborts
+startup with a plugin-named error. Runtime Chat-turn resolution stays graceful (a
+Workspace pointing at a since-removed Tool set degrades to no tools, as before) —
+strict at boot, forgiving at runtime.
+
+### Deploy-time plugin config & credentials
+
+A plugin can declare **plugin-level** `configSchema` / `credentialsSchema` on its
+manifest — separate from the per-contribution schemas a Sandbox backend declares
+for its per-Workspace `config` / `credentials`. These describe deploy-time,
+**Operator-owned** settings: a region, an API token. The Operator supplies them
+through [`PLATYPUS_PLUGIN_CONFIG`](/self-hosting/configuration#plugin-config--credentials)
+— a JSON object keyed by plugin name.
+
+Core validates the supplied values at boot (fail-loud) and injects the resolved
+block into **every** one of that plugin's contribution factories:
+
+- A **Tool set** factory receives it as an appended second argument,
+  `(ctx, plugin) => …`.
+- A **Sandbox backend** `create(config, credentials, plugin)` receives it as a
+  third argument, alongside the per-Workspace `config` / `credentials`.
+
+Both arguments are optional to consume, so existing factories keep working
+unchanged. The key property: **one block is shared** across all of a plugin's
+contributions and all tenants (it is a _deployment_ layer, not per-Workspace).
+That is how a plugin's Sandbox backend and its management Tool set authenticate
+with the **same** credential — e.g. one Daytona token driving both:
+
+```ts
+export const plugin: PlatypusPlugin = {
+  name: "@example/cloud-sandbox",
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  // Plugin-level, deploy-time schemas — validated at boot.
+  configSchema: z.object({ region: z.string().default("us") }),
+  credentialsSchema: z.object({ apiToken: z.string() }),
+  contributes: {
+    sandboxBackends: [
+      {
+        backend: "sandbox",
+        name: "Example Cloud Sandbox",
+        configSchema: z.object({}), // per-Workspace (none here)
+        credentialsSchema: z.object({}),
+        // The shared deploy-time token arrives as the third argument.
+        create: (_cfg, _creds, plugin) => new ExampleBackend(plugin),
+      },
+    ],
+    toolSets: [
+      {
+        id: "management",
+        name: "Example Management",
+        category: "Sandbox",
+        // …and the SAME block arrives here as the second argument.
+        tools: (_ctx, plugin) => createManagementTools(plugin.credentials),
+      },
+    ],
+  },
+};
+```
+
+The in-repo reference is `apps/backend/src/plugins/example/` — a two-contribution
+plugin that proves the single credential block reaches both. This is distinct
+from, and layers above, the per-Workspace Sandbox `config` / `credentials`
+(unchanged); the two do not merge.
 
 ## Sandbox backends
 
@@ -368,16 +429,17 @@ What's live and what's still in-tree today:
 
 - **Live:** the `@platypuschat/plugin-sdk` surface (Tool sets _and_
   Sandbox-backend contributions), the boot-time loader, the built-in map / core
-  allowlist, the first core plugin `@platypus/tools-basic` (math, time), and the
-  Docker Sandbox backend as the core plugin `@platypus/docker` — each flowing
-  manifest → loader → registry in a Chat turn.
+  allowlist, the first core plugin `@platypus/tools-basic` (math, time), the
+  Docker Sandbox backend as the core plugin `@platypus/docker`, and
+  [deploy-time plugin config/credentials](#deploy-time-plugin-config--credentials)
+  (the shared credential block) — each flowing manifest → loader → registry in a
+  Chat turn.
 - **Still in-tree, pending migration:** the remaining built-in Tool sets
   (`kanban`, `triggers`, `sandbox`, …) still call `registerToolSet` directly at
   boot. They keep working unchanged; the same registration functions are what the
   loader drives.
-- **Follow-up slices:** third-party id namespacing, deploy-time plugin
-  config/credentials, `apiVersion` compatibility windowing, and a read-only
-  `GET /plugins` catalog.
+- **Follow-up slices:** third-party id namespacing, `apiVersion` compatibility
+  windowing, and a read-only `GET /plugins` catalog.
 
 ## Reference ADRs
 

--- a/apps/docs/content/reference/backend-configuration.mdx
+++ b/apps/docs/content/reference/backend-configuration.mdx
@@ -31,12 +31,14 @@ For a guided walkthrough of configuring a deployment, see
 
 ## Plugins
 
-| Variable           | Purpose                                                                                                                                                                                       | Default                 | Required |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | -------- |
-| `PLATYPUS_PLUGINS` | Comma-separated list of plugins to load and enable at boot (core built-ins included). List membership both loads _and_ enables a plugin. Empty ⇒ no plugin-provided tools. Fail-loud at boot. | `@platypus/tools-basic` | No       |
+| Variable                 | Purpose                                                                                                                                                                                                                                                                                                                                          | Default                 | Required |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- | -------- |
+| `PLATYPUS_PLUGINS`       | Comma-separated list of plugins to load and enable at boot (core built-ins included). List membership both loads _and_ enables a plugin. Empty ⇒ no plugin-provided tools. Fail-loud at boot.                                                                                                                                                     | `@platypus/tools-basic` | No       |
+| `PLATYPUS_PLUGIN_CONFIG` | Deploy-time, Operator-owned plugin config/credentials as a JSON object keyed by plugin name, each `{ "config": {…}, "credentials": {…} }`. Validated at boot against the plugin's manifest schemas (fail-loud). One block is shared deployment-wide across all of a plugin's contributions and tenants. Distinct from per-Workspace Sandbox config. | _(unset)_               | No       |
 
 See [Extending → the plugin model](/extending#the-plugin-model) and
-[Configuration → Plugins](/self-hosting/configuration#plugins).
+[Configuration → Plugins](/self-hosting/configuration#plugins) (incl.
+[plugin config & credentials](/self-hosting/configuration#plugin-config--credentials)).
 
 ## Authentication
 

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -92,6 +92,45 @@ comma-separated list of plugin names; core built-ins are listed too (e.g.
 See [Extending → the plugin model](/extending#the-plugin-model) for how a
 manifest's `contributes` block fills extension points.
 
+### Plugin config & credentials
+
+Some plugins need deploy-time settings — a region, an API token — that are the
+**Operator's** to set, not an end user's. `PLATYPUS_PLUGIN_CONFIG` carries them:
+a single JSON object keyed by plugin name, each value an optional `config`
+(non-secret) and `credentials` (secret) block.
+
+```jsonc
+// PLATYPUS_PLUGIN_CONFIG (as a single-line env value)
+{
+  "@acme/cloud-sandbox": {
+    "config": { "region": "eu" },
+    "credentials": { "apiToken": "dtn_live_…" }
+  }
+}
+```
+
+- **One namespace, one block per plugin.** A plugin's config/credentials are
+  keyed by its plugin name and validated **at boot** against the schemas its
+  manifest declares. A malformed or missing required value is **fail-loud** —
+  startup aborts with a plugin-named error, the same posture as the plugin list.
+- **The credential block is shared, deployment-wide.** The one block is injected
+  into _every_ one of that plugin's contributions and serves _all_ tenants — a
+  plugin's Sandbox backend and its management Tool set read the same token. This
+  is not a per-user or per-Workspace secret.
+- **Distinct from per-Workspace Sandbox config.** The genuinely tenant-specific
+  settings — which Docker networks _this_ Workspace's sandbox may attach to, its
+  environment variables — still live on the per-Workspace Sandbox row (see
+  [Sandbox](#sandbox) below) and are unchanged. Plugin config is a _deployment_
+  layer **above** per-Workspace _resource_ config; the two layer, they do not
+  merge.
+- **Only plugins that declare schemas consume it.** A plugin with no
+  plugin-level `configSchema` / `credentialsSchema` (e.g. `@platypus/tools-basic`)
+  ignores any entry. `@platypus/docker` keeps taking its per-Workspace config as
+  before and needs no entry here.
+
+Treat `PLATYPUS_PLUGIN_CONFIG` like any secret-bearing env var: inject it from
+your secret manager, never commit it.
+
 ## Sandbox
 
 The [Sandbox](/concepts) (agent shell/filesystem access) is **off by default**.

--- a/packages/plugin-sdk/index.test.ts
+++ b/packages/plugin-sdk/index.test.ts
@@ -4,6 +4,8 @@ import { tool } from "ai";
 import {
   PLUGIN_API_VERSION,
   type PlatypusPlugin,
+  type PluginConfigContext,
+  type SandboxBackendContribution,
   type ToolSetContribution,
 } from "./index.ts";
 
@@ -63,5 +65,50 @@ describe("@platypuschat/plugin-sdk", () => {
 
     expect(typeof plugin.contributes.toolSets?.[0].tools).toBe("function");
     expect(plugin.configSchema).toBeDefined();
+  });
+
+  it("injects a shared PluginConfigContext into factories (optional to consume)", () => {
+    const shared: PluginConfigContext<
+      { region: string },
+      { apiToken: string }
+    > = {
+      config: { region: "eu" },
+      credentials: { apiToken: "tok" },
+    };
+
+    // A tool-set factory may accept the appended `plugin` argument…
+    const toolSet: ToolSetContribution = {
+      id: "scoped",
+      name: "Scoped",
+      category: "Productivity",
+      tools: (_ctx, plugin) => {
+        expect(plugin?.credentials).toEqual({ apiToken: "tok" });
+        return {};
+      },
+    };
+    (toolSet.tools as (ctx: unknown, plugin: PluginConfigContext) => unknown)(
+      {
+        workspaceId: "w",
+        agentId: "a",
+        orgId: "o",
+        frontendUrl: undefined,
+        userId: "u",
+      },
+      shared,
+    );
+
+    // …and a Sandbox-backend factory takes it as a third argument, sharing the
+    // same block. A two-argument factory (ignoring `plugin`) still type-checks.
+    const backend: SandboxBackendContribution = {
+      backend: "cloud",
+      name: "Cloud",
+      configSchema: z.object({}),
+      credentialsSchema: z.object({}),
+      create: (_config, _credentials, plugin) => {
+        expect(plugin).toBe(shared);
+        return {} as never;
+      },
+    };
+    backend.create({}, {}, shared);
   });
 });

--- a/packages/plugin-sdk/index.ts
+++ b/packages/plugin-sdk/index.ts
@@ -25,14 +25,43 @@ export interface ToolSetContext {
 }
 
 /**
+ * Deploy-time, Operator-owned config for one plugin, resolved at boot and
+ * injected into **every** one of that plugin's contribution factories (ADR-0013).
+ * Keyed by plugin name — the "one config namespace" — and validated at boot
+ * against the manifest's plugin-level `configSchema` / `credentialsSchema`.
+ *
+ * One block is shared across all of a plugin's contributions and all tenants
+ * (deployment-wide): a plugin's Sandbox backend and its management Tool set read
+ * the same `credentials` here. This is a layer *above* per-Workspace Sandbox
+ * config/credentials (ADR-0001/0006); the two layer, they do not merge.
+ *
+ * `config` / `credentials` are `undefined` when the manifest declares no
+ * corresponding schema (nothing to validate against).
+ */
+export interface PluginConfigContext<
+  TConfig = unknown,
+  TCredentials = unknown,
+> {
+  config: TConfig;
+  credentials: TCredentials;
+}
+
+/**
  * The tools a Tool set contributes: either a static map keyed by tool id, or a
  * factory resolved with the {@link ToolSetContext} at Chat-turn time (use the
  * factory when tools need Workspace/Agent scope). Tools are Vercel AI SDK tools.
+ *
+ * The factory's second argument is the deploy-time {@link PluginConfigContext}
+ * — the plugin's shared config/credentials block, the same object handed to
+ * every one of the plugin's contribution factories. It is appended and optional
+ * so existing single-argument factories keep working unchanged (append-only
+ * compatibility, ADR-0013). Core always supplies it at Chat-turn time.
  */
 export type ToolSetTools =
   | Record<string, Tool>
   | ((
       ctx: ToolSetContext,
+      plugin?: PluginConfigContext,
     ) => Record<string, Tool> | Promise<Record<string, Tool>>);
 
 /**
@@ -153,7 +182,19 @@ export interface SandboxBackendContribution<
   name: string;
   configSchema: z.ZodType<TConfig>;
   credentialsSchema: z.ZodType<TCredentials>;
-  create(config: TConfig, credentials: TCredentials): SandboxBackend;
+  /**
+   * Instantiate the adapter. `config` / `credentials` are the per-Workspace
+   * values validated against the schemas above; `plugin` is the deploy-time
+   * {@link PluginConfigContext} shared across every one of the plugin's
+   * contributions (ADR-0013). `plugin` is appended and optional so existing
+   * two-argument factories keep working unchanged (append-only compatibility).
+   * Core always supplies it when instantiating the adapter.
+   */
+  create(
+    config: TConfig,
+    credentials: TCredentials,
+    plugin?: PluginConfigContext,
+  ): SandboxBackend;
 }
 
 /**
@@ -173,8 +214,9 @@ export interface PluginContributions {
  * registration itself; plugin authors never call the internal `register*()`.
  *
  * `configSchema` / `credentialsSchema` describe deploy-time, Operator-owned
- * config keyed by plugin name; they are part of the locked manifest shape but
- * are not consumed until the plugin-config follow-up slice.
+ * config keyed by plugin name. Core validates the Operator-supplied values
+ * against them at boot (fail-loud on mismatch) and injects the resolved
+ * {@link PluginConfigContext} into every contribution factory.
  */
 export interface PlatypusPlugin {
   name: string;


### PR DESCRIPTION
Closes #293.

Implements the deploy-time, Operator-owned plugin config/credentials mechanism from [ADR-0013](https://github.com/willdady/platypus/blob/main/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md) — the "one config namespace" and the shared credential block.

## What changed

- **SDK (`@platypuschat/plugin-sdk`):** new `PluginConfigContext` type, threaded (appended, **optional**) into the tool-set factory (`(ctx, plugin?) => …`) and `SandboxBackendContribution.create(config, credentials, plugin?)`. Append-only, so every existing factory keeps working unchanged. `configSchema`/`credentialsSchema` were already on the manifest; they're now consumed.
- **Loader:**
  - `parsePluginConfig` reads `PLATYPUS_PLUGIN_CONFIG` — a JSON object keyed by plugin name, each value an optional `{ config, credentials }` (plugin names carry `@scope/name` slashes, so a single JSON blob is the one config namespace rather than per-plugin env vars).
  - Validates each plugin's config/credentials **at boot** against its manifest schemas — **fail-loud**, plugin-named error, aborting startup.
  - Resolves **one shared block per plugin** and binds it into every tool-set/sandbox contribution factory, so core's registries and Chat-turn callers stay ignorant of it (they still invoke factories with the per-turn / per-Workspace values only).
  - Per-Workspace Sandbox config/credentials and ADR-0006 authorization are **unchanged**.
- **Example third-party plugin** (`apps/backend/src/plugins/example/`): a Daytona-style plugin whose Sandbox backend **and** management Tool set authenticate with the **same** deploy-time credential block — proving one block shared across two contributions.
- **Docs (same PR):** `PLATYPUS_PLUGIN_CONFIG` documented in `self-hosting/configuration.mdx` and `reference/backend-configuration.mdx`, explicitly distinguished from per-Workspace Sandbox config; `extending/index.mdx` gains a "Deploy-time plugin config & credentials" section; `.env.example` gets a commented example. Docs build passes.

## Acceptance criteria

- [x] A plugin can declare plugin-level config/credentials schemas; core validates at boot and fails loud on mismatch.
- [x] Resolved plugin config/credentials are injected into every contribution factory of that plugin.
- [x] The example plugin proves one credential block shared across two contributions.
- [x] Per-Workspace Sandbox config/credentials behaviour is unchanged.
- [x] Tests cover valid config injection, boot-time validation failure, and the shared-credential path.
- [x] Deploy-time plugin config documented and distinguished from per-Workspace Sandbox config; docs build passes.

## Verification

- `pnpm --filter backend test` → 1007 passed
- `pnpm typecheck` → clean
- `pnpm --filter @platypuschat/plugin-sdk test` → 4 passed
- `pnpm --filter docs build` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)