### PR TITLE
feat(backend): SSH sandbox backend — shell.exec end-to-end (BYO host)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -48,6 +48,7 @@
     "pino": "^10.3.1",
     "robots-parser": "^3.0.1",
     "sharp": "^0.35.3",
+    "ssh2": "^1.16.0",
     "turndown": "^7.2.4",
     "zod": "^4.4.3"
   },
@@ -58,6 +59,7 @@
     "@types/jsdom": "^28.0.3",
     "@types/node": "^24.13.2",
     "@types/pg": "^8.20.0",
+    "@types/ssh2": "^1.15.5",
     "@types/turndown": "^5.0.6",
     "@vitest/coverage-v8": "^4.1.9",
     "drizzle-kit": "^0.31.10",

--- a/apps/backend/src/plugins/builtin.ts
+++ b/apps/backend/src/plugins/builtin.ts
@@ -16,6 +16,7 @@ export const BUILTIN_PLUGINS: Record<
   "@platypus/web-fetch": () => import("./web-fetch/index.ts"),
   "@platypus/tools-platform": () => import("./tools-platform/index.ts"),
   "@platypus/docker": () => import("./docker/index.ts"),
+  "@platypus/ssh": () => import("./ssh/index.ts"),
 };
 
 // The always-on core set (ADR-0013 amendment): these core plugins load

--- a/apps/backend/src/plugins/ssh/backend.test.ts
+++ b/apps/backend/src/plugins/ssh/backend.test.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock ssh2. `new Client()` returns a fake EventEmitter-based client. connect()
+// emits "ready" (or "error"); exec() invokes its callback with a fake channel
+// that emits data/exit/close. Happy-path emissions are synchronous (so awaits
+// resolve without needing timer advancement); a `closeDelayMs` uses a real
+// timer to exercise the timeout path. State is pulled from `mockState`.
+// ---------------------------------------------------------------------------
+
+type ExecConfig = {
+  stdout?: string | Buffer;
+  stderr?: string | Buffer;
+  exitCode?: number;
+  /** Delay (ms) before the channel emits + closes — used for the timeout test. */
+  closeDelayMs?: number;
+};
+
+type MockState = {
+  connectConfigs: Record<string, unknown>[];
+  execCommands: string[];
+  execQueue: ExecConfig[];
+  // stdout returned for the connect-time root-resolution exec.
+  resolvedRoot: string;
+  // When set, connect() emits this error instead of "ready".
+  connectShouldFail: Error | null;
+  // When true, the connect-time root-resolution exec exits non-zero.
+  rootCreateFails: boolean;
+  // Count of client.end() calls (disconnects).
+  ended: number;
+};
+
+// The factory closure reads `mockState` lazily (at call time), by which point
+// beforeEach has assigned it — so a plain `let` is fine.
+let mockState: MockState;
+
+// The Client class is defined INSIDE the factory: a top-level `class` would be
+// in the TDZ when the hoisted factory runs, and a top-level `import` binding is
+// likewise uninitialised at that point (vi.mock hoists above imports). So
+// EventEmitter is required inside the factory, cast to its real type to keep the
+// fakes fully typed.
+vi.mock("ssh2", () => {
+  const { EventEmitter } =
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require("node:events") as typeof import("node:events");
+
+  const toBuf = (v: string | Buffer): Buffer =>
+    typeof v === "string" ? Buffer.from(v, "utf8") : v;
+
+  class FakeChannel extends EventEmitter {
+    stderr = new EventEmitter();
+    closed = false;
+
+    // Adapter calls this on timeout to close the channel.
+    close(): void {
+      if (this.closed) return;
+      this.closed = true;
+      this.emit("close");
+    }
+
+    destroy(): this {
+      this.close();
+      return this;
+    }
+  }
+
+  class FakeClient extends EventEmitter {
+    connect(config: Record<string, unknown>): this {
+      mockState.connectConfigs.push(config);
+      // Listeners are registered by the adapter before connect() is called, so
+      // a synchronous emit is safe and keeps awaits resolving via microtasks.
+      if (mockState.connectShouldFail) {
+        this.emit("error", mockState.connectShouldFail);
+      } else {
+        this.emit("ready");
+      }
+      return this;
+    }
+
+    exec(
+      command: string,
+      cb: (err: Error | undefined, channel: FakeChannel) => void,
+    ): this {
+      mockState.execCommands.push(command);
+      const isResolve = command.includes('printf %s "$ROOT"');
+      const cfg: ExecConfig = isResolve
+        ? {
+            stdout: mockState.resolvedRoot,
+            stderr: mockState.rootCreateFails ? "permission denied" : undefined,
+            exitCode: mockState.rootCreateFails ? 1 : 0,
+          }
+        : (mockState.execQueue.shift() ?? { exitCode: 0 });
+
+      const channel = new FakeChannel();
+      cb(undefined, channel);
+
+      const emit = () => {
+        if (channel.closed) return;
+        if (cfg.stdout) channel.emit("data", toBuf(cfg.stdout));
+        if (cfg.stderr) channel.stderr.emit("data", toBuf(cfg.stderr));
+        channel.emit("exit", cfg.exitCode ?? 0);
+        channel.closed = true;
+        channel.emit("close");
+      };
+
+      if (cfg.closeDelayMs && cfg.closeDelayMs > 0) {
+        setTimeout(emit, cfg.closeDelayMs);
+      } else {
+        emit();
+      }
+      return this;
+    }
+
+    end(): this {
+      mockState.ended += 1;
+      this.emit("close");
+      return this;
+    }
+  }
+
+  return { Client: FakeClient };
+});
+
+vi.mock("../../logger.ts", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Import AFTER vi.mock so the adapter binds to the mocked ssh2 + logger.
+import {
+  SshSandboxBackend,
+  sshSandboxConfigSchema,
+  sshSandboxCredentialsSchema,
+} from "./backend.ts";
+import { logger } from "../../logger.ts";
+import { MAX_SHELL_OUTPUT_BYTES } from "../../sandbox/index.ts";
+import type { SandboxContext } from "../../sandbox/types.ts";
+
+const ctx: SandboxContext = {
+  orgId: "org-1",
+  workspaceId: "ws-abc",
+  userId: "user-1",
+};
+
+const CONFIG = {
+  host: "ssh.example.com",
+  port: 22,
+  user: "platypus",
+};
+const CREDENTIALS = { privateKey: "PRIVATE_KEY_PEM" };
+
+function resetMockState() {
+  mockState = {
+    connectConfigs: [],
+    execCommands: [],
+    execQueue: [],
+    resolvedRoot: "/home/platypus/platypus-workspace",
+    connectShouldFail: null,
+    rootCreateFails: false,
+    ended: 0,
+  };
+}
+
+function queueExec(cfg: ExecConfig = {}) {
+  mockState.execQueue.push(cfg);
+}
+
+beforeEach(() => {
+  resetMockState();
+  vi.clearAllMocks();
+});
+
+describe("sshSandboxConfigSchema / credentialsSchema", () => {
+  it("defaults port to 22 and accepts optional rootDir/hostKey", () => {
+    const parsed = sshSandboxConfigSchema.parse({
+      host: "h",
+      user: "u",
+    });
+    expect(parsed.port).toBe(22);
+    expect(parsed.rootDir).toBeUndefined();
+    expect(parsed.hostKey).toBeUndefined();
+  });
+
+  it("rejects unknown config fields (strict) and missing host/user", () => {
+    expect(sshSandboxConfigSchema.safeParse({ user: "u" }).success).toBe(false);
+    expect(sshSandboxConfigSchema.safeParse({ host: "h" }).success).toBe(false);
+    expect(
+      sshSandboxConfigSchema.safeParse({ host: "h", user: "u", extra: 1 })
+        .success,
+    ).toBe(false);
+  });
+
+  it("requires a privateKey and allows an optional passphrase", () => {
+    expect(sshSandboxCredentialsSchema.safeParse({}).success).toBe(false);
+    expect(
+      sshSandboxCredentialsSchema.safeParse({ privateKey: "k" }).success,
+    ).toBe(true);
+    expect(
+      sshSandboxCredentialsSchema.safeParse({
+        privateKey: "k",
+        passphrase: "p",
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe("SshSandboxBackend — connect", () => {
+  it("connects with public-key auth and creates the default workspace root", async () => {
+    queueExec({ stdout: "hi", exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.shellExec(ctx, { command: "echo hi" });
+
+    expect(mockState.connectConfigs).toHaveLength(1);
+    const cc = mockState.connectConfigs[0];
+    expect(cc.host).toBe("ssh.example.com");
+    expect(cc.port).toBe(22);
+    expect(cc.username).toBe("platypus");
+    expect(cc.privateKey).toBe("PRIVATE_KEY_PEM");
+
+    // First exec resolves $HOME and mkdir -p's the default root.
+    expect(mockState.execCommands[0]).toContain(
+      'ROOT="$HOME/platypus-workspace"',
+    );
+    expect(mockState.execCommands[0]).toContain('mkdir -p "$ROOT"');
+    expect(mockState.execCommands[0]).toContain('printf %s "$ROOT"');
+  });
+
+  it("passes the passphrase through when provided", async () => {
+    queueExec({ exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, {
+      privateKey: "K",
+      passphrase: "secret",
+    });
+    await backend.shellExec(ctx, { command: "true" });
+    expect(mockState.connectConfigs[0].passphrase).toBe("secret");
+  });
+
+  it("warns loudly about MITM when no hostKey is pinned", async () => {
+    queueExec({ exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.shellExec(ctx, { command: "true" });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ host: "ssh.example.com" }),
+      expect.stringContaining("WITHOUT host-key verification"),
+    );
+  });
+
+  it("uses a custom rootDir when configured", async () => {
+    queueExec({ exitCode: 0 });
+    const backend = new SshSandboxBackend(
+      { ...CONFIG, rootDir: "/srv/agent" },
+      CREDENTIALS,
+    );
+    await backend.shellExec(ctx, { command: "true" });
+    expect(mockState.execCommands[0]).toContain("ROOT='/srv/agent'");
+  });
+
+  it("rejects when the SSH connection errors", async () => {
+    mockState.connectShouldFail = new Error("auth failed");
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
+      /auth failed/,
+    );
+  });
+
+  it("throws when the workspace root cannot be created", async () => {
+    mockState.rootCreateFails = true;
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
+      /failed to create workspace root/,
+    );
+  });
+});
+
+describe("SshSandboxBackend — shellExec", () => {
+  it("prefixes cd <rootDir> and returns stdout/stderr/exitCode/durationMs", async () => {
+    queueExec({ stdout: "out", stderr: "err", exitCode: 3 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const res = await backend.shellExec(ctx, { command: "run" });
+
+    const cmd = mockState.execCommands[1];
+    expect(cmd).toBe("cd '/home/platypus/platypus-workspace' && run");
+    expect(res.stdout).toBe("out");
+    expect(res.stderr).toBe("err");
+    expect(res.exitCode).toBe(3);
+    expect(res.truncated).toBe(false);
+    expect(typeof res.durationMs).toBe("number");
+  });
+
+  it("resolves cwd relative to the rootDir", async () => {
+    queueExec({ exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.shellExec(ctx, { command: "ls", cwd: "sub/dir" });
+    expect(mockState.execCommands[1]).toBe(
+      "cd '/home/platypus/platypus-workspace/sub/dir' && ls",
+    );
+  });
+
+  it("applies env via export statements (not the ssh2 env option)", async () => {
+    queueExec({ exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.shellExec(ctx, {
+      command: "printenv",
+      env: { FOO: "bar", TOKEN: "a b'c" },
+    });
+    const cmd = mockState.execCommands[1];
+    expect(cmd).toContain("export FOO='bar'; ");
+    // Single quotes in the value are escaped with the '\'' idiom.
+    expect(cmd).toContain("export TOKEN='a b'\\''c'; ");
+    // env is applied inside the command string, never via a connect/env option.
+    expect(mockState.connectConfigs[0].env).toBeUndefined();
+  });
+
+  it("drops env keys that are not valid POSIX identifiers", async () => {
+    queueExec({ exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.shellExec(ctx, {
+      command: "run",
+      // A malformed key (model-supplied env is not schema-key-validated) must
+      // never be interpolated raw into the shell string.
+      env: { GOOD: "1", "bad;rm -rf": "x" },
+    });
+    const cmd = mockState.execCommands[1];
+    expect(cmd).toContain("export GOOD='1'; ");
+    expect(cmd).not.toContain("rm -rf");
+  });
+
+  it("caps stdout at MAX_SHELL_OUTPUT_BYTES and flags truncated", async () => {
+    const huge = "a".repeat(MAX_SHELL_OUTPUT_BYTES + 5_000);
+    queueExec({ stdout: huge, exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const res = await backend.shellExec(ctx, { command: "yes" });
+    expect(res.stdout.length).toBe(MAX_SHELL_OUTPUT_BYTES);
+    expect(res.truncated).toBe(true);
+  });
+
+  it("returns exit code 124 when a command exceeds its timeout", async () => {
+    // Channel closes after 200ms; timeout is 20ms, so the adapter closes first.
+    queueExec({ closeDelayMs: 200, exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const res = await backend.shellExec(ctx, {
+      command: "sleep 5",
+      timeoutMs: 20,
+    });
+    expect(res.exitCode).toBe(124);
+  });
+});
+
+describe("SshSandboxBackend — connection lifecycle", () => {
+  it("reuses a single connection across tool calls within a turn", async () => {
+    queueExec({ exitCode: 0 });
+    queueExec({ exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.shellExec(ctx, { command: "a" });
+    await backend.shellExec(ctx, { command: "b" });
+
+    // One connect, one root-resolution exec, then two command execs.
+    expect(mockState.connectConfigs).toHaveLength(1);
+    expect(mockState.execCommands).toHaveLength(3);
+  });
+
+  it("concurrent first-callers share one connect (inflight promise)", async () => {
+    queueExec({ exitCode: 0 });
+    queueExec({ exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await Promise.all([
+      backend.shellExec(ctx, { command: "a" }),
+      backend.shellExec(ctx, { command: "b" }),
+    ]);
+    expect(mockState.connectConfigs).toHaveLength(1);
+  });
+
+  it("closes the connection via the idle reaper after inactivity", async () => {
+    vi.useFakeTimers();
+    try {
+      queueExec({ exitCode: 0 });
+      const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+      await backend.shellExec(ctx, { command: "true" });
+      expect(mockState.ended).toBe(0);
+
+      // Advance past the idle timeout — the reaper disconnects.
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(mockState.ended).toBe(1);
+
+      // A subsequent call reconnects.
+      queueExec({ exitCode: 0 });
+      await backend.shellExec(ctx, { command: "again" });
+      expect(mockState.connectConfigs).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("SshSandboxBackend — destroy() is a no-op", () => {
+  it("disconnects without running any remote mutation command", async () => {
+    queueExec({ exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.shellExec(ctx, { command: "true" });
+    const execCountBefore = mockState.execCommands.length;
+
+    await backend.destroy(ctx);
+
+    // No extra exec issued (no rm / cleanup) — just a disconnect.
+    expect(mockState.execCommands.length).toBe(execCountBefore);
+    expect(mockState.ended).toBe(1);
+  });
+
+  it("is safe to call when never connected", async () => {
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await expect(backend.destroy(ctx)).resolves.toBeUndefined();
+    expect(mockState.connectConfigs).toHaveLength(0);
+    expect(mockState.ended).toBe(0);
+  });
+});
+
+describe("SshSandboxBackend — fs.* deferred to follow-up slices", () => {
+  const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+
+  it("fsRead throws not-implemented", async () => {
+    await expect(backend.fsRead(ctx, { path: "a" })).rejects.toThrow(
+      /not yet supported/,
+    );
+  });
+  it("fsWrite throws not-implemented", async () => {
+    await expect(
+      backend.fsWrite(ctx, { path: "a", content: "x", mode: "overwrite" }),
+    ).rejects.toThrow(/not yet supported/);
+  });
+  it("fsEdit throws not-implemented", async () => {
+    await expect(
+      backend.fsEdit(ctx, { path: "a", oldString: "x", newString: "y" }),
+    ).rejects.toThrow(/not yet supported/);
+  });
+  it("fsList throws not-implemented", async () => {
+    await expect(backend.fsList(ctx, {})).rejects.toThrow(/not yet supported/);
+  });
+});

--- a/apps/backend/src/plugins/ssh/backend.ts
+++ b/apps/backend/src/plugins/ssh/backend.ts
@@ -1,0 +1,414 @@
+import { Client, type ClientChannel, type ConnectConfig } from "ssh2";
+import { z } from "zod";
+import { logger } from "../../logger.ts";
+import {
+  DEFAULT_SHELL_TIMEOUT_MS,
+  MAX_SHELL_OUTPUT_BYTES,
+  MAX_SHELL_TIMEOUT_MS,
+} from "../../sandbox/index.ts";
+import type {
+  FsEditInput,
+  FsEditOutput,
+  FsListInput,
+  FsListOutput,
+  FsReadInput,
+  FsReadOutput,
+  FsWriteInput,
+  FsWriteOutput,
+  SandboxBackend,
+  SandboxContext,
+  ShellExecInput,
+  ShellExecOutput,
+} from "../../sandbox/types.ts";
+
+// The SSH reference Sandbox adapter (ADR-0012). Attaches to a pre-existing,
+// operator-owned host over SSH (public-key auth only) and runs the fixed tool
+// core against it — this slice carries only `shell.exec`; the `fs.*` tools land
+// in follow-up slices. The adapter never provisions or destroys the machine.
+
+const DEFAULT_SSH_PORT = 22;
+// rootDir default (ADR-0012): resolved to `$HOME/platypus-workspace` on the host
+// at connect time. SFTP does not expand `~`, so $HOME is resolved once per
+// connection and the physical root is absolute.
+const DEFAULT_ROOT_DIR_NAME = "platypus-workspace";
+
+// Self-managed connection lifecycle (ADR-0012): a single connection is reused
+// across all tool calls within a Chat turn and closed by this idle reaper after
+// inactivity. The timer is `unref()`'d so it never keeps the process alive.
+const IDLE_TIMEOUT_MS = 60_000;
+
+// Per-Workspace Sandbox config/credentials (ADR-0001/0006). These remain
+// per-Workspace settings — ADR-0013's deploy-time *plugin* config does not apply
+// here. Every field except a hypothetical display name is admin-only (ADR-0006);
+// the route enforces that gating, so no per-field logic is needed here.
+export const sshSandboxConfigSchema = z
+  .object({
+    host: z.string().min(1),
+    port: z.number().int().min(1).max(65535).default(DEFAULT_SSH_PORT),
+    user: z.string().min(1),
+    // Optional; defaults to `$HOME/platypus-workspace`, resolved on connect. A
+    // relative value is resolved against the login `$HOME`; an absolute value is
+    // used verbatim.
+    rootDir: z.string().min(1).optional(),
+    // Accepted now for forward-compatibility; strict host-key verification is a
+    // follow-up slice (ADR-0012). This slice connects with a loud MITM warning
+    // when it is absent — the shipped fallback.
+    hostKey: z.string().min(1).optional(),
+  })
+  .strict();
+
+// Public-key auth only (ADR-0012). `privateKey` is a PEM/OpenSSH private key;
+// `passphrase` decrypts it when it is encrypted. Both are server-side secrets,
+// never returned to non-admins or the model.
+export const sshSandboxCredentialsSchema = z
+  .object({
+    privateKey: z.string().min(1),
+    passphrase: z.string().optional(),
+  })
+  .strict();
+
+export type SshSandboxConfig = z.infer<typeof sshSandboxConfigSchema>;
+export type SshSandboxCredentials = z.infer<typeof sshSandboxCredentialsSchema>;
+
+// A live, ready connection plus the absolute workspace root resolved on it.
+type Connection = {
+  client: Client;
+  rootDir: string;
+};
+
+type ExecResult = {
+  stdout: Buffer;
+  stderr: Buffer;
+  exitCode: number;
+  durationMs: number;
+  timedOut: boolean;
+};
+
+// Single-quote a value for safe interpolation into a `/bin/sh` command line.
+// Wraps in single quotes and escapes embedded single quotes with the classic
+// `'\''` idiom. Used for the operator-supplied rootDir and for model-supplied
+// cwd/env values so neither can break out into shell syntax.
+function shQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+// A valid POSIX environment-variable name. `adminEnv`/`userEnv` are already held
+// to this by the schema, but the model-supplied `input.env` keys are not — so we
+// guard here before interpolating a key into the shell string. A key that isn't
+// a valid identifier can't be a usable env var anyway (`export 1FOO=…` errors),
+// so dropping it is both safe and correct.
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+// Build the `export KEY=val;` prefix for the merged env (ADR-0004). Applied via
+// export statements rather than the ssh2 `env` option, since sshd's `AcceptEnv`
+// rejects arbitrary variables by default (ADR-0012). Keys are guarded to POSIX
+// identifiers (above) so they can't inject shell syntax; values are single-quoted.
+function buildEnvPrefix(env: Record<string, string> | undefined): string {
+  if (!env) return "";
+  return Object.entries(env)
+    .filter(([k]) => ENV_KEY_PATTERN.test(k))
+    .map(([k, v]) => `export ${k}=${shQuote(v)}; `)
+    .join("");
+}
+
+// A method not carried by this slice. `fs.*` land in follow-up slices (ADR-0012);
+// until then they fail loudly rather than silently misbehaving. The Sandbox tool
+// set still exposes all five tools (there is no per-backend tool filtering), so a
+// model that calls one gets this error as its tool result.
+function notImplemented(tool: string): Promise<never> {
+  return Promise.reject(
+    new Error(
+      `${tool} is not yet supported by the SSH sandbox backend (follow-up slice); only shell.exec is available.`,
+    ),
+  );
+}
+
+export class SshSandboxBackend implements SandboxBackend {
+  private config: SshSandboxConfig;
+  private credentials: SshSandboxCredentials;
+  // Single reused connection and its in-flight promise (mirrors the Docker
+  // adapter's ensureContainer): concurrent first-callers share one connect.
+  private connection: Connection | null;
+  private inflight: Promise<Connection> | null;
+  private idleTimer: NodeJS.Timeout | null;
+
+  constructor(config: SshSandboxConfig, credentials: SshSandboxCredentials) {
+    this.config = config;
+    this.credentials = credentials;
+    this.connection = null;
+    this.inflight = null;
+    this.idleTimer = null;
+  }
+
+  // Lazy-connect on first use; reuse the single connection across all tool calls
+  // in the turn. Concurrent callers before the connection is ready share the one
+  // in-flight promise. Every call refreshes the idle reaper.
+  private ensureConnection(): Promise<Connection> {
+    if (this.connection) {
+      this.touchIdleTimer();
+      return Promise.resolve(this.connection);
+    }
+    if (this.inflight) return this.inflight;
+
+    const p = this.connect()
+      .then((conn) => {
+        this.connection = conn;
+        this.inflight = null;
+        this.touchIdleTimer();
+        return conn;
+      })
+      .catch((err) => {
+        this.inflight = null;
+        throw err;
+      });
+    this.inflight = p;
+    return p;
+  }
+
+  // Open the SSH connection (public-key auth), then resolve $HOME and `mkdir -p`
+  // the workspace root in a single exec, returning the absolute root.
+  private async connect(): Promise<Connection> {
+    const { host, port, user, hostKey } = this.config;
+    const { privateKey, passphrase } = this.credentials;
+
+    if (!hostKey) {
+      // Shipped fallback for this slice (ADR-0012): connect without host-key
+      // verification and warn loudly. Public-key auth still prevents credential
+      // theft by an impostor host; the residual risk is session/output exposure
+      // to a MITM. Pin `hostKey` on internet-facing hosts.
+      logger.warn(
+        { host, port },
+        "SSH sandbox connecting WITHOUT host-key verification — session and injected env are exposed to a MITM. Set `hostKey` to pin the host.",
+      );
+    } else {
+      // hostKey is accepted but strict verification is not wired yet — a
+      // follow-up slice. Be explicit so an operator who pinned a key is not
+      // misled into thinking it is enforced.
+      logger.warn(
+        { host, port },
+        "SSH sandbox `hostKey` is set but strict verification is not yet enforced (follow-up slice); connecting without pinning.",
+      );
+    }
+
+    const client = new Client();
+    const connectConfig: ConnectConfig = {
+      host,
+      port: port ?? DEFAULT_SSH_PORT,
+      username: user,
+      privateKey,
+      ...(passphrase ? { passphrase } : {}),
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: Error) => {
+        client.removeListener("ready", onReady);
+        reject(err);
+      };
+      const onReady = () => {
+        client.removeListener("error", onError);
+        resolve();
+      };
+      client.once("ready", onReady);
+      client.once("error", onError);
+      client.connect(connectConfig);
+    });
+
+    // Resolve $HOME and create the root in one round-trip. A relative rootDir is
+    // resolved against $HOME; an absolute one is used verbatim. The command
+    // prints the resolved absolute path on stdout.
+    const rootExpr = this.config.rootDir
+      ? shQuote(this.config.rootDir)
+      : `"$HOME/${DEFAULT_ROOT_DIR_NAME}"`;
+    const resolveCmd =
+      `ROOT=${rootExpr}; ` +
+      `case "$ROOT" in /*) ;; *) ROOT="$HOME/$ROOT" ;; esac; ` +
+      `mkdir -p "$ROOT" && printf %s "$ROOT"`;
+
+    const res = await this.runExec(
+      client,
+      resolveCmd,
+      DEFAULT_SHELL_TIMEOUT_MS,
+    );
+    if (res.exitCode !== 0) {
+      const detail = res.stderr.toString("utf8").trim() || "unknown error";
+      try {
+        client.end();
+      } catch {
+        // ignore
+      }
+      throw new Error(
+        `SSH sandbox: failed to create workspace root on ${host}: ${detail}`,
+      );
+    }
+    const rootDir = res.stdout.toString("utf8").trim();
+
+    return { client, rootDir };
+  }
+
+  // (Re)arm the idle reaper. Closes the connection after IDLE_TIMEOUT_MS of
+  // inactivity. `unref()` so a pending timer never keeps the process alive.
+  private touchIdleTimer(): void {
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    this.idleTimer = setTimeout(() => {
+      this.closeConnection();
+    }, IDLE_TIMEOUT_MS);
+    this.idleTimer.unref?.();
+  }
+
+  // Close the connection (if any) and cancel the idle reaper. Idempotent.
+  private closeConnection(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+    const conn = this.connection;
+    this.connection = null;
+    if (conn) {
+      try {
+        conn.client.end();
+      } catch {
+        // best-effort — the connection may already be gone
+      }
+    }
+  }
+
+  // Run a single command over `exec`, capping stdout/stderr at
+  // MAX_SHELL_OUTPUT_BYTES and enforcing a timeout. On timeout the channel is
+  // closed and exit code 124 is reported (a remote command may keep running as
+  // an orphan — the host is not ours to reap; ADR-0012).
+  private runExec(
+    client: Client,
+    command: string,
+    timeoutMs: number,
+  ): Promise<ExecResult> {
+    return new Promise<ExecResult>((resolve, reject) => {
+      const started = Date.now();
+      client.exec(command, (err: Error | undefined, stream: ClientChannel) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        const stdoutChunks: Buffer[] = [];
+        const stderrChunks: Buffer[] = [];
+        let stdoutBytes = 0;
+        let stderrBytes = 0;
+        let exitCode = 0;
+        let timedOut = false;
+        let settled = false;
+
+        const timer = setTimeout(() => {
+          timedOut = true;
+          try {
+            stream.close();
+          } catch {
+            // ignore — resolve on the close event regardless
+          }
+        }, timeoutMs);
+        timer.unref?.();
+
+        const capture = (
+          chunk: Buffer,
+          chunks: Buffer[],
+          bytes: number,
+        ): number => {
+          if (bytes >= MAX_SHELL_OUTPUT_BYTES) return bytes;
+          const room = MAX_SHELL_OUTPUT_BYTES - bytes;
+          const take = chunk.length <= room ? chunk : chunk.subarray(0, room);
+          chunks.push(take);
+          return bytes + take.length;
+        };
+
+        stream.on("data", (chunk: Buffer) => {
+          stdoutBytes = capture(chunk, stdoutChunks, stdoutBytes);
+        });
+        stream.stderr.on("data", (chunk: Buffer) => {
+          stderrBytes = capture(chunk, stderrChunks, stderrBytes);
+        });
+        // The exit code arrives on `exit`; `close` fires afterwards and is when
+        // we settle. A signal-killed process reports a null code.
+        stream.on("exit", (code: number | null) => {
+          if (typeof code === "number") exitCode = code;
+        });
+        stream.on("close", () => {
+          clearTimeout(timer);
+          if (settled) return;
+          settled = true;
+          resolve({
+            stdout: Buffer.concat(stdoutChunks),
+            stderr: Buffer.concat(stderrChunks),
+            exitCode: timedOut ? 124 : exitCode,
+            durationMs: Date.now() - started,
+            timedOut,
+          });
+        });
+        stream.on("error", (streamErr: Error) => {
+          clearTimeout(timer);
+          if (settled) return;
+          settled = true;
+          reject(streamErr);
+        });
+      });
+    });
+  }
+
+  async shellExec(
+    _ctx: SandboxContext,
+    input: ShellExecInput,
+  ): Promise<ShellExecOutput> {
+    const conn = await this.ensureConnection();
+    const timeoutMs = Math.min(
+      input.timeoutMs ?? DEFAULT_SHELL_TIMEOUT_MS,
+      MAX_SHELL_TIMEOUT_MS,
+    );
+
+    // Honour cwd by prefixing `cd <rootDir>/<cwd> && …` (no native WorkingDir
+    // over SSH). cwd is model input (schema-validated relative); rootDir is
+    // resolved-absolute. Both are single-quoted so neither escapes into shell
+    // syntax. The merged env (ADR-0004) is applied via `export` statements.
+    const cwd = input.cwd ? `${conn.rootDir}/${input.cwd}` : conn.rootDir;
+    const envPrefix = buildEnvPrefix(input.env);
+    const command = `cd ${shQuote(cwd)} && ${envPrefix}${input.command}`;
+
+    const res = await this.runExec(conn.client, command, timeoutMs);
+    this.touchIdleTimer();
+
+    const truncated =
+      res.stdout.length >= MAX_SHELL_OUTPUT_BYTES ||
+      res.stderr.length >= MAX_SHELL_OUTPUT_BYTES;
+
+    return {
+      stdout: res.stdout.toString("utf8"),
+      stderr: res.stderr.toString("utf8"),
+      exitCode: res.exitCode,
+      truncated,
+      durationMs: res.durationMs,
+    };
+  }
+
+  // fs.* are deferred to follow-up slices (ADR-0012). They will use SFTP for
+  // read/write/edit and `find -printf` for list.
+  fsRead(_ctx: SandboxContext, _input: FsReadInput): Promise<FsReadOutput> {
+    return notImplemented("fs.read");
+  }
+
+  fsWrite(_ctx: SandboxContext, _input: FsWriteInput): Promise<FsWriteOutput> {
+    return notImplemented("fs.write");
+  }
+
+  fsEdit(_ctx: SandboxContext, _input: FsEditInput): Promise<FsEditOutput> {
+    return notImplemented("fs.edit");
+  }
+
+  fsList(_ctx: SandboxContext, _input: FsListInput): Promise<FsListOutput> {
+    return notImplemented("fs.list");
+  }
+
+  // destroy() is a no-op beyond disconnecting (ADR-0012): the host is not
+  // Platypus-owned, so we never mutate its filesystem. Just tear down our
+  // connection so no socket or idle timer leaks.
+  destroy(_ctx: SandboxContext): Promise<void> {
+    this.closeConnection();
+    return Promise.resolve();
+  }
+}

--- a/apps/backend/src/plugins/ssh/index.test.ts
+++ b/apps/backend/src/plugins/ssh/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import { plugin } from "./index.ts";
+import { loadPlugins } from "../loader.ts";
+import { getSandboxBackend } from "../../sandbox/index.ts";
+
+describe("@platypus/ssh plugin manifest", () => {
+  it("declares its identity and API version", () => {
+    expect(plugin.name).toBe("@platypus/ssh");
+    expect(plugin.version).toBe("0.1.0");
+    expect(plugin.apiVersion).toBe(PLUGIN_API_VERSION);
+  });
+
+  it("contributes the ssh sandbox backend with the unprefixed core id", () => {
+    const backends = plugin.contributes.sandboxBackends ?? [];
+    expect(backends).toHaveLength(1);
+
+    const [ssh] = backends;
+    expect(ssh.backend).toBe("ssh");
+    expect(ssh.name).toBe("SSH (Remote Host)");
+    expect(typeof ssh.create).toBe("function");
+    expect(ssh.configSchema).toBeDefined();
+    expect(ssh.credentialsSchema).toBeDefined();
+  });
+
+  it("registers the ssh backend into the core registry when loaded", async () => {
+    // The registry is module-global; vitest isolates modules per file, so this
+    // load doesn't leak into other test files. Exercise the real plugin path:
+    // loader → registerSandboxBackend → getSandboxBackend.
+    expect(getSandboxBackend("ssh")).toBeUndefined();
+
+    const loaded = await loadPlugins({ pluginNames: ["@platypus/ssh"] });
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toMatchObject({
+      name: "@platypus/ssh",
+      origin: "core",
+      sandboxBackendIds: ["ssh"],
+    });
+
+    const registration = getSandboxBackend("ssh");
+    expect(registration?.backend).toBe("ssh");
+    expect(registration?.name).toBe("SSH (Remote Host)");
+    expect(typeof registration?.create).toBe("function");
+  });
+});

--- a/apps/backend/src/plugins/ssh/index.ts
+++ b/apps/backend/src/plugins/ssh/index.ts
@@ -1,0 +1,41 @@
+import type {
+  PlatypusPlugin,
+  SandboxBackendContribution,
+} from "@platypuschat/plugin-sdk";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import {
+  SshSandboxBackend,
+  sshSandboxConfigSchema,
+  sshSandboxCredentialsSchema,
+  type SshSandboxConfig,
+  type SshSandboxCredentials,
+} from "./backend.ts";
+
+// Core plugin: the SSH reference Sandbox backend (ADR-0012). Attaches to a
+// pre-existing, operator-owned host — the recommended backend for
+// horizontally-scaled deployments where the Docker adapter cannot run (ADR-0003).
+// Stands alone as a gate-able plugin: an Operator would plausibly want to deny
+// remote-host access in isolation (ADR-0013). Enable it by listing
+// "@platypus/ssh" in PLATYPUS_PLUGINS; omitting it leaves the backend
+// unregistered (the same degradation as any absent backend — no
+// PLATYPUS_SANDBOX_SSH_ENABLED gate). The discriminator stays the unprefixed
+// core id "ssh".
+const sshBackend: SandboxBackendContribution<
+  SshSandboxConfig,
+  SshSandboxCredentials
+> = {
+  backend: "ssh",
+  name: "SSH (Remote Host)",
+  configSchema: sshSandboxConfigSchema,
+  credentialsSchema: sshSandboxCredentialsSchema,
+  create: (config, credentials) => new SshSandboxBackend(config, credentials),
+};
+
+export const plugin: PlatypusPlugin = {
+  name: "@platypus/ssh",
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  contributes: {
+    sandboxBackends: [sshBackend],
+  },
+};

--- a/apps/backend/src/routes/sandbox.test.ts
+++ b/apps/backend/src/routes/sandbox.test.ts
@@ -19,6 +19,19 @@ registerSandboxBackend({
   },
 });
 
+// A backend whose credentials schema requires a field, so the route's
+// credentials validation (ADR-0012 / ADR-0013) has something to reject against.
+const CREDS_BACKEND = "test-creds";
+registerSandboxBackend({
+  backend: CREDS_BACKEND,
+  name: "Test Creds",
+  configSchema: z.object({}).strict(),
+  credentialsSchema: z.object({ privateKey: z.string().min(1) }).strict(),
+  create: () => {
+    throw new Error("not used in this test");
+  },
+});
+
 describe("Sandbox Routes", () => {
   beforeEach(() => {
     resetMockDb();
@@ -113,6 +126,30 @@ describe("Sandbox Routes", () => {
       expect(body).not.toHaveProperty("credentials");
       expect(body.id).toBe("sbx-1");
       expect(body.backend).toBe("docker");
+    });
+
+    it("returns 400 when credentials fail the backend's schema", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          workspaceId,
+          name: "Creds backend",
+          backend: CREDS_BACKEND,
+          config: {},
+          credentials: {}, // missing required privateKey
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toMatch(/Invalid sandbox credentials/);
     });
 
     it("returns 409 when a sandbox already exists for the workspace", async () => {

--- a/apps/backend/src/routes/sandbox.ts
+++ b/apps/backend/src/routes/sandbox.ts
@@ -42,6 +42,23 @@ const validateSandboxConfig = (
   return result.error.issues.map((i) => i.message).join("; ");
 };
 
+// Validate adapter-specific credentials at write time, same rationale as
+// {@link validateSandboxConfig}: catch e.g. an SSH sandbox saved without a
+// private key as an immediate 400 rather than a silent "no sandbox tools" at
+// chat-turn time. Returns an error message, or null when valid / backend not
+// registered. Callers pass `undefined` to skip (a PUT that preserves stored
+// credentials, which GET never returns).
+const validateSandboxCredentials = (
+  backend: string,
+  credentials: Record<string, unknown> | undefined,
+): string | null => {
+  const registration = getSandboxBackend(backend);
+  if (!registration) return null;
+  const result = registration.credentialsSchema.safeParse(credentials ?? {});
+  if (result.success) return null;
+  return result.error.issues.map((i) => i.message).join("; ");
+};
+
 // The owner may never override an admin-set env key (ADR-0004 amendment).
 // Returns the colliding keys, or [] when there is no overlap.
 const envCollisions = (
@@ -139,6 +156,17 @@ sandbox.post(
     const configError = validateSandboxConfig(data.backend, data.config);
     if (configError) {
       return c.json({ error: `Invalid sandbox config: ${configError}` }, 400);
+    }
+
+    const credentialsError = validateSandboxCredentials(
+      data.backend,
+      data.credentials,
+    );
+    if (credentialsError) {
+      return c.json(
+        { error: `Invalid sandbox credentials: ${credentialsError}` },
+        400,
+      );
     }
 
     const collisions = envCollisions(data.adminEnv, data.userEnv);
@@ -246,6 +274,21 @@ sandbox.put(
     const configError = validateSandboxConfig(data.backend, data.config);
     if (configError) {
       return c.json({ error: `Invalid sandbox config: ${configError}` }, 400);
+    }
+    // Validate credentials only when present — GET strips them, so an edit that
+    // leaves the field untouched preserves the stored value (Drizzle skips
+    // undefined columns) and must not be rejected for being absent.
+    if (data.credentials !== undefined) {
+      const credentialsError = validateSandboxCredentials(
+        data.backend,
+        data.credentials,
+      );
+      if (credentialsError) {
+        return c.json(
+          { error: `Invalid sandbox credentials: ${credentialsError}` },
+          400,
+        );
+      }
     }
     const collisions = envCollisions(
       data.adminEnv ?? current.adminEnv,

--- a/apps/frontend/components/sandbox-settings.tsx
+++ b/apps/frontend/components/sandbox-settings.tsx
@@ -46,6 +46,12 @@ type SandboxBackend = { backend: string; name: string };
 // fields. See ADR-0005. Other backends ignore them.
 const DOCKER_BACKEND = "docker";
 
+// The SSH reference backend (ADR-0012) attaches to a pre-existing host. Its
+// config (host/port/user/rootDir) and credentials (privateKey/passphrase) are
+// all admin-only, inherited from the existing requireSandboxAdmin gating.
+const SSH_BACKEND = "ssh";
+const DEFAULT_SSH_PORT = "22";
+
 // Rows are kept as an ordered array (not a Record) so a user can edit keys, add
 // empties, and tolerate duplicate-during-edit without the UI reshuffling on
 // every keystroke. Converted on save.
@@ -60,6 +66,15 @@ type SandboxFormData = {
   // Docker host reachability (ADR-0005), admin-only.
   networks: string[];
   extraHosts: Row[]; // key = hostname, value = ip / host-gateway
+  // SSH connection (ADR-0012), admin-only. Port is kept as a string for the
+  // input and parsed on save. privateKey/passphrase are credentials (never
+  // returned by GET, so blank on edit means "keep the stored value").
+  sshHost: string;
+  sshPort: string;
+  sshUser: string;
+  sshRootDir: string;
+  sshPrivateKey: string;
+  sshPassphrase: string;
 };
 
 const DEFAULT_FORM: SandboxFormData = {
@@ -69,6 +84,12 @@ const DEFAULT_FORM: SandboxFormData = {
   userEnv: [],
   networks: [],
   extraHosts: [],
+  sshHost: "",
+  sshPort: DEFAULT_SSH_PORT,
+  sshUser: "",
+  sshRootDir: "",
+  sshPrivateKey: "",
+  sshPassphrase: "",
 };
 
 const recordToRows = (rec: Record<string, string> | undefined): Row[] =>
@@ -261,14 +282,25 @@ const SandboxSettings = ({
       const config = (data.config ?? {}) as {
         networks?: string[];
         extraHosts?: string[];
+        host?: string;
+        port?: number;
+        user?: string;
+        rootDir?: string;
       };
       setFormData({
+        ...DEFAULT_FORM,
         name: data.name,
         backend: data.backend,
         adminEnv: recordToRows(data.adminEnv),
         userEnv: recordToRows(data.userEnv),
         networks: config.networks ?? [],
         extraHosts: extraHostsToRows(config.extraHosts),
+        // SSH config (credentials are stripped by GET, so left blank — an edit
+        // that doesn't re-enter the key preserves the stored one server-side).
+        sshHost: config.host ?? "",
+        sshPort: config.port ? String(config.port) : DEFAULT_SSH_PORT,
+        sshUser: config.user ?? "",
+        sshRootDir: config.rootDir ?? "",
       });
     }
   });
@@ -294,6 +326,7 @@ const SandboxSettings = ({
   };
 
   const isDocker = formData.backend === DOCKER_BACKEND;
+  const isSsh = formData.backend === SSH_BACKEND;
 
   const performSave = async (
     options: { force?: boolean } = {},
@@ -304,6 +337,45 @@ const SandboxSettings = ({
     const url =
       isCreate || !options.force ? sandboxUrl : `${sandboxUrl}?force=true`;
 
+    // Backend-specific config. Docker carries host reachability (ADR-0005); SSH
+    // carries the connection target (ADR-0012). Other backends take no config.
+    const config = isDocker
+      ? {
+          networks: formData.networks,
+          extraHosts: rowsToExtraHosts(formData.extraHosts),
+        }
+      : isSsh
+        ? {
+            host: formData.sshHost.trim(),
+            port: Number(formData.sshPort) || Number(DEFAULT_SSH_PORT),
+            user: formData.sshUser.trim(),
+            // rootDir is optional — omit when blank so the backend applies its
+            // `$HOME/platypus-workspace` default.
+            ...(formData.sshRootDir.trim()
+              ? { rootDir: formData.sshRootDir.trim() }
+              : {}),
+          }
+        : {};
+
+    // The `credentials` slice of the payload (spread below). For SSH (ADR-0012)
+    // we only send credentials when a private key was entered: on edit the key
+    // comes back blank (GET strips it), so omitting `credentials` preserves the
+    // stored value server-side rather than clearing it. Other backends send an
+    // empty credentials object, as before.
+    const credentialsPayload =
+      isSsh && formData.sshPrivateKey.trim()
+        ? {
+            credentials: {
+              privateKey: formData.sshPrivateKey,
+              ...(formData.sshPassphrase
+                ? { passphrase: formData.sshPassphrase }
+                : {}),
+            },
+          }
+        : isSsh
+          ? {} // omit credentials — preserve stored
+          : { credentials: {} };
+
     // Non-admin owners may only change name + userEnv (ADR-0006); everything
     // else is admin-controlled and ignored server-side, so we don't send it.
     const payload = isOrgAdmin
@@ -311,13 +383,8 @@ const SandboxSettings = ({
           ...(isCreate ? { workspaceId } : {}),
           name: formData.name,
           backend: formData.backend,
-          config: isDocker
-            ? {
-                networks: formData.networks,
-                extraHosts: rowsToExtraHosts(formData.extraHosts),
-              }
-            : {},
-          credentials: {},
+          config,
+          ...credentialsPayload,
           adminEnv: rowsToRecord(formData.adminEnv),
           userEnv: rowsToRecord(formData.userEnv),
         }
@@ -658,6 +725,147 @@ const SandboxSettings = ({
                 {validationErrors.config && (
                   <FieldError>{validationErrors.config}</FieldError>
                 )}
+              </Field>
+            </>
+          )}
+
+          {/* SSH connection (ADR-0012) — admin-only, ssh backend only. */}
+          {isOrgAdmin && isSsh && (
+            <>
+              <Field data-invalid={!!validationErrors.config}>
+                <FieldLabel htmlFor="ssh-host">Host</FieldLabel>
+                <Input
+                  id="ssh-host"
+                  placeholder="ssh.example.com"
+                  value={formData.sshHost}
+                  onChange={(e) => {
+                    clearError("config");
+                    setFormData((prev) => ({
+                      ...prev,
+                      sshHost: e.target.value,
+                    }));
+                  }}
+                  disabled={isSubmitting}
+                  className="font-mono"
+                />
+                <FieldDescription>
+                  Hostname or IP of the operator-owned host to attach to.
+                </FieldDescription>
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="ssh-port">Port</FieldLabel>
+                <Input
+                  id="ssh-port"
+                  type="number"
+                  placeholder={DEFAULT_SSH_PORT}
+                  value={formData.sshPort}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      sshPort: e.target.value,
+                    }))
+                  }
+                  disabled={isSubmitting}
+                  className="font-mono"
+                />
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="ssh-user">User</FieldLabel>
+                <Input
+                  id="ssh-user"
+                  placeholder="platypus"
+                  value={formData.sshUser}
+                  onChange={(e) => {
+                    clearError("config");
+                    setFormData((prev) => ({
+                      ...prev,
+                      sshUser: e.target.value,
+                    }));
+                  }}
+                  disabled={isSubmitting}
+                  className="font-mono"
+                />
+                <FieldDescription>
+                  SSH login user. Public-key auth only.
+                </FieldDescription>
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="ssh-root-dir">
+                  Workspace root (optional)
+                </FieldLabel>
+                <Input
+                  id="ssh-root-dir"
+                  placeholder="$HOME/platypus-workspace"
+                  value={formData.sshRootDir}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      sshRootDir: e.target.value,
+                    }))
+                  }
+                  disabled={isSubmitting}
+                  className="font-mono"
+                />
+                <FieldDescription>
+                  Absolute or $HOME-relative directory the sandbox works in.
+                  Defaults to{" "}
+                  <span className="font-mono">$HOME/platypus-workspace</span>,
+                  created on first connect.
+                </FieldDescription>
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="ssh-private-key">Private key</FieldLabel>
+                <textarea
+                  id="ssh-private-key"
+                  placeholder={
+                    hasSandbox
+                      ? "Leave blank to keep the stored key"
+                      : "-----BEGIN OPENSSH PRIVATE KEY-----"
+                  }
+                  value={formData.sshPrivateKey}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      sshPrivateKey: e.target.value,
+                    }))
+                  }
+                  disabled={isSubmitting}
+                  rows={5}
+                  autoComplete="off"
+                  spellCheck={false}
+                  className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                />
+                <FieldDescription>
+                  PEM or OpenSSH private key. Kept server-side, never sent to
+                  the model.
+                  {hasSandbox &&
+                    " Leave blank to keep the currently stored key."}
+                </FieldDescription>
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="ssh-passphrase">
+                  Key passphrase (optional)
+                </FieldLabel>
+                <Input
+                  id="ssh-passphrase"
+                  type="password"
+                  placeholder="Passphrase for the private key"
+                  value={formData.sshPassphrase}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      sshPassphrase: e.target.value,
+                    }))
+                  }
+                  disabled={isSubmitting}
+                  autoComplete="off"
+                  className="font-mono"
+                />
               </Field>
             </>
           )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@24.13.2)
+      ssh2:
+        specifier: ^1.16.0
+        version: 1.17.0
       turndown:
         specifier: ^7.2.4
         version: 7.2.4
@@ -133,6 +136,9 @@ importers:
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
+      '@types/ssh2':
+        specifier: ^1.15.5
+        version: 1.15.5
       '@types/turndown':
         specifier: ^5.0.6
         version: 5.0.6


### PR DESCRIPTION
Implements the first vertical slice of the SSH reference Sandbox backend ([ADR-0012](docs/adr/0012-ssh-reference-sandbox-byo-host-adapter.md)): a `backend: "ssh"` adapter that attaches to a pre-existing, operator-owned host over SSH (**public-key auth only**) and runs `shell.exec` end-to-end. Registered plugin-native ([ADR-0013](docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md)) as the core plugin **`@platypus/ssh`** via `contributes.sandboxBackends` — no `PLATYPUS_SANDBOX_SSH_ENABLED` gate; enabled by listing `@platypus/ssh` in `PLATYPUS_PLUGINS`.

Closes #283.

## What's included

- **`SshSandboxBackend`** (`apps/backend/src/plugins/ssh/backend.ts`) using `ssh2`:
  - Self-managed connection lifecycle — lazy-connect on first tool call, a single connection reused across the turn via an inflight promise, closed by an `unref()`'d idle reaper.
  - `shell.exec` honours `cwd` (`cd <rootDir>/<cwd> && …`), applies the merged env (ADR-0004) via `export KEY=val;` statements (POSIX-key guard so model-supplied env keys can't inject shell), enforces the ADR-0002 output caps + `truncated` flag, and reports exit code **124** on timeout (channel closed).
  - `rootDir` defaults to `$HOME/platypus-workspace`, resolved + `mkdir -p` on connect.
  - `destroy()` is a **no-op** (disconnect only) — never mutates the host.
  - `fs.*` deferred to a follow-up slice (throw a clear error).
  - Connects with a **loud MITM warning** when `hostKey` is absent (strict verification is a follow-up slice; `hostKey` is accepted in the schema now).
- **`@platypus/ssh`** manifest (`index.ts`) contributing the backend under the unprefixed core id `ssh`; registered in `builtin.ts` (gate-able, not always-on).
- **Route** (`routes/sandbox.ts`): credentials are now validated against the contribution schema on create/edit (config already was).
- **Frontend** (`sandbox-settings.tsx`): "SSH (Remote Host)" backend option with an admin-only config form (host, port, user, rootDir, private key, passphrase). Private key is preserved on edit when left blank.
- **Dependency:** `ssh2` + `@types/ssh2`.

## Acceptance criteria

- [x] `backend: "ssh"` registered via the `@platypus/ssh` plugin's `contributes.sandboxBackends`, available only when listed in `PLATYPUS_PLUGINS` (no `PLATYPUS_SANDBOX_SSH_ENABLED`).
- [x] Org Admin can create/edit an SSH sandbox via the UI; config/credentials validate against the contribution schemas; non-admin owner cannot edit SSH config fields.
- [x] `shell.exec` returns `stdout`/`stderr`/`exitCode`/`durationMs`/`truncated`.
- [x] `cwd` resolves relative to `rootDir`; workspace env (adminEnv ▸ userEnv ▸ input.env) applied without transiting the model.
- [x] Output over the cap sets `truncated: true`; timeout returns exit code 124.
- [x] `rootDir` defaults to `$HOME/platypus-workspace`, created on first connect; `destroy()` performs no remote mutation.
- [x] Single SSH connection reused across tool calls within a turn, closed by the idle reaper (test-verified).
- [x] Backend unit tests cover connect, shell.exec, cwd/env/timeout/caps, and no-op destroy.

## Testing

- Backend `tsc --noEmit`, frontend `tsc --noEmit`, ESLint, Prettier — all clean.
- Full backend suite passes (**1069 tests**), including 27 new SSH/route tests.
- SSH backend tests use a mocked `ssh2` (no live host required); a containerised-sshd integration test is left for a follow-up.

> [!NOTE]
> `hostKey` strict verification and the `fs.*` tools are intentionally out of scope for this tracer-bullet slice (per ADR-0012) and land in follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)