### PR TITLE
fix(frontend): show agent indicator on org-scoped skill cards

### DIFF
--- a/apps/frontend/components/skills-list.tsx
+++ b/apps/frontend/components/skills-list.tsx
@@ -62,6 +62,40 @@ import {
 // manages org-scoped Skills directly (ADR-0007).
 type SkillWithScope = Skill & { scope?: "organization" | "workspace" };
 
+// The agent-association indicator shown on workspace skill cards: a Bot icon
+// with an "N agent(s)" count whose tooltip lists the agents, or a warning when
+// the Skill is attached to no agents. Rendered for both workspace-scoped and
+// attached org-scoped (Shared) Skills (#296). The trigger uses preventDefault
+// (not stopPropagation) so the card's own click — navigation or opening the
+// manage dialog — still fires.
+const SkillAgentsIndicator = ({ agents }: { agents: Agent[] }) => (
+  <div className="mt-1 text-xs text-muted-foreground">
+    {agents.length > 0 ? (
+      <Tooltip>
+        <TooltipTrigger
+          className="flex items-center gap-1 cursor-default"
+          onClick={(e) => e.preventDefault()}
+        >
+          <Bot className="h-3 w-3" />
+          {agents.length} agent{agents.length !== 1 && "s"}
+        </TooltipTrigger>
+        <TooltipContent>
+          <ul className="text-left">
+            {agents.map((agent) => (
+              <li key={agent.id}>{agent.name}</li>
+            ))}
+          </ul>
+        </TooltipContent>
+      </Tooltip>
+    ) : (
+      <span className="flex items-center gap-1 cursor-default text-warning-foreground">
+        <TriangleAlert className="h-3 w-3" />
+        <strong>WARNING:</strong> Skill not associated with any agents.
+      </span>
+    )}
+  </div>
+);
+
 export const SkillsList = ({
   orgId,
   workspaceId,
@@ -252,6 +286,9 @@ export const SkillsList = ({
           const isOrgScopedInWorkspace =
             Boolean(workspaceId) && skill.scope === "organization";
 
+          const skillAgents = getAgentsForSkill(skill.id);
+          const agentCount = skillAgents.length;
+
           if (isOrgScopedInWorkspace) {
             return (
               <li key={skill.id}>
@@ -271,6 +308,7 @@ export const SkillsList = ({
                     <ItemDescription className="text-xs line-clamp-2">
                       {skill.description}
                     </ItemDescription>
+                    <SkillAgentsIndicator agents={skillAgents} />
                   </ItemContent>
                   <ItemActions>
                     <Pencil className="size-4" />
@@ -279,9 +317,6 @@ export const SkillsList = ({
               </li>
             );
           }
-
-          const skillAgents = getAgentsForSkill(skill.id);
-          const agentCount = skillAgents.length;
 
           return (
             <li key={skill.id}>
@@ -299,32 +334,7 @@ export const SkillsList = ({
                       {skill.description}
                     </ItemDescription>
                     {workspaceId && (
-                      <div className="mt-1 text-xs text-muted-foreground">
-                        {agentCount > 0 ? (
-                          <Tooltip>
-                            <TooltipTrigger
-                              className="flex items-center gap-1 cursor-default"
-                              onClick={(e) => e.preventDefault()}
-                            >
-                              <Bot className="h-3 w-3" />
-                              {agentCount} agent{agentCount !== 1 && "s"}
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <ul className="text-left">
-                                {skillAgents.map((agent) => (
-                                  <li key={agent.id}>{agent.name}</li>
-                                ))}
-                              </ul>
-                            </TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          <span className="flex items-center gap-1 cursor-default text-warning-foreground">
-                            <TriangleAlert className="h-3 w-3" />
-                            <strong>WARNING:</strong> Skill not associated with
-                            any agents.
-                          </span>
-                        )}
-                      </div>
+                      <SkillAgentsIndicator agents={skillAgents} />
                     )}
                     {!workspaceId && isOrgAdmin && (
                       <div className="mt-1">


### PR DESCRIPTION
Closes #296

## Problem

On the workspace home screen, org-scoped (Shared) skill cards took a separate early-return render path that showed only name, description, and the "Organization" badge. They never rendered the agent-association indicator (Bot icon + "N agent(s)" label + tooltip listing agents) that workspace-scoped cards show — so a Shared skill used by attached org-level agents appeared to have no associated agents.

## Fix

`apps/frontend/components/skills-list.tsx`:

- Hoisted the `getAgentsForSkill` lookup above the org-scoped branch so both card types compute their associated agents.
- Extracted the indicator markup into a shared `SkillAgentsIndicator` component, rendered on both the org-scoped and workspace-scoped paths (avoids duplicating the JSX).
- The tooltip trigger uses `preventDefault` (not `stopPropagation`), matching the workspace path, so the org card's own click still opens the manage/detach dialog.

This is a frontend-only presentation fix — no backend, schema, or data-fetching changes. The agents endpoint already returns attached org-scoped agents with their `skillIds`.

## Scope

- Keeps the generic `Bot` glyph (no per-agent avatars).
- Leaves the org-settings surface and the `border-warning` styling untouched (out of scope).
- Workspace-scoped cards unchanged.

## Verification

- `pnpm --filter frontend lint` ✅
- `tsc --noEmit` (frontend) ✅
- Full test suite: 1111 tests, 93 files ✅

Note: the frontend has no React component test harness (only `lib/` unit tests), so this presentational change was verified via typecheck/lint/existing suite and a two-axis code review rather than a new component test. Worth a manual hover-check that the tooltip lists attached org-level agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)