### PR TITLE
fix(backend): relay sub-agent text across all steps (#324)

### DIFF
--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -201,9 +201,11 @@ describe("createSubAgentTool", () => {
           { type: "reasoning-start", id: "r1" },
           { type: "reasoning-end", id: "r1" },
           { type: "text-start", id: "t1" },
+          { type: "text-delta", id: "t1", text: "Sub-agent result" },
           { type: "text-end", id: "t1" },
         ]),
-        text: Promise.resolve("Sub-agent result"),
+        // v7: final-step-only text property is intentionally NOT relied upon.
+        text: Promise.resolve(""),
       });
 
       const { tool } = createSubAgentTool(baseOptions);
@@ -214,7 +216,9 @@ describe("createSubAgentTool", () => {
 
       const { yielded } = await consumeGenerator(gen);
 
-      // Should have yielded 6 activity updates + 1 final with text
+      // Should have yielded 6 activity updates + 1 final with text. The
+      // text-delta between text-start and text-end carries content but does not
+      // change the activity log, so it produces no extra yield.
       expect(yielded).toHaveLength(7);
 
       // First yield: tool-call running
@@ -251,6 +255,101 @@ describe("createSubAgentTool", () => {
       // Final yield has text (yielded, not returned, since SDK discards return values)
       expect(yielded[6].text).toBe("Sub-agent result");
       expect(yielded[6].entries).toHaveLength(3);
+    });
+
+    // Regression for #324: AI SDK v6→v7 redefined `result.text` as the FINAL
+    // step's text only. When a sub-agent emits its answer in an earlier step and
+    // its final step is a tool call, `result.text` is empty and the parent gets
+    // nothing. The fix aggregates text-deltas off the fullStream across ALL
+    // steps, so this reproduces that shape with realistic v7 stream events and
+    // an empty final-step `text` promise.
+    it("aggregates assistant text across steps from the stream, not the final-step text property", async () => {
+      mockStream.mockResolvedValue({
+        fullStream: createMockFullStream([
+          // Step 1: the model emits its answer, then decides to call a tool.
+          { type: "start-step" },
+          { type: "text-start", id: "t1" },
+          { type: "text-delta", id: "t1", text: "Here are " },
+          { type: "text-delta", id: "t1", text: "the boards." },
+          { type: "text-end", id: "t1" },
+          { type: "tool-input-start", toolName: "listBoards", id: "tc1" },
+          // Step 2: the tool result is the FINAL step — no trailing text.
+          { type: "start-step" },
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "listBoards",
+            output: [{ id: "b1" }],
+          },
+        ]),
+        // v7 semantics: final-step-only text is empty because the last step is
+        // the tool result. The old code returned this verbatim.
+        text: Promise.resolve(""),
+      });
+
+      const { tool } = createSubAgentTool(baseOptions);
+      const gen = tool.execute(
+        { task: "list all boards" },
+        {} as ToolExecutionOptions<Record<string, unknown>>,
+      ) as AsyncGenerator<SubAgentActivity>;
+
+      const { yielded } = await consumeGenerator(gen);
+      const final = yielded.at(-1)!;
+
+      expect(final.text).toBe("Here are the boards.");
+    });
+
+    it("joins multiple distinct text blocks with blank lines", async () => {
+      mockStream.mockResolvedValue({
+        fullStream: createMockFullStream([
+          { type: "text-start", id: "t1" },
+          { type: "text-delta", id: "t1", text: "First block." },
+          { type: "text-end", id: "t1" },
+          { type: "text-start", id: "t2" },
+          { type: "text-delta", id: "t2", text: "Second block." },
+          { type: "text-end", id: "t2" },
+        ]),
+        text: Promise.resolve(""),
+      });
+
+      const { tool } = createSubAgentTool(baseOptions);
+      const gen = tool.execute(
+        { task: "Do something" },
+        {} as ToolExecutionOptions<Record<string, unknown>>,
+      ) as AsyncGenerator<SubAgentActivity>;
+
+      const { yielded } = await consumeGenerator(gen);
+
+      expect(yielded.at(-1)!.text).toBe("First block.\n\nSecond block.");
+    });
+
+    it("falls back to a summary of the final tool result when the sub-agent produced no assistant text", async () => {
+      mockStream.mockResolvedValue({
+        fullStream: createMockFullStream([
+          { type: "tool-input-start", toolName: "listBoards", id: "tc1" },
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "listBoards",
+            output: [{ id: "b1", name: "Board One" }],
+          },
+        ]),
+        text: Promise.resolve(""),
+      });
+
+      const { tool } = createSubAgentTool(baseOptions);
+      const gen = tool.execute(
+        { task: "list all boards" },
+        {} as ToolExecutionOptions<Record<string, unknown>>,
+      ) as AsyncGenerator<SubAgentActivity>;
+
+      const { yielded } = await consumeGenerator(gen);
+      const final = yielded.at(-1)!;
+
+      // Not silently empty — carries the tool name and the result payload so the
+      // parent can still relay something meaningful.
+      expect(final.text).toContain("listBoards");
+      expect(final.text).toContain("Board One");
     });
 
     it("marks tool-call entry as error on tool-error event", async () => {
@@ -294,7 +393,9 @@ describe("createSubAgentTool", () => {
       const abortController = new AbortController();
       const gen = tool.execute({ task: "Do something" }, {
         abortSignal: abortController.signal,
-      } as ToolExecutionOptions<Record<string, unknown>>) as AsyncGenerator<SubAgentActivity>;
+      } as ToolExecutionOptions<
+        Record<string, unknown>
+      >) as AsyncGenerator<SubAgentActivity>;
 
       await consumeGenerator(gen);
 

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -37,6 +37,26 @@ export type SubAgentActivity = {
   text?: string;
 };
 
+/** The subset of a streamed tool-result part used to synthesize a fallback answer. */
+type ToolResultSummary = { toolName?: string; output: unknown };
+
+/**
+ * Builds a fallback answer from the sub-agent's final tool result for the case
+ * where the sub-agent produced no assistant text at all (e.g. its loop ended on
+ * the tool call). Keeps the delegation result meaningful to the parent rather
+ * than silently empty. Returns "" when there is no tool result to summarize —
+ * `toModelOutput` then supplies its own generic fallback.
+ */
+const summarizeToolResult = (
+  toolResult: ToolResultSummary | undefined,
+): string => {
+  if (!toolResult) return "";
+  const { toolName, output } = toolResult;
+  const rendered = typeof output === "string" ? output : JSON.stringify(output);
+  const label = toolName ? `${toolName} result` : "Tool result";
+  return `${label}: ${rendered}`;
+};
+
 /**
  * Options for creating a sub-agent tool.
  */
@@ -117,6 +137,16 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
         const result = await agent.stream({ prompt: task, abortSignal });
         const entries: SubAgentActivityEntry[] = [];
 
+        // Accumulate the sub-agent's assistant text off the stream, keyed by
+        // text-block id. In AI SDK v7 `result.text` carries ONLY the final
+        // step's text, so a sub-agent whose answer landed in an earlier step —
+        // or whose final step is a tool call — comes back empty (#324). Reading
+        // text-deltas from the fullStream captures every step's output in order.
+        const textBlocks = new Map<string, string>();
+        // Last tool result, used to synthesize a meaningful fallback when the
+        // sub-agent produced no assistant text at all.
+        let lastToolResult: ToolResultSummary | undefined;
+
         const completeLastRunning = (type: SubAgentActivityEntry["type"]) => {
           const entry = entries.findLast(
             (e) => e.type === type && e.status === "running",
@@ -137,6 +167,10 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
               break;
             case "tool-result":
               completeLastRunning("tool-call");
+              lastToolResult = {
+                toolName: part.toolName,
+                output: part.output,
+              };
               break;
             case "tool-error": {
               const entry = entries.findLast(
@@ -155,7 +189,17 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
               completeLastRunning("thinking");
               break;
             case "text-start":
+              textBlocks.set(part.id, "");
               entries.push({ type: "generating", status: "running" });
+              break;
+            case "text-delta":
+              textBlocks.set(
+                part.id,
+                (textBlocks.get(part.id) ?? "") + part.text,
+              );
+              // Deltas grow the answer but don't change the activity log, so
+              // they must not trigger a yield (would spam the SSE stream).
+              changed = false;
               break;
             case "text-end":
               completeLastRunning("generating");
@@ -170,9 +214,15 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
           }
         }
 
+        const aggregatedText = Array.from(textBlocks.values())
+          .map((t) => t.trim())
+          .filter(Boolean)
+          .join("\n\n");
+        const text = aggregatedText || summarizeToolResult(lastToolResult);
+
         // Yield (not return) the final value with text — the SDK's executeTool
         // uses for-await-of which discards generator return values.
-        yield { entries, text: await result.text } satisfies SubAgentActivity;
+        yield { entries, text } satisfies SubAgentActivity;
       },
       toModelOutput: ({ output }) => ({
         type: "text" as const,


### PR DESCRIPTION
## Summary

Fixes #324 — delegating to a sub-agent returned an empty `text` field despite the sub-agent's tool call completing, so the parent orchestrator had nothing to relay.

**Root cause:** the AI SDK v6→v7 upgrade (#316) redefined a stream result's `text` property to be *the final step's text only* (v6 aggregated across all steps). The delegation tool read `await result.text`, so when a sub-agent's answer landed in a non-final step — or its final step was a tool call — the result came back `{ entries: [...], text: "" }`.

The two mechanisms from the triage brief were disambiguated:
- **Loop stops on the tool call (no summarizing step) — ruled out.** `ToolLoopAgent` already continues after tool calls; the loop re-invokes the model as long as tool calls executed and no `stopWhen` fires (ours is only `stepCountIs(50)`). No loop-continuation bug.
- **Text in a non-final step — the actual cause,** fixed here.

## Changes

- Aggregate the sub-agent's assistant text from the `fullStream`'s `text-delta` parts across **all** steps, keyed by text-block id and joined with blank lines (deltas don't trigger a yield, avoiding SSE spam).
- Added a `summarizeToolResult` fallback: when the sub-agent produced no assistant text at all, derive a meaningful summary from the final tool result rather than returning a silent empty string. `toModelOutput`'s `"Task completed."` remains the last-resort fallback.
- Replaced the sub-agent unit tests, which mocked `result.text` as a pre-resolved promise (exercising none of v7's real streaming — why this regressed with green CI). New tests are stream-driven, including a **regression reproducing the multi-step / tool-final shape** that fails against the old code, plus multi-block joining and the no-text fallback.

## Verification

- `pnpm --filter backend typecheck` — clean
- Full suite: 1121 backend + 16 frontend tests pass
- Confirmed working locally against a real provider on the dev server (reporter's "list all boards" Kanban Agent case; parent relays sub-agent output end-to-end)

## Out of scope

Unchanged: the streamed activity-log `entries` shape / SSE mechanism, sub-agent tool loading, security-guardrail append, per-step timeout/`onProgress` wiring, and the #322 tool-result JSON normalization.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)