### PR TITLE
fix(ci): make publish-sdk workflow work with OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -42,16 +42,18 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
 
-      # NOTE: deliberately NO `registry-url` here. setup-node's registry-url
-      # writes an .npmrc with `_authToken=${NODE_AUTH_TOKEN}` + `always-auth=true`
-      # and injects a placeholder NODE_AUTH_TOKEN; npm then sends that bogus token
-      # and never attempts the OIDC handshake (registry replies 404 on PUT). With
-      # no auth configured, npm uses OIDC against the default registry.
+      # registry-url writes the .npmrc that points npm at the public registry —
+      # required for the OIDC flow. It also injects a placeholder NODE_AUTH_TOKEN,
+      # which is harmless ONLY because we publish with `--provenance` below: a
+      # provenance attestation requires the OIDC identity, so npm performs the
+      # OIDC exchange rather than sending the placeholder token. (Without
+      # --provenance npm uses that placeholder and the registry replies 404.)
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -75,13 +77,11 @@ jobs:
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # Trusted publishing needs npm CLI >= 11.5.1; Node's bundled npm (11.3.x on
-      # Node 24) is too old and fails with a misleading E404 (the registry treats
-      # an unsupported OIDC handshake as anonymous). Upgrade and publish in the
-      # SAME step — a global upgrade in a prior step doesn't reliably become the
-      # `npm` this step resolves — with `hash -r` so bash re-resolves the binary.
-      # No token env: npm detects the OIDC environment and authenticates via the
-      # trusted-publisher trust, then attaches provenance automatically.
+      # Trusted publishing needs npm CLI >= 11.5.1; Node's bundled npm is too old,
+      # so upgrade and publish in the SAME step (a global upgrade in a prior step
+      # doesn't reliably become the `npm` this step resolves) with `hash -r` so
+      # bash re-resolves the binary. `--provenance` is what forces the OIDC
+      # exchange (see the setup-node note above); no token env is needed.
       - name: Publish to npm
         if: steps.check.outputs.publish == 'true'
         working-directory: packages/plugin-sdk
@@ -90,4 +90,4 @@ jobs:
           hash -r
           echo "Publishing with npm $(npm --version) on node $(node --version)"
           echo "OIDC token endpoint present: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
-          npm publish
+          npm publish --provenance

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -49,11 +49,6 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      # Trusted publishing needs npm CLI >= 11.5.1; the runner's bundled npm can
-      # be older, which fails with a misleading E404. Pin to a compatible npm.
-      - name: Upgrade npm for OIDC support
-        run: npm install -g npm@^11.5.1
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -76,9 +71,18 @@ jobs:
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # No token: npm detects the OIDC environment and authenticates via the
+      # Trusted publishing needs npm CLI >= 11.5.1; Node's bundled npm (11.3.x on
+      # Node 24) is too old and fails with a misleading E404 (the registry treats
+      # an unsupported OIDC handshake as anonymous). Upgrade and publish in the
+      # SAME step — a global upgrade in a prior step doesn't reliably become the
+      # `npm` this step resolves — with `hash -r` so bash re-resolves the binary.
+      # No token env: npm detects the OIDC environment and authenticates via the
       # trusted-publisher trust, then attaches provenance automatically.
       - name: Publish to npm
         if: steps.check.outputs.publish == 'true'
         working-directory: packages/plugin-sdk
-        run: npm publish
+        run: |
+          npm install -g npm@latest
+          hash -r
+          echo "Publishing with npm $(npm --version) on node $(node --version)"
+          npm publish

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -42,12 +42,16 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
 
+      # NOTE: deliberately NO `registry-url` here. setup-node's registry-url
+      # writes an .npmrc with `_authToken=${NODE_AUTH_TOKEN}` + `always-auth=true`
+      # and injects a placeholder NODE_AUTH_TOKEN; npm then sends that bogus token
+      # and never attempts the OIDC handshake (registry replies 404 on PUT). With
+      # no auth configured, npm uses OIDC against the default registry.
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
-          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -85,4 +89,5 @@ jobs:
           npm install -g npm@latest
           hash -r
           echo "Publishing with npm $(npm --version) on node $(node --version)"
+          echo "OIDC token endpoint present: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
           npm publish


### PR DESCRIPTION
## Problem

The `publish-sdk` workflow (added in #317) failed on its first real `workflow_dispatch` with a misleading `E404 ... could not be found or you do not have permission` on `PUT`. Debugging took several iterations against a live dispatch:

1. **npm version** — folded the npm upgrade into the publish step (`hash -r` so bash re-resolves the binary) and echoed the version. Confirmed npm `12.0.1` — version was never the issue.
2. **Placeholder token** — with `registry-url`, `setup-node` injects a placeholder `NODE_AUTH_TOKEN` + `always-auth=true`; without `--provenance`, npm sent that bogus token → `E404`.
3. **Removing `registry-url`** — overcorrected: npm then had no registry configured and returned `ENEEDAUTH` (never attempted OIDC).
4. **The fix** — restore `registry-url` **and** publish with `--provenance`. Provenance requires the OIDC identity, which forces npm to perform the OIDC exchange instead of using the placeholder token.

Once the YAML was correct, npm signed a provenance statement successfully but still `404`'d — which pinpointed the last cause as an incomplete **trusted-publisher config on npmjs.com** (now fixed).

## Result

`@platypuschat/plugin-sdk@0.1.1` published via OIDC with provenance ([sigstore log](https://search.sigstore.dev/?logIndex=2148327164)); `latest` → `0.1.1`, README now on the npm page.

## Net change to the workflow

- `registry-url: https://registry.npmjs.org` restored on `setup-node`.
- Publish step: `npm install -g npm@latest && hash -r && npm publish --provenance` in a single step, no token `env`.
- Small non-secret diagnostics (npm/node version, OIDC endpoint presence) retained for future debugging.

Verified green via `workflow_dispatch` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)