### PR TITLE
fix(frontend): hoist @tailwindcss/postcss so Turbopack can resolve it

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,6 @@
 min-release-age=3
+
+# Hoist the Tailwind PostCSS plugin to the workspace-root node_modules. Next's
+# Turbopack infers the monorepo root and resolves bare PostCSS plugin names
+# (postcss.config.mjs) from there; without this it can't find @tailwindcss/postcss.
+public-hoist-pattern[]=@tailwindcss/postcss


### PR DESCRIPTION
## Problem

`pnpm dev` crashes the frontend with a 500:

```
Error: Cannot find module '@tailwindcss/postcss'
  at .../transforms/postcss.ts
Import trace:
  ./apps/frontend/app/globals.css
  ./apps/frontend/app/layout.tsx
```

## Root cause

Next 16's Turbopack infers the **monorepo root** as its project root and resolves the bare PostCSS plugin name in `apps/frontend/postcss.config.mjs` (`{ "@tailwindcss/postcss": {} }`) from *there*. pnpm only symlinks `@tailwindcss/postcss` into `apps/frontend/node_modules`, not the workspace root, so Turbopack can't find it. Surfaced after a recent dependency bump.

## Fix

Hoist the plugin to the root `node_modules` via `public-hoist-pattern` in the root `.npmrc`:

```
public-hoist-pattern[]=@tailwindcss/postcss
```

Keeping the **bare-string** plugin form is deliberate. Turbopack loads a bare-name plugin as an *external Node module*, where its native `lightningcss` binary loads correctly. Alternatives were tried and rejected:

- **`turbopack.root = apps/frontend`** → worse crash: sandboxes Turbopack to the app dir, but all packages physically live in the root `.pnpm` store *outside* it, so `next` itself becomes unreachable.
- **Importing the plugin / absolute `require.resolve` path** → gets past resolution but makes Turbopack *bundle* the plugin, which fails on lightningcss's dynamic `require('../lightningcss.<platform>.node')`.

## Verification

After `CI=true pnpm install` (hoist change rebuilds `node_modules`), ran `next dev` on a spare port with the unchanged `postcss.config.mjs`: **HTTP 200, no CSS/module errors**.

> Note: applying this requires a `pnpm install` so pnpm materialises the root-level symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)