### PR TITLE
feat(backend): third-party plugin loading with contribution-id namespacing

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@platypus-examples/tool-set": "workspace:*",
     "@types/dockerode": "^4.0.1",
     "@types/jsdom": "^28.0.3",
     "@types/node": "^24.13.2",

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -7,6 +7,7 @@ import type {
   ToolSetContribution,
 } from "@platypuschat/plugin-sdk";
 import { loadPlugins, parsePluginList } from "./loader.ts";
+import { registerToolSet, getToolSet } from "../tools/index.ts";
 
 // A capturing `register` and the builtin/import module shapes the loader expects.
 const makeRegister = () => {
@@ -132,8 +133,11 @@ describe("loadPlugins", () => {
     });
 
     expect(importPlugin).toHaveBeenCalledWith("@third/party");
-    expect(calls.map((c) => c.id)).toEqual(["custom"]);
+    // Third-party ids are auto-prefixed with the manifest name at load; authors
+    // write the bare `custom`.
+    expect(calls.map((c) => c.id)).toEqual(["@third/party.custom"]);
     expect(loaded[0].origin).toBe("third-party");
+    expect(loaded[0].toolSetIds).toEqual(["@third/party.custom"]);
   });
 
   it("exercises both resolution paths in one load", async () => {
@@ -159,7 +163,8 @@ describe("loadPlugins", () => {
 
     expect(importPlugin).toHaveBeenCalledTimes(1);
     expect(importPlugin).toHaveBeenCalledWith("@third/party");
-    expect(calls.map((c) => c.id)).toEqual(["time", "custom"]);
+    // Core keeps its bare id; third-party is prefixed with its manifest name.
+    expect(calls.map((c) => c.id)).toEqual(["time", "@third/party.custom"]);
     expect(loaded.map((p) => p.origin)).toEqual(["core", "third-party"]);
   });
 
@@ -228,39 +233,63 @@ describe("loadPlugins", () => {
 
   it("aborts (fail-loud) on a duplicate id, naming both owning plugins", async () => {
     const { register } = makeRegister();
-    const importPlugin = vi.fn((name: string) =>
-      Promise.resolve({
-        plugin: manifest(name, [toolSet("time")]),
-      }),
-    );
+    // Two core plugins keep bare ids, so a shared `time` id collides directly.
+    const builtinPlugins = {
+      "@a/plugin": () =>
+        Promise.resolve({ plugin: manifest("@a/plugin", [toolSet("time")]) }),
+      "@b/plugin": () =>
+        Promise.resolve({ plugin: manifest("@b/plugin", [toolSet("time")]) }),
+    };
 
     await expect(
       loadPlugins({
         pluginNames: ["@a/plugin", "@b/plugin"],
-        builtinPlugins: {},
-        importPlugin,
+        builtinPlugins,
         register,
       }),
     ).rejects.toThrow(/"time".*"@a\/plugin".*"@b\/plugin"/s);
   });
 
+  it("aborts (fail-loud) when two third-party plugins share a manifest name and id", async () => {
+    const { register } = makeRegister();
+    // Both packages resolve to a manifest named "dup", so their bare `custom`
+    // ids both namespace to `dup.custom` and collide.
+    const importPlugin = vi.fn(() =>
+      Promise.resolve({ plugin: manifest("dup", [toolSet("custom")]) }),
+    );
+
+    await expect(
+      loadPlugins({
+        pluginNames: ["@a/pkg", "@b/pkg"],
+        builtinPlugins: {},
+        importPlugin,
+        register,
+      }),
+    ).rejects.toThrow(/"dup\.custom".*"dup".*"dup"/s);
+  });
+
   it("re-throws a legacy-registry collision with plugin attribution", async () => {
     // A `register` that rejects the id (as the real registry does for an
-    // already-registered legacy tool set) surfaces with plugin attribution.
+    // already-registered legacy tool set) surfaces with plugin attribution. This
+    // is a core plugin, so its `kanban` id stays bare and collides with the
+    // legacy static registration.
     const register = () => {
       throw new Error("Tool set with id 'kanban' has already been registered.");
     };
     await expect(
       loadPlugins({
-        pluginNames: ["@collides/plugin"],
-        builtinPlugins: {},
-        importPlugin: () =>
-          Promise.resolve({
-            plugin: manifest("@collides/plugin", [toolSet("kanban")]),
-          }),
+        pluginNames: ["@platypus/collides"],
+        builtinPlugins: {
+          "@platypus/collides": () =>
+            Promise.resolve({
+              plugin: manifest("@platypus/collides", [toolSet("kanban")]),
+            }),
+        },
         register,
       }),
-    ).rejects.toThrow(/@collides\/plugin.*"kanban".*already been registered/s);
+    ).rejects.toThrow(
+      /@platypus\/collides.*"kanban".*already been registered/s,
+    );
   });
 });
 
@@ -297,17 +326,22 @@ describe("loadPlugins — sandbox backends", () => {
   it("aborts (fail-loud) on a duplicate sandbox backend id, naming both plugins", async () => {
     const { register } = makeRegister();
     const { registerSandbox } = makeSandboxRegister();
-    const importPlugin = vi.fn((name: string) =>
-      Promise.resolve({
-        plugin: sandboxManifest(name, [sandboxBackend("docker")]),
-      }),
-    );
+    // Two core plugins keep bare backend ids, so a shared `docker` collides.
+    const builtinPlugins = {
+      "@a/plugin": () =>
+        Promise.resolve({
+          plugin: sandboxManifest("@a/plugin", [sandboxBackend("docker")]),
+        }),
+      "@b/plugin": () =>
+        Promise.resolve({
+          plugin: sandboxManifest("@b/plugin", [sandboxBackend("docker")]),
+        }),
+    };
 
     await expect(
       loadPlugins({
         pluginNames: ["@a/plugin", "@b/plugin"],
-        builtinPlugins: {},
-        importPlugin,
+        builtinPlugins,
         register,
         registerSandbox,
       }),
@@ -319,20 +353,25 @@ describe("loadPlugins — sandbox backends", () => {
     const registerSandbox = () => {
       throw new Error("Sandbox backend 'docker' has already been registered.");
     };
+    // A core plugin keeps its bare `docker` backend id, colliding with a legacy
+    // static registration.
     await expect(
       loadPlugins({
-        pluginNames: ["@collides/plugin"],
-        builtinPlugins: {},
-        importPlugin: () =>
-          Promise.resolve({
-            plugin: sandboxManifest("@collides/plugin", [
-              sandboxBackend("docker"),
-            ]),
-          }),
+        pluginNames: ["@platypus/collides"],
+        builtinPlugins: {
+          "@platypus/collides": () =>
+            Promise.resolve({
+              plugin: sandboxManifest("@platypus/collides", [
+                sandboxBackend("docker"),
+              ]),
+            }),
+        },
         register,
         registerSandbox,
       }),
-    ).rejects.toThrow(/@collides\/plugin.*"docker".*already been registered/s);
+    ).rejects.toThrow(
+      /@platypus\/collides.*"docker".*already been registered/s,
+    );
   });
 
   it("aborts (fail-loud) when sandboxBackends is not an array", async () => {
@@ -354,5 +393,122 @@ describe("loadPlugins — sandbox backends", () => {
         registerSandbox: () => {},
       }),
     ).rejects.toThrow(/@bad\/plugin.*sandboxBackends.*array/s);
+  });
+});
+
+describe("loadPlugins — third-party namespacing (ADR-0013)", () => {
+  it("prefixes third-party tool-set ids with the manifest name; core stays bare", async () => {
+    const { register, calls } = makeRegister();
+    const builtinPlugins = {
+      "@platypus/tools-basic": () =>
+        Promise.resolve({
+          plugin: manifest("@platypus/tools-basic", [toolSet("time")]),
+        }),
+    };
+    const importPlugin = vi.fn(() =>
+      Promise.resolve({ plugin: manifest("example", [toolSet("greeting")]) }),
+    );
+
+    const loaded = await loadPlugins({
+      pluginNames: ["@platypus/tools-basic", "@example-org/pkg"],
+      builtinPlugins,
+      importPlugin,
+      register,
+    });
+
+    // Core keeps its bare id; third-party is `${manifest.name}.${id}`.
+    expect(calls.map((c) => c.id)).toEqual(["time", "example.greeting"]);
+    expect(loaded[0].toolSetIds).toEqual(["time"]);
+    expect(loaded[1].toolSetIds).toEqual(["example.greeting"]);
+  });
+
+  it("prefixes third-party sandbox-backend ids too", async () => {
+    const { register } = makeRegister();
+    const { registerSandbox, calls } = makeSandboxRegister();
+
+    const loaded = await loadPlugins({
+      pluginNames: ["@third/infra"],
+      builtinPlugins: {},
+      importPlugin: () =>
+        Promise.resolve({
+          plugin: sandboxManifest("acme", [sandboxBackend("cloud")]),
+        }),
+      register,
+      registerSandbox,
+    });
+
+    // The discriminator registered (and stored in `sandbox.backend`) is prefixed.
+    expect(calls.map((c) => c.backend)).toEqual(["acme.cloud"]);
+    expect(loaded[0].sandboxBackendIds).toEqual(["acme.cloud"]);
+  });
+
+  it("treats a package borrowing an @platypus/* name as third-party (prefixed)", async () => {
+    const { register, calls } = makeRegister();
+    // The static built-in map is the SOLE authority for core. This package is
+    // absent from it, so even though its manifest borrows the `@platypus/*`
+    // scope it is third-party — prefixed, not smuggled in as core.
+    const importPlugin = vi.fn(() =>
+      Promise.resolve({
+        plugin: manifest("@platypus/impostor", [toolSet("kanban")]),
+      }),
+    );
+
+    const loaded = await loadPlugins({
+      pluginNames: ["@platypus/impostor"],
+      builtinPlugins: {},
+      importPlugin,
+      register,
+    });
+
+    expect(importPlugin).toHaveBeenCalledWith("@platypus/impostor");
+    // Prefixed — it cannot claim the bare `kanban` core namespace.
+    expect(calls.map((c) => c.id)).toEqual(["@platypus/impostor.kanban"]);
+    expect(loaded[0].origin).toBe("third-party");
+  });
+});
+
+describe("loadPlugins — example third-party plugin (end to end)", () => {
+  // These exercise the real path: resolve the installed `@platypus-examples/
+  // tool-set` package via the loader's default dynamic `import()`, prove its
+  // bare `greeting` id namespaces to `example.greeting`, and prove the Chat-turn
+  // lookup resolves it under that prefixed id.
+
+  it("loads the installed package via dynamic import and namespaces its id", async () => {
+    const { register, calls } = makeRegister();
+
+    const loaded = await loadPlugins({
+      pluginNames: ["@platypus-examples/tool-set"],
+      builtinPlugins: {},
+      register,
+    });
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].origin).toBe("third-party");
+    expect(loaded[0].name).toBe("example");
+    expect(loaded[0].toolSetIds).toEqual(["example.greeting"]);
+    expect(calls.map((c) => c.id)).toEqual(["example.greeting"]);
+  });
+
+  it("registers into the real registry so a Chat turn resolves it by the prefixed id", async () => {
+    await loadPlugins({
+      pluginNames: ["@platypus-examples/tool-set"],
+      builtinPlugins: {},
+      register: registerToolSet,
+    });
+
+    // Chat-turn resolution walks the tool-set registry by id (ADR-0013): the
+    // example plugin is reachable only under its namespaced id.
+    const set = getToolSet("example.greeting");
+    expect(set.category).toBe("Examples");
+    expect(() => getToolSet("greeting")).toThrow(/has not been registered/);
+
+    if (typeof set.tools === "function") {
+      throw new Error("expected a static tool map");
+    }
+    const result = (await set.tools.greet.execute!(
+      { name: "Ada" },
+      { toolCallId: "t1", messages: [] },
+    )) as string;
+    expect(result).toContain("Ada");
   });
 });

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -101,6 +101,12 @@ const validateManifest = (name: string, mod: PluginModule): PlatypusPlugin => {
  * via their static thunk; third-party plugins load via dynamic `import()`.
  * "Loaded identically" means an identical manifest → register flow, not
  * identical module resolution.
+ *
+ * Contribution ids are namespaced by origin (ADR-0013): core keeps flat, bare
+ * ids; third-party ids are auto-prefixed with the plugin's manifest `name`
+ * (`example.<id>`). The built-in map is the sole authority for "core", so a
+ * package borrowing an `@platypus/*` name but absent from the map is treated as
+ * third-party and prefixed.
  */
 export async function loadPlugins(
   opts: LoadPluginsOptions = {},
@@ -122,6 +128,11 @@ export async function loadPlugins(
   const loaded: LoadedPlugin[] = [];
 
   for (const name of names) {
+    // The static built-in map IS the core allowlist and the SOLE authority for
+    // "core" (ADR-0013): membership here — not the `@platypus/*` scope on the
+    // package or the manifest name — decides origin. A package that borrows an
+    // `@platypus/*` name but is absent from the map is third-party, so scope
+    // impersonation cannot smuggle a package in as core.
     const isCore = Object.prototype.hasOwnProperty.call(builtins, name);
     const origin: LoadedPlugin["origin"] = isCore ? "core" : "third-party";
 
@@ -138,62 +149,79 @@ export async function loadPlugins(
     }
 
     const manifest = validateManifest(name, mod);
+
+    // Core Contributions keep their flat, bare ids (no data migration — every
+    // persisted `agent.toolSetIds` / `sandbox.backend` reference keeps working).
+    // Third-party Contributions are auto-namespaced by the plugin's manifest
+    // `name` (`example.<id>`): authors write bare ids, core prefixes at load so a
+    // third-party id can never collide with a current or future core built-in.
+    const contributionId = (id: string): string =>
+      isCore ? id : `${manifest.name}.${id}`;
+
     const toolSetIds: string[] = [];
 
     for (const contribution of manifest.contributes.toolSets ?? []) {
       const { id, name: tsName, category, description, tools } = contribution;
+      const effectiveId = contributionId(id);
 
-      const existingOwner = owners.get(id);
+      const existingOwner = owners.get(effectiveId);
       if (existingOwner) {
         throw new Error(
-          `Tool set id "${id}" is contributed by both "${existingOwner}" and "${manifest.name}".`,
+          `Tool set id "${effectiveId}" is contributed by both "${existingOwner}" and "${manifest.name}".`,
         );
       }
 
       try {
-        register(id, { name: tsName, category, description, tools });
+        register(effectiveId, { name: tsName, category, description, tools });
       } catch (cause) {
         // A collision with a Tool set registered outside the loader (a legacy
         // static registration) surfaces here — re-throw with plugin attribution.
         throw new Error(
-          `Plugin "${manifest.name}": failed to register tool set "${id}" (${
+          `Plugin "${manifest.name}": failed to register tool set "${effectiveId}" (${
             cause instanceof Error ? cause.message : String(cause)
           }).`,
           { cause },
         );
       }
 
-      owners.set(id, manifest.name);
-      toolSetIds.push(id);
+      owners.set(effectiveId, manifest.name);
+      toolSetIds.push(effectiveId);
     }
 
     const sandboxBackendIds: string[] = [];
 
     for (const contribution of manifest.contributes.sandboxBackends ?? []) {
-      const { backend } = contribution;
+      const effectiveBackend = contributionId(contribution.backend);
 
-      const existingOwner = sandboxOwners.get(backend);
+      const existingOwner = sandboxOwners.get(effectiveBackend);
       if (existingOwner) {
         throw new Error(
-          `Sandbox backend id "${backend}" is contributed by both "${existingOwner}" and "${manifest.name}".`,
+          `Sandbox backend id "${effectiveBackend}" is contributed by both "${existingOwner}" and "${manifest.name}".`,
         );
       }
 
+      // Third-party backends register under the namespaced discriminator so the
+      // `sandbox.backend` column resolves to the prefixed id, mirroring tool sets.
+      const effectiveContribution =
+        effectiveBackend === contribution.backend
+          ? contribution
+          : { ...contribution, backend: effectiveBackend };
+
       try {
-        registerSandbox(contribution);
+        registerSandbox(effectiveContribution);
       } catch (cause) {
         // A collision with a backend registered outside the loader surfaces
         // here — re-throw with plugin attribution.
         throw new Error(
-          `Plugin "${manifest.name}": failed to register sandbox backend "${backend}" (${
+          `Plugin "${manifest.name}": failed to register sandbox backend "${effectiveBackend}" (${
             cause instanceof Error ? cause.message : String(cause)
           }).`,
           { cause },
         );
       }
 
-      sandboxOwners.set(backend, manifest.name);
-      sandboxBackendIds.push(backend);
+      sandboxOwners.set(effectiveBackend, manifest.name);
+      sandboxBackendIds.push(effectiveBackend);
     }
 
     loaded.push({

--- a/apps/docs/content/building-with-platypus/mcp.mdx
+++ b/apps/docs/content/building-with-platypus/mcp.mdx
@@ -62,9 +62,12 @@ Under **Custom Headers**, add any extra HTTP headers to send with every request
 
 An Agent's granted tools are stored as a list of **tool set IDs**. When you grant
 an MCP, its ID goes into that same list. At **Chat-turn time**, Platypus walks the
-list: anything that isn't a built-in tool set is looked up as an MCP, and — using
-the auth and headers you configured — Platypus connects to the server and fetches
-its tools live. Those tools are merged into what the model can call for that turn.
+list: an ID that matches a **registered tool set** — one contributed by a plugin,
+whether a core built-in like `web-fetch` or a third-party plugin like
+`example.greeting` — resolves from that registry, and any other ID is looked up
+as an MCP. For an MCP, Platypus — using the auth and headers you configured —
+connects to the server and fetches its tools live. Either way, the resolved tools
+are merged into what the model can call for that turn.
 
 <Callout type="info">
   Resolution is **fail-soft**: if an MCP server is unreachable when a turn runs,
@@ -76,7 +79,8 @@ its tools live. Those tools are merged into what the model can call for that tur
 
 Open the [Agent form](/building-with-platypus/agents) and find the **Tools** card.
 Registered MCP servers appear there grouped under the **MCP** category, alongside
-built-in tool sets. Flip a switch to grant the server's tool set to that Agent.
+the plugin-contributed tool sets (core built-ins and any third-party plugins).
+Flip a switch to grant the server's tool set to that Agent.
 
 ## Workspace vs Shared scope
 

--- a/apps/docs/content/concepts/tools.mdx
+++ b/apps/docs/content/concepts/tools.mdx
@@ -14,10 +14,14 @@ explains how tools are bundled and where they come from.
 A **Tool set** is a named bundle of tools you can grant to an **Agent**. Instead
 of wiring up individual tools one by one, you give an Agent a whole tool set.
 
-Tool sets come from two places:
+Tool sets come from two kinds of source:
 
-- **built in** — registered in Platypus's code and available out of the box, or
-- **backed by an MCP server** — contributed from outside Platypus (see below).
+- **contributed by a plugin** — a plugin declares tool sets in its manifest and
+  core loads them at boot. This covers both the **core built-ins** that ship
+  with Platypus (math, Kanban, sandbox…) and **third-party plugins** installed
+  as npm packages. See [Extending → Tool sets](/extending#tool-sets).
+- **backed by an MCP server** — contributed at runtime from outside Platypus,
+  without a code change or a plugin install (see below).
 
 When an Agent runs, each tool set it's been granted is resolved into the actual
 tools the model can call.
@@ -42,8 +46,9 @@ one up.
 ## How it fits together
 
 > An **Agent** is granted zero or more **tool sets**. Each tool set is either
-> built in or backed by an **MCP** server, and resolves to a concrete set of
-> tools the model can call during a **Chat turn**.
+> contributed by a **plugin** (a core built-in or a third-party plugin) or
+> backed by an **MCP** server, and resolves to a concrete set of tools the model
+> can call during a **Chat turn**.
 
 A **[Sandbox](/concepts/sandboxes)** also resolves to a tool set — its shell and
 filesystem tools — which is why sandboxes get their own page.

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -30,12 +30,13 @@ a fixed set of core-owned **Extension points**:
 <Callout type="info">
   The plugin loader is being rolled out incrementally (see
   [ADR-0013](https://github.com/willdady/platypus/blob/main/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md)).
-  The first core plugin — `@platypus/tools-basic` (math, time) — ships through
-  it today; the remaining built-in Tool sets and the Docker Sandbox backend are
-  still registered in-tree pending migration. Either way the underlying
-  `registerToolSet` / `registerSandboxBackend` functions are the same — they are
-  now **core-internal**, driven by the loader rather than called by plugin
-  authors.
+  The core plugins `@platypus/tools-basic` (math, time) and `@platypus/docker`
+  (the Sandbox backend) ship through it today, and **third-party plugins** load
+  from installed npm packages with their contribution ids namespaced by plugin
+  name; the remaining built-in Tool sets are still registered in-tree pending
+  migration. Either way the underlying `registerToolSet` /
+  `registerSandboxBackend` functions are the same — they are now
+  **core-internal**, driven by the loader rather than called by plugin authors.
 </Callout>
 
 ## The plugin model
@@ -319,15 +320,80 @@ field instead:
    `apps/backend/src/plugins/builtin.ts` (the built-in map / core allowlist).
 3. Add the plugin name to the deployment's `PLATYPUS_PLUGINS` list so it loads.
 
-**To ship a third-party tool set:** publish a package that depends on
-`@platypuschat/plugin-sdk` and exports a `plugin` manifest; the Operator adds
-its package name to `PLATYPUS_PLUGINS`.
-
 Core Contribution ids stay unprefixed (`math-conversions`, `time`) so persisted
 `agent.toolSetIds` references keep working. A tool set is granted to Agents like
 any other; if its dependencies aren't present at turn time it degrades
 gracefully (the `sandbox` tool set, for example, resolves to no tools when a
 Workspace has no Sandbox configured).
+
+### Third-party plugins
+
+A **third-party plugin** is any plugin that isn't one of the core built-ins — it
+lives out of tree, ships as its own npm package, and is enabled by adding its
+package name to `PLATYPUS_PLUGINS`. You don't fork Platypus to ship one.
+
+1. Create a package that depends on
+   [`@platypuschat/plugin-sdk`](https://www.npmjs.com/package/@platypuschat/plugin-sdk)
+   and exports a `plugin` manifest from its entry point. Author your
+   contributions exactly as a core plugin does — the SDK types are identical.
+2. Install it into the deployment (`pnpm add my-platypus-plugin`) so it resolves
+   from `node_modules`; core loads third-party plugins by dynamic
+   `import(packageName)`.
+3. Add the **package name** to `PLATYPUS_PLUGINS`.
+
+```ts
+import type { PlatypusPlugin } from "@platypuschat/plugin-sdk";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import { tool } from "ai";
+import { z } from "zod";
+
+export const plugin: PlatypusPlugin = {
+  name: "example", // ← the namespace prefix (see below)
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  contributes: {
+    toolSets: [
+      {
+        id: "greeting", // ← bare id; core prefixes it to `example.greeting`
+        name: "Greeting",
+        category: "Examples",
+        tools: {
+          greet: tool({
+            description: "Return a friendly greeting.",
+            inputSchema: z.object({ name: z.string() }),
+            execute: ({ name }) => `Hello, ${name}!`,
+          }),
+        },
+      },
+    ],
+  },
+};
+```
+
+The repo ships this exact plugin as a runnable reference under
+[`packages/example-plugin`](https://github.com/willdady/platypus/tree/main/packages/example-plugin)
+(the `@platypus-examples/tool-set` package).
+
+#### Contribution-id namespacing
+
+Third-party Contribution ids are **auto-prefixed with the plugin's manifest
+`name`** at load — `example.greeting`, and so on. You write **bare** ids in your
+manifest; core prefixes them. Core built-in ids stay flat and un-prefixed
+(`math-conversions`, `time`, `docker`). This split (ADR-0013) means a
+third-party id can never collide with a current — or _future_ — core built-in
+and silently break a deployment on upgrade.
+
+Two consequences worth internalising:
+
+- **Grant and reference the namespaced id.** An Agent that uses the tool set
+  above stores `example.greeting` in its `toolSetIds`, and that's the id a Chat
+  turn resolves.
+- **The core allowlist is the sole authority for "core".** Membership in the
+  built-in map (`apps/backend/src/plugins/builtin.ts`) — _not_ the package scope
+  — decides origin. A package that installs itself under an `@platypus/*` name
+  it doesn't own is still absent from the allowlist, so it's treated as
+  third-party and prefixed. Scope impersonation can't smuggle a package in as
+  core.
 
 <Callout type="info">
   Frontend tool / tool-set presentation (icons, custom UI) lives separately. If
@@ -368,16 +434,18 @@ What's live and what's still in-tree today:
 
 - **Live:** the `@platypuschat/plugin-sdk` surface (Tool sets _and_
   Sandbox-backend contributions), the boot-time loader, the built-in map / core
-  allowlist, the first core plugin `@platypus/tools-basic` (math, time), and the
-  Docker Sandbox backend as the core plugin `@platypus/docker` — each flowing
-  manifest → loader → registry in a Chat turn.
+  allowlist, the first core plugin `@platypus/tools-basic` (math, time), the
+  Docker Sandbox backend as the core plugin `@platypus/docker`, and
+  **third-party plugin loading with contribution-id namespacing** (dynamic
+  `import()` of an installed package, ids prefixed by the manifest `name`; see
+  the `@platypus-examples/tool-set` reference plugin) — each flowing manifest →
+  loader → registry in a Chat turn.
 - **Still in-tree, pending migration:** the remaining built-in Tool sets
   (`kanban`, `triggers`, `sandbox`, …) still call `registerToolSet` directly at
   boot. They keep working unchanged; the same registration functions are what the
   loader drives.
-- **Follow-up slices:** third-party id namespacing, deploy-time plugin
-  config/credentials, `apiVersion` compatibility windowing, and a read-only
-  `GET /plugins` catalog.
+- **Follow-up slices:** deploy-time plugin config/credentials, `apiVersion`
+  compatibility windowing, and a read-only `GET /plugins` catalog.
 
 ## Reference ADRs
 

--- a/packages/example-plugin/index.test.ts
+++ b/packages/example-plugin/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import { plugin } from "./index.ts";
+
+describe("@platypus-examples/tool-set", () => {
+  it("exports a well-formed manifest with a short namespace name", () => {
+    // The manifest `name` is the namespace the loader prefixes onto every
+    // contribution id for a third-party plugin — kept short and bare ("example")
+    // rather than the scoped package specifier.
+    expect(plugin.name).toBe("example");
+    expect(plugin.apiVersion).toBe(PLUGIN_API_VERSION);
+    expect(plugin.contributes.toolSets).toHaveLength(1);
+  });
+
+  it("contributes a bare (unprefixed) tool set id", () => {
+    // Authors write bare ids; core prefixes at load. The package must NOT
+    // pre-namespace its own ids.
+    const toolSet = plugin.contributes.toolSets?.[0];
+    expect(toolSet?.id).toBe("greeting");
+    expect(toolSet).not.toBeUndefined();
+  });
+
+  it("greet returns a greeting for the given name", async () => {
+    const toolSet = plugin.contributes.toolSets?.[0];
+    if (!toolSet || typeof toolSet.tools === "function") {
+      throw new Error("expected a static tool map");
+    }
+    const greet = toolSet.tools.greet;
+    const result = await greet.execute!(
+      { name: "Ada" },
+      { toolCallId: "t1", messages: [] },
+    );
+    expect(result).toContain("Ada");
+  });
+});

--- a/packages/example-plugin/index.ts
+++ b/packages/example-plugin/index.ts
@@ -1,0 +1,39 @@
+import type { PlatypusPlugin } from "@platypuschat/plugin-sdk";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import { tool } from "ai";
+import { z } from "zod";
+
+// A minimal, runnable example of a THIRD-PARTY Platypus plugin — the kind an
+// Operator installs as an npm package and lists in `PLATYPUS_PLUGINS`. It exists
+// to prove the third-party path end to end: dynamic `import()` resolution and
+// contribution-id namespacing (ADR-0013).
+//
+// The manifest `name` ("example") is the namespace: because this package is NOT
+// in core's built-in allowlist, the loader auto-prefixes every contribution id
+// with it, so the bare `greeting` tool set below registers as `example.greeting`.
+// Authors write bare ids; core prefixes at load. Core plugins stay unprefixed.
+export const plugin: PlatypusPlugin = {
+  name: "example",
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  contributes: {
+    toolSets: [
+      {
+        id: "greeting",
+        name: "Greeting",
+        category: "Examples",
+        description:
+          "A tiny example tool set contributed by a third-party plugin",
+        tools: {
+          greet: tool({
+            description: "Return a friendly greeting for the given name.",
+            inputSchema: z.object({
+              name: z.string().describe("Who to greet"),
+            }),
+            execute: ({ name }) => `Hello, ${name}! 👋`,
+          }),
+        },
+      },
+    ],
+  },
+};

--- a/packages/example-plugin/package.json
+++ b/packages/example-plugin/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@platypus-examples/tool-set",
+  "version": "0.1.0",
+  "description": "Example third-party Platypus plugin — a reference for authoring out-of-tree plugins against @platypuschat/plugin-sdk.",
+  "license": "MIT",
+  "author": "Will Dady",
+  "type": "module",
+  "main": "index.ts",
+  "types": "index.ts",
+  "files": ["index.ts", "dist"],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit",
+    "test": "vitest run"
+  },
+  "publishConfig": {
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  },
+  "dependencies": {
+    "@platypuschat/plugin-sdk": "workspace:*",
+    "ai": "^6.0.217",
+    "zod": "^4.4.3"
+  },
+  "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa",
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/example-plugin/tsconfig.build.json
+++ b/packages/example-plugin/tsconfig.build.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["esnext"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/example-plugin/turbo.json
+++ b/packages/example-plugin/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
+      '@platypus-examples/tool-set':
+        specifier: workspace:*
+        version: link:../../packages/example-plugin
       '@types/dockerode':
         specifier: ^4.0.1
         version: 4.0.1
@@ -478,6 +481,25 @@ importers:
       wrangler:
         specifier: ^4.106.0
         version: 4.106.0
+
+  packages/example-plugin:
+    dependencies:
+      '@platypuschat/plugin-sdk':
+        specifier: workspace:*
+        version: link:../plugin-sdk
+      ai:
+        specifier: ^6.0.217
+        version: 6.0.217(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/plugin-sdk:
     dependencies:


### PR DESCRIPTION
Closes #291.

Supports out-of-tree third-party plugins per [ADR-0013](https://github.com/willdady/platypus/blob/main/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md): load them as installed npm packages and namespace their contributions.

## What changed

### Loader — namespacing (`apps/backend/src/plugins/loader.ts`)
- Third-party contributions (any plugin **not** in the built-in allowlist) are auto-prefixed with the manifest `name` → `example.<id>`. Core stays flat/unprefixed, so persisted `agent.toolSetIds` / `sandbox.backend` references keep working.
- Applied to **both** tool sets and sandbox backends (the backend discriminator is rewritten so the `sandbox.backend` column resolves to the prefixed id).
- Collision detection and fail-loud attribution key on the *effective* (prefixed) id.
- The static built-in map remains the **sole** authority for "core" — a package borrowing an `@platypus/*` name but absent from the map is treated as third-party (prefixed). Scope impersonation can't smuggle a package in as core.

### Example third-party plugin fixture (`packages/example-plugin`)
- New `@platypus-examples/tool-set` package depending on `@platypuschat/plugin-sdk`, manifest `name: "example"`, contributing a bare `greeting` tool set. Added as a backend devDependency so it resolves via real dynamic `import()`.

### Tests
- Updated existing loader tests whose premise assumed un-prefixed third-party ids.
- New coverage: third-party tool-set/backend prefixing, core-stays-bare, name-borrowing `@platypus/*` package treated as third-party, and **end-to-end** loading of the installed example package via real dynamic import + Chat-turn resolution under `example.greeting`.

### Docs (same PR)
- `extending/index.mdx`: new "Third-party plugins" + "Contribution-id namespacing" sections; migration status updated.
- `mcp.mdx` / `concepts/tools.mdx`: reconciled the "anything that isn't a built-in tool set is an MCP" wording with the plugin reframing.

## Acceptance criteria
- [x] An installed third-party plugin listed in `PLATYPUS_PLUGINS` loads and registers its contributions.
- [x] Its Tool set contribution id is prefixed by the plugin name (`example.<id>`) and works in a Chat turn under that id.
- [x] A package not in the core allowlist is treated as third-party even if named `@platypus/...`.
- [x] Collision handling and fail-loud boot behave as for core.
- [x] Tests cover example-plugin loading, namespacing, and a name-borrowing package treated as third-party.
- [x] Third-party authoring is documented and the built-in-vs-MCP wording is accurate; the docs build passes.

## Verification
- `pnpm test` — all packages green (backend 1000 tests, example-plugin 3 tests)
- `pnpm typecheck` — green (backend, plugin-sdk, example-plugin)
- `pnpm lint` — green
- `pnpm --filter @platypus/docs build` — passes

> **Note:** the example plugin is wired as a fixture/reference (backend devDependency), not enabled in the default `PLATYPUS_PLUGINS`. Operators opt in by listing a plugin's package name, as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)