### PR TITLE
feat(backend): SSH sandbox fs.list via exec find (#285)

### DIFF
--- a/apps/backend/src/plugins/ssh/backend.test.ts
+++ b/apps/backend/src/plugins/ssh/backend.test.ts
@@ -271,7 +271,11 @@ import {
   sshSandboxCredentialsSchema,
 } from "./backend.ts";
 import { logger } from "../../logger.ts";
-import { MAX_READ_BYTES, MAX_SHELL_OUTPUT_BYTES } from "../../sandbox/index.ts";
+import {
+  MAX_LIST_ENTRIES,
+  MAX_READ_BYTES,
+  MAX_SHELL_OUTPUT_BYTES,
+} from "../../sandbox/index.ts";
 import type { SandboxContext } from "../../sandbox/types.ts";
 
 const ctx: SandboxContext = {
@@ -784,9 +788,180 @@ describe("SshSandboxBackend — SFTP session lifecycle", () => {
   });
 });
 
-describe("SshSandboxBackend — fs.list still deferred", () => {
-  it("fsList throws not-implemented", async () => {
+// Build a `find -printf '%y\t%s\t%P\n'` line for the mocked exec output.
+function findLine(type: "f" | "d" | "l", size: number, path: string): string {
+  return `${type}\t${size}\t${path}`;
+}
+
+// The find command is the second exec (execCommands[0] is the connect-time root
+// resolution). Grab it for command-shape assertions.
+const lastFindCommand = () =>
+  mockState.execCommands[mockState.execCommands.length - 1];
+
+describe("SshSandboxBackend — fs.list (exec find)", () => {
+  it("lists a flat directory non-recursively with type and size", async () => {
+    queueExec({
+      stdout:
+        [
+          findLine("f", 12, "a.txt"),
+          findLine("d", 4096, "sub"),
+          findLine("f", 0, "empty.txt"),
+        ].join("\n") + "\n",
+      exitCode: 0,
+    });
     const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    await expect(backend.fsList(ctx, {})).rejects.toThrow(/not yet supported/);
+    const res = await backend.fsList(ctx, {});
+
+    expect(res.truncated).toBe(false);
+    expect(res.entries).toEqual([
+      { path: "a.txt", type: "file", size: 12 },
+      { path: "sub", type: "dir", size: 4096 },
+      { path: "empty.txt", type: "file", size: 0 },
+    ]);
+
+    // Non-recursive → -maxdepth 1; roots at the resolved workspace root.
+    const cmd = lastFindCommand();
+    expect(cmd).toBe(
+      `find '${ROOT}' -maxdepth 1 -mindepth 1 -printf '%y\\t%s\\t%P\\n'`,
+    );
+  });
+
+  it("lists recursively (no -maxdepth) under a subpath", async () => {
+    queueExec({
+      stdout:
+        [findLine("f", 3, "x"), findLine("f", 3, "d/y")].join("\n") + "\n",
+      exitCode: 0,
+    });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const res = await backend.fsList(ctx, { path: "src", recursive: true });
+
+    expect(res.entries.map((e) => e.path)).toEqual(["x", "d/y"]);
+    const cmd = lastFindCommand();
+    expect(cmd).toBe(
+      `find '${ROOT}/src' -mindepth 1 -printf '%y\\t%s\\t%P\\n'`,
+    );
+    expect(cmd).not.toContain("-maxdepth");
+  });
+
+  it("ignores symlinks / sockets / devices (only file and dir)", async () => {
+    queueExec({
+      stdout:
+        [
+          findLine("f", 1, "real.txt"),
+          findLine("l", 7, "link"),
+          "s\t0\tsock",
+        ].join("\n") + "\n",
+      exitCode: 0,
+    });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const res = await backend.fsList(ctx, {});
+    expect(res.entries).toEqual([{ path: "real.txt", type: "file", size: 1 }]);
+  });
+
+  it("translates a bare glob to -name (single-quoted, no shell expansion)", async () => {
+    queueExec({ stdout: findLine("f", 5, "a.ts") + "\n", exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.fsList(ctx, { glob: "*.ts" });
+    const cmd = lastFindCommand();
+    expect(cmd).toContain("-name '*.ts'");
+    expect(cmd).not.toContain("-path");
+  });
+
+  it("translates a slashed glob to -path", async () => {
+    queueExec({ stdout: findLine("f", 5, "src/a.ts") + "\n", exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.fsList(ctx, { glob: "src/*.ts", recursive: true });
+    expect(lastFindCommand()).toContain("-path '*/src/*.ts'");
+  });
+
+  it("collapses ** to * for -path (documented lossy translation)", async () => {
+    queueExec({ stdout: "", exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.fsList(ctx, { glob: "**/*.ts", recursive: true });
+    expect(lastFindCommand()).toContain("-path '*/*/*.ts'");
+  });
+
+  it("truncates to MAX_LIST_ENTRIES and flags truncated", async () => {
+    const lines: string[] = [];
+    for (let i = 0; i < MAX_LIST_ENTRIES + 1; i++) {
+      lines.push(findLine("f", 1, `f${i}.txt`));
+    }
+    queueExec({ stdout: lines.join("\n") + "\n", exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const res = await backend.fsList(ctx, { recursive: true });
+    expect(res.entries).toHaveLength(MAX_LIST_ENTRIES);
+    expect(res.truncated).toBe(true);
+  });
+
+  it("does not flag truncated at exactly MAX_LIST_ENTRIES entries", async () => {
+    const lines: string[] = [];
+    for (let i = 0; i < MAX_LIST_ENTRIES; i++) {
+      lines.push(findLine("f", 1, `f${i}.txt`));
+    }
+    queueExec({ stdout: lines.join("\n") + "\n", exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const res = await backend.fsList(ctx, { recursive: true });
+    expect(res.entries).toHaveLength(MAX_LIST_ENTRIES);
+    expect(res.truncated).toBe(false);
+  });
+
+  it("single-quotes the list path so shell metacharacters cannot break out", async () => {
+    queueExec({ stdout: "", exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    // A metachar-laden path (schema rejects absolute/`..`, but quote defensively).
+    await backend.fsList(ctx, { path: `foo; rm -rf ~` });
+    const cmd = lastFindCommand();
+    // The whole path is inside one single-quoted argument.
+    expect(cmd).toBe(
+      `find '${ROOT}/foo; rm -rf ~' -maxdepth 1 -mindepth 1 -printf '%y\\t%s\\t%P\\n'`,
+    );
+  });
+
+  it("escapes an embedded single quote in the path", async () => {
+    queueExec({ stdout: "", exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.fsList(ctx, { path: `it's` });
+    // classic '\'' escape idiom, matching shQuote.
+    expect(lastFindCommand()).toContain(`find '${ROOT}/it'\\''s'`);
+  });
+
+  it("returns an empty list for an empty directory", async () => {
+    queueExec({ stdout: "", exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const res = await backend.fsList(ctx, {});
+    expect(res.entries).toEqual([]);
+    expect(res.truncated).toBe(false);
+  });
+
+  it("emits partial results when find exits non-zero but printed rows", async () => {
+    queueExec({
+      stdout: findLine("f", 1, "readable.txt") + "\n",
+      stderr: "find: 'sub': Permission denied",
+      exitCode: 1,
+    });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const res = await backend.fsList(ctx, { recursive: true });
+    expect(res.entries).toEqual([
+      { path: "readable.txt", type: "file", size: 1 },
+    ]);
+  });
+
+  it("throws when find fails with no output", async () => {
+    queueExec({
+      stdout: "",
+      stderr: "find: '/nope': No such file or directory",
+      exitCode: 1,
+    });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await expect(backend.fsList(ctx, { path: "nope" })).rejects.toThrow(
+      /No such file or directory/,
+    );
+  });
+
+  it("omits size for a file with an unparseable size field", async () => {
+    queueExec({ stdout: "f\t?\tweird.txt\n", exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const res = await backend.fsList(ctx, {});
+    expect(res.entries).toEqual([{ path: "weird.txt", type: "file" }]);
   });
 });

--- a/apps/backend/src/plugins/ssh/backend.ts
+++ b/apps/backend/src/plugins/ssh/backend.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { logger } from "../../logger.ts";
 import {
   DEFAULT_SHELL_TIMEOUT_MS,
+  MAX_LIST_ENTRIES,
   MAX_READ_BYTES,
   MAX_SHELL_OUTPUT_BYTES,
   MAX_SHELL_TIMEOUT_MS,
@@ -16,6 +17,7 @@ import {
 import type {
   FsEditInput,
   FsEditOutput,
+  FsListEntry,
   FsListInput,
   FsListOutput,
   FsReadInput,
@@ -33,8 +35,11 @@ import type {
 // core against it. `shell.exec` runs over the `exec` channel; `fs.read`,
 // `fs.write`, and `fs.edit` run over the SFTP subsystem (the faithful analogue
 // of Docker's `putArchive` writes — literal paths, no shell-injection surface,
-// native `wx`=create / `w`=overwrite). `fs.list` lands in a follow-up slice.
-// The adapter never provisions or destroys the machine.
+// native `wx`=create / `w`=overwrite). `fs.list` runs over `exec` as a single
+// `find -printf` recursive listing (ADR-0012 rejected a client-side SFTP walk),
+// making it the sole shell-injection surface in `fs.*` — every model-supplied
+// value it interpolates is single-quoted. The adapter never provisions or
+// destroys the machine.
 
 const DEFAULT_SSH_PORT = 22;
 // rootDir default (ADR-0012): resolved to `$HOME/platypus-workspace` on the host
@@ -124,17 +129,11 @@ function buildEnvPrefix(env: Record<string, string> | undefined): string {
     .join("");
 }
 
-// A method not carried by this slice. `fs.list` lands in a follow-up slice
-// (ADR-0012: `find -printf`); until then it fails loudly rather than silently
-// misbehaving. The Sandbox tool set still exposes all five tools (there is no
-// per-backend tool filtering), so a model that calls it gets this as its result.
-function notImplemented(tool: string): Promise<never> {
-  return Promise.reject(
-    new Error(
-      `${tool} is not yet supported by the SSH sandbox backend (follow-up slice).`,
-    ),
-  );
-}
+// Cap for `fs.list` find(1) output. Larger than MAX_SHELL_OUTPUT_BYTES because a
+// recursive listing of up to MAX_LIST_ENTRIES rows can exceed the shell-output
+// cap; matches the Docker adapter's 4 MiB list buffer. Node-side truncation to
+// MAX_LIST_ENTRIES is the authoritative bound (this only guards memory).
+const FS_LIST_OUTPUT_CAP = 4 * 1024 * 1024;
 
 // Resolve a workspace-root-relative path to an absolute path on the host. The
 // schema already enforces the path is relative; SFTP takes the result literally,
@@ -396,14 +395,16 @@ export class SshSandboxBackend implements SandboxBackend {
     }
   }
 
-  // Run a single command over `exec`, capping stdout/stderr at
-  // MAX_SHELL_OUTPUT_BYTES and enforcing a timeout. On timeout the channel is
-  // closed and exit code 124 is reported (a remote command may keep running as
-  // an orphan — the host is not ours to reap; ADR-0012).
+  // Run a single command over `exec`, capping stdout/stderr at `outputCap`
+  // (default MAX_SHELL_OUTPUT_BYTES; fs.list raises it) and enforcing a timeout.
+  // On timeout the channel is closed and exit code 124 is reported (a remote
+  // command may keep running as an orphan — the host is not ours to reap;
+  // ADR-0012).
   private runExec(
     client: Client,
     command: string,
     timeoutMs: number,
+    outputCap: number = MAX_SHELL_OUTPUT_BYTES,
   ): Promise<ExecResult> {
     return new Promise<ExecResult>((resolve, reject) => {
       const started = Date.now();
@@ -436,8 +437,8 @@ export class SshSandboxBackend implements SandboxBackend {
           chunks: Buffer[],
           bytes: number,
         ): number => {
-          if (bytes >= MAX_SHELL_OUTPUT_BYTES) return bytes;
-          const room = MAX_SHELL_OUTPUT_BYTES - bytes;
+          if (bytes >= outputCap) return bytes;
+          const room = outputCap - bytes;
           const take = chunk.length <= room ? chunk : chunk.subarray(0, room);
           chunks.push(take);
           return bytes + take.length;
@@ -682,9 +683,87 @@ export class SshSandboxBackend implements SandboxBackend {
     return { replacements: 1 };
   }
 
-  // fs.list is deferred to a follow-up slice (ADR-0012: `find -printf`).
-  fsList(_ctx: SandboxContext, _input: FsListInput): Promise<FsListOutput> {
-    return notImplemented("fs.list");
+  // List directory entries via a single `find -printf` over `exec` (ADR-0012:
+  // one round-trip recursive listing, vs a per-directory SFTP walk). This is the
+  // only shell-injection surface in fs.*, so both model-supplied values that
+  // reach the command line — the list path and the glob — are single-quoted.
+  async fsList(
+    _ctx: SandboxContext,
+    input: FsListInput,
+  ): Promise<FsListOutput> {
+    const conn = await this.ensureConnection();
+    const target = input.path
+      ? absPath(conn.rootDir, input.path)
+      : conn.rootDir;
+
+    // Node-side truncation (below) is authoritative; `find` is not `| head`ed.
+    const parts = ["find", shQuote(target)];
+    if (!input.recursive) parts.push("-maxdepth", "1");
+    parts.push("-mindepth", "1");
+    if (input.glob) {
+      // -name matches a bare file-name glob; -path matches a pattern that
+      // contains a slash or `**`. `**` collapses to `*` for find(1) — a lossy
+      // but pragmatic translation (documented in the tool description), matching
+      // the Docker adapter. Single-quoting also stops the login shell from
+      // expanding the glob before find sees it, so find(1) does the matching.
+      if (input.glob.includes("/") || input.glob.includes("**")) {
+        parts.push("-path", shQuote(`*/${input.glob.replace(/\*\*/g, "*")}`));
+      } else {
+        parts.push("-name", shQuote(input.glob));
+      }
+    }
+    // Single-quoted so find receives the `\t`/`\n` escapes literally and
+    // interprets them itself (rather than the shell mangling them).
+    parts.push("-printf", `'%y\\t%s\\t%P\\n'`);
+    const command = parts.join(" ");
+
+    const res = await this.runExec(
+      conn.client,
+      command,
+      DEFAULT_SHELL_TIMEOUT_MS,
+      FS_LIST_OUTPUT_CAP,
+    );
+    this.touchIdleTimer();
+
+    // find exits non-zero on partial errors (e.g. an unreadable subdirectory)
+    // while still printing what it could — only fail hard when nothing came out.
+    if (res.exitCode !== 0 && res.stdout.length === 0) {
+      const detail = res.stderr.toString("utf8").trim() || "fs.list failed";
+      throw new Error(`fs.list: ${detail}`);
+    }
+
+    const lines = res.stdout
+      .toString("utf8")
+      .split("\n")
+      .filter((l) => l.length > 0);
+
+    const entries: FsListEntry[] = [];
+    let truncated = false;
+    for (const line of lines) {
+      const tab1 = line.indexOf("\t");
+      const tab2 = line.indexOf("\t", tab1 + 1);
+      if (tab1 === -1 || tab2 === -1) continue;
+      const typeChar = line.slice(0, tab1);
+      const sizeStr = line.slice(tab1 + 1, tab2);
+      const path = line.slice(tab2 + 1);
+      let type: "file" | "dir";
+      if (typeChar === "f") type = "file";
+      else if (typeChar === "d") type = "dir";
+      else continue; // ignore symlinks / sockets / devices in v1
+      const size = Number.parseInt(sizeStr, 10);
+      entries.push({
+        path,
+        type,
+        ...(Number.isFinite(size) ? { size } : {}),
+      });
+      if (entries.length >= MAX_LIST_ENTRIES) {
+        // Mark truncated only if find emitted more rows than we kept.
+        truncated = entries.length < lines.length;
+        break;
+      }
+    }
+
+    return { entries, truncated };
   }
 
   // destroy() is a no-op beyond disconnecting (ADR-0012): the host is not


### PR DESCRIPTION
Closes #285.

## What this does

Implements `fs.list` for the SSH sandbox backend as a single `find -printf '%y\t%s\t%P\n'` invocation over the `exec` channel — the analogue of the Docker adapter's one-shot recursive listing. Per [ADR-0012](docs/adr/0012-ssh-reference-sandbox-byo-host-adapter.md), a client-side SFTP walk (a round-trip per directory) was rejected in favour of one `find` round-trip. Replaces the previous `notImplemented("fs.list")` stub.

Ported near-verbatim from `DockerSandboxBackend.fsList`, adapted for the SSH `exec` primitive (a shell command string rather than argv):

- **Flat + recursive** — `-maxdepth 1` when non-recursive; always `-mindepth 1`. Roots at `<rootDir>` or `<rootDir>/<path>`.
- **Entries** — `path`, `type` (`file`/`dir` only; symlinks/sockets/devices ignored), and `size` for files (omitted when the size field is unparseable).
- **glob translation** — bare name → `-name`; contains `/` or `**` → `-path '*/<glob>'`, with the same documented lossy `**`→`*` collapse as the Docker adapter.
- **Truncation** — Node-side to `MAX_LIST_ENTRIES` (1000) with `truncated: true` when exceeded; the `find` output buffer cap (4 MiB) only guards memory.

### Shell-injection surface

`fs.list` is the **only** shell-injection surface in `fs.*` (`read`/`write`/`edit` run over SFTP with literal paths). Both model-supplied values that reach the command line — the **list path** and the **glob** — are single-quoted via the existing `shQuote`. Quoting the glob also prevents the login shell from expanding it before `find(1)` performs the match. The input schema already rejects absolute paths; the quoting is defensive on top of that.

`runExec` gains an optional `outputCap` param (defaults to `MAX_SHELL_OUTPUT_BYTES`, unchanged for existing callers); `fs.list` raises it to 4 MiB to match the Docker list buffer.

## Acceptance criteria

- [x] Non-recursive and recursive listing both work; entries carry `path`, `type`, and `size` for files.
- [x] `glob` filtering works for both name-only and path patterns; the `**`→`*` limitation matches the Docker adapter.
- [x] Results are truncated to `MAX_LIST_ENTRIES` with `truncated: true` when exceeded.
- [x] The list path is safely quoted; a path containing shell metacharacters cannot break out (verified: `find '<root>/foo; rm -rf ~' …` — whole path in one quoted arg; embedded-quote `'\''` escaping tested).
- [x] Integration tests cover flat, recursive, glob, and truncation cases.
- [ ] **Containerised-sshd integration test** — still a known gap across the whole SSH effort. Every slice ships mocked-only; this follows that precedent. The 13 new tests use the in-memory ssh2 mock, driving `find` output through the exec queue.

## Verification

- `pnpm --filter backend exec vitest run src/plugins/ssh/backend.test.ts` → **52 passing** (13 new for `fs.list`).
- `pnpm typecheck` — clean.
- `eslint` on both changed files — clean.
- `prettier --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)