### PR TITLE
chore: sync repo formatting to pinned prettier 3.9.4

### DIFF
--- a/.agents/skills/grill-with-docs/ADR-FORMAT.md
+++ b/.agents/skills/grill-with-docs/ADR-FORMAT.md
@@ -12,7 +12,7 @@ Create the `docs/adr/` directory lazily — only when the first ADR is needed.
 {1-3 sentences: what's the context, what did we decide, and why.}
 ```
 
-That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+That's it. An ADR can be a single paragraph. The value is in recording _that_ a decision was made and _why_ — not in filling out sections.
 
 ## Optional sections
 

--- a/.agents/skills/humanizer/README.md
+++ b/.agents/skills/humanizer/README.md
@@ -92,65 +92,66 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 
 ### Content Patterns
 
-| # | Pattern | Before | After |
-|---|---------|--------|-------|
-| 1 | **Significance inflation** | "marking a pivotal moment in the evolution of..." | "was established in 1989 to collect regional statistics" |
-| 2 | **Notability name-dropping** | "cited in NYT, BBC, FT, and The Hindu" | "In a 2024 NYT interview, she argued..." |
-| 3 | **Superficial -ing analyses** | "symbolizing... reflecting... showcasing..." | Remove or expand with actual sources |
-| 4 | **Promotional language** | "nestled within the breathtaking region" | "is a town in the Gonder region" |
-| 5 | **Vague attributions** | "Experts believe it plays a crucial role" | "according to a 2019 survey by..." |
-| 6 | **Formulaic challenges** | "Despite challenges... continues to thrive" | Specific facts about actual challenges |
+| #   | Pattern                       | Before                                            | After                                                    |
+| --- | ----------------------------- | ------------------------------------------------- | -------------------------------------------------------- |
+| 1   | **Significance inflation**    | "marking a pivotal moment in the evolution of..." | "was established in 1989 to collect regional statistics" |
+| 2   | **Notability name-dropping**  | "cited in NYT, BBC, FT, and The Hindu"            | "In a 2024 NYT interview, she argued..."                 |
+| 3   | **Superficial -ing analyses** | "symbolizing... reflecting... showcasing..."      | Remove or expand with actual sources                     |
+| 4   | **Promotional language**      | "nestled within the breathtaking region"          | "is a town in the Gonder region"                         |
+| 5   | **Vague attributions**        | "Experts believe it plays a crucial role"         | "according to a 2019 survey by..."                       |
+| 6   | **Formulaic challenges**      | "Despite challenges... continues to thrive"       | Specific facts about actual challenges                   |
 
 ### Language Patterns
 
-| # | Pattern | Before | After |
-|---|---------|--------|-------|
-| 7 | **AI vocabulary** | "Actually... additionally... testament... landscape... showcasing" | "also... remain common" |
-| 8 | **Copula avoidance** | "serves as... features... boasts" | "is... has" |
-| 9 | **Negative parallelisms / tailing negations** | "It's not just X, it's Y", "..., no guessing" | State the point directly |
-| 10 | **Rule of three** | "innovation, inspiration, and insights" | Use natural number of items |
-| 11 | **Synonym cycling** | "protagonist... main character... central figure... hero" | "protagonist" (repeat when clearest) |
-| 12 | **False ranges** | "from the Big Bang to dark matter" | List topics directly |
-| 13 | **Passive voice / subjectless fragments** | "No configuration file needed" | Name the actor when it helps clarity |
+| #   | Pattern                                       | Before                                                             | After                                |
+| --- | --------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------ |
+| 7   | **AI vocabulary**                             | "Actually... additionally... testament... landscape... showcasing" | "also... remain common"              |
+| 8   | **Copula avoidance**                          | "serves as... features... boasts"                                  | "is... has"                          |
+| 9   | **Negative parallelisms / tailing negations** | "It's not just X, it's Y", "..., no guessing"                      | State the point directly             |
+| 10  | **Rule of three**                             | "innovation, inspiration, and insights"                            | Use natural number of items          |
+| 11  | **Synonym cycling**                           | "protagonist... main character... central figure... hero"          | "protagonist" (repeat when clearest) |
+| 12  | **False ranges**                              | "from the Big Bang to dark matter"                                 | List topics directly                 |
+| 13  | **Passive voice / subjectless fragments**     | "No configuration file needed"                                     | Name the actor when it helps clarity |
 
 ### Style Patterns
 
-| # | Pattern | Before | After |
-|---|---------|--------|-------|
-| 14 | **Em/en dashes** | "institutions—not the people—yet this continues—" | Cut them: periods, commas, colons, or parentheses |
-| 15 | **Boldface overuse** | "**OKRs**, **KPIs**, **BMC**" | "OKRs, KPIs, BMC" |
-| 16 | **Inline-header lists** | "**Performance:** Performance improved" | Convert to prose |
-| 17 | **Title Case Headings** | "Strategic Negotiations And Partnerships" | "Strategic negotiations and partnerships" |
-| 18 | **Emojis** | "🚀 Launch Phase: 💡 Key Insight:" | Remove emojis |
-| 19 | **Curly quotes** | `said “the project”` | `said “the project”` |
-| 26 | **Hyphenated word pairs** | “cross-functional, data-driven, client-facing” | Drop hyphens on common word pairs |
-| 27 | **Persuasive authority tropes** | "At its core, what matters is..." | State the point directly |
-| 28 | **Signposting announcements** | "Let's dive in", "Here's what you need to know" | Start with the content |
-| 29 | **Fragmented headers** | "## Performance" + "Speed matters." | Let the heading do the work |
-| 30 | **Diff-anchored writing** | "This function was added to replace..." | Describe what it does, not what changed |
-| 31 | **Manufactured punchlines / staccato drama** | "It had no preference. No prior. No nostalgia." | Use varied sentence lengths and concrete claims |
-| 32 | **Aphorism formulas** | "Symmetry is the language of trust" | Replace the formula with the actual claim |
-| 33 | **Conversational rhetorical openers** | "Honestly? It depends..." | Remove the fake-candid setup |
+| #   | Pattern                                      | Before                                            | After                                             |
+| --- | -------------------------------------------- | ------------------------------------------------- | ------------------------------------------------- |
+| 14  | **Em/en dashes**                             | "institutions—not the people—yet this continues—" | Cut them: periods, commas, colons, or parentheses |
+| 15  | **Boldface overuse**                         | "**OKRs**, **KPIs**, **BMC**"                     | "OKRs, KPIs, BMC"                                 |
+| 16  | **Inline-header lists**                      | "**Performance:** Performance improved"           | Convert to prose                                  |
+| 17  | **Title Case Headings**                      | "Strategic Negotiations And Partnerships"         | "Strategic negotiations and partnerships"         |
+| 18  | **Emojis**                                   | "🚀 Launch Phase: 💡 Key Insight:"                | Remove emojis                                     |
+| 19  | **Curly quotes**                             | `said “the project”`                              | `said “the project”`                              |
+| 26  | **Hyphenated word pairs**                    | “cross-functional, data-driven, client-facing”    | Drop hyphens on common word pairs                 |
+| 27  | **Persuasive authority tropes**              | "At its core, what matters is..."                 | State the point directly                          |
+| 28  | **Signposting announcements**                | "Let's dive in", "Here's what you need to know"   | Start with the content                            |
+| 29  | **Fragmented headers**                       | "## Performance" + "Speed matters."               | Let the heading do the work                       |
+| 30  | **Diff-anchored writing**                    | "This function was added to replace..."           | Describe what it does, not what changed           |
+| 31  | **Manufactured punchlines / staccato drama** | "It had no preference. No prior. No nostalgia."   | Use varied sentence lengths and concrete claims   |
+| 32  | **Aphorism formulas**                        | "Symmetry is the language of trust"               | Replace the formula with the actual claim         |
+| 33  | **Conversational rhetorical openers**        | "Honestly? It depends..."                         | Remove the fake-candid setup                      |
 
 ### Communication Patterns
 
-| # | Pattern | Before | After |
-|---|---------|--------|-------|
-| 20 | **Chatbot artifacts** | "I hope this helps! Let me know if..." | Remove entirely |
-| 21 | **Cutoff disclaimers** | "While details are limited in available sources..." | Find sources or remove |
-| 22 | **Sycophantic tone** | "Great question! You're absolutely right!" | Respond directly |
+| #   | Pattern                | Before                                              | After                  |
+| --- | ---------------------- | --------------------------------------------------- | ---------------------- |
+| 20  | **Chatbot artifacts**  | "I hope this helps! Let me know if..."              | Remove entirely        |
+| 21  | **Cutoff disclaimers** | "While details are limited in available sources..." | Find sources or remove |
+| 22  | **Sycophantic tone**   | "Great question! You're absolutely right!"          | Respond directly       |
 
 ### Filler and Hedging
 
-| # | Pattern | Before | After |
-|---|---------|--------|-------|
-| 23 | **Filler phrases** | "In order to", "Due to the fact that" | "To", "Because" |
-| 24 | **Excessive hedging** | "could potentially possibly" | "may" |
-| 25 | **Generic conclusions** | "The future looks bright" | Specific plans or facts |
+| #   | Pattern                 | Before                                | After                   |
+| --- | ----------------------- | ------------------------------------- | ----------------------- |
+| 23  | **Filler phrases**      | "In order to", "Due to the fact that" | "To", "Because"         |
+| 24  | **Excessive hedging**   | "could potentially possibly"          | "may"                   |
+| 25  | **Generic conclusions** | "The future looks bright"             | Specific plans or facts |
 
 ## Full Example
 
 **Before (AI-sounding):**
+
 > Great question! Here is an essay on this topic. I hope this helps!
 >
 > AI-assisted coding serves as an enduring testament to the transformative potential of large language models, marking a pivotal moment in the evolution of software development. In today's rapidly evolving technological landscape, these groundbreaking tools—nestled at the intersection of research and practice—are reshaping how engineers ideate, iterate, and deliver, underscoring their vital role in modern workflows.
@@ -168,6 +169,7 @@ The skill also includes a final "obviously AI generated" audit pass and a second
 > In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you’d like me to expand on any section!
 
 **After (Humanized):**
+
 > AI coding assistants can speed up the boring parts of the job. They're great at boilerplate: config files and the little glue code you don't want to write. They can also help you sketch a test, but you still have to read it.
 >
 > The dangerous part is how confident the suggestions look. I've accepted code that compiled and passed lint, then discovered later it missed the point because I stopped paying attention.

--- a/.agents/skills/humanizer/SKILL.md
+++ b/.agents/skills/humanizer/SKILL.md
@@ -34,7 +34,6 @@ When given text to humanize:
 
 The draft → audit → final loop and the deliverable are defined under Process and Output, below.
 
-
 ## Voice Calibration (Optional)
 
 If the user provides a writing sample (their own previous writing), analyze it before rewriting:
@@ -52,17 +51,18 @@ If the user provides a writing sample (their own previous writing), analyze it b
 3. **When no sample is provided,** fall back to the default behavior (natural, varied, opinionated voice from the PERSONALITY AND SOUL section below).
 
 ### How to provide a sample
+
 - Inline: "Humanize this text. Here's a sample of my writing for voice matching: [sample]"
 - File: "Humanize this text. Use my writing style from [file path] as a reference."
-
 
 ## PERSONALITY AND SOUL
 
 Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
 
-**Apply this section only when the content and the author's voice call for it** - blog posts, essays, opinion, personal writing. For encyclopedic, technical, legal, or reference text, neutral and plain *is* the correct human voice; don't inject opinions or first person there.
+**Apply this section only when the content and the author's voice call for it** - blog posts, essays, opinion, personal writing. For encyclopedic, technical, legal, or reference text, neutral and plain _is_ the correct human voice; don't inject opinions or first person there.
 
 ### Signs of soulless writing (even if technically "clean"):
+
 - Every sentence is the same length and structure
 - No opinions, just neutral reporting
 - No acknowledgment of uncertainty or mixed feelings
@@ -79,11 +79,12 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
 
 ### Before (clean but soulless):
+
 > The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
 
 ### After (has a pulse):
-> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
 
+> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
 
 ## CONTENT PATTERNS
 
@@ -94,11 +95,12 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
 
 **Before:**
+
 > The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
 
 **After:**
-> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
 
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
 
 ### 2. Undue Emphasis on Notability and Media Coverage
 
@@ -107,11 +109,12 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
 
 **Before:**
+
 > Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
 
 **After:**
-> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
 
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
 
 ### 3. Superficial Analyses with -ing Endings
 
@@ -120,11 +123,12 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
 
 **Before:**
+
 > The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
 
 **After:**
-> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
 
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
 
 ### 4. Promotional and Advertisement-like Language
 
@@ -133,11 +137,12 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics.
 
 **Before:**
+
 > Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
 
 **After:**
-> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
 
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
 
 ### 5. Vague Attributions and Weasel Words
 
@@ -146,11 +151,12 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
 
 **Before:**
+
 > Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
 
 **After:**
-> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
 
+> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
 
 ### 6. Outline-like "Challenges and Future Prospects" Sections
 
@@ -159,11 +165,12 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
 
 **Before:**
+
 > Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
 
 **After:**
-> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
 
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
 
 ## LANGUAGE AND GRAMMAR PATTERNS
 
@@ -174,11 +181,12 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
 
 **Before:**
+
 > Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
 
 **After:**
-> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
 
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
 
 ### 8. Avoidance of "is"/"are" (Copula Avoidance)
 
@@ -187,152 +195,168 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 **Problem:** LLMs substitute elaborate constructions for simple copulas.
 
 **Before:**
+
 > Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
 
 **After:**
-> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
 
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
 
 ### 9. Negative Parallelisms and Tailing Negations
 
 **Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused. So are clipped tailing-negation fragments such as "no guessing" or "no wasted motion" tacked onto the end of a sentence instead of written as a real clause.
 
 **Before:**
+
 > It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
 
 **After:**
+
 > The heavy beat adds to the aggressive tone.
 
 **Before (tailing negation):**
+
 > The options come from the selected item, no guessing.
 
 **After:**
-> The options come from the selected item without forcing the user to guess.
 
+> The options come from the selected item without forcing the user to guess.
 
 ### 10. Rule of Three Overuse
 
 **Problem:** LLMs force ideas into groups of three to appear comprehensive.
 
 **Before:**
+
 > The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
 
 **After:**
-> The event includes talks and panels. There's also time for informal networking between sessions.
 
+> The event includes talks and panels. There's also time for informal networking between sessions.
 
 ### 11. Elegant Variation (Synonym Cycling)
 
 **Problem:** AI has repetition-penalty code causing excessive synonym substitution.
 
 **Before:**
+
 > The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
 
 **After:**
-> The protagonist faces many challenges but eventually triumphs and returns home.
 
+> The protagonist faces many challenges but eventually triumphs and returns home.
 
 ### 12. False Ranges
 
 **Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
 
 **Before:**
+
 > Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
 
 **After:**
-> The book covers the Big Bang, star formation, and current theories about dark matter.
 
+> The book covers the Big Bang, star formation, and current theories about dark matter.
 
 ### 13. Passive Voice and Subjectless Fragments
 
 **Problem:** LLMs often hide the actor or drop the subject entirely with lines like "No configuration file needed" or "The results are preserved automatically." Rewrite these when active voice makes the sentence clearer and more direct.
 
 **Before:**
+
 > No configuration file needed. The results are preserved automatically.
 
 **After:**
-> You do not need a configuration file. The system preserves the results automatically.
 
+> You do not need a configuration file. The system preserves the results automatically.
 
 ## STYLE PATTERNS
 
 ### 14. Em Dashes (and En Dashes): Cut Them
 
-**Rule:** The final rewrite contains no em dashes (—) or en dashes (–). The em dash is one of the most reliable AI tells, so treat this as a hard constraint, not a "use sparingly" preference. Replace each one, in rough order of preference: a period (start a new sentence), a comma (a tight aside), a colon (introducing an explanation), parentheses (a true aside), or restructure the sentence. Also catch spaced em dashes (` — `) and double hyphens (` -- `) used the same way.
+**Rule:** The final rewrite contains no em dashes (—) or en dashes (–). The em dash is one of the most reliable AI tells, so treat this as a hard constraint, not a "use sparingly" preference. Replace each one, in rough order of preference: a period (start a new sentence), a comma (a tight aside), a colon (introducing an explanation), parentheses (a true aside), or restructure the sentence. Also catch spaced em dashes (`—`) and double hyphens (`--`) used the same way.
 
 **Before:**
+
 > The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
 
 **After:**
+
 > The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
 
 **Before:**
+
 > The new policy — announced without warning — affects thousands of workers. The changes -- long overdue according to critics -- will take effect immediately.
 
 **After:**
+
 > The new policy, announced without warning, affects thousands of workers. The changes, long overdue according to critics, will take effect immediately.
 
 Before returning the final rewrite, scan it for `—` and `–`. Any hit means the draft isn't done.
-
 
 ### 15. Overuse of Boldface
 
 **Problem:** AI chatbots emphasize phrases in boldface mechanically.
 
 **Before:**
+
 > It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
 
 **After:**
-> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
 
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
 
 ### 16. Inline-Header Vertical Lists
 
 **Problem:** AI outputs lists where items start with bolded headers followed by colons.
 
 **Before:**
+
 > - **User Experience:** The user experience has been significantly improved with a new interface.
 > - **Performance:** Performance has been enhanced through optimized algorithms.
 > - **Security:** Security has been strengthened with end-to-end encryption.
 
 **After:**
-> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
 
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
 
 ### 17. Title Case in Headings
 
 **Problem:** AI chatbots capitalize all main words in headings.
 
 **Before:**
+
 > ## Strategic Negotiations And Global Partnerships
 
 **After:**
-> ## Strategic negotiations and global partnerships
 
+> ## Strategic negotiations and global partnerships
 
 ### 18. Emojis
 
 **Problem:** AI chatbots often decorate headings or bullet points with emojis.
 
 **Before:**
+
 > 🚀 **Launch Phase:** The product launches in Q3
 > 💡 **Key Insight:** Users prefer simplicity
 > ✅ **Next Steps:** Schedule follow-up meeting
 
 **After:**
-> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
 
+> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
 
 ### 19. Curly Quotation Marks
 
 **Problem:** ChatGPT uses curly quotes (“...”) instead of straight quotes ("...").
 
 **Before:**
+
 > He said “the project is on track” but others disagreed.
 
 **After:**
-> He said "the project is on track" but others disagreed.
 
+> He said "the project is on track" but others disagreed.
 
 ## COMMUNICATION PATTERNS
 
@@ -343,47 +367,53 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 **Problem:** Text meant as chatbot correspondence gets pasted as content.
 
 **Before:**
+
 > Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
 
 **After:**
-> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
 
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
 
 ### 21. Knowledge-Cutoff Disclaimers and Speculative Gap-Filling
 
 **Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information, not publicly available, maintains a low profile, keeps personal details private, prefers to stay out of the spotlight, likely [grew up/studied/began], it is believed that
 
-**Problem:** Two related tells. (a) Older models leave hard knowledge-cutoff disclaimers in the text. (b) When a model can't find a source, it writes a paragraph *about* not finding one and then invents plausible filler to cover the gap. For a private person the guess almost always lands on the same stock phrases ("maintains a low profile," "keeps personal details private"), none of it sourced. Say what isn't known, or cut the sentence; don't dress a guess up as fact.
+**Problem:** Two related tells. (a) Older models leave hard knowledge-cutoff disclaimers in the text. (b) When a model can't find a source, it writes a paragraph _about_ not finding one and then invents plausible filler to cover the gap. For a private person the guess almost always lands on the same stock phrases ("maintains a low profile," "keeps personal details private"), none of it sourced. Say what isn't known, or cut the sentence; don't dress a guess up as fact.
 
 **Before (cutoff disclaimer):**
+
 > While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
 
 **After:**
+
 > The company was founded in 1994, according to its registration documents.
 
 **Before (speculative gap-fill):**
+
 > Information about her early life is not publicly available, suggesting she maintains a low profile and keeps personal details private. She likely grew up in a middle-class household, which shaped her later interest in education reform.
 
 **After:**
-> Her early life is not documented in the available sources. (Or omit the section.)
 
+> Her early life is not documented in the available sources. (Or omit the section.)
 
 ### 22. Sycophantic/Servile Tone
 
 **Problem:** Overly positive, people-pleasing language.
 
 **Before:**
+
 > Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
 
 **After:**
-> The economic factors you mentioned are relevant here.
 
+> The economic factors you mentioned are relevant here.
 
 ## FILLER AND HEDGING
 
 ### 23. Filler Phrases
 
 **Before → After:**
+
 - "In order to achieve this goal" → "To achieve this"
 - "Due to the fact that it was raining" → "Because it was raining"
 - "At this point in time" → "Now"
@@ -391,28 +421,29 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 - "The system has the ability to process" → "The system can process"
 - "It is important to note that the data shows" → "The data shows"
 
-
 ### 24. Excessive Hedging
 
 **Problem:** Over-qualifying statements.
 
 **Before:**
+
 > It could potentially possibly be argued that the policy might have some effect on outcomes.
 
 **After:**
-> The policy may affect outcomes.
 
+> The policy may affect outcomes.
 
 ### 25. Generic Positive Conclusions
 
 **Problem:** Vague upbeat endings.
 
 **Before:**
+
 > The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
 
 **After:**
-> The company plans to open two more locations next year.
 
+> The company plans to open two more locations next year.
 
 ### 26. Hyphenated Word Pair Overuse
 
@@ -421,11 +452,12 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 **Problem:** AI hyphenates these uniformly, including in predicate position (`the report is high-quality`). Humans hyphenate inconsistently — typically only when the compound is attributive (`a high-quality report`) and often dropping the hyphen otherwise (`the report is high quality`). Keep attributive-position hyphens; drop them when the compound follows the noun.
 
 **Before:**
+
 > The cross-functional team delivered a high-quality, data-driven report. The team is cross-functional, the report is high-quality, and the methodology is data-driven.
 
 **After:**
-> The cross-functional team delivered a high-quality, data-driven report. The team is cross functional, the report is high quality, and the methodology is data driven.
 
+> The cross-functional team delivered a high-quality, data-driven report. The team is cross functional, the report is high quality, and the methodology is data driven.
 
 ### 27. Persuasive Authority Tropes
 
@@ -434,11 +466,12 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 **Problem:** LLMs use these phrases to pretend they are cutting through noise to some deeper truth, when the sentence that follows usually just restates an ordinary point with extra ceremony.
 
 **Before:**
+
 > The real question is whether teams can adapt. At its core, what really matters is organizational readiness.
 
 **After:**
-> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
 
+> The question is whether teams can adapt. That mostly depends on whether the organization is ready to change its habits.
 
 ### 28. Signposting and Announcements
 
@@ -447,11 +480,12 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 **Problem:** LLMs announce what they are about to do instead of doing it. This meta-commentary slows the writing down and gives it a tutorial-script feel.
 
 **Before:**
+
 > Let's dive into how caching works in Next.js. Here's what you need to know.
 
 **After:**
-> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
 
+> Next.js caches data at multiple layers, including request memoization, the data cache, and the router cache.
 
 ### 29. Fragmented Headers
 
@@ -460,6 +494,7 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 **Problem:** LLMs often add a generic sentence after a heading as a rhetorical warm-up. It usually adds nothing and makes the prose feel padded.
 
 **Before:**
+
 > ## Performance
 >
 > Speed matters.
@@ -467,32 +502,34 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 > When users hit a slow page, they leave.
 
 **After:**
+
 > ## Performance
 >
 > When users hit a slow page, they leave.
-
 
 ### 30. Diff-Anchored Writing
 
 **Problem:** Documentation or comments written as if narrating a change rather than describing the thing as it is. Unless the document is inherently version-scoped (changelogs, release notes, migration guides), it should read coherently without knowing what changed in the last commit.
 
 **Before:**
+
 > This function was added to replace the previous approach of iterating through all items, which caused O(n²) performance.
 
 **After:**
-> This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
 
+> This function uses a hash map for O(1) lookups, avoiding the O(n²) cost of naive iteration.
 
 ### 31. Manufactured Punchlines and Staccato Drama
 
 **Problem:** LLMs often make every sentence land like a quotable closer, then stack short declarative fragments to manufacture drama. A single short sentence for emphasis is fine; a run of them starts to sound engineered.
 
 **Before:**
+
 > Then AlphaEvolve arrived. It had no preference for symmetry. No aesthetic prior. No nostalgia for human taste. The old rules were gone.
 
 **After:**
-> AlphaEvolve changed the search because it did not favor symmetry or human-looking designs. That made some of the older assumptions less useful.
 
+> AlphaEvolve changed the search because it did not favor symmetry or human-looking designs. That made some of the older assumptions less useful.
 
 ### 32. Aphorism Formulas
 
@@ -501,11 +538,12 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 **Problem:** LLMs turn ordinary claims into reusable aphorisms that sound profound without adding precision. Replace the formula with the concrete claim it is gesturing at.
 
 **Before:**
+
 > Symmetry is the language of trust. Efficiency becomes a trap when teams forget the human layer.
 
 **After:**
-> Symmetric layouts often feel more predictable to users. Teams can over-optimize workflows and miss how people actually use them.
 
+> Symmetric layouts often feel more predictable to users. Teams can over-optimize workflows and miss how people actually use them.
 
 ### 33. Conversational Rhetorical Openers
 
@@ -514,24 +552,25 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 **Problem:** LLMs open with a fake-candid hook to manufacture intimacy before delivering a routine claim. The tell is the theatrical pause-and-reveal: a one-word question or aside, then the "real" answer. A person being honest usually just says the thing.
 
 **Before:**
+
 > Is it worth the price? Honestly? It depends on how often you'll use it.
 
 **After:**
-> Whether it's worth the price depends on how often you'll use it.
 
+> Whether it's worth the price depends on how often you'll use it.
 
 ## DETECTION GUIDANCE
 
 ### What NOT to flag (false positives)
 
-A clean human writer can hit several of the patterns above without any AI involvement. Before rewriting, sanity-check that you are not gutting legitimate prose. The following are *not* reliable indicators on their own:
+A clean human writer can hit several of the patterns above without any AI involvement. Before rewriting, sanity-check that you are not gutting legitimate prose. The following are _not_ reliable indicators on their own:
 
 - **Perfect grammar and consistent style.** Many writers are professionals or have been edited. Polish does not equal AI.
 - **Mixed casual and formal registers.** This often signals a person in a technical field, a young writer, or someone with neurodivergent prose habits — not a chatbot.
-- **"Bland" or "robotic" prose.** AI prose has *specific* tells. Generic dryness without those tells is just dry writing.
-- **Formal or academic vocabulary.** AI overuses *specific* fancy words (see §7), not all fancy words. Don't flatten "ostensibly" or "constituent" just because they sound brainy.
+- **"Bland" or "robotic" prose.** AI prose has _specific_ tells. Generic dryness without those tells is just dry writing.
+- **Formal or academic vocabulary.** AI overuses _specific_ fancy words (see §7), not all fancy words. Don't flatten "ostensibly" or "constituent" just because they sound brainy.
 - **Letter-style opening or closing on a comment.** Salutations and sign-offs predate ChatGPT by centuries.
-- **Common transition words in isolation.** *Additionally*, *moreover*, *consequently* are AI-coded only when piled up. One *however* is not a tell.
+- **Common transition words in isolation.** _Additionally_, _moreover_, _consequently_ are AI-coded only when piled up. One _however_ is not a tell.
 - **Curly quotes alone.** macOS, Word, Google Docs, and most CMSes auto-curl by default. Curly quotes only count when stacked with other tells.
 - **Em dashes alone.** Many editors and journalists use them often. Em dashes are evidence only when paired with formulaic sales-y rhythm.
 - **One short emphatic sentence.** Humans use clipped sentences to land a point. Flag staccato drama only when several short fragments appear in a row and inflate the tone.
@@ -539,8 +578,7 @@ A clean human writer can hit several of the patterns above without any AI involv
 - **Unsourced claims.** Most of the web is unsourced. Lack of citations doesn't prove anything.
 - **Correct, complex formatting.** Visual editors and templates produce clean output without any AI.
 
-When in doubt, look for **clusters** of tells, not isolated ones. A single em dash means nothing; em dashes plus rule-of-three plus *vibrant tapestry* plus a "Conclusion" section is a confession.
-
+When in doubt, look for **clusters** of tells, not isolated ones. A single em dash means nothing; em dashes plus rule-of-three plus _vibrant tapestry_ plus a "Conclusion" section is a confession.
 
 ### Signs of human writing (preserve these)
 
@@ -549,11 +587,10 @@ When you see these, lean toward leaving the prose alone — they are evidence of
 - **Specific, unusual, hard-to-fabricate detail.** A real address. A weird quote. The phrase "the lawyer who used to work upstairs from my dentist." LLMs round off specifics; humans hoard them.
 - **Mixed feelings and unresolved tension.** "I think this is mostly good, but it bothers me, and I can't fully explain why." LLMs default to clean takes.
 - **Dated, era-bound references.** Slang, memes, or in-jokes that map to a specific year and subculture. Models lag by a year or more.
-- **First-person editorial choices the writer can defend.** If the writer can explain *why* they made a particular cut or used a particular word, that's a strong human signal.
+- **First-person editorial choices the writer can defend.** If the writer can explain _why_ they made a particular cut or used a particular word, that's a strong human signal.
 - **Variety in sentence length.** Real writing alternates short and long. AI writing tends toward an even, mid-length cadence.
 - **Genuine asides, parentheticals, or self-corrections.** "(I keep wanting to say 'almost' here, but it really was certain.)" Models rarely interrupt themselves like this.
 - **Edits made before November 30, 2022.** ChatGPT's public launch. Anything older than that is, with very rare exceptions, not AI-written.
-
 
 ---
 
@@ -566,10 +603,10 @@ When you see these, lean toward leaving the prose alone — they are evidence of
 
 Deliver the draft, the brief "still-AI" bullets, the final rewrite, and (optionally) a short summary of changes.
 
-
 ## Full Example
 
 **Before (AI-sounding):**
+
 > Great question! Here is an essay on this topic. I hope this helps!
 >
 > AI-assisted coding serves as an enduring testament to the transformative potential of large language models, marking a pivotal moment in the evolution of software development. In today's rapidly evolving technological landscape, these groundbreaking tools—nestled at the intersection of research and practice—are reshaping how engineers ideate, iterate, and deliver, underscoring their vital role in modern workflows.
@@ -587,6 +624,7 @@ Deliver the draft, the brief "still-AI" bullets, the final rewrite, and (optiona
 > In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you’d like me to expand on any section!
 
 **Draft rewrite:**
+
 > AI coding assistants speed up some tasks. In a 2024 study by Google, developers using Codex completed simple functions 55% faster than a control group, but showed no improvement on debugging or architectural decisions.
 >
 > The tools are good at boilerplate: config files, test scaffolding, repetitive refactors. They are bad at knowing when they are wrong. I have mass-accepted suggestions that compiled, passed lint, and still did the wrong thing because I stopped paying attention.
@@ -598,11 +636,13 @@ Deliver the draft, the brief "still-AI" bullets, the final rewrite, and (optiona
 > None of this means the tools are useless. It means they are tools. They do not replace judgment, and they do not eliminate the need for tests. If you do not have tests, you cannot tell whether the suggestion is right.
 
 **What makes the below so obviously AI generated?**
+
 - The rhythm is still a bit too tidy (clean contrasts, evenly paced paragraphs).
 - The named people and study citations can read like plausible-but-made-up placeholders unless they're real and sourced.
 - The closer leans a touch slogan-y ("If you do not have tests...") rather than sounding like a person talking.
 
 **Now make it not obviously AI generated.**
+
 > AI coding assistants can make you faster at the boring parts. Not everything. Definitely not architecture.
 >
 > They're great at boilerplate: config files, test scaffolding, repetitive refactors. They're also great at sounding right while being wrong. I've accepted suggestions that compiled, passed lint, and still missed the point because I stopped paying attention.
@@ -612,7 +652,6 @@ Deliver the draft, the brief "still-AI" bullets, the final rewrite, and (optiona
 > The productivity metrics are slippery. GitHub can say Copilot users "accept 30% of suggestions," but acceptance isn't correctness, and correctness isn't value. If you don't have tests, you're basically guessing.
 
 **Changes made:** Stripped the chatbot framing, significance inflation, promotional and -ing padding, rule-of-three and synonym cycling, false ranges, copula avoidance, em dashes/emojis/boldface/curly quotes, the formulaic "challenges" section, cutoff and hedging disclaimers, filler and persuasive framing, and the generic upbeat conclusion - then rebuilt the voice with varied rhythm and concrete detail.
-
 
 ## Reference
 

--- a/.agents/skills/improve-codebase-architecture/DEEPENING.md
+++ b/.agents/skills/improve-codebase-architecture/DEEPENING.md
@@ -18,7 +18,7 @@ Dependencies that have local test stand-ins (PGLite for Postgres, in-memory file
 
 Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
 
-Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+Recommendation shape: _"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."_
 
 ### 4. True external (Mock)
 

--- a/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
+++ b/.agents/skills/improve-codebase-architecture/HTML-REPORT.md
@@ -13,14 +13,24 @@ The architectural review is rendered as a single self-contained HTML file in the
     <script src="https://cdn.tailwindcss.com"></script>
     <script type="module">
       import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
-      mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+      mermaid.initialize({
+        startOnLoad: true,
+        theme: "neutral",
+        securityLevel: "loose",
+      });
     </script>
     <style>
       /* small custom layer for things Tailwind doesn't cover cleanly:
          dashed seam lines, hand-drawn-feeling arrow heads, etc. */
-      .seam { stroke-dasharray: 4 4; }
-      .leak { stroke: #dc2626; }
-      .deep { background: linear-gradient(135deg, #0f172a, #1e293b); }
+      .seam {
+        stroke-dasharray: 4 4;
+      }
+      .leak {
+        stroke: #dc2626;
+      }
+      .deep {
+        background: linear-gradient(135deg, #0f172a, #1e293b);
+      }
     </style>
   </head>
   <body class="bg-stone-50 text-slate-900 font-sans">
@@ -118,6 +128,6 @@ Plain English, concise — but the architectural nouns and verbs come straight f
 - "Deepen: one interface, one place to test."
 - "Two adapters justify the seam: HTTP in prod, in-memory in tests."
 
-**Wins bullets** name the gain in glossary terms: *"locality: bugs concentrate in one module"*, *"leverage: one interface, N call sites"*, *"interface shrinks; implementation absorbs the wrappers"*. Don't write *"easier to maintain"* or *"cleaner code"* — those terms aren't in the glossary and don't earn their place.
+**Wins bullets** name the gain in glossary terms: _"locality: bugs concentrate in one module"_, _"leverage: one interface, N call sites"_, _"interface shrinks; implementation absorbs the wrappers"_. Don't write _"easier to maintain"_ or _"cleaner code"_ — those terms aren't in the glossary and don't earn their place.
 
 No hedging, no throat-clearing, no "it's worth noting that…". If a sentence could be a bullet, make it a bullet. If a bullet could be cut, cut it. If a term isn't in [LANGUAGE.md](LANGUAGE.md), reach for one that is before inventing a new one.

--- a/.agents/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/.agents/skills/improve-codebase-architecture/LANGUAGE.md
@@ -19,11 +19,11 @@ What's inside a module — its body of code. Distinct from **Adapter**: a thing 
 Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
 
 **Seam** _(from Michael Feathers)_
-A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+A place where you can alter behaviour without editing in that place. The _location_ at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
 _Avoid_: boundary (overloaded with DDD's bounded context).
 
 **Adapter**
-A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+A concrete thing that satisfies an interface at a seam. Describes _role_ (what slot it fills), not substance (what's inside).
 
 **Leverage**
 What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
@@ -35,7 +35,7 @@ What maintainers get from depth. Change, bugs, knowledge, and verification conce
 
 - **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
 - **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
-- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test _past_ the interface, the module is probably the wrong shape.
 - **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
 
 ## Relationships

--- a/.agents/skills/setup-matt-pocock-skills/SKILL.md
+++ b/.agents/skills/setup-matt-pocock-skills/SKILL.md
@@ -46,7 +46,7 @@ Default posture: these skills were designed for GitHub. If a `git remote` points
 
 **Section B — Triage label vocabulary.**
 
-> Explainer: When the `triage` skill processes an incoming issue, it moves it through a state machine — needs evaluation, waiting on reporter, ready for an AFK agent to pick up, ready for a human, or won't fix. To do that, it needs to apply labels (or the equivalent in your issue tracker) that match strings *you've actually configured*. If your repo already uses different label names (e.g. `bug:triage` instead of `needs-triage`), map them here so the skill applies the right ones instead of creating duplicates.
+> Explainer: When the `triage` skill processes an incoming issue, it moves it through a state machine — needs evaluation, waiting on reporter, ready for an AFK agent to pick up, ready for a human, or won't fix. To do that, it needs to apply labels (or the equivalent in your issue tracker) that match strings _you've actually configured_. If your repo already uses different label names (e.g. `bug:triage` instead of `needs-triage`), map them here so the skill applies the right ones instead of creating duplicates.
 
 The five canonical roles:
 

--- a/.agents/skills/shadcn/customization.md
+++ b/.agents/skills/shadcn/customization.md
@@ -52,11 +52,11 @@ Colors use OKLCH: `--primary: oklch(0.205 0 0)` where values are lightness (0–
 Class-based toggle via `.dark` on the root element. In Next.js, use `next-themes`:
 
 ```tsx
-import { ThemeProvider } from "next-themes"
+import { ThemeProvider } from "next-themes";
 
 <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
   {children}
-</ThemeProvider>
+</ThemeProvider>;
 ```
 
 ---
@@ -122,7 +122,7 @@ module.exports = {
       },
     },
   },
-}
+};
 ```
 
 ```tsx
@@ -187,7 +187,7 @@ export function ConfirmDialog({ title, description, onConfirm, children }) {
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
-  )
+  );
 }
 ```
 

--- a/.agents/skills/shadcn/mcp.md
+++ b/.agents/skills/shadcn/mcp.md
@@ -13,13 +13,13 @@ shadcn mcp init   # write config for your editor
 
 Editor config files:
 
-| Editor | Config file |
-|--------|------------|
-| Claude Code | `.mcp.json` |
-| Cursor | `.cursor/mcp.json` |
-| VS Code | `.vscode/mcp.json` |
-| OpenCode | `opencode.json` |
-| Codex | `~/.codex/config.toml` (manual) |
+| Editor      | Config file                     |
+| ----------- | ------------------------------- |
+| Claude Code | `.mcp.json`                     |
+| Cursor      | `.cursor/mcp.json`              |
+| VS Code     | `.vscode/mcp.json`              |
+| OpenCode    | `opencode.json`                 |
+| Codex       | `~/.codex/config.toml` (manual) |
 
 ---
 

--- a/.agents/skills/shadcn/rules/base-vs-radix.md
+++ b/.agents/skills/shadcn/rules/base-vs-radix.md
@@ -90,7 +90,9 @@ Same for triggers whose `render` is not a `Button`:
 
 ```tsx
 <Select>
-  <SelectTrigger><SelectValue placeholder="Select a fruit" /></SelectTrigger>
+  <SelectTrigger>
+    <SelectValue placeholder="Select a fruit" />
+  </SelectTrigger>
 </Select>
 ```
 
@@ -157,7 +159,9 @@ Base supports `multiple`, render-function children on `SelectValue`, and object 
 <Select items={items} multiple defaultValue={[]}>
   <SelectTrigger>
     <SelectValue>
-      {(value: string[]) => value.length === 0 ? "Select fruits" : `${value.length} selected`}
+      {(value: string[]) =>
+        value.length === 0 ? "Select fruits" : `${value.length} selected`
+      }
     </SelectValue>
   </SelectTrigger>
   ...

--- a/.agents/skills/shadcn/rules/composition.md
+++ b/.agents/skills/shadcn/rules/composition.md
@@ -44,13 +44,13 @@ Never render items directly inside the content container.
 
 This applies to all group-based components:
 
-| Item | Group |
-|------|-------|
-| `SelectItem`, `SelectLabel` | `SelectGroup` |
+| Item                                                       | Group               |
+| ---------------------------------------------------------- | ------------------- |
+| `SelectItem`, `SelectLabel`                                | `SelectGroup`       |
 | `DropdownMenuItem`, `DropdownMenuLabel`, `DropdownMenuSub` | `DropdownMenuGroup` |
-| `MenubarItem` | `MenubarGroup` |
-| `ContextMenuItem` | `ContextMenuGroup` |
-| `CommandItem` | `CommandGroup` |
+| `MenubarItem`                                              | `MenubarGroup`      |
+| `ContextMenuItem`                                          | `ContextMenuGroup`  |
+| `CommandItem`                                              | `CommandGroup`      |
 
 ---
 
@@ -70,7 +70,9 @@ This applies to all group-based components:
 ```tsx
 <Empty>
   <EmptyHeader>
-    <EmptyMedia variant="icon"><FolderIcon /></EmptyMedia>
+    <EmptyMedia variant="icon">
+      <FolderIcon />
+    </EmptyMedia>
     <EmptyTitle>No projects yet</EmptyTitle>
     <EmptyDescription>Get started by creating a new project.</EmptyDescription>
   </EmptyHeader>
@@ -85,27 +87,27 @@ This applies to all group-based components:
 ## Toast notifications use sonner
 
 ```tsx
-import { toast } from "sonner"
+import { toast } from "sonner";
 
-toast.success("Changes saved.")
-toast.error("Something went wrong.")
+toast.success("Changes saved.");
+toast.error("Something went wrong.");
 toast("File deleted.", {
   action: { label: "Undo", onClick: () => undoDelete() },
-})
+});
 ```
 
 ---
 
 ## Choosing between overlay components
 
-| Use case | Component |
-|----------|-----------|
-| Focused task that requires input | `Dialog` |
-| Destructive action confirmation | `AlertDialog` |
-| Side panel with details or filters | `Sheet` |
-| Mobile-first bottom panel | `Drawer` |
-| Quick info on hover | `HoverCard` |
-| Small contextual content on click | `Popover` |
+| Use case                           | Component     |
+| ---------------------------------- | ------------- |
+| Focused task that requires input   | `Dialog`      |
+| Destructive action confirmation    | `AlertDialog` |
+| Side panel with details or filters | `Sheet`       |
+| Mobile-first bottom panel          | `Drawer`      |
+| Quick info on hover                | `HoverCard`   |
+| Small contextual content on click  | `Popover`     |
 
 ---
 
@@ -188,8 +190,8 @@ Always include `AvatarFallback` for when the image fails to load:
 
 ## Use existing components instead of custom markup
 
-| Instead of | Use |
-|---|---|
-| `<hr>` or `<div className="border-t">` | `<Separator />` |
+| Instead of                                         | Use                                  |
+| -------------------------------------------------- | ------------------------------------ |
+| `<hr>` or `<div className="border-t">`             | `<Separator />`                      |
 | `<div className="animate-pulse">` with styled divs | `<Skeleton className="h-4 w-3/4" />` |
-| `<span className="rounded-full bg-green-100 ...">` | `<Badge variant="secondary">` |
+| `<span className="rounded-full bg-green-100 ...">` | `<Badge variant="secondary">`        |

--- a/.agents/skills/shadcn/rules/forms.md
+++ b/.agents/skills/shadcn/rules/forms.md
@@ -59,11 +59,11 @@ Never use raw `Input` or `Textarea` inside an `InputGroup`.
 **Correct:**
 
 ```tsx
-import { InputGroup, InputGroupInput } from "@/components/ui/input-group"
+import { InputGroup, InputGroupInput } from "@/components/ui/input-group";
 
 <InputGroup>
   <InputGroupInput placeholder="Search..." />
-</InputGroup>
+</InputGroup>;
 ```
 
 ---
@@ -86,7 +86,11 @@ Never place a `Button` directly inside or adjacent to an `Input` with custom pos
 **Correct:**
 
 ```tsx
-import { InputGroup, InputGroupInput, InputGroupAddon } from "@/components/ui/input-group"
+import {
+  InputGroup,
+  InputGroupInput,
+  InputGroupAddon,
+} from "@/components/ui/input-group";
 
 <InputGroup>
   <InputGroupInput placeholder="Search..." />
@@ -95,7 +99,7 @@ import { InputGroup, InputGroupInput, InputGroupAddon } from "@/components/ui/in
       <SearchIcon data-icon="inline-start" />
     </Button>
   </InputGroupAddon>
-</InputGroup>
+</InputGroup>;
 ```
 
 ---
@@ -125,13 +129,13 @@ const [selected, setSelected] = useState("daily")
 **Correct:**
 
 ```tsx
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
 <ToggleGroup spacing={2}>
   <ToggleGroupItem value="daily">Daily</ToggleGroupItem>
   <ToggleGroupItem value="weekly">Weekly</ToggleGroupItem>
   <ToggleGroupItem value="monthly">Monthly</ToggleGroupItem>
-</ToggleGroup>
+</ToggleGroup>;
 ```
 
 Combine with `Field` for labelled toggle groups:
@@ -162,7 +166,9 @@ Use `FieldSet` + `FieldLegend` for related checkboxes, radios, or switches — n
   <FieldGroup className="gap-3">
     <Field orientation="horizontal">
       <Checkbox id="dark" />
-      <FieldLabel htmlFor="dark" className="font-normal">Dark mode</FieldLabel>
+      <FieldLabel htmlFor="dark" className="font-normal">
+        Dark mode
+      </FieldLabel>
     </Field>
   </FieldGroup>
 </FieldSet>

--- a/.agents/skills/shadcn/rules/icons.md
+++ b/.agents/skills/shadcn/rules/icons.md
@@ -77,25 +77,25 @@ Use `icon={CheckIcon}`, not a string key to a lookup map.
 const iconMap = {
   check: CheckIcon,
   alert: AlertIcon,
-}
+};
 
 function StatusBadge({ icon }: { icon: string }) {
-  const Icon = iconMap[icon]
-  return <Icon />
+  const Icon = iconMap[icon];
+  return <Icon />;
 }
 
-<StatusBadge icon="check" />
+<StatusBadge icon="check" />;
 ```
 
 **Correct:**
 
 ```tsx
 // Import from the project's configured iconLibrary (e.g. lucide-react, @tabler/icons-react).
-import { CheckIcon } from "lucide-react"
+import { CheckIcon } from "lucide-react";
 
 function StatusBadge({ icon: Icon }: { icon: React.ComponentType }) {
-  return <Icon />
+  return <Icon />;
 }
 
-<StatusBadge icon={CheckIcon} />
+<StatusBadge icon={CheckIcon} />;
 ```

--- a/.agents/skills/shadcn/rules/styling.md
+++ b/.agents/skills/shadcn/rules/styling.md
@@ -99,6 +99,7 @@ Use `className` for layout (e.g. `max-w-md`, `mx-auto`, `mt-4`), **not** for ove
 ```
 
 To customize a component's appearance, prefer these approaches in order:
+
 1. **Built-in variants** — `variant="outline"`, `variant="destructive"`, etc.
 2. **Semantic color tokens** — `bg-primary`, `text-muted-foreground`.
 3. **CSS variables** — define custom colors in the global CSS file (see [customization.md](../customization.md)).

--- a/.agents/skills/tdd/mocking.md
+++ b/.agents/skills/tdd/mocking.md
@@ -43,7 +43,7 @@ Create specific functions for each external operation instead of one generic fun
 const api = {
   getUser: (id) => fetch(`/users/${id}`),
   getOrders: (userId) => fetch(`/users/${userId}/orders`),
-  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+  createOrder: (data) => fetch("/orders", { method: "POST", body: data }),
 };
 
 // BAD: Mocking requires conditional logic inside the mock
@@ -53,6 +53,7 @@ const api = {
 ```
 
 The SDK approach means:
+
 - Each mock returns one specific shape
 - No conditional logic in test setup
 - Easier to see which endpoints a test exercises

--- a/.agents/skills/triage/AGENT-BRIEF.md
+++ b/.agents/skills/triage/AGENT-BRIEF.md
@@ -51,16 +51,19 @@ Describe what should happen after the agent's work is complete.
 Be specific about edge cases and error conditions.
 
 **Key interfaces:**
+
 - `TypeName` — what needs to change and why
 - `functionName()` return type — what it currently returns vs what it should return
 - Config shape — any new configuration options needed
 
 **Acceptance criteria:**
+
 - [ ] Specific, testable criterion 1
 - [ ] Specific, testable criterion 2
 - [ ] Specific, testable criterion 3
 
 **Out of scope:**
+
 - Thing that should NOT be changed or addressed in this issue
 - Adjacent feature that might seem related but is separate
 ```
@@ -85,12 +88,14 @@ Truncation should break at the last word boundary before 1024 characters
 and append "..." to indicate truncation.
 
 **Key interfaces:**
+
 - The `SkillMetadata` type's `description` field — no type change needed,
   but the validation/processing logic that populates it needs to respect
   word boundaries
 - Any function that reads SKILL.md frontmatter and extracts the description
 
 **Acceptance criteria:**
+
 - [ ] Descriptions under 1024 chars are unchanged
 - [ ] Descriptions over 1024 chars are truncated at the last word boundary
       before 1024 chars
@@ -98,6 +103,7 @@ and append "..." to indicate truncation.
 - [ ] The total length including "..." does not exceed 1024 chars
 
 **Out of scope:**
+
 - Changing the 1024 char limit itself
 - Multi-line description support
 ```
@@ -123,6 +129,7 @@ requested the feature. When triaging new issues, these files should be
 checked for matches.
 
 **Key interfaces:**
+
 - Markdown file format in `.out-of-scope/` — each file should have a
   `# Concept Name` heading, a `**Decision:**` line, a `**Reason:**` line,
   and a `**Prior requests:**` list with issue links
@@ -130,6 +137,7 @@ checked for matches.
   and match incoming issues against them by concept similarity
 
 **Acceptance criteria:**
+
 - [ ] Closing a feature as wontfix creates/updates a file in `.out-of-scope/`
 - [ ] The file includes the decision, reasoning, and link to the closed issue
 - [ ] If a matching `.out-of-scope/` file already exists, the new issue is
@@ -138,6 +146,7 @@ checked for matches.
       when a new issue matches a prior rejection
 
 **Out of scope:**
+
 - Automated matching (human confirms the match)
 - Reopening previously rejected features
 - Bug reports (only enhancement rejections go to `.out-of-scope/`)
@@ -155,11 +164,13 @@ The triage thing is broken. Look at the main file and fix it.
 The function around line 150 has the issue.
 
 **Files to change:**
+
 - src/triage/handler.ts (line 150)
 - src/types.ts (line 42)
 ```
 
 This is bad because:
+
 - No category
 - Vague description ("the triage thing is broken")
 - References file paths and line numbers that will go stale

--- a/.agents/skills/triage/OUT-OF-SCOPE.md
+++ b/.agents/skills/triage/OUT-OF-SCOPE.md
@@ -20,7 +20,7 @@ One file per **concept**, not per issue. Multiple issues requesting the same thi
 
 The file should be written in a relaxed, readable style — more like a short design document than a database entry. Use paragraphs, code samples, and examples to make the reasoning clear and useful to someone encountering it for the first time.
 
-```markdown
+````markdown
 # Dark Mode
 
 This project does not support dark mode or user-facing theming.
@@ -45,12 +45,14 @@ interface ThemeConfig {
   fonts: FontStack;
 }
 ```
+````
 
 ## Prior requests
 
 - #42 — "Add dark mode support"
 - #87 — "Night theme for accessibility"
 - #134 — "Dark theme option"
+
 ```
 
 ### Naming the file
@@ -99,3 +101,4 @@ If the maintainer changes their mind about a previously rejected concept:
 - Delete the `.out-of-scope/` file
 - The skill does not need to reopen old issues — they're historical records
 - The new issue that triggered the reconsideration proceeds through normal triage
+```

--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -46,8 +46,7 @@ const { mockPrepareChatTurn, mockGenerateText, mockStreamText, streamHarness } =
         // drive step-completion and stream-completion by hand.
         onStepFinish: undefined as ((step: unknown) => void) | undefined,
         onFinish: undefined as
-          | ((ctx: { messages: unknown[] }) => Promise<void> | void)
-          | undefined,
+          ((ctx: { messages: unknown[] }) => Promise<void> | void) | undefined,
         responseSentinel: { __isResponse: true },
       },
     };

--- a/apps/backend/src/tools/trigger.ts
+++ b/apps/backend/src/tools/trigger.ts
@@ -254,8 +254,7 @@ export function createTriggerTools(
         // Validate config based on type
         if (effectiveType === "cron") {
           const cronExpression = effectiveConfig.cronExpression as
-            | string
-            | undefined;
+            string | undefined;
           if (!cronExpression) {
             return {
               success: false,

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/[dashboardId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/[dashboardId]/page.tsx
@@ -830,9 +830,7 @@ const DashboardPage = ({
                 );
                 if (!expandedWidget) return null;
                 const expandedData = expandedWidget.data as
-                  | { content: string }
-                  | null
-                  | undefined;
+                  { content: string } | null | undefined;
                 return (
                   <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-8">
                     <motion.div

--- a/apps/frontend/components/ai-elements/prompt-input.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.tsx
@@ -1062,11 +1062,9 @@ interface SpeechRecognition extends EventTarget {
   onstart: ((this: SpeechRecognition, ev: Event) => void) | null;
   onend: ((this: SpeechRecognition, ev: Event) => void) | null;
   onresult:
-    | ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void)
-    | null;
+    ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null;
   onerror:
-    | ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void)
-    | null;
+    ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null;
 }
 
 interface SpeechRecognitionEvent extends Event {

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -240,11 +240,9 @@ export const ChatMessage = memo(function ChatMessage({
         } else if (part.type.startsWith("tool-")) {
           const toolPart = part as ToolUIPart;
           const toolInput = toolPart.input as
-            | Record<string, unknown>
-            | undefined;
+            Record<string, unknown> | undefined;
           const toolLabel = (toolInput?.label ?? toolInput?.name) as
-            | string
-            | undefined;
+            string | undefined;
           return (
             <Tool key={`${message.id}-${i}`}>
               <ToolHeader


### PR DESCRIPTION
## What

`pnpm format` reformats **22 files that no feature change touched** — the committed code was formatted by an older Prettier and has drifted from the currently-pinned `prettier@3.9.4`. This PR brings the repo back in sync.

## Why

`prettier@3.9.4` is what `package.json` (`^3.9.4`) and the lockfile resolve to, but many files were last formatted by an earlier Prettier. `prettier --check` currently fails on `main`; after this PR it passes clean.

## Nature of the changes

Formatting only, no behavioural changes:
- **`.agents/skills/**` markdown** — prose re-wrapping (the bulk of the diff).
- **A few TS/TSX files** (`trigger.ts`, `agent-runner.test.ts`, `chat-message.tsx`, `prompt-input.tsx`, dashboard `page.tsx`) — collapsed multi-line union types that now fit within print width.

## Verification

- `npx prettier --check "**/*.{ts,tsx,md}"` → *All matched files use Prettier code style!*

> Heads-up: this is a broad, mechanical sweep separate from the issue-294 work (PR #303). Kept on its own `chore/` branch so #303's diff stays scoped. If you'd rather not churn the skill markdown, we can narrow this to just the source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)