### PR TITLE
feat(backend): SSH sandbox optional host-key pin verification (#286)

### DIFF
--- a/apps/backend/src/plugins/ssh/backend.test.ts
+++ b/apps/backend/src/plugins/ssh/backend.test.ts
@@ -39,6 +39,10 @@ type MockState = {
   sftpOpens: number;
   // When set, client.sftp() invokes its callback with this error.
   sftpShouldFail: Error | null;
+  // The raw host-key blob the fake server presents to a configured
+  // hostVerifier. When a verifier is present and rejects it, connect() emits an
+  // "error" instead of "ready" (mirroring ssh2's handshake failure).
+  presentedHostKey: Buffer | null;
 };
 
 // The factory closure reads `mockState` lazily (at call time), by which point
@@ -195,9 +199,21 @@ vi.mock("ssh2", () => {
       // a synchronous emit is safe and keeps awaits resolving via microtasks.
       if (mockState.connectShouldFail) {
         this.emit("error", mockState.connectShouldFail);
-      } else {
-        this.emit("ready");
+        return this;
       }
+      // Honour a configured hostVerifier (sync form: returns boolean). ssh2
+      // presents the raw key blob during the handshake; a false result aborts
+      // with a handshake error rather than reaching "ready".
+      const verifier = config.hostVerifier as
+        ((key: Buffer) => boolean) | undefined;
+      if (typeof verifier === "function") {
+        const presented = mockState.presentedHostKey ?? Buffer.alloc(0);
+        if (!verifier(presented)) {
+          this.emit("error", new Error("Handshake failed: host key rejected"));
+          return this;
+        }
+      }
+      this.emit("ready");
       return this;
     }
 
@@ -291,6 +307,15 @@ const CONFIG = {
 };
 const CREDENTIALS = { privateKey: "PRIVATE_KEY_PEM" };
 
+// Fake ed25519-shaped host-key blobs (base64). Real SSH key blobs base64-encode
+// a length-prefixed algorithm name, so they begin with "AAAA" — the adapter's
+// pin parser keys off that. The adapter compares the decoded bytes of the pin
+// against the raw blob the (mock) server presents.
+const HOST_KEY_B64 =
+  "AAAAC3NzaC1lZDI1NTE5AAAAIExampleHostKeyBlobBytesForTestingAbc123";
+const WRONG_HOST_KEY_B64 =
+  "AAAAC3NzaC1lZDI1NTE5AAAAIWrongWrongWrongWrongWrongWrongWrong99999";
+
 function resetMockState() {
   mockState = {
     connectConfigs: [],
@@ -306,6 +331,7 @@ function resetMockState() {
     nextHandle: 1,
     sftpOpens: 0,
     sftpShouldFail: null,
+    presentedHostKey: null,
   };
 }
 
@@ -417,6 +443,65 @@ describe("SshSandboxBackend — connect", () => {
     await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
       /failed to create workspace root/,
     );
+  });
+});
+
+describe("SshSandboxBackend — host-key verification", () => {
+  it("connects when the pinned hostKey matches the presented host key", async () => {
+    queueExec({ exitCode: 0 });
+    mockState.presentedHostKey = Buffer.from(HOST_KEY_B64, "base64");
+    const backend = new SshSandboxBackend(
+      // A full `ssh-keyscan`-style line: the parser picks the base64 blob token.
+      { ...CONFIG, hostKey: `ssh-ed25519 ${HOST_KEY_B64}` },
+      CREDENTIALS,
+    );
+    await backend.shellExec(ctx, { command: "true" });
+
+    expect(mockState.connectConfigs).toHaveLength(1);
+    expect(typeof mockState.connectConfigs[0].hostVerifier).toBe("function");
+    // The root-resolution exec ran → the connection is live.
+    expect(mockState.execCommands.length).toBeGreaterThan(0);
+    // No MITM warning is emitted when a pin is enforced.
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("rejects the connection with a clear error when the pin mismatches", async () => {
+    // A bare base64 blob (single token) is also accepted as a pin.
+    mockState.presentedHostKey = Buffer.from(HOST_KEY_B64, "base64");
+    const backend = new SshSandboxBackend(
+      { ...CONFIG, hostKey: WRONG_HOST_KEY_B64 },
+      CREDENTIALS,
+    );
+    await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
+      /host-key verification failed/,
+    );
+    // No tools run — connect aborts before the root-resolution exec.
+    expect(mockState.execCommands).toHaveLength(0);
+  });
+
+  it("connects without a hostVerifier and warns exactly once when no hostKey is pinned", async () => {
+    queueExec({ exitCode: 0 });
+    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.shellExec(ctx, { command: "true" });
+
+    expect(mockState.connectConfigs[0].hostVerifier).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ host: "ssh.example.com" }),
+      expect.stringContaining("WITHOUT host-key verification"),
+    );
+  });
+
+  it("throws a clear error when the pinned hostKey cannot be parsed", async () => {
+    const backend = new SshSandboxBackend(
+      { ...CONFIG, hostKey: "# not a key" },
+      CREDENTIALS,
+    );
+    await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
+      /hostKey/,
+    );
+    // Never even attempted to connect.
+    expect(mockState.connectConfigs).toHaveLength(0);
   });
 });
 

--- a/apps/backend/src/plugins/ssh/backend.ts
+++ b/apps/backend/src/plugins/ssh/backend.ts
@@ -65,9 +65,11 @@ export const sshSandboxConfigSchema = z
     // relative value is resolved against the login `$HOME`; an absolute value is
     // used verbatim.
     rootDir: z.string().min(1).optional(),
-    // Accepted now for forward-compatibility; strict host-key verification is a
-    // follow-up slice (ADR-0012). This slice connects with a loud MITM warning
-    // when it is absent — the shipped fallback.
+    // Optional host-key pin (ADR-0012). When set, the presented host key is
+    // strictly verified against it and a mismatch aborts the connection; when
+    // absent, we connect with a loud MITM warning (the frictionless fallback).
+    // Accepts `ssh-keyscan`/known_hosts output (`[host] <type> <base64>`) or a
+    // bare base64 key blob — see parseHostKeyPin.
     hostKey: z.string().min(1).optional(),
   })
   .strict();
@@ -246,6 +248,40 @@ async function sftpReadCapped(
   return buf.subarray(0, total);
 }
 
+// Parse an operator-supplied host-key pin to the raw public-key blob bytes that
+// ssh2's `hostVerifier` presents (with no `hostHash` set, it receives the raw
+// key Buffer). Accepts three shapes: a full `ssh-keyscan` / known_hosts line
+// (`[host] <type> <base64> [comment]`), a `<type> <base64>` pair, or a bare
+// base64 blob. Every SSH public-key blob base64-encodes a length-prefixed
+// algorithm name, so the blob token always begins with `AAAA` — we pick that
+// token when the input has several, else treat the sole token as the blob.
+// Throws on input we cannot turn into a non-empty key so a misconfigured pin
+// surfaces at connect time rather than silently failing every handshake.
+function parseHostKeyPin(pin: string): Buffer {
+  const firstLine = pin
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.length > 0 && !line.startsWith("#"));
+  if (!firstLine) {
+    throw new Error("SSH sandbox: `hostKey` is empty or comment-only");
+  }
+  const tokens = firstLine.split(/\s+/);
+  const blob =
+    tokens.find((t) => t.startsWith("AAAA")) ??
+    (tokens.length === 1 ? tokens[0] : undefined);
+  if (!blob) {
+    throw new Error(
+      "SSH sandbox: could not find a base64 host key in `hostKey` " +
+        "(expected `ssh-keyscan` output or a base64 key blob)",
+    );
+  }
+  const decoded = Buffer.from(blob, "base64");
+  if (decoded.length === 0) {
+    throw new Error("SSH sandbox: `hostKey` did not decode to a valid key");
+  }
+  return decoded;
+}
+
 export class SshSandboxBackend implements SandboxBackend {
   private config: SshSandboxConfig;
   private credentials: SshSandboxCredentials;
@@ -294,22 +330,17 @@ export class SshSandboxBackend implements SandboxBackend {
     const { host, port, user, hostKey } = this.config;
     const { privateKey, passphrase } = this.credentials;
 
-    if (!hostKey) {
-      // Shipped fallback for this slice (ADR-0012): connect without host-key
-      // verification and warn loudly. Public-key auth still prevents credential
-      // theft by an impostor host; the residual risk is session/output exposure
-      // to a MITM. Pin `hostKey` on internet-facing hosts.
+    // Parse the pin up front so a malformed value fails loudly here rather than
+    // silently rejecting every handshake. Absent → connect with a loud MITM
+    // warning (the frictionless fallback for localhost/dev; ADR-0012).
+    const expectedHostKey = hostKey ? parseHostKeyPin(hostKey) : null;
+    if (!expectedHostKey) {
+      // Public-key auth still prevents credential theft by an impostor host; the
+      // residual risk is session/output exposure to a MITM. Pin `hostKey` on
+      // internet-facing hosts.
       logger.warn(
         { host, port },
         "SSH sandbox connecting WITHOUT host-key verification — session and injected env are exposed to a MITM. Set `hostKey` to pin the host.",
-      );
-    } else {
-      // hostKey is accepted but strict verification is not wired yet — a
-      // follow-up slice. Be explicit so an operator who pinned a key is not
-      // misled into thinking it is enforced.
-      logger.warn(
-        { host, port },
-        "SSH sandbox `hostKey` is set but strict verification is not yet enforced (follow-up slice); connecting without pinning.",
       );
     }
 
@@ -322,9 +353,32 @@ export class SshSandboxBackend implements SandboxBackend {
       ...(passphrase ? { passphrase } : {}),
     };
 
+    // Strict host-key pinning (ADR-0012). ssh2 calls this synchronous verifier
+    // with the presented raw key blob during the handshake; returning false
+    // aborts with a handshake `error`. `hostKeyMismatch` lets onError turn that
+    // opaque failure into a clear, actionable message.
+    let hostKeyMismatch = false;
+    if (expectedHostKey) {
+      const expected = expectedHostKey;
+      connectConfig.hostVerifier = (presented: Buffer): boolean => {
+        const match = presented.equals(expected);
+        if (!match) hostKeyMismatch = true;
+        return match;
+      };
+    }
+
     await new Promise<void>((resolve, reject) => {
       const onError = (err: Error) => {
         client.removeListener("ready", onReady);
+        if (hostKeyMismatch) {
+          reject(
+            new Error(
+              `SSH sandbox: host-key verification failed for ${host}:${port ?? DEFAULT_SSH_PORT} — the presented host key does not match the pinned \`hostKey\`. Refusing to connect.`,
+              { cause: err },
+            ),
+          );
+          return;
+        }
         reject(err);
       };
       const onReady = () => {

--- a/apps/frontend/components/sandbox-settings.tsx
+++ b/apps/frontend/components/sandbox-settings.tsx
@@ -73,6 +73,9 @@ type SandboxFormData = {
   sshPort: string;
   sshUser: string;
   sshRootDir: string;
+  // Optional host-key pin (ADR-0012). Part of config, not credentials — returned
+  // by GET like the rest of the SSH config.
+  sshHostKey: string;
   sshPrivateKey: string;
   sshPassphrase: string;
 };
@@ -88,6 +91,7 @@ const DEFAULT_FORM: SandboxFormData = {
   sshPort: DEFAULT_SSH_PORT,
   sshUser: "",
   sshRootDir: "",
+  sshHostKey: "",
   sshPrivateKey: "",
   sshPassphrase: "",
 };
@@ -286,6 +290,7 @@ const SandboxSettings = ({
         port?: number;
         user?: string;
         rootDir?: string;
+        hostKey?: string;
       };
       setFormData({
         ...DEFAULT_FORM,
@@ -301,6 +306,7 @@ const SandboxSettings = ({
         sshPort: config.port ? String(config.port) : DEFAULT_SSH_PORT,
         sshUser: config.user ?? "",
         sshRootDir: config.rootDir ?? "",
+        sshHostKey: config.hostKey ?? "",
       });
     }
   });
@@ -353,6 +359,11 @@ const SandboxSettings = ({
             // `$HOME/platypus-workspace` default.
             ...(formData.sshRootDir.trim()
               ? { rootDir: formData.sshRootDir.trim() }
+              : {}),
+            // hostKey is optional — omit when blank so the backend connects with
+            // the MITM warning rather than pinning.
+            ...(formData.sshHostKey.trim()
+              ? { hostKey: formData.sshHostKey.trim() }
               : {}),
           }
         : {};
@@ -814,6 +825,36 @@ const SandboxSettings = ({
                   Defaults to{" "}
                   <span className="font-mono">$HOME/platypus-workspace</span>,
                   created on first connect.
+                </FieldDescription>
+              </Field>
+
+              <Field>
+                <FieldLabel htmlFor="ssh-host-key">
+                  Host key (optional)
+                </FieldLabel>
+                <textarea
+                  id="ssh-host-key"
+                  placeholder="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5..."
+                  value={formData.sshHostKey}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      sshHostKey: e.target.value,
+                    }))
+                  }
+                  disabled={isSubmitting}
+                  rows={3}
+                  autoComplete="off"
+                  spellCheck={false}
+                  className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                />
+                <FieldDescription>
+                  Pin the host&apos;s public key to reject a man-in-the-middle.
+                  Obtain it with{" "}
+                  <span className="font-mono">
+                    ssh-keyscan -t ed25519 {formData.sshHost || "<host>"}
+                  </span>
+                  . Leave blank to connect unverified (a warning is logged).
                 </FieldDescription>
               </Field>
 


### PR DESCRIPTION
Closes #286.

Adds optional host-key verification to the SSH sandbox backend (ADR-0012). Public-key auth already blocks an impostor host from stealing credentials; the residual risk is leaking the session — including ADR-0004 injected env secrets and all command output — to a MITM. An optional pin closes that for internet-facing hosts while keeping localhost/dev frictionless.

## Backend (`apps/backend/src/plugins/ssh/backend.ts`)

- `parseHostKeyPin()` normalises the pin to the raw public-key blob bytes ssh2 presents. Accepts a full `ssh-keyscan`/known_hosts line (`[host] <type> <base64>`), a `<type> <base64>` pair, or a bare base64 blob (the blob token always begins `AAAA`). Throws at connect time on input it can't turn into a non-empty key, so a misconfigured pin fails loudly instead of silently rejecting every handshake.
- `connect()` wires a synchronous `hostVerifier` onto `ConnectConfig` when `hostKey` is set — `presented.equals(expected)`. A mismatch sets a flag so `onError` rejects with a clear, actionable message (`host-key verification failed … Refusing to connect`); the connection never reaches `ready`, so no tools run.
- Absent → the loud MITM `logger.warn`, once per connection. The interim "set but not enforced yet" warning is removed.
- Verified against the installed **ssh2@1.17.0**: with no `hostHash` set the verifier receives the raw key `Buffer`, and a `false` return aborts with a handshake `error` (caught by our existing `onError`).

## Frontend (`apps/frontend/components/sandbox-settings.tsx`)

- New **Host key (optional)** textarea inside the existing `isOrgAdmin && isSsh` block — admin-only, hidden for non-admin Owners by the same gating. Hint: `ssh-keyscan -t ed25519 <host>` (interpolates the entered host).
- Threaded through form state/defaults, loaded from `config.hostKey`, and saved into the SSH `config` (omitted when blank so the backend keeps the frictionless fallback).

## Acceptance criteria

- [x] Correct `hostKey` → connection succeeds; mismatched `hostKey` → connection fails with a clear error and no tools run.
- [x] Absent `hostKey` → connection succeeds, warning logged exactly once per connection.
- [x] `hostKey` field editable only by an Org Admin; hidden for a non-admin Owner.
- [x] Tests cover match, mismatch, and absent-with-warning paths (plus unparseable-pin).

## Tests

Taught the ssh2 mock's `FakeClient.connect()` to invoke a configured `hostVerifier` with a presented key and honour accept/reject. Added match / mismatch / absent-with-warning / unparseable-pin tests.

- `vitest run src/plugins/ssh/backend.test.ts` → **56 passing** (4 new)
- backend `pnpm typecheck` clean; ESLint + Prettier clean on all changed files; frontend `tsc --noEmit` clean on the changed file

## Known gap

Ships mocked-only. A live end-to-end mismatch check needs a real SSH host to MITM — consistent with the containerised-sshd integration-test gap flagged across the whole SSH effort (#284/#285).

🤖 Generated with [Claude Code](https://claude.com/claude-code)