### PR TITLE
feat(backend): plugin observability — boot log, GET /plugins, catalog annotations

### DIFF
--- a/apps/backend/index.ts
+++ b/apps/backend/index.ts
@@ -14,6 +14,7 @@ import { logger } from "./src/logger.ts";
 import { startMemoryScheduler } from "./src/jobs/memory-scheduler.ts";
 import { startTriggerScheduler } from "./src/jobs/trigger-scheduler.ts";
 import { loadPlugins } from "./src/plugins/loader.ts";
+import { setLoadedPlugins } from "./src/plugins/registry.ts";
 
 const PORT = process.env.PORT || "4001";
 
@@ -106,10 +107,25 @@ const main = async () => {
   // contributions are registered by the time Chat turns resolve tools. Fail-loud
   // and all-or-nothing: a bad plugin aborts startup (ADR-0013).
   const loadedPlugins = await loadPlugins();
-  logger.info(
-    { plugins: loadedPlugins },
-    `Loaded ${loadedPlugins.length} plugin(s)`,
-  );
+
+  // Enumerate each loaded plugin — version, origin, and the contributions it
+  // fills — so the boot log is a complete, auditable statement of what runs
+  // (ADR-0013 observability). Then hand the result to the registry, the single
+  // read-only source behind `GET /plugins` and the catalog annotations.
+  for (const p of loadedPlugins) {
+    logger.info(
+      {
+        plugin: p.name,
+        version: p.version,
+        origin: p.origin,
+        toolSets: p.toolSetIds,
+        sandboxBackends: p.sandboxBackendIds,
+      },
+      `Loaded plugin ${p.name}@${p.version} (${p.origin}): ${p.toolSetIds.length} tool set(s), ${p.sandboxBackendIds.length} sandbox backend(s)`,
+    );
+  }
+  setLoadedPlugins(loadedPlugins);
+  logger.info(`Loaded ${loadedPlugins.length} plugin(s)`);
 
   serve({
     fetch: app.fetch,

--- a/apps/backend/src/plugins/registry.ts
+++ b/apps/backend/src/plugins/registry.ts
@@ -1,0 +1,45 @@
+import type { LoadedPlugin } from "./loader.ts";
+
+// Read-only observability store for the plugins loaded at boot (ADR-0013).
+//
+// `loadPlugins()` returns its result to the boot sequence; `index.ts` hands that
+// result here once, after a successful, fail-loud load. From this single source
+// the process serves the read-only `GET /plugins` catalog and annotates the
+// existing catalogs (`GET /backends`, the Tools listing) with each
+// contribution's originating plugin. There is deliberately no mutation path —
+// enable/disable is deploy-time only (ADR-0013), so this module exposes setters
+// for boot/tests and getters for request handlers, nothing more.
+
+let loadedPlugins: readonly LoadedPlugin[] = [];
+let toolSetOwners = new Map<string, string>();
+let sandboxBackendOwners = new Map<string, string>();
+
+/**
+ * Record the plugins loaded at boot. Called once from the boot sequence after
+ * {@link loadPlugins} succeeds; also used by tests to seed the catalog. Rebuilds
+ * the id → plugin-name lookups used to annotate existing catalogs.
+ */
+export const setLoadedPlugins = (plugins: readonly LoadedPlugin[]): void => {
+  loadedPlugins = plugins;
+  toolSetOwners = new Map();
+  sandboxBackendOwners = new Map();
+  for (const p of plugins) {
+    for (const id of p.toolSetIds) toolSetOwners.set(id, p.name);
+    for (const id of p.sandboxBackendIds) sandboxBackendOwners.set(id, p.name);
+  }
+};
+
+/** The plugins loaded at boot, for the read-only `GET /plugins` catalog. */
+export const getLoadedPlugins = (): readonly LoadedPlugin[] => loadedPlugins;
+
+/**
+ * The plugin that contributed a Tool set, or `undefined` when the id belongs to
+ * no loaded plugin (e.g. the core-internal `sandbox` Tool set, which is a static
+ * registration rather than a plugin contribution — see `tools/index.ts`).
+ */
+export const getToolSetPlugin = (toolSetId: string): string | undefined =>
+  toolSetOwners.get(toolSetId);
+
+/** The plugin that contributed a Sandbox backend, or `undefined` if none. */
+export const getSandboxBackendPlugin = (backend: string): string | undefined =>
+  sandboxBackendOwners.get(backend);

--- a/apps/backend/src/routes/plugins.test.ts
+++ b/apps/backend/src/routes/plugins.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  mockDb,
+  mockNoSession,
+  mockSession,
+  resetMockDb,
+} from "../test-utils.ts";
+import app from "../server.ts";
+import { setLoadedPlugins } from "../plugins/registry.ts";
+import type { LoadedPlugin } from "../plugins/loader.ts";
+
+const LOADED: LoadedPlugin[] = [
+  {
+    name: "@platypus/tools-basic",
+    version: "1.0.0",
+    origin: "core",
+    toolSetIds: ["math-conversions", "time"],
+    sandboxBackendIds: [],
+  },
+  {
+    name: "acme-sandbox",
+    version: "2.3.1",
+    origin: "third-party",
+    toolSetIds: ["acme-sandbox.management"],
+    sandboxBackendIds: ["acme-sandbox.sandbox"],
+  },
+];
+
+describe("Plugins Routes", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+    setLoadedPlugins(LOADED);
+  });
+
+  const baseUrl = "/organizations/org-1/plugins";
+
+  describe("GET /plugins", () => {
+    it("lets an Org Admin view loaded plugins with versions, origin, and contributions", async () => {
+      // A regular platform user (not a super admin) who is an admin of the org.
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess(["admin"])
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        results: Array<{
+          name: string;
+          version: string;
+          origin: string;
+          contributions: { toolSets: string[]; sandboxBackends: string[] };
+        }>;
+      };
+
+      expect(body.results).toEqual([
+        {
+          name: "@platypus/tools-basic",
+          version: "1.0.0",
+          origin: "core",
+          contributions: {
+            toolSets: ["math-conversions", "time"],
+            sandboxBackends: [],
+          },
+        },
+        {
+          name: "acme-sandbox",
+          version: "2.3.1",
+          origin: "third-party",
+          contributions: {
+            toolSets: ["acme-sandbox.management"],
+            sandboxBackends: ["acme-sandbox.sandbox"],
+          },
+        },
+      ]);
+    });
+
+    it("requires authentication", async () => {
+      mockNoSession();
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(401);
+    });
+
+    it("forbids a non-admin org member — the view is Org-Admin only", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess(["admin"])
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(403);
+    });
+
+    it("exposes no enable/disable mutation — writes are not routed", async () => {
+      // The catalog is read-only (ADR-0013): there is no mutation endpoint, so
+      // any write verb falls through to a 404 rather than toggling a plugin.
+      for (const method of ["POST", "PUT", "PATCH", "DELETE"] as const) {
+        const res = await app.request(baseUrl, { method });
+        expect(res.status).toBe(404);
+      }
+    });
+  });
+});

--- a/apps/backend/src/routes/plugins.ts
+++ b/apps/backend/src/routes/plugins.ts
@@ -1,0 +1,32 @@
+import { Hono } from "hono";
+import { requireAuth } from "../middleware/authentication.ts";
+import { requireOrgAccess } from "../middleware/authorization.ts";
+import { getLoadedPlugins } from "../plugins/registry.ts";
+import type { Variables } from "../server.ts";
+
+const plugins = new Hono<{ Variables: Variables }>();
+
+// Read-only catalog of the plugins loaded at boot (ADR-0013): name, version,
+// origin, and the contributions each fills. There is deliberately no enable/
+// disable mutation here — enablement is deploy-time list membership
+// (`PLATYPUS_PLUGINS`), Operator-owned, not an API action.
+//
+// This backs the read-only Org-Admin "Installed plugins" view (#295), so it is
+// gated to Org Admins. Plugins are a deployment-wide concern — the payload is
+// identical for every org; the orgId in the path scopes *access*, not the data
+// (the same pattern as `GET /backends` and the Tools listing, which expose
+// process-wide registries under an org/workspace path). Super admins bypass.
+plugins.get("/", requireAuth, requireOrgAccess(["admin"]), (c) => {
+  const results = getLoadedPlugins().map((p) => ({
+    name: p.name,
+    version: p.version,
+    origin: p.origin,
+    contributions: {
+      toolSets: p.toolSetIds,
+      sandboxBackends: p.sandboxBackendIds,
+    },
+  }));
+  return c.json({ results });
+});
+
+export { plugins };

--- a/apps/backend/src/routes/sandbox.test.ts
+++ b/apps/backend/src/routes/sandbox.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { z } from "zod";
 import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
 import app from "../server.ts";
+import { registerSandboxBackend } from "../sandbox/index.ts";
+import { setLoadedPlugins } from "../plugins/registry.ts";
+
+// Register a backend directly (bypassing the loader) so the /backends catalog
+// has a stable entry to assert against, and record its owning plugin in the
+// registry so the annotation (ADR-0013) has something to resolve.
+const ANNOTATED_BACKEND = "test-annotated";
+registerSandboxBackend({
+  backend: ANNOTATED_BACKEND,
+  name: "Test Annotated",
+  configSchema: z.object({}),
+  credentialsSchema: z.object({}),
+  create: () => {
+    throw new Error("not used in this test");
+  },
+});
 
 describe("Sandbox Routes", () => {
   beforeEach(() => {
@@ -22,27 +39,46 @@ describe("Sandbox Routes", () => {
   };
 
   describe("GET /backends", () => {
-    it("returns the list of registered backends with name and id only", async () => {
+    it("returns registered backends with id, name, and originating plugin", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
+      // Attribute the pre-registered backend to a plugin (ADR-0013).
+      setLoadedPlugins([
+        {
+          name: "@platypus/test",
+          version: "1.0.0",
+          origin: "core",
+          toolSetIds: [],
+          sandboxBackendIds: [ANNOTATED_BACKEND],
+        },
+      ]);
 
       const res = await app.request(`${baseUrl}/backends`);
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
-        results: Array<{ backend: string; name: string }>;
+        results: Array<{
+          backend: string;
+          name: string;
+          plugin: string | null;
+        }>;
       };
-      // The registry is process-wide; tests don't run the plugin loader, so
-      // the Docker adapter (contributed by @platypus/docker) is not registered
-      // here. We assert the list shape, not specific entries.
+      // Every entry carries backend/name/plugin — plugin is `null` when the id
+      // belongs to no loaded plugin, and the contributing plugin's name when it
+      // does.
       expect(Array.isArray(body.results)).toBe(true);
       for (const r of body.results) {
         expect(typeof r.backend).toBe("string");
         expect(typeof r.name).toBe("string");
-        expect(Object.keys(r).sort()).toEqual(["backend", "name"]);
+        expect(Object.keys(r).sort()).toEqual(["backend", "name", "plugin"]);
       }
+      expect(body.results).toContainEqual({
+        backend: ANNOTATED_BACKEND,
+        name: "Test Annotated",
+        plugin: "@platypus/test",
+      });
     });
   });
 

--- a/apps/backend/src/routes/sandbox.ts
+++ b/apps/backend/src/routes/sandbox.ts
@@ -15,6 +15,7 @@ import type { Variables } from "../server.ts";
 import { destroySandboxRow } from "../sandbox/teardown.ts";
 import { getSandboxBackend, getSandboxBackends } from "../sandbox/index.ts";
 import { readAllowedDockerNetworks } from "../plugins/docker/backend.ts";
+import { getSandboxBackendPlugin } from "../plugins/registry.ts";
 import { logger } from "../logger.ts";
 
 type SandboxRecord = typeof sandboxTable.$inferSelect;
@@ -70,7 +71,9 @@ const sanitizeSandboxResponse = (record: SandboxRecord, isAdmin: boolean) => {
 
 // List the Sandbox backends registered in this process. Returns metadata only
 // (no Zod schemas); the frontend renders forms per known backend type for v1.
-// Declared before "/" so the literal "/backends" path takes precedence.
+// Each entry is annotated with the `plugin` that contributed it (ADR-0013
+// observability); `null` when the id belongs to no loaded plugin. Declared
+// before "/" so the literal "/backends" path takes precedence.
 sandbox.get(
   "/backends",
   requireAuth,
@@ -80,6 +83,7 @@ sandbox.get(
     const results = getSandboxBackends().map((r) => ({
       backend: r.backend,
       name: r.name,
+      plugin: getSandboxBackendPlugin(r.backend) ?? null,
     }));
     return c.json({ results });
   },

--- a/apps/backend/src/routes/tool.test.ts
+++ b/apps/backend/src/routes/tool.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
 import app from "../server.ts";
+import { setLoadedPlugins } from "../plugins/registry.ts";
 
 vi.mock("../tools/index.ts", () => ({
   getToolSets: vi.fn().mockReturnValue({
@@ -12,6 +13,14 @@ vi.mock("../tools/index.ts", () => ({
         add: { description: "Add numbers" },
       },
     },
+    // A core-internal static set (e.g. `sandbox`) with no owning plugin: it
+    // must annotate as `plugin: null`, not crash.
+    sandbox: {
+      name: "Sandbox",
+      category: "Sandbox",
+      description: "Sandbox tools",
+      tools: () => ({}),
+    },
   }),
 }));
 
@@ -20,6 +29,18 @@ describe("Tool Routes", () => {
     resetMockDb();
     vi.clearAllMocks();
     mockDb.where.mockReturnValue(mockDb);
+    // Seed the plugin registry so the Tools listing can annotate the `math`
+    // set with its originating plugin (ADR-0013). `sandbox` is intentionally
+    // absent — it is a static registration, not a plugin contribution.
+    setLoadedPlugins([
+      {
+        name: "@platypus/tools-basic",
+        version: "1.0.0",
+        origin: "core",
+        toolSetIds: ["math"],
+        sandboxBackendIds: [],
+      },
+    ]);
   });
 
   const orgId = "org-1";
@@ -44,12 +65,22 @@ describe("Tool Routes", () => {
       expect(res.status).toBe(200);
       const json = (await res.json()) as Record<string, unknown>;
 
-      // Static tools
+      // Static tools, annotated with the contributing plugin (ADR-0013).
       expect(json.results).toContainEqual(
         expect.objectContaining({
           id: "math",
           name: "Math",
           category: "Utilities",
+          plugin: "@platypus/tools-basic",
+        }),
+      );
+
+      // A set with no owning plugin annotates as null, not undefined/omitted.
+      expect(json.results).toContainEqual(
+        expect.objectContaining({
+          id: "sandbox",
+          name: "Sandbox",
+          plugin: null,
         }),
       );
 

--- a/apps/backend/src/routes/tool.ts
+++ b/apps/backend/src/routes/tool.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { getToolSets } from "../tools/index.ts";
+import { getToolSetPlugin } from "../plugins/registry.ts";
 import { db } from "../index.ts";
 import { mcp as mcpTable } from "../db/schema.ts";
 import { eq } from "drizzle-orm";
@@ -20,12 +21,15 @@ tool.get(
   requireWorkspaceAccess,
   async (c) => {
     const workspaceId = c.req.param("workspaceId")!;
-    // Get static tools
+    // Get static tools. Each set is annotated with the `plugin` that
+    // contributed it (ADR-0013 observability); `null` for the core-internal
+    // `sandbox` set, which is a static registration, not a plugin contribution.
     const toolSetsList = Object.entries(getToolSets()).map(([id, toolSet]) => ({
       id,
       name: toolSet.name,
       category: toolSet.category,
       description: toolSet.description,
+      plugin: getToolSetPlugin(id) ?? null,
       tools:
         typeof toolSet.tools === "function"
           ? []

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -30,6 +30,7 @@ import { dashboard } from "./routes/dashboard.ts";
 import { notification } from "./routes/notification.ts";
 import { webhook } from "./routes/webhook.ts";
 import { mcpOauthCallback } from "./routes/mcp-oauth-callback.ts";
+import { plugins } from "./routes/plugins.ts";
 import { organizationMember } from "./db/schema.ts";
 import { logger } from "./logger.ts";
 import { mapError } from "./errors.ts";
@@ -177,6 +178,10 @@ app.route("/organizations/:orgId/members", member);
 app.route("/users/me/invitations", userInvitation);
 app.route("/users/me/contexts", context);
 app.route("/oauth/mcp/callback", mcpOauthCallback);
+// Read-only, deployment-wide plugin catalog (ADR-0013), backing the Org-Admin
+// "Installed plugins" view (#295). Org-scoped for access control only — the
+// payload is identical across orgs; the handler gates it to Org Admins.
+app.route("/organizations/:orgId/plugins", plugins);
 
 // Central error seam (ADR-0010): typed domain errors and Postgres unique
 // violations map to their HTTP status here, so routes throw instead of


### PR DESCRIPTION
Closes #294.

Exposes what plugins are loaded, **read-only**, per [ADR-0013](docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md). No enable/disable over the API — enablement is deploy-time list membership (`PLATYPUS_PLUGINS`).

## What changed

- **Boot log** — `index.ts` now emits a line per loaded plugin with its version, origin (`core` / `third-party`), and contributions (tool set / sandbox backend ids), then the existing summary count.
- **`GET /organizations/:orgId/plugins`** — new read-only route returning `{ results: [{ name, version, origin, contributions: { toolSets, sandboxBackends } }] }`. **Org-Admin gated**, backing the #295 "Installed plugins" view. The payload is deployment-wide and identical across orgs — the `orgId` scopes *access*, not the data, matching how `GET /backends` and the Tools listing expose process-wide registries under an org/workspace path. Super admins bypass. There is **no** mutation endpoint.
- **Catalog annotations** — `GET /backends` and the Tools listing now include a `plugin` field naming each contribution's originating plugin (`null` when the id belongs to no loaded plugin, e.g. the core-internal `sandbox` tool set, which is a static registration rather than a plugin contribution).
- **Registry module** (`src/plugins/registry.ts`) — the single read-only source behind the above. Boot hands it the `loadPlugins()` result once; handlers read from it. No mutation path, matching the ADR's read-only stance.

## Acceptance criteria

- [x] Boot log lists loaded plugins with versions and contributions.
- [x] `GET /plugins` returns that data read-only; no enable/disable mutation endpoint.
- [x] `GET /backends` and the Tools listing include the originating plugin for each contribution.
- [x] Tests cover the endpoint shape and the catalog annotations.

## Auth scoping

Route is **Org-Admin** gated (`requireOrgAccess(["admin"])`), per #295 which frames the consumer as a read-only Org-Admin "Installed plugins" view. It's exposed under `/organizations/:orgId/plugins` for access control; the plugin catalog itself is deployment-global (same for every org).

## Testing

- `pnpm --filter backend typecheck` ✓
- `pnpm lint` ✓
- `pnpm --filter backend test` — 1023 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)