### PR TITLE
fix(backend): normalize tool results to JSON at the wrapper choke point

### DIFF
--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -71,6 +71,8 @@ import {
   ValidationError,
   createToolHeartbeat,
   shouldInjectNativeSearch,
+  wrapToolsWithBump,
+  normalizeToolResult,
 } from "./chat-execution.ts";
 import { createInMemoryChatTurnQueries } from "./chat-execution.test-fixtures.ts";
 
@@ -664,6 +666,99 @@ describe("chat-execution", () => {
           nativeSearchEnabled: undefined as unknown as boolean,
         }),
       ).toBe(true);
+    });
+  });
+
+  describe("normalizeToolResult", () => {
+    it("converts Date fields to ISO-8601 strings", () => {
+      const createdAt = new Date("2026-07-13T10:20:30.000Z");
+      const result = normalizeToolResult({ id: "b1", createdAt }) as {
+        id: string;
+        createdAt: string;
+      };
+      expect(result.createdAt).toBe("2026-07-13T10:20:30.000Z");
+      expect(result.id).toBe("b1");
+    });
+
+    it("leaves already-JSON-safe values structurally unchanged", () => {
+      const value = { a: 1, b: "x", c: [true, null], d: { nested: 2 } };
+      expect(normalizeToolResult(value)).toEqual(value);
+    });
+
+    it("passes a top-level undefined return through unchanged", () => {
+      expect(normalizeToolResult(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("wrapToolsWithBump", () => {
+    const noop = () => {};
+
+    const wrapSingle = (execute: unknown) => {
+      const wrapped = wrapToolsWithBump(
+        {
+          t: { execute } as unknown as Parameters<
+            typeof wrapToolsWithBump
+          >[0]["t"],
+        },
+        noop,
+        noop,
+        noop,
+      );
+      return (wrapped.t as { execute: (a: unknown, o: unknown) => unknown })
+        .execute;
+    };
+
+    it("normalizes a Date-containing result on the promise-resolved path", async () => {
+      const execute = wrapSingle(async () => ({
+        createdAt: new Date("2026-07-13T10:20:30.000Z"),
+      }));
+      const result = (await execute({}, {})) as { createdAt: string };
+      expect(result.createdAt).toBe("2026-07-13T10:20:30.000Z");
+    });
+
+    it("normalizes a Date-containing result on the synchronous path", () => {
+      const execute = wrapSingle(() => ({
+        createdAt: new Date("2026-07-13T10:20:30.000Z"),
+      }));
+      const result = execute({}, {}) as { createdAt: string };
+      expect(result.createdAt).toBe("2026-07-13T10:20:30.000Z");
+    });
+
+    it("leaves the async-iterable path intact (yields pass through untouched)", async () => {
+      const date = new Date("2026-07-13T10:20:30.000Z");
+      const execute = wrapSingle(async function* () {
+        yield { part: 1, date };
+        yield { part: 2 };
+      });
+      const iterable = execute({}, {}) as AsyncIterable<{
+        part: number;
+        date?: Date;
+      }>;
+      const parts: Array<{ part: number; date?: Date }> = [];
+      for await (const part of iterable) parts.push(part);
+      expect(parts).toEqual([{ part: 1, date }, { part: 2 }]);
+      // The Date is yielded verbatim, not serialized to a string.
+      expect(parts[0].date).toBeInstanceOf(Date);
+    });
+
+    it("runs the tool lifecycle callbacks around a normalized result", async () => {
+      const onStart = vi.fn();
+      const onEnd = vi.fn();
+      const wrapped = wrapToolsWithBump(
+        {
+          t: {
+            execute: async () => ({ createdAt: new Date() }),
+          } as unknown as Parameters<typeof wrapToolsWithBump>[0]["t"],
+        },
+        noop,
+        onStart,
+        onEnd,
+      );
+      await (
+        wrapped.t as { execute: (a: unknown, o: unknown) => Promise<unknown> }
+      ).execute({}, {});
+      expect(onStart).toHaveBeenCalledTimes(1);
+      expect(onEnd).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -709,9 +709,11 @@ describe("chat-execution", () => {
     };
 
     it("normalizes a Date-containing result on the promise-resolved path", async () => {
-      const execute = wrapSingle(async () => ({
-        createdAt: new Date("2026-07-13T10:20:30.000Z"),
-      }));
+      const execute = wrapSingle(() =>
+        Promise.resolve({
+          createdAt: new Date("2026-07-13T10:20:30.000Z"),
+        }),
+      );
       const result = (await execute({}, {})) as { createdAt: string };
       expect(result.createdAt).toBe("2026-07-13T10:20:30.000Z");
     });
@@ -727,6 +729,7 @@ describe("chat-execution", () => {
     it("leaves the async-iterable path intact (yields pass through untouched)", async () => {
       const date = new Date("2026-07-13T10:20:30.000Z");
       const execute = wrapSingle(async function* () {
+        await Promise.resolve();
         yield { part: 1, date };
         yield { part: 2 };
       });
@@ -747,7 +750,7 @@ describe("chat-execution", () => {
       const wrapped = wrapToolsWithBump(
         {
           t: {
-            execute: async () => ({ createdAt: new Date() }),
+            execute: () => Promise.resolve({ createdAt: new Date() }),
           } as unknown as Parameters<typeof wrapToolsWithBump>[0]["t"],
         },
         noop,

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -691,7 +691,31 @@ export const createToolHeartbeat = (
  * yields continue to bump the timer via `onProgress` for visibility, but
  * correctness no longer depends on those yields being frequent enough.
  */
-const wrapToolsWithBump = (
+/**
+ * Normalize a tool's final result into a JSON-serializable value.
+ *
+ * AI SDK v7 feeds each tool result into the next model step, where
+ * `standardizePrompt()` validates tool-result parts against a strict JSON-value
+ * schema. Non-JSON values — most commonly a raw `Date` from a Drizzle/`pg` query
+ * row (a `createdAt`/`updatedAt` timestamp) — fail that validation and crash the
+ * turn with `InvalidPromptError`. A JSON round-trip converts `Date` → ISO string
+ * and drops `undefined`. Applied at the wrapper's result paths (promise-resolved
+ * and synchronous return), it covers every current and future value-returning
+ * tool at once. The async-iterable path (sub-agent tools) is intentionally
+ * exempt — its yields are streamed UI parts, not the result fed to the model.
+ *
+ * Deliberate trade-off: a plain round-trip throws on `BigInt`. Tools are not
+ * expected to return `BigInt`, so we accept that rather than complicate the
+ * normalizer. A top-level `undefined`/function return (whose `JSON.stringify` is
+ * `undefined`) is passed through unchanged instead of crashing `JSON.parse`.
+ */
+export const normalizeToolResult = (value: unknown): unknown => {
+  const json = JSON.stringify(value);
+  if (json === undefined) return value;
+  return JSON.parse(json);
+};
+
+export const wrapToolsWithBump = (
   tools: Record<string, Tool>,
   onActivity: (event?: ToolActivityEvent) => void,
   onToolStart: () => void,
@@ -730,7 +754,9 @@ const wrapToolsWithBump = (
           result != null &&
           typeof (result as { then?: unknown }).then === "function"
         ) {
-          return (result as Promise<unknown>).finally(finish);
+          return (result as Promise<unknown>)
+            .then(normalizeToolResult)
+            .finally(finish);
         }
         // Async iterable / generator path (sub-agent tools). Wrap it so the
         // counter decrements once the consumer drains the iterator.
@@ -750,8 +776,11 @@ const wrapToolsWithBump = (
             }
           })();
         }
+        // Normalize before finish() so the sync path mirrors the promise path:
+        // a throw (e.g. a BigInt in the result) happens before the "end" event.
+        const normalized = normalizeToolResult(result);
         finish();
-        return result;
+        return normalized;
       },
     };
   }


### PR DESCRIPTION
Closes #321

## Problem

Tool `execute` results containing non-JSON values — most commonly a raw `Date` from a Drizzle/`pg` timestamp column (e.g. `createdAt`) — crashed multi-step turns with:

```
Invalid prompt: The messages do not match the ModelMessage[] schema.
```

AI SDK v7 validates each tool-result part against a strict JSON-value schema (`standardizePrompt()`) before the next model step. `Date` (and `BigInt`, `Map`, etc.) satisfy none of its union members. The tool ran and its output streamed to the UI, but the turn then failed — reproducible in **brand-new chats** with no prior history.

## Fix

Normalize the resolved result at the single `wrapToolsWithBump` choke point rather than patching individual tools:

- Added `normalizeToolResult()` — a JSON round-trip (`JSON.parse(JSON.stringify(value))`) that converts `Date` → ISO string and drops `undefined`. Guards a top-level `undefined`/function return so it passes through instead of crashing `JSON.parse`.
- Applied on **both** result paths: promise-resolved (`.then(normalizeToolResult)`) and synchronous return.
- The **async-iterable path (sub-agent tools) is left untouched** — its yields are streamed UI parts, not the result fed to the model.
- `BigInt` still throws — accepted deliberately and documented, since tools are not expected to return it.

This covers every current and future value-returning tool at once (kanban board/card/comment tools, dashboard listing, agent discovery, etc.), superseding per-tool `.toISOString()` calls.

## Tests

New `describe` blocks for `normalizeToolResult` and `wrapToolsWithBump` cover:
- `Date` → ISO on both the sync and promise-resolved paths
- Iterable yields passing through as real `Date` objects (path left intact)
- JSON-safe values unchanged, top-level `undefined`, and lifecycle callbacks firing

## Verification

- `pnpm --filter backend test` — all 1118 pass
- `pnpm typecheck` — clean across the workspace
- `/code-review` (Standards + Spec axes) — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)