### PR TITLE
feat(frontend): read-only Installed Plugins Org-Admin view (#295)

### DIFF
--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -559,12 +559,17 @@ What's live and what's still in-tree today:
   [third-party plugin loading with contribution-id namespacing](#third-party-plugins)
   (dynamic `import()` of an installed package, ids prefixed by the manifest
   `name`; see the `@platypus-examples/tool-set` reference plugin) — each flowing
-  manifest → loader → registry in a Chat turn.
+  manifest → loader → registry in a Chat turn. Observability is live too: a boot
+  log enumerating loaded plugins, a read-only `GET /plugins` catalog, and
+  originating-plugin annotations on the `GET /backends` and Tools listings. That
+  catalog backs the read-only
+  [**Installed plugins** Org-Admin view](/self-hosting/configuration#inspecting-installed-plugins)
+  — versions and contributions per plugin, no enable/disable (enablement is the
+  deploy-time `PLATYPUS_PLUGINS` list).
 - **Still in-tree, pending migration:** the remaining built-in Tool sets
   (`kanban`, `triggers`, `sandbox`, …) still call `registerToolSet` directly at
   boot. They keep working unchanged; the same registration functions are what the
   loader drives.
-- **Follow-up slices:** a read-only `GET /plugins` catalog.
 
 ## Reference ADRs
 

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -111,6 +111,21 @@ from `.env.example` gets this list; pin your own by editing the value.
 See [Extending → the plugin model](/extending#the-plugin-model) for how a
 manifest's `contributes` block fills extension points.
 
+### Inspecting installed plugins
+
+An **Org Admin** can confirm what's actually loaded from the app:
+**Organization settings → Plugins** lists every plugin loaded at boot, its
+version, its origin (**Core** or **Third-party**), and the contributions it
+registered — the Tool sets and Sandbox backends it provides. That last part ties
+a Tool set or Sandbox backend back to the plugin it came from.
+
+The view is **strictly read-only**: there is no enable / disable / install
+control, because enablement is the deploy-time `PLATYPUS_PLUGINS` list above — a
+trust boundary owned by the operator, not an in-app action. It simply reflects
+the current `GET /plugins` response, so it changes only when you edit the list
+and restart the backend. To add or remove a plugin, edit `PLATYPUS_PLUGINS` and
+restart.
+
 ### Plugin config & credentials
 
 Some plugins need deploy-time settings — a region, an API token — that are the

--- a/apps/frontend/app/[orgId]/settings/plugins/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/plugins/page.tsx
@@ -1,0 +1,24 @@
+import { PluginsList } from "@/components/plugins-list";
+
+const OrgPluginsPage = async ({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}) => {
+  const { orgId } = await params;
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Installed Plugins</h1>
+      <p className="text-muted-foreground mb-6">
+        Plugins extend this deployment with Tool sets and Sandbox backends. They
+        are installed and enabled at deploy time by the operator (via the{" "}
+        <code>PLATYPUS_PLUGINS</code> environment variable), not from the app —
+        this view is read-only.
+      </p>
+      <PluginsList orgId={orgId} />
+    </div>
+  );
+};
+
+export default OrgPluginsPage;

--- a/apps/frontend/components/org-settings-menu.tsx
+++ b/apps/frontend/components/org-settings-menu.tsx
@@ -9,6 +9,7 @@ import {
   SidebarMenu,
 } from "@/components/ui/sidebar";
 import {
+  Blocks,
   Bot,
   Layers,
   Mail,
@@ -35,6 +36,7 @@ export function OrgSettingsMenu({ orgId }: OrgSettingsMenuProps) {
   const skillsHref = `/${orgId}/settings/skills`;
   const agentsHref = `/${orgId}/settings/agents`;
   const blueprintsHref = `/${orgId}/settings/blueprints`;
+  const pluginsHref = `/${orgId}/settings/plugins`;
 
   return (
     <SidebarContent>
@@ -115,6 +117,16 @@ export function OrgSettingsMenu({ orgId }: OrgSettingsMenuProps) {
               >
                 <Link href={blueprintsHref}>
                   <Layers /> Blueprints
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                asChild
+                isActive={pathname.startsWith(pluginsHref)}
+              >
+                <Link href={pluginsHref}>
+                  <Blocks /> Plugins
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>

--- a/apps/frontend/components/plugins-list.tsx
+++ b/apps/frontend/components/plugins-list.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import useSWR from "swr";
+import { Blocks, Container, Wrench } from "lucide-react";
+import { useAuth } from "@/components/auth-provider";
+import { useBackendUrl } from "@/app/client-context";
+import { cn, fetcher, joinUrl } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemMedia,
+  ItemTitle,
+} from "@/components/ui/item";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// Mirrors the read-only `GET /organizations/:orgId/plugins` payload (ADR-0013).
+// Contributions are the ids the plugin registered — tool sets and sandbox
+// backends tie back to their originating plugin here.
+interface InstalledPlugin {
+  name: string;
+  version: string;
+  origin: "core" | "third-party";
+  contributions: {
+    toolSets: string[];
+    sandboxBackends: string[];
+  };
+}
+
+const PluginsList = ({
+  className,
+  orgId,
+}: {
+  className?: string;
+  orgId: string;
+}) => {
+  const { user } = useAuth();
+  const backendUrl = useBackendUrl();
+
+  const fetchUrl =
+    backendUrl && user
+      ? joinUrl(backendUrl, `/organizations/${orgId}/plugins`)
+      : null;
+
+  const { data, error, isLoading } = useSWR<{ results: InstalledPlugin[] }>(
+    fetchUrl,
+    fetcher,
+  );
+
+  if (isLoading) {
+    return (
+      <ul className={cn(className)}>
+        {[0, 1, 2].map((i) => (
+          <li key={i} className="mb-2">
+            <Skeleton className="h-20 w-full rounded-md" />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (error) {
+    return (
+      <Empty className="border-2 border-dashed">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Blocks className="size-6" />
+          </EmptyMedia>
+          <EmptyTitle>Couldn&apos;t load plugins</EmptyTitle>
+          <EmptyDescription>
+            The installed-plugins catalog is temporarily unavailable. Try
+            refreshing the page.
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  const plugins = data?.results ?? [];
+
+  if (!plugins.length) {
+    return (
+      <Empty className="border-2 border-dashed">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <Blocks className="size-6" />
+          </EmptyMedia>
+          <EmptyTitle>No plugins installed</EmptyTitle>
+          <EmptyDescription>
+            Plugins are enabled at deploy time via the{" "}
+            <code>PLATYPUS_PLUGINS</code> environment variable. Ask your
+            operator to add one — there is no in-app install.
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  return (
+    <ul className={cn(className)}>
+      {plugins.map((plugin) => {
+        const toolSets = plugin.contributions.toolSets ?? [];
+        const sandboxBackends = plugin.contributions.sandboxBackends ?? [];
+
+        return (
+          <li key={plugin.name} className="mb-2">
+            <Item variant="outline" className="items-start">
+              <ItemMedia variant="icon">
+                <Blocks className="size-5" />
+              </ItemMedia>
+              <ItemContent>
+                <ItemTitle>
+                  <span className="font-mono">{plugin.name}</span>
+                  <Badge variant="secondary">v{plugin.version}</Badge>
+                  <Badge
+                    variant={plugin.origin === "core" ? "default" : "outline"}
+                  >
+                    {plugin.origin === "core" ? "Core" : "Third-party"}
+                  </Badge>
+                </ItemTitle>
+                {toolSets.length === 0 && sandboxBackends.length === 0 ? (
+                  <ItemDescription>No contributions.</ItemDescription>
+                ) : (
+                  <div className="flex flex-col gap-2 mt-1">
+                    {toolSets.length > 0 && (
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground mr-1">
+                          <Wrench className="size-3" /> Tool sets
+                        </span>
+                        {toolSets.map((id) => (
+                          <Badge
+                            key={id}
+                            variant="outline"
+                            className="font-mono font-normal"
+                          >
+                            {id}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+                    {sandboxBackends.length > 0 && (
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground mr-1">
+                          <Container className="size-3" /> Sandbox backends
+                        </span>
+                        {sandboxBackends.map((id) => (
+                          <Badge
+                            key={id}
+                            variant="outline"
+                            className="font-mono font-normal"
+                          >
+                            {id}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </ItemContent>
+            </Item>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export { PluginsList };


### PR DESCRIPTION
Closes #295.

## What

A read-only Org-Admin **Installed Plugins** view that consumes the `GET /organizations/:orgId/plugins` catalog landed in #294/#303 (ADR-0013). The trust boundary is the deployment — there is no install/enable/disable control anywhere in this view.

## Changes

**Frontend**
- `components/plugins-list.tsx` — SWR-backed list. Each plugin shows its **name**, **version**, **origin** (Core / Third-party), and **contributions** (Tool sets + Sandbox backends as labelled chips), tying each contribution back to its originating plugin. Loading skeletons, error state, and an empty state that explains plugins are enabled at deploy time.
- `app/[orgId]/settings/plugins/page.tsx` — new Org-Admin page. Sits under the existing `settings/layout.tsx`, which already gates to `requiredOrgRole="admin"`, matching the endpoint's admin gate.
- `components/org-settings-menu.tsx` — **Plugins** nav entry.

**Docs (same PR)**
- `self-hosting/configuration.mdx` — new "Inspecting installed plugins" subsection: what it shows, that it's read-only, that enablement is the deploy-time `PLATYPUS_PLUGINS` list.
- `extending/index.mdx` — migration status updated: `GET /plugins` + catalog annotations now marked live; links to the new view.

## Acceptance criteria

- [x] An Org Admin can view installed plugins, versions, and their contributions.
- [x] The view is strictly read-only (no enable/disable/install controls).
- [x] It reflects the current `GET /plugins` response.
- [x] The Installed Plugins view is documented as read-only/deploy-time; the docs build passes.

## Verification

- `pnpm --filter @platypus/frontend lint` — clean
- `tsc --noEmit` (frontend) — clean
- `pnpm --filter docs build` — passes (27 pages indexed)

Not exercised in a running browser (no dev stack running in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)