### PR TITLE
chore(docs): document the SSH sandbox backend for self-hosting (#287)

### DIFF
--- a/apps/docs/content/reference/backend-configuration.mdx
+++ b/apps/docs/content/reference/backend-configuration.mdx
@@ -116,14 +116,34 @@ is the production option.
 
 ## Sandbox
 
-The Docker reference Sandbox adapter. Disabled by default and scoped to
-development / single-node self-hosting only. Enable it by listing
-`@platypus/docker` in `PLATYPUS_PLUGINS` (it ships as a core plugin — see
-[Plugins](#plugins) above); this requires a reachable Docker daemon and the
-`compose.sandbox.yaml` overlay. See
-[ADR-0003](https://github.com/willdady/platypus/blob/main/docs/adr/0003-docker-reference-sandbox-adapter-socket-mount.md)
-and the [Extending](/extending#sandbox-backends) section.
+Platypus ships two reference Sandbox adapters, both **off by default** and each
+enabled by listing its plugin in `PLATYPUS_PLUGINS` (both ship as core plugins —
+see [Plugins](#plugins) above). Adding the name both loads _and_ registers the
+backend type; omit it and that backend can't be selected at all. See the
+[Extending](/extending#sandbox-backends) section and
+[Sandbox infrastructure](/self-hosting/sandbox).
+
+- **Docker** (`@platypus/docker`) — one container per Workspace via the host's
+  Docker daemon. Scoped to development / single-node self-hosting; requires a
+  reachable Docker daemon and the `compose.sandbox.yaml` overlay. See
+  [ADR-0003](https://github.com/willdady/platypus/blob/main/docs/adr/0003-docker-reference-sandbox-adapter-socket-mount.md).
+- **SSH** (`@platypus/ssh`) — attaches to a pre-existing, operator-owned host
+  over SSH (bring-your-own-host). The one backend viable in horizontally-scaled
+  deployments, where Docker cannot run. See
+  [ADR-0012](https://github.com/willdady/platypus/blob/main/docs/adr/0012-ssh-reference-sandbox-byo-host-adapter.md).
+
+### Docker
 
 | Variable                                   | Purpose                                                                                                                                            | Default   | Required |
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | -------- |
 | `PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS` | Comma-separated Docker networks a Sandbox may attach to. Admins select a per-Sandbox subset; unset/empty means none are attachable (default-deny). | _(unset)_ | No       |
+
+### SSH
+
+The SSH backend takes **no deployment environment variables**. Its entire
+connection surface — host, port, user, workspace root, optional host-key pin, and
+the private-key credential — is **per-Workspace** Sandbox configuration set in the
+app by an Org Admin, not env vars. See
+[Sandbox infrastructure](/self-hosting/sandbox) for the setup narrative and the
+security model (notably: no resource limits and no `networks`/`extraHosts`
+reachability model).

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -182,18 +182,24 @@ your secret manager, never commit it.
 ## Sandbox
 
 The [Sandbox](/concepts) (agent shell/filesystem access) is **off by default**.
-Enabling the Docker reference backend and curating what it can reach is an
-Operator concern with its own page:
+Platypus ships two reference backends, each enabled by listing its plugin in
+`PLATYPUS_PLUGINS`. Without the plugin listed, that backend type isn't registered
+and its sandbox configuration is inert:
 
-- **Enable Docker by listing `@platypus/docker` in `PLATYPUS_PLUGINS`** — the
-  Docker backend ships as a core plugin; without it in the list, sandbox
-  configuration is inert.
-- **`PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS`** — the Operator's allowlist that
-  bounds which Docker networks an Org Admin may attach a sandbox to
-  (default-deny).
+- **Docker** — `@platypus/docker`. One container per Workspace on the local
+  daemon; development / single-node only. Its Operator allowlist,
+  `PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS`, bounds which Docker networks an Org
+  Admin may attach a sandbox to (default-deny), and it needs the opt-in
+  `compose.sandbox.yaml` overlay.
+- **SSH** — `@platypus/ssh`. Attaches to a pre-existing, operator-owned host over
+  SSH. It takes **no deployment env vars** — the connection target (host, user,
+  key, optional host-key pin) is per-Workspace Sandbox config set in-app. It is the
+  only backend that runs in **horizontally-scaled deployments**, where Docker
+  cannot.
 
-See [Sandbox infrastructure](/self-hosting/sandbox) for the security model and
-the opt-in `compose.sandbox.yaml` overlay.
+See [Sandbox infrastructure](/self-hosting/sandbox) for the full security model,
+the SSH connection fields, host-key pinning, and the opt-in `compose.sandbox.yaml`
+overlay.
 
 ## Other operational areas
 

--- a/apps/docs/content/self-hosting/sandbox.mdx
+++ b/apps/docs/content/self-hosting/sandbox.mdx
@@ -10,8 +10,10 @@ import { Callout } from "nextra/components";
 A **Sandbox** is a configured, isolated execution environment registered on a
 [Workspace](/concepts), giving agents shell and filesystem tools that run inside
 it. The Sandbox interface is pluggable so different backends — local container,
-remote VM, hosted sandbox-as-a-service — can be contributed. Platypus ships one
-reference backend: **Docker**.
+remote VM, hosted sandbox-as-a-service — can be contributed. Platypus ships two
+reference backends: **Docker** (one container per Workspace on the local daemon)
+and **SSH** (attach to a pre-existing, operator-owned host). Neither is enabled by
+default — each is turned on by listing its plugin in `PLATYPUS_PLUGINS`.
 
 This page is for the **Operator** and **Org Admin** who stand up and curate that
 infrastructure.
@@ -97,6 +99,114 @@ badge with a "Recreate now" action.
   your allowlist configuration, not a structural guarantee — don't add the
   database network.
 </Callout>
+
+## The SSH reference adapter
+
+The SSH adapter (`backend: "ssh"`) attaches to a host you already run: Platypus
+connects, ensures a workspace directory exists, and runs tools over the
+connection. The host must let the login user open a shell and expose the SFTP
+subsystem — both are on by default in a stock OpenSSH `sshd`.
+
+Unlike the Docker adapter, the SSH adapter **works in horizontally-scaled
+deployments**. Because the target host is external and shared, any backend replica
+can connect to the same host and see the same filesystem state — so it's the
+recommended backend for multi-node / HA topologies, where Docker cannot run.
+
+### Enabling it
+
+Add `@platypus/ssh` to `PLATYPUS_PLUGINS` and restart the backend:
+
+```
+PLATYPUS_PLUGINS=@platypus/web-fetch,@platypus/ssh
+```
+
+It ships as a core plugin, so no package install is needed; plugin-list membership
+is the enable switch (see
+[Configuration → Plugins](/self-hosting/configuration#plugins)). Omit the name and
+the `"ssh"` backend type isn't registered, so it can't be selected when
+configuring a Sandbox. Unlike Docker, the SSH backend needs no compose overlay and
+no daemon socket.
+
+### Per-Workspace connection config
+
+Everything the adapter needs to reach a host lives on the per-Workspace Sandbox
+row, set in the app under **Workspace settings → Sandbox** by an Org Admin (like
+every credential-bearing Sandbox field, it is **not** delegatable to a Workspace
+Owner). It is _not_ deployment env or plugin config.
+
+| Field              | Required | Meaning                                                                                                                                 |
+| ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Host**           | Yes      | Hostname or IP of the operator-owned host to attach to.                                                                                 |
+| **Port**           | No       | SSH port. Defaults to `22`.                                                                                                             |
+| **User**           | Yes      | SSH login user. Public-key auth only.                                                                                                   |
+| **Workspace root** | No       | Directory the sandbox works in. Absolute, or resolved against the login `$HOME`. Defaults to `$HOME/platypus-workspace`, `mkdir -p`'d on first connect. |
+| **Host key**       | No       | Optional host-key pin (see [below](#host-key-verification)). Blank ⇒ connect unverified with a logged warning.                          |
+| **Private key**    | Yes      | PEM or OpenSSH private key for the login user. Kept server-side, never sent to the model. On edit, leave blank to keep the stored key.  |
+| **Key passphrase** | No       | Passphrase decrypting the private key, when it is encrypted.                                                                            |
+
+### Public-key setup
+
+The adapter authenticates with a private key only — there is no password option.
+Generate a dedicated key pair for Platypus and authorize its public half on the
+host, under the login **User** above:
+
+```bash
+# On a machine you control
+ssh-keygen -t ed25519 -f platypus_sandbox -C platypus-sandbox
+
+# Authorize the public key on the target host (as the login user)
+ssh-copy-id -i platypus_sandbox.pub platypus@ssh.example.com
+```
+
+Paste the **private** key (`platypus_sandbox`) into the Sandbox's **Private key**
+field; if you protected it with a passphrase, put that in **Key passphrase**. The
+private key is stored server-side and is never returned to non-admins or exposed
+to the model. Use a key scoped to this host so it can be rotated or revoked
+independently.
+
+### Host-key verification
+
+The **Host key** field pins the host's public key so a man-in-the-middle can't
+impersonate the host. Fetch it with `ssh-keyscan` and paste the output in:
+
+```bash
+ssh-keyscan -t ed25519 ssh.example.com
+```
+
+The field accepts full `ssh-keyscan` / `known_hosts` output or a bare base64 key
+blob. When set, the presented host key is strictly verified on every connect and a
+mismatch aborts the connection with a clear error.
+
+<Callout type="warning">
+  Leaving **Host key** blank connects **without** host-key verification — the
+  backend logs a loud MITM warning and proceeds. Public-key auth still stops an
+  impostor host from stealing your credentials, but session traffic and the
+  server-injected environment (including secrets) are exposed to a
+  man-in-the-middle. **Pin the host key on any host reached over an untrusted
+  network.**
+</Callout>
+
+### Security posture
+
+The SSH adapter, like Docker, is scoped to hosts and network paths you trust; it
+is **not** a hostile-tenant isolation boundary. But its guarantees differ from
+Docker's in ways you must plan around:
+
+- **No Platypus-layer resource limits.** Docker's process, memory, and CPU caps
+  (`PidsLimit` / memory ceiling / `no-new-privileges`, per
+  [ADR-0003](https://github.com/willdady/platypus/blob/main/docs/adr/0003-docker-reference-sandbox-adapter-socket-mount.md))
+  have **no** SSH equivalent. A runaway or hostile workload — a fork bomb, a
+  memory hog — is bounded only by the host itself. Protecting the host (via
+  `ulimit`, `systemd-run`, cgroups, a dedicated user, or a throwaway VM) is the
+  **operator's** responsibility.
+- **No `networks` / `extraHosts` model, and the "database is unreachable"
+  property does _not_ hold.** There is no default-deny reachability allowlist
+  ([ADR-0005](https://github.com/willdady/platypus/blob/main/docs/adr/0005-sandbox-host-reachability-is-admin-curated-default-deny.md)
+  is Docker-only). The sandbox reaches **whatever the host can route to** —
+  including the Platypus database if the network permits it. Reachability is
+  entirely your host and network posture; isolate the host accordingly.
+- **Not a tenant isolation boundary.** Trust rests on the host and the network
+  path, not on the adapter.
 
 ## Workspace-default environment variables
 


### PR DESCRIPTION
## What changed

Documents the SSH reference Sandbox adapter (`@platypus/ssh`, [ADR-0012](https://github.com/willdady/platypus/blob/main/docs/adr/0012-ssh-reference-sandbox-byo-host-adapter.md)) across the reference and self-hosting docs, mirroring the Docker backend's coverage. Docs-only — no code changes.

- **`reference/backend-configuration.mdx`** — reworked the `## Sandbox` section to cover both backends. Enabling SSH is documented as listing `@platypus/ssh` in `PLATYPUS_PLUGINS`; the SSH backend takes **no deployment env vars** (all connection config is per-Workspace). No `PLATYPUS_SANDBOX_SSH_ENABLED` row introduced — that gate does not exist under the plugin model.
- **`self-hosting/sandbox.mdx`** — new `## The SSH reference adapter` section: what the host must provide (shell + SFTP subsystem), enabling via the plugin list, a per-Workspace connection-config table matching the in-app field labels, public-key setup (`ssh-keygen`/`ssh-copy-id`), optional host-key pinning (`ssh-keyscan`, with a MITM warning), and a **Security posture** subsection contrasting with Docker.
- **`self-hosting/configuration.mdx`** — the `## Sandbox` narrative now covers both backends, noting SSH's HA capability and lack of deployment env vars.

## Security posture documented (per the issue)

- **No Platypus-layer resource limits** (unlike Docker's ADR-0003 pids/memory/cpu caps) — host protection is the operator's job.
- **No `networks`/`extraHosts` reachability model**, so the Docker "database is unreachable" property does **not** hold — a BYO host reaches whatever it can route to.
- **Works in horizontally-scaled deployments**, where Docker cannot.
- Not a hostile-tenant isolation boundary — trust the host and network path.

## Acceptance criteria

- [x] Enabling SSH by listing `@platypus/ssh` in `PLATYPUS_PLUGINS` is documented in `reference/backend-configuration.mdx`; no `PLATYPUS_SANDBOX_SSH_ENABLED` row introduced.
- [x] Self-hosting docs describe SSH sandbox setup (enable via plugin list, per-Workspace connection config, public-key + optional host-key pin).
- [x] Security non-guarantees (no resource limits; DB reachable if routable) and the HA-deployment benefit are documented clearly.
- [x] The docs build passes.

## Verification

```
pnpm --filter @platypus/docs build
✓ Compiled successfully
✓ Generating static pages (31/31)
```

All internal ADR links verified against actual filenames. Nextra zod override untouched.

## Follow-up

Filed #312 (`needs-triage`) to migrate `PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS` onto `@platypus/docker`'s plugin config — a code change, out of scope here.

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)
