### PR TITLE
chore: publish plugin SDK to npm + add 2.0 upgrade guide

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,84 @@
+name: Publish Plugin SDK
+
+# Publishes @platypuschat/plugin-sdk to npm — the surface third-party plugin
+# authors depend on (see docs/extending). release-please versions only the root
+# `platypus` component, NOT this package, so the SDK is versioned by hand in its
+# own package.json. This workflow therefore fires on every release publish but
+# only actually publishes when the SDK's version is not already on npm; bump
+# packages/plugin-sdk/package.json when you want a new SDK release to go out.
+#
+# Auth is npm Trusted Publishing (OIDC) — no NPM_TOKEN secret. The trust is
+# configured on npmjs.com against this repo + workflow filename; `id-token: write`
+# lets the runner mint the OIDC token npm exchanges for short-lived credentials,
+# and provenance attestations are generated automatically (no --provenance flag).
+#
+# ONE-TIME SETUP (npm requires a package to exist before a trusted publisher can
+# be registered): publish 0.1.0 once manually (`cd packages/plugin-sdk && npm
+# publish`), then on npmjs.com add a GitHub Actions trusted publisher for
+# willdady/platypus with workflow file `publish-sdk.yml`. Every release after
+# that publishes tokenlessly here. Uses `npm publish` (not `pnpm publish`) for
+# the publish step: pnpm 10 supports OIDC but pnpm 11 has an open 404 regression
+# (pnpm/pnpm#11513), so npm — the reference OIDC implementation — is the safe bet.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # npm Trusted Publishing (OIDC)
+
+concurrency:
+  group: publish-sdk
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      # Trusted publishing needs npm CLI >= 11.5.1; the runner's bundled npm can
+      # be older, which fails with a misleading E404. Pin to a compatible npm.
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@^11.5.1
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build SDK
+        run: pnpm --filter @platypuschat/plugin-sdk build
+
+      # Idempotency guard: this workflow runs on every release, but the SDK is
+      # versioned independently of the root release. Publish only when the local
+      # version isn't already on npm (a fresh version returns nothing → publish).
+      - name: Check whether this version needs publishing
+        id: check
+        run: |
+          LOCAL=$(node -p "require('./packages/plugin-sdk/package.json').version")
+          REMOTE=$(npm view @platypuschat/plugin-sdk@"$LOCAL" version 2>/dev/null || true)
+          echo "local=$LOCAL remote=${REMOTE:-<none>}"
+          if [ -n "$REMOTE" ]; then
+            echo "@platypuschat/plugin-sdk@$LOCAL is already published — skipping."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # No token: npm detects the OIDC environment and authenticates via the
+      # trusted-publisher trust, then attaches provenance automatically.
+      - name: Publish to npm
+        if: steps.check.outputs.publish == 'true'
+        working-directory: packages/plugin-sdk
+        run: npm publish

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -38,10 +38,6 @@ MEMORY_EXTRACTION_INTERVAL_MS=300000  # 5 minutes
 SCHEDULE_SCHEDULER_INTERVAL_MS=60000  # 1 minute
 SCHEDULE_MAX_CONCURRENT=5  # Max parallel schedule executions
 
-# Fetch tool configuration
-# Set to true to skip robots.txt checks when fetching URLs
-FETCH_TOOL_IGNORE_ROBOTS_TXT=false
-
 # Storage backend: "disk" (default) or "s3"
 STORAGE_BACKEND=disk
 

--- a/apps/docs/content/self-hosting/_meta.ts
+++ b/apps/docs/content/self-hosting/_meta.ts
@@ -5,6 +5,7 @@ const meta = {
   configuration: "Configuration & environment",
   "providers-and-auth": "Providers & authentication",
   sandbox: "Sandbox infrastructure",
+  "upgrading-to-v2": "Upgrading to 2.0",
 };
 
 export default meta;

--- a/apps/docs/content/self-hosting/upgrading-to-v2.mdx
+++ b/apps/docs/content/self-hosting/upgrading-to-v2.mdx
@@ -1,0 +1,103 @@
+---
+title: Upgrading to 2.0
+description: What changes for operators upgrading a self-hosted deployment from 1.x to 2.0, and the exact env-var migration.
+---
+
+import { Callout } from "nextra/components";
+
+# Upgrading to 2.0
+
+Platypus 2.0 introduces the [plugin system](/extending#the-plugin-model): the
+web-fetch tool set and the Docker Sandbox backend are no longer configured by
+their own dedicated environment variables — they are **plugins**, enabled via
+`PLATYPUS_PLUGINS` and configured via `PLATYPUS_PLUGIN_CONFIG`
+([ADR-0013](https://github.com/willdady/platypus/blob/main/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md)).
+
+The changes are **deployment configuration only** — three environment variables
+are removed and their behaviour moves onto the plugin surface. There is **no
+database migration** and no application-data change; this is an edit to your
+`.env` (or wherever you inject env), then a backend restart.
+
+<Callout type="warning">
+  **The most common upgrade mistake: losing the web-fetch tool.** An unset or
+  empty `PLATYPUS_PLUGINS` loads **only** the always-on core tool sets — there is
+  no built-in default. If your 1.x `.env` predates the plugin system (no
+  `PLATYPUS_PLUGINS` line), upgrading silently drops the web-fetch tool set from
+  every Agent. To keep it, you **must** add `@platypus/web-fetch` to
+  `PLATYPUS_PLUGINS`.
+</Callout>
+
+## What changed
+
+| Removed in 2.0                          | Replaced by                                                                                               |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `PLATYPUS_SANDBOX_DOCKER_ENABLED`       | Listing `@platypus/docker` in `PLATYPUS_PLUGINS` (list membership _is_ the enable switch).                |
+| `PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS` | `config.allowedNetworks` on `@platypus/docker` in `PLATYPUS_PLUGIN_CONFIG`.                             |
+| `FETCH_TOOL_IGNORE_ROBOTS_TXT`          | `config.ignoreRobotsTxt` on `@platypus/web-fetch` in `PLATYPUS_PLUGIN_CONFIG`.                            |
+
+In addition, the **web-fetch tool set is now a gate-able plugin**
+(`@platypus/web-fetch`) rather than always-on, so it must be listed in
+`PLATYPUS_PLUGINS` to load (see the warning above). Boot is **fail-loud**: a
+listed plugin that can't be resolved, or a `PLATYPUS_PLUGIN_CONFIG` entry that is
+malformed or keyed to a plugin that isn't loaded, aborts startup with a
+plugin-named error rather than silently degrading.
+
+## Migration checklist
+
+1. **Keep web-fetch.** Add `@platypus/web-fetch` to `PLATYPUS_PLUGINS` (it's in
+   the shipped [`.env.example`](https://github.com/willdady/platypus/blob/main/apps/backend/.env.example)
+   default, but not in a pre-2.0 `.env`).
+2. **If you ran the Docker sandbox** (`PLATYPUS_SANDBOX_DOCKER_ENABLED=true`): add
+   `@platypus/docker` to `PLATYPUS_PLUGINS`. The `compose.sandbox.yaml` overlay
+   requirement is unchanged.
+3. **If you set `PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS`:** move the value into
+   `config.allowedNetworks` on `@platypus/docker` in `PLATYPUS_PLUGIN_CONFIG` (a
+   JSON array — the old comma-separated list becomes JSON strings).
+4. **If you set `FETCH_TOOL_IGNORE_ROBOTS_TXT=true`:** move it to
+   `config.ignoreRobotsTxt` on `@platypus/web-fetch` in `PLATYPUS_PLUGIN_CONFIG`.
+5. **Delete the three removed variables** from your env — they are inert in 2.0.
+6. **Restart the backend.** Plugin loading is a deploy-time boundary; changes take
+   effect on restart. Confirm the result in **Organization settings → Plugins**,
+   which lists everything loaded at boot.
+
+<Callout type="info">
+  `PLATYPUS_PLUGIN_CONFIG` is a **single** JSON object keyed by plugin name. If
+  you're migrating more than one setting, merge them into one object — don't set
+  the variable twice.
+</Callout>
+
+## Before / after
+
+A 1.x deployment that enabled the Docker sandbox with a network allowlist and
+skipped `robots.txt`:
+
+```bash
+# 1.x
+PLATYPUS_SANDBOX_DOCKER_ENABLED=true
+PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS=shared-services,public-tools
+FETCH_TOOL_IGNORE_ROBOTS_TXT=true
+```
+
+becomes, in 2.0:
+
+```bash
+# 2.0
+PLATYPUS_PLUGINS=@platypus/web-fetch,@platypus/docker
+PLATYPUS_PLUGIN_CONFIG={"@platypus/docker":{"config":{"allowedNetworks":["shared-services","public-tools"]}},"@platypus/web-fetch":{"config":{"ignoreRobotsTxt":true}}}
+```
+
+Treat `PLATYPUS_PLUGIN_CONFIG` like any secret-bearing variable (it can carry a
+plugin's `credentials` block): inject it from your secret manager, never commit
+it.
+
+## Related
+
+- [Configuration & environment → Plugins](/self-hosting/configuration#plugins) —
+  the full narrative on the plugin model, list semantics, and plugin config.
+- [Backend configuration](/reference/backend-configuration#plugins) — the flat
+  variable reference.
+- [Sandbox infrastructure](/self-hosting/sandbox) — the Docker and SSH backends
+  in depth. The **SSH** backend (`@platypus/ssh`) is new in 2.0 — the one Sandbox
+  option viable in horizontally-scaled deployments.
+- [Extending](/extending) — writing your own plugins against
+  [`@platypuschat/plugin-sdk`](https://www.npmjs.com/package/@platypuschat/plugin-sdk).

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -1,0 +1,98 @@
+# @platypuschat/plugin-sdk
+
+[![npm version](https://img.shields.io/npm/v/@platypuschat/plugin-sdk.svg)](https://www.npmjs.com/package/@platypuschat/plugin-sdk)
+[![license](https://img.shields.io/npm/l/@platypuschat/plugin-sdk.svg)](https://github.com/willdady/platypus/blob/main/LICENSE)
+
+The plugin SDK for [Platypus](https://github.com/willdady/platypus) — the
+compile-time contract third-party plugins are built against.
+
+Platypus loads its extensions — **Tool sets** and **Sandbox backends** — as
+plugins. This package is the typed surface they depend on: the `PlatypusPlugin`
+manifest type, the contribution types, and the `PLUGIN_API_VERSION` constant. A
+plugin is an npm package that exports a manifest built against these types; an
+Operator installs it by adding the package to the `PLATYPUS_PLUGINS` list at
+deploy time.
+
+## Install
+
+```bash
+npm install @platypuschat/plugin-sdk
+# plugins that define tools also use these directly:
+npm install ai zod
+```
+
+## Quick start
+
+Export a `PlatypusPlugin` manifest from your package entry point. This minimal
+plugin contributes one Tool set with a single tool:
+
+```ts
+import type { PlatypusPlugin } from "@platypuschat/plugin-sdk";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import { tool } from "ai";
+import { z } from "zod";
+
+export const plugin: PlatypusPlugin = {
+  // A third-party plugin's `name` is a short url-safe slug, distinct from the
+  // npm package specifier an Operator lists in PLATYPUS_PLUGINS. Core prefixes
+  // every contribution id with it, so `greeting` registers as `example.greeting`.
+  name: "example",
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  contributes: {
+    toolSets: [
+      {
+        id: "greeting",
+        name: "Greeting",
+        category: "Examples",
+        description: "A tiny example tool set contributed by a plugin",
+        tools: {
+          greet: tool({
+            description: "Return a friendly greeting for the given name.",
+            inputSchema: z.object({
+              name: z.string().describe("Who to greet"),
+            }),
+            execute: ({ name }) => `Hello, ${name}! 👋`,
+          }),
+        },
+      },
+    ],
+  },
+};
+```
+
+An Operator then installs it by listing the published package in `PLATYPUS_PLUGINS`.
+
+## API versioning
+
+Set `apiVersion` from the exported `PLUGIN_API_VERSION` — it declares the
+**minimum** core API major your plugin needs, not an exact match. Core supports
+the current major **and one previous (N and N−1)** at the same time, and every
+extension-point contract evolves **append-only** within a major (new capabilities
+arrive as optional members). A plugin built against an older minor keeps working
+after a core upgrade; a genuinely breaking change is a windowed major bump. Boot
+is fail-loud: a plugin outside the supported window is rejected with a
+plugin-named error.
+
+## What you can contribute
+
+- **Tool sets** (`contributes.toolSets`) — named, categorised groups of
+  [Vercel AI SDK](https://sdk.vercel.ai) tools an Agent can be granted. Provide a
+  static map or a factory resolved with Workspace/Agent scope at chat-turn time.
+- **Sandbox backends** (`contributes.sandboxBackends`) — shell/filesystem
+  execution backends for the Platypus Sandbox (e.g. the built-in Docker and SSH
+  backends).
+
+Plugins may also declare deploy-time, Operator-owned `configSchema` /
+`credentialsSchema`, supplied via `PLATYPUS_PLUGIN_CONFIG` and validated at boot.
+
+## Documentation
+
+- [Extending Platypus](https://docs.platypus.chat/extending) — the full plugin
+  model, contribution reference, and Sandbox backend guide.
+- [Plugin configuration](https://docs.platypus.chat/self-hosting/configuration#plugins)
+  — how Operators enable and configure plugins.
+
+## License
+
+MIT

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,9 +1,14 @@
 {
   "name": "@platypuschat/plugin-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Plugin SDK for Platypus — the manifest type and extension-point surface third-party plugins depend on.",
   "license": "MIT",
   "author": "Will Dady",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/willdady/platypus.git",
+    "directory": "packages/plugin-sdk"
+  },
   "type": "module",
   "main": "index.ts",
   "types": "index.ts",
@@ -14,6 +19,7 @@
     "test": "vitest run"
   },
   "publishConfig": {
+    "access": "public",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "exports": {


### PR DESCRIPTION
## Why

Two gaps surfaced while reviewing the 2.0.0 release (#281):

1. **`@platypuschat/plugin-sdk` wasn't published to npm** — yet the extending docs tell third-party plugin authors to `npm install` it and link to its npm page (a 404). The headline "third-party plugin loading" feature was dead-on-arrival for anyone outside the monorepo.
2. **No consolidated upgrade guide** for operators — 2.0 removes three deploy-time env vars, but the migration facts were scattered across reference pages and ADRs.

## What's here

### SDK publishing (OIDC / Trusted Publishing)
- **`.github/workflows/publish-sdk.yml`** — publishes the SDK on `release: [published]` (+ `workflow_dispatch`) via **npm Trusted Publishing (OIDC)** — no `NPM_TOKEN` secret, provenance generated automatically. release-please only versions the root component, so the SDK is **hand-versioned**; an `npm view` guard makes the job **idempotent** (publishes only when the SDK version bumps). Uses `npm publish` (build/install stay on pnpm) to sidestep the pnpm 11 OIDC 404 regression (pnpm/pnpm#11513), and upgrades npm to ≥ 11.5.1 for OIDC support.
- **`packages/plugin-sdk`** — adds a **README** (the npm page had none), a `repository` field, and `publishConfig.access: "public"`. Bumped `0.1.0` → `0.1.1` to ship the README.

### Docs
- **`self-hosting/upgrading-to-v2.mdx`** — "Upgrading to 2.0" page: the removed vars (`PLATYPUS_SANDBOX_DOCKER_ENABLED`, `PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS`, `FETCH_TOOL_IGNORE_ROBOTS_TXT`) mapped to their `PLATYPUS_PLUGINS` / `PLATYPUS_PLUGIN_CONFIG` replacements, a migration checklist, and a before/after `.env`. Leads with the main gotcha: an unset `PLATYPUS_PLUGINS` has **no code-level default**, so a pre-2.0 `.env` silently loses the web-fetch tool set.
- **`.env.example`** — drops the stale `FETCH_TOOL_IGNORE_ROBOTS_TXT` line.

## Follow-up (not in this PR — manual, on npm's side)
`0.1.0` was already bootstrap-published manually (npm requires a package to exist before a trusted publisher can be registered). After this lands on `main`:
1. Register the GitHub Actions **trusted publisher** on npmjs.com for `willdady/platypus`, workflow `publish-sdk.yml`.
2. `0.1.1` (with the README) then publishes automatically on the 2.0.0 release, or via **Run workflow** manually.

## Notes
- No app-behavior or DB changes; docs + tooling only. Verified: docs build passes, SDK builds, publish dry-run includes the README.
- `chore:` type is intentional so this doesn't perturb release-please's version computation for #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)