### PR TITLE
feat(backend): reframe web-fetch & platform tool sets as core plugins (#290)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -12,8 +12,14 @@ LOG_LEVEL=info
 # Defaults to UTC if not set
 TIMEZONE=UTC
 
-# Comma-separated plugins to load and enable at boot (fail-loud). Empty = no plugin tools.
-PLATYPUS_PLUGINS=@platypus/tools-basic
+# Comma-separated core/third-party plugins to load and enable at boot (fail-loud).
+# List membership IS the enable switch (ADR-0013); empty = no plugin tools at all.
+# The default below is the standard core tool set: basic utilities (math, time),
+# web fetch, and the Platypus-domain tools (kanban, dashboards, triggers, memory,
+# notifications, agent discovery/management, skill management). Drop "@platypus/web-fetch"
+# to deny network egress in isolation. The Docker sandbox backend is opt-in: add
+# "@platypus/docker" (see below) -- it is intentionally NOT in the default list.
+PLATYPUS_PLUGINS=@platypus/tools-basic,@platypus/web-fetch,@platypus/tools-platform
 
 # Deploy-time, Operator-owned plugin config/credentials (ADR-0013). A JSON object
 # keyed by plugin name; each value is an optional { "config": {..}, "credentials":

--- a/apps/backend/src/plugins/builtin.ts
+++ b/apps/backend/src/plugins/builtin.ts
@@ -13,5 +13,7 @@ export const BUILTIN_PLUGINS: Record<
   () => Promise<{ plugin: PlatypusPlugin }>
 > = {
   "@platypus/tools-basic": () => import("./tools-basic/index.ts"),
+  "@platypus/web-fetch": () => import("./web-fetch/index.ts"),
+  "@platypus/tools-platform": () => import("./tools-platform/index.ts"),
   "@platypus/docker": () => import("./docker/index.ts"),
 };

--- a/apps/backend/src/plugins/tools-platform/index.test.ts
+++ b/apps/backend/src/plugins/tools-platform/index.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ToolSetContext } from "@platypuschat/plugin-sdk";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+
+// The domain tool sets transitively import the db and a few services; mock them
+// so importing the manifest (and resolving its factories) needs no live
+// Postgres. Factories return AI SDK tool maps without touching the db until a
+// tool's `execute` runs, so these stubs are enough.
+vi.mock("../../index.ts", () => ({ db: {} }));
+vi.mock("../../logger.ts", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("../../services/event-dispatch.ts", () => ({ dispatchEvent: vi.fn() }));
+vi.mock("../../services/sub-agent-validation.ts", () => ({
+  validateSubAgentAssignment: vi.fn(),
+}));
+vi.mock("../../storage/index.ts", () => ({ getStorage: vi.fn() }));
+
+import { plugin } from "./index.ts";
+import { loadPlugins } from "../loader.ts";
+import { getToolSet, getToolSets } from "../../tools/index.ts";
+
+const EXPECTED_IDS = [
+  "kanban",
+  "dashboards",
+  "triggers",
+  "agent-discovery",
+  "skill-management",
+  "agent-management",
+  "notifications",
+  "memory",
+];
+
+const ctx: ToolSetContext = {
+  workspaceId: "ws-1",
+  agentId: "a-1",
+  orgId: "org-1",
+  frontendUrl: "http://localhost:3000",
+  userId: "u-1",
+};
+
+describe("@platypus/tools-platform plugin manifest", () => {
+  it("declares its identity and API version", () => {
+    expect(plugin.name).toBe("@platypus/tools-platform");
+    expect(plugin.version).toBe("0.1.0");
+    expect(plugin.apiVersion).toBe(PLUGIN_API_VERSION);
+  });
+
+  it("contributes the domain tool sets with unprefixed core ids", () => {
+    const ids = (plugin.contributes.toolSets ?? []).map((t) => t.id);
+    expect(ids).toEqual(EXPECTED_IDS);
+  });
+
+  it("exposes every tool set as a context factory", () => {
+    for (const ts of plugin.contributes.toolSets ?? []) {
+      expect(typeof ts.tools).toBe("function");
+    }
+  });
+});
+
+describe("@platypus/tools-platform — loaded into the core registry", () => {
+  it("registers all eight domain tool sets with bare ids", async () => {
+    // Module-global registry; vitest isolates modules per file so this doesn't
+    // leak. Exercise the real path: loader → registerToolSet → getToolSet.
+    for (const id of EXPECTED_IDS) {
+      expect(getToolSets()).not.toHaveProperty(id);
+    }
+
+    const loaded = await loadPlugins({
+      pluginNames: ["@platypus/tools-platform"],
+    });
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toMatchObject({
+      name: "@platypus/tools-platform",
+      origin: "core",
+      toolSetIds: EXPECTED_IDS,
+    });
+
+    for (const id of EXPECTED_IDS) {
+      expect(getToolSets()).toHaveProperty(id);
+    }
+  });
+
+  it("resolves each tool set's factory to a non-empty tool map at chat-turn time", () => {
+    for (const id of EXPECTED_IDS) {
+      const set = getToolSet(id);
+      expect(typeof set.tools).toBe("function");
+      const tools =
+        typeof set.tools === "function" ? set.tools(ctx) : set.tools;
+      expect(Object.keys(tools).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("resolves the read/write agent-management split tools as before", () => {
+    const discovery = getToolSet("agent-discovery");
+    const discoveryTools =
+      typeof discovery.tools === "function"
+        ? discovery.tools(ctx)
+        : discovery.tools;
+    expect(Object.keys(discoveryTools).sort()).toEqual(
+      ["getAgent", "listAgents", "listModelProviders", "listToolSets"].sort(),
+    );
+
+    const management = getToolSet("agent-management");
+    const managementTools =
+      typeof management.tools === "function"
+        ? management.tools(ctx)
+        : management.tools;
+    expect(Object.keys(managementTools).sort()).toEqual(
+      ["createAgent", "deleteAgent", "updateAgent"].sort(),
+    );
+  });
+});

--- a/apps/backend/src/plugins/tools-platform/index.ts
+++ b/apps/backend/src/plugins/tools-platform/index.ts
@@ -1,0 +1,97 @@
+import type { PlatypusPlugin } from "@platypuschat/plugin-sdk";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import { createKanbanTools } from "../../tools/kanban.ts";
+import { createDashboardTools } from "../../tools/dashboard.ts";
+import { createTriggerTools } from "../../tools/trigger.ts";
+import { createAgentDiscoveryTools } from "../../tools/agent-discovery.ts";
+import { createSkillManagementTools } from "../../tools/skill-management.ts";
+import { createAgentManagementTools } from "../../tools/agent-management.ts";
+import { createNotificationTools } from "../../tools/notification.ts";
+import { createMemoryTools } from "../../tools/memory.ts";
+
+// Core plugin: the Platypus-domain Tool sets — the ones that touch Platypus's
+// own data (kanban boards, dashboards, triggers, memory, notifications, agent
+// discovery/management, skill management). Grouped by cohesion per ADR-0013: no
+// single one of these is a capability an Operator would deny in isolation (that
+// carve-out is reserved for @platypus/web-fetch's egress and @platypus/docker's
+// infra). Every id stays unprefixed (core), so persisted `agent.toolSetIds`
+// references keep resolving unchanged.
+//
+// Each Tool set uses the factory form — its tools resolve at Chat-turn time from
+// the ToolSetContext (Workspace/Agent/Org scope) core supplies.
+export const plugin: PlatypusPlugin = {
+  name: "@platypus/tools-platform",
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  contributes: {
+    toolSets: [
+      {
+        id: "kanban",
+        name: "Kanban",
+        category: "Productivity",
+        description: "Manage kanban boards in this workspace",
+        tools: ({ workspaceId, agentId, orgId, frontendUrl }) =>
+          createKanbanTools(workspaceId, agentId, orgId, frontendUrl),
+      },
+      {
+        id: "dashboards",
+        name: "Dashboards",
+        category: "Productivity",
+        description:
+          "List dashboards and widgets, and update widget data in this workspace",
+        tools: ({ workspaceId }) => createDashboardTools(workspaceId),
+      },
+      {
+        id: "triggers",
+        name: "Triggers",
+        category: "Automation",
+        description:
+          "Manage triggers (cron schedules and event-based) including listing agents, creating, editing, and viewing triggers",
+        tools: ({ workspaceId, orgId, frontendUrl }) =>
+          createTriggerTools(workspaceId, orgId, frontendUrl),
+      },
+      {
+        id: "agent-discovery",
+        name: "Agent Discovery",
+        category: "Productivity",
+        description:
+          "Read-only tools for discovering agents, providers, and tool sets in this workspace",
+        tools: ({ workspaceId, orgId, frontendUrl }) =>
+          createAgentDiscoveryTools(workspaceId, orgId, frontendUrl),
+      },
+      {
+        id: "skill-management",
+        name: "Skill Management",
+        category: "Productivity",
+        description:
+          "List, create, update, and delete skills in this workspace",
+        tools: ({ workspaceId, orgId, frontendUrl }) =>
+          createSkillManagementTools(workspaceId, orgId, frontendUrl),
+      },
+      {
+        id: "agent-management",
+        name: "Agent Management",
+        category: "Productivity",
+        description: "Create, update, and delete agents in this workspace",
+        tools: ({ workspaceId, orgId, frontendUrl }) =>
+          createAgentManagementTools(workspaceId, orgId, frontendUrl),
+      },
+      {
+        id: "notifications",
+        name: "Notifications",
+        category: "Communication",
+        description: "Post notifications visible to users in this workspace",
+        tools: ({ workspaceId, agentId, orgId }) =>
+          createNotificationTools(workspaceId, agentId, orgId),
+      },
+      {
+        id: "memory",
+        name: "Memory",
+        category: "Memory",
+        description: "Search and retrieve memories from past conversations",
+        tools: ({ workspaceId, userId }) =>
+          createMemoryTools(workspaceId, userId),
+      },
+    ],
+  },
+};

--- a/apps/backend/src/plugins/web-fetch/index.test.ts
+++ b/apps/backend/src/plugins/web-fetch/index.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import { plugin } from "./index.ts";
+import { loadPlugins } from "../loader.ts";
+import { getToolSet, getToolSets } from "../../tools/index.ts";
+
+describe("@platypus/web-fetch plugin manifest", () => {
+  it("declares its identity and API version", () => {
+    expect(plugin.name).toBe("@platypus/web-fetch");
+    expect(plugin.version).toBe("0.1.0");
+    expect(plugin.apiVersion).toBe(PLUGIN_API_VERSION);
+  });
+
+  it("contributes the web-fetch tool set with the unprefixed core id", () => {
+    const ids = (plugin.contributes.toolSets ?? []).map((t) => t.id);
+    expect(ids).toEqual(["web-fetch"]);
+  });
+
+  it("exposes fetchUrl as a static tool map", () => {
+    const [webFetch] = plugin.contributes.toolSets ?? [];
+    expect(typeof webFetch.tools).not.toBe("function");
+    expect(webFetch.tools).toHaveProperty("fetchUrl");
+  });
+
+  it("registers the web-fetch tool set into the core registry when loaded", async () => {
+    // The registry is module-global; vitest isolates modules per file, so this
+    // load doesn't leak into other test files. Exercise the real plugin path:
+    // loader → registerToolSet → getToolSet.
+    expect(getToolSets()).not.toHaveProperty("web-fetch");
+
+    const loaded = await loadPlugins({ pluginNames: ["@platypus/web-fetch"] });
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toMatchObject({
+      name: "@platypus/web-fetch",
+      origin: "core",
+      toolSetIds: ["web-fetch"],
+    });
+
+    const set = getToolSet("web-fetch");
+    expect(set.name).toBe("Web Fetch");
+    expect(set.category).toBe("Web");
+    expect(set.tools).toHaveProperty("fetchUrl");
+  });
+});

--- a/apps/backend/src/plugins/web-fetch/index.ts
+++ b/apps/backend/src/plugins/web-fetch/index.ts
@@ -1,0 +1,29 @@
+import type { PlatypusPlugin } from "@platypuschat/plugin-sdk";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import { fetchUrl } from "../../tools/fetch.ts";
+
+// Core plugin: the Web Fetch Tool set. Stands alone (not grouped into
+// @platypus/tools-platform) because it performs network egress — the one
+// capability here an Operator would plausibly want to deny in isolation
+// (ADR-0013). Omit "@platypus/web-fetch" from PLATYPUS_PLUGINS to disable it
+// without touching the rest of the standard tools. The Tool set id stays the
+// unprefixed core id "web-fetch", so existing `agent.toolSetIds` references
+// keep working.
+export const plugin: PlatypusPlugin = {
+  name: "@platypus/web-fetch",
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  contributes: {
+    toolSets: [
+      {
+        id: "web-fetch",
+        name: "Web Fetch",
+        category: "Web",
+        description: "Fetch content from URLs on the web",
+        tools: {
+          fetchUrl,
+        },
+      },
+    ],
+  },
+};

--- a/apps/backend/src/tools/index.test.ts
+++ b/apps/backend/src/tools/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 
-// Mock the db used by transitive imports (kanban, trigger, etc.)
+// Mock the db used by transitive imports (the sandbox tool set, etc.)
 vi.mock("../index.ts", () => ({
   db: {},
 }));
@@ -21,38 +21,58 @@ vi.mock("../storage/index.ts", () => ({
   getStorage: vi.fn(),
 }));
 
-import { getToolSets, getToolSet, registerToolSet } from "./index.ts";
+import {
+  getToolSets,
+  getToolSet,
+  registerToolSet,
+  SANDBOX_TOOLSET_ID,
+} from "./index.ts";
 
 describe("Tool Set Registry", () => {
   describe("getToolSets", () => {
-    it("returns all registered tool sets", () => {
+    it("returns the statically-registered tool sets", () => {
       const sets = getToolSets();
       expect(Object.keys(sets).length).toBeGreaterThan(0);
     });
 
-    it("includes the expected built-in tool sets", () => {
+    it("no longer statically registers the plugin-migrated tool sets", () => {
+      // Every native Tool set now ships as a core plugin loaded via the plugin
+      // loader (ADR-0013): `math-conversions`/`time` → @platypus/tools-basic,
+      // `web-fetch` → @platypus/web-fetch, and the Platypus-domain sets →
+      // @platypus/tools-platform. None register at import time here anymore.
       const sets = getToolSets();
-      // `math-conversions` and `time` now ship as the @platypus/tools-basic
-      // plugin (loaded via the plugin loader), so they are absent from this
-      // statically-registered set. See apps/backend/src/plugins/tools-basic.
-      expect(sets).not.toHaveProperty("math-conversions");
-      expect(sets).not.toHaveProperty("time");
-      expect(sets).toHaveProperty("web-fetch");
-      expect(sets).toHaveProperty("kanban");
-      expect(sets).toHaveProperty("triggers");
-      expect(sets).toHaveProperty("agent-discovery");
-      expect(sets).toHaveProperty("skill-management");
-      expect(sets).toHaveProperty("agent-management");
-      expect(sets).toHaveProperty("notifications");
+      for (const id of [
+        "math-conversions",
+        "time",
+        "web-fetch",
+        "kanban",
+        "dashboards",
+        "triggers",
+        "agent-discovery",
+        "skill-management",
+        "agent-management",
+        "notifications",
+        "memory",
+      ]) {
+        expect(sets).not.toHaveProperty(id);
+      }
+    });
+
+    it("still statically registers the sandbox tool set (core sandbox infra)", () => {
+      // The `sandbox` set is the consumer side of the Sandbox-backend extension
+      // point (ADR-0002), not a native Tool set, so it stays a core-internal
+      // static registration — the lone one left in tools/index.ts.
+      expect(getToolSets()).toHaveProperty(SANDBOX_TOOLSET_ID);
     });
   });
 
   describe("getToolSet", () => {
-    it("returns a tool set by id", () => {
-      const set = getToolSet("web-fetch");
+    it("returns the sandbox tool set by id", () => {
+      const set = getToolSet(SANDBOX_TOOLSET_ID);
       expect(set).toBeDefined();
-      expect(set.name).toBe("Web Fetch");
-      expect(set.category).toBe("Web");
+      expect(set.name).toBe("Sandbox");
+      expect(set.category).toBe("Sandbox");
+      expect(typeof set.tools).toBe("function");
     });
 
     it("throws for an unregistered id", () => {
@@ -65,87 +85,24 @@ describe("Tool Set Registry", () => {
   describe("registerToolSet", () => {
     it("throws when registering a duplicate id", () => {
       expect(() =>
-        registerToolSet("web-fetch", {
+        registerToolSet(SANDBOX_TOOLSET_ID, {
           name: "Duplicate",
           category: "Test",
           tools: {},
         }),
-      ).toThrow("Tool set with id 'web-fetch' has already been registered.");
-    });
-  });
-
-  describe("tool set metadata", () => {
-    it("web-fetch has static tools object", () => {
-      const set = getToolSet("web-fetch");
-      expect(typeof set.tools).toBe("object");
-      expect(set.tools).toHaveProperty("fetchUrl");
-    });
-
-    it("kanban has a factory function for tools", () => {
-      const set = getToolSet("kanban");
-      expect(typeof set.tools).toBe("function");
-    });
-
-    it("triggers has a factory function for tools", () => {
-      const set = getToolSet("triggers");
-      expect(typeof set.tools).toBe("function");
-    });
-
-    it("agent-discovery has a factory function for tools", () => {
-      const set = getToolSet("agent-discovery");
-      expect(typeof set.tools).toBe("function");
-    });
-
-    it("skill-management has a factory function for tools", () => {
-      const set = getToolSet("skill-management");
-      expect(typeof set.tools).toBe("function");
-    });
-
-    it("agent-management has a factory function for tools", () => {
-      const set = getToolSet("agent-management");
-      expect(typeof set.tools).toBe("function");
-    });
-  });
-
-  describe("agent-management split toolsets contain expected tools", () => {
-    const ctx = {
-      workspaceId: "ws-1",
-      agentId: "a-1",
-      orgId: "org-1",
-      frontendUrl: "http://localhost:3000",
-      userId: "u-1",
-    };
-
-    it("agent-discovery exposes read-only agent and catalogue tools", () => {
-      const set = getToolSet("agent-discovery");
-      const tools =
-        typeof set.tools === "function" ? set.tools(ctx) : set.tools;
-      expect(Object.keys(tools).sort()).toEqual(
-        ["getAgent", "listAgents", "listModelProviders", "listToolSets"].sort(),
+      ).toThrow(
+        `Tool set with id '${SANDBOX_TOOLSET_ID}' has already been registered.`,
       );
     });
 
-    it("skill-management exposes the skill CRUD tools", () => {
-      const set = getToolSet("skill-management");
-      const tools =
-        typeof set.tools === "function" ? set.tools(ctx) : set.tools;
-      expect(Object.keys(tools).sort()).toEqual(
-        ["deleteSkill", "getSkill", "listSkills", "upsertSkill"].sort(),
-      );
-    });
-
-    it("agent-management exposes only write-side agent tools", () => {
-      const set = getToolSet("agent-management");
-      const tools =
-        typeof set.tools === "function" ? set.tools(ctx) : set.tools;
-      expect(Object.keys(tools).sort()).toEqual(
-        ["createAgent", "deleteAgent", "updateAgent"].sort(),
-      );
-    });
-
-    it("notifications has a factory function for tools", () => {
-      const set = getToolSet("notifications");
-      expect(typeof set.tools).toBe("function");
+    it("registers a new tool set and returns it with its id folded in", () => {
+      const set = registerToolSet("test-only-set", {
+        name: "Test Only",
+        category: "Test",
+        tools: {},
+      });
+      expect(set.id).toBe("test-only-set");
+      expect(getToolSet("test-only-set")).toBe(set);
     });
   });
 });

--- a/apps/backend/src/tools/index.ts
+++ b/apps/backend/src/tools/index.ts
@@ -1,14 +1,5 @@
 import { type Tool } from "ai";
 import { eq } from "drizzle-orm";
-import { fetchUrl } from "./fetch.ts";
-import { createKanbanTools } from "./kanban.ts";
-import { createDashboardTools } from "./dashboard.ts";
-import { createTriggerTools } from "./trigger.ts";
-import { createAgentDiscoveryTools } from "./agent-discovery.ts";
-import { createSkillManagementTools } from "./skill-management.ts";
-import { createAgentManagementTools } from "./agent-management.ts";
-import { createNotificationTools } from "./notification.ts";
-import { createMemoryTools } from "./memory.ts";
 import { db } from "../index.ts";
 import { sandbox as sandboxTable } from "../db/schema.ts";
 import { getSandboxBackend } from "../sandbox/index.ts";
@@ -62,87 +53,20 @@ export const getToolSets = (): typeof TOOL_SETS_REGISTRY => TOOL_SETS_REGISTRY;
 export const MEMORY_TOOLSET_ID = "memory";
 
 // REGISTER TOOL SETS HERE!
-// Note: the `math-conversions` and `time` tool sets now ship as the
-// `@platypus/tools-basic` plugin (apps/backend/src/plugins/tools-basic), loaded
-// via the plugin loader from `PLATYPUS_PLUGINS`. See ADR-0013. The tool sets
-// below remain statically registered pending migration in later slices.
-registerToolSet("web-fetch", {
-  name: "Web Fetch",
-  category: "Web",
-  description: "Fetch content from URLs on the web",
-  tools: {
-    fetchUrl,
-  },
-});
-
-registerToolSet("kanban", {
-  name: "Kanban",
-  category: "Productivity",
-  description: "Manage kanban boards in this workspace",
-  tools: ({ workspaceId, agentId, orgId, frontendUrl }) =>
-    createKanbanTools(workspaceId, agentId, orgId, frontendUrl),
-});
-
-registerToolSet("dashboards", {
-  name: "Dashboards",
-  category: "Productivity",
-  description:
-    "List dashboards and widgets, and update widget data in this workspace",
-  tools: ({ workspaceId }) => createDashboardTools(workspaceId),
-});
-
-registerToolSet("triggers", {
-  name: "Triggers",
-  category: "Automation",
-  description:
-    "Manage triggers (cron schedules and event-based) including listing agents, creating, editing, and viewing triggers",
-  tools: ({ workspaceId, orgId, frontendUrl }) =>
-    createTriggerTools(workspaceId, orgId, frontendUrl),
-});
-
-registerToolSet("agent-discovery", {
-  name: "Agent Discovery",
-  category: "Productivity",
-  description:
-    "Read-only tools for discovering agents, providers, and tool sets in this workspace",
-  tools: ({ workspaceId, orgId, frontendUrl }) =>
-    createAgentDiscoveryTools(workspaceId, orgId, frontendUrl),
-});
-
-registerToolSet("skill-management", {
-  name: "Skill Management",
-  category: "Productivity",
-  description: "List, create, update, and delete skills in this workspace",
-  tools: ({ workspaceId, orgId, frontendUrl }) =>
-    createSkillManagementTools(workspaceId, orgId, frontendUrl),
-});
-
-registerToolSet("agent-management", {
-  name: "Agent Management",
-  category: "Productivity",
-  description: "Create, update, and delete agents in this workspace",
-  tools: ({ workspaceId, orgId, frontendUrl }) =>
-    createAgentManagementTools(workspaceId, orgId, frontendUrl),
-});
-
-registerToolSet("notifications", {
-  name: "Notifications",
-  category: "Communication",
-  description: "Post notifications visible to users in this workspace",
-  tools: ({ workspaceId, agentId, orgId }) =>
-    createNotificationTools(workspaceId, agentId, orgId),
-});
-
-registerToolSet("memory", {
-  name: "Memory",
-  category: "Memory",
-  description: "Search and retrieve memories from past conversations",
-  tools: ({ workspaceId, userId }) => createMemoryTools(workspaceId, userId),
-});
-
-// The sandbox tool set resolves at chat-turn time: load the Workspace's
-// sandbox row, look up the registered adapter, validate config/credentials,
-// then build the five AI SDK Tools. Missing-row, unregistered-backend, and
+// Note: the native Tool sets now ship as core plugins loaded via the plugin
+// loader from `PLATYPUS_PLUGINS` (see ADR-0013) — `math-conversions`/`time` as
+// `@platypus/tools-basic`, `web-fetch` as `@platypus/web-fetch`, and the
+// Platypus-domain sets (kanban, dashboards, triggers, agent-discovery,
+// skill-management, agent-management, notifications, memory) as
+// `@platypus/tools-platform`. Their factories live in `./*.ts`; the manifests
+// live under `apps/backend/src/plugins/`.
+//
+// The `sandbox` Tool set below is the lone exception: it is the consumer side of
+// the Sandbox-backend extension point (ADR-0002) rather than a native Tool set,
+// so it stays a core-internal static registration here. It resolves at chat-turn
+// time: load the Workspace's sandbox row, look up the registered adapter,
+// validate config/credentials, then build the five AI SDK Tools. Missing-row,
+// unregistered-backend, and
 // validation failures all degrade gracefully to "no tools this turn" (with a
 // warning log). See ADR-0001 / ADR-0002.
 export const SANDBOX_TOOLSET_ID = "sandbox";

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -28,15 +28,20 @@ a fixed set of core-owned **Extension points**:
   codebase. Reach for them first; see the comparison below.
 
 <Callout type="info">
-  The plugin loader is being rolled out incrementally (see
-  [ADR-0013](https://github.com/willdady/platypus/blob/main/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md)).
-  The core plugins `@platypus/tools-basic` (math, time) and `@platypus/docker`
-  (the Sandbox backend) ship through it today, and **third-party plugins** load
-  from installed npm packages with their contribution ids namespaced by plugin
-  name; the remaining built-in Tool sets are still registered in-tree pending
-  migration. Either way the underlying `registerToolSet` /
-  `registerSandboxBackend` functions are the same — they are now
-  **core-internal**, driven by the loader rather than called by plugin authors.
+  Every native Tool set now ships as a core plugin loaded through the manifest
+  loader (see
+  [ADR-0013](https://github.com/willdady/platypus/blob/main/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md)):
+  `@platypus/tools-basic` (math, time), `@platypus/web-fetch` (web fetch, split
+  out so its network egress can be denied in isolation), `@platypus/tools-platform`
+  (the Platypus-domain sets — kanban, dashboards, triggers, memory, notifications,
+  agent discovery/management, skill management), and `@platypus/docker` (the
+  Sandbox backend). **Third-party plugins** load the same way from installed npm
+  packages, with their contribution ids namespaced by plugin name. The one
+  remaining in-tree registration is the `sandbox` Tool set — the consumer side of
+  the Sandbox-backend extension point, core glue rather than a native Tool set.
+  Either way the underlying `registerToolSet` / `registerSandboxBackend` functions
+  are the same — they are now **core-internal**, driven by the loader rather than
+  called by plugin authors.
 </Callout>
 
 ## The plugin model
@@ -400,20 +405,39 @@ field instead:
 
 **To add a core tool set (in-tree plugin):**
 
+A core tool set is a **contribution in a plugin manifest's `contributes.toolSets`
+array** — you never call `registerToolSet` directly (it is core-internal, driven
+by the loader). Concretely:
+
 1. Define your tools with `tool({ description, inputSchema, execute })`. Put
    them in a new file under `apps/backend/src/tools/` (see `math.ts` for a
    stateless example, `kanban.ts` for a context-factory example).
-2. Add the contribution to an existing core plugin's manifest, or create a new
-   plugin under `apps/backend/src/plugins/<name>/index.ts` and register its
-   logical `@platypus/*` name in
-   `apps/backend/src/plugins/builtin.ts` (the built-in map / core allowlist).
-3. Add the plugin name to the deployment's `PLATYPUS_PLUGINS` list so it loads.
+2. Add a `ToolSetContribution` entry to the `contributes.toolSets` array of the
+   fitting core plugin's manifest — a Platypus-domain set belongs in
+   `@platypus/tools-platform` (`apps/backend/src/plugins/tools-platform/`), a
+   pure utility in `@platypus/tools-basic`. If the capability is one an Operator
+   would plausibly want to deny in isolation (network egress, infra), give it its
+   own plugin instead — mirror `@platypus/web-fetch` — under
+   `apps/backend/src/plugins/<name>/index.ts` and register its logical
+   `@platypus/*` name in `apps/backend/src/plugins/builtin.ts` (the built-in map
+   / core allowlist).
+3. Add the plugin name to the deployment's `PLATYPUS_PLUGINS` list so it loads
+   (the standard core set is in `.env.example`).
 
-Core Contribution ids stay unprefixed (`math-conversions`, `time`) so persisted
-`agent.toolSetIds` references keep working. A tool set is granted to Agents like
-any other; if its dependencies aren't present at turn time it degrades
-gracefully (the `sandbox` tool set, for example, resolves to no tools when a
-Workspace has no Sandbox configured).
+Core Contribution ids stay unprefixed (`math-conversions`, `web-fetch`,
+`kanban`) so persisted `agent.toolSetIds` references keep working. A tool set is
+granted to Agents like any other; if its dependencies aren't present at turn time
+it degrades gracefully (the `sandbox` tool set, for example, resolves to no tools
+when a Workspace has no Sandbox configured).
+
+<Callout type="info">
+  The `sandbox` tool set is the one core tool set **not** contributed through a
+  manifest — it is the consumer side of the Sandbox-backend extension point
+  (ADR-0002), core glue that turns whichever backend a Workspace configured into
+  the fixed five tools, so it stays a core-internal static registration in
+  `apps/backend/src/tools/index.ts`. It is not a template for new tool sets;
+  contribute those through a plugin manifest as above.
+</Callout>
 
 ### Third-party plugins
 

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -76,13 +76,32 @@ Platypus loads its extensions — starting with Tool sets — as **plugins**, an
 comma-separated list of plugin names; core built-ins are listed too (e.g.
 `@platypus/tools-basic`).
 
+**The default list shipped in `.env.example`** is the standard core tool set:
+
+```
+PLATYPUS_PLUGINS=@platypus/tools-basic,@platypus/web-fetch,@platypus/tools-platform
+```
+
+- `@platypus/tools-basic` — pure utilities (math conversions, time).
+- `@platypus/web-fetch` — the web-fetch Tool set. It ships as its own plugin so
+  its **network egress** can be denied in isolation: drop it from the list and
+  the rest of the standard tools stay.
+- `@platypus/tools-platform` — the Platypus-domain sets (kanban, dashboards,
+  triggers, memory, notifications, agent discovery/management, skill management).
+- `@platypus/docker` — the Docker Sandbox backend — is **intentionally not** in
+  the default. It's opt-in infra; add it only when you want a Sandbox (see
+  [Sandbox](#sandbox)).
+
+Since `compose.yaml` reads the backend's `env_file: .env`, a deployment seeded
+from `.env.example` gets this list; pin your own by editing the value.
+
 - **List membership both loads and enables a plugin.** There is no separate
   enable switch — adding a name turns a plugin on, removing it turns it off.
   Both take effect on the next backend restart (this is a deploy-time trust
   boundary — there is no in-app install button).
-- **An empty list yields a deployment with no plugin-provided tools** (the
-  `@platypus/tools-basic` math/time tools disappear, for example). That's
-  accepted and self-documenting.
+- **An empty list yields a deployment with no plugin-provided tools** (all the
+  Tool sets above disappear — an Agent granted `kanban` resolves to no tools).
+  That's accepted and self-documenting.
 - **Boot is fail-loud.** A listed plugin that can't be resolved or exports an
   invalid manifest, or two plugins whose tool-set ids collide, aborts startup
   with a plugin-named error — a misconfigured plugin never silently drops tools.


### PR DESCRIPTION
Closes #290.

Migrates the remaining native Tool sets to core plugins under the [ADR-0013](https://github.com/willdady/platypus/blob/main/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md) manifest model and retires the import-time `registerToolSet` calls.

## What changed

- **`@platypus/web-fetch`** — the `web-fetch` Tool set as its own plugin (network egress, so an Operator can deny it in isolation by omitting it from the list).
- **`@platypus/tools-platform`** — the Platypus-domain Tool sets grouped by cohesion: kanban, dashboards, triggers, agent-discovery, skill-management, agent-management, notifications, memory.
- Both registered in the built-in map (`builtin.ts`) and driven through `contributes.toolSets`.
- Removed the nine import-time `registerToolSet(...)` calls from `tools/index.ts`. The lone remaining static registration is the **`sandbox`** Tool set — the consumer side of the Sandbox-backend extension point (ADR-0002), core glue rather than a native Tool set.
- **All Tool set ids preserved** (core, unprefixed) — no change to persisted `agent.toolSetIds`.
- Default `PLATYPUS_PLUGINS` in `.env.example` now ships the standard core set (`@platypus/tools-basic,@platypus/web-fetch,@platypus/tools-platform`); Docker stays opt-in. `compose.yaml` inherits it via `env_file: .env`.
- **Docs** — rewrote the extending "To add a tool set" section to the plugin-manifest workflow and documented the default plugin list in `self-hosting/configuration.mdx`.

## Acceptance criteria

- [x] web-fetch and the platform tool sets load via plugin manifests; no native Tool set registers at import time (only `sandbox`, core sandbox infra by design).
- [x] Existing Tool set ids unchanged; existing agents keep their tools.
- [x] `web-fetch` can be disabled independently by omitting `@platypus/web-fetch`.
- [x] `.env.example` ships a default `PLATYPUS_PLUGINS` covering the standard core plugins.
- [x] Tests confirm each reframed tool set resolves and works in a Chat turn.
- [x] Docs describe native Tool sets as plugin contributions and document the default plugin list; the docs build passes.

## Verification

- `pnpm --filter @platypus/backend typecheck` — clean
- `pnpm --filter @platypus/backend lint` — clean
- Backend tests — 1017 passing. The only 2 failures are a **pre-existing** e2e test needing `@platypus-examples/tool-set` linked in `node_modules` (confirmed identical on a clean tree, unrelated to this change).
- `pnpm --filter @platypus/docs build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)