### PR TITLE
chore(docs): normalize ADR status headers to accepted

### DIFF
--- a/docs/adr/0001-sandbox-as-workspace-keyed-execution-environment.md
+++ b/docs/adr/0001-sandbox-as-workspace-keyed-execution-environment.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # Sandbox is a persistent, Workspace-keyed execution environment parallel to Provider
 
 A Sandbox is a configured, isolated execution environment registered on a Workspace, exposing a fixed set of shell and filesystem tools to Agents. We model it as a sibling of Provider — a `sandbox` row per Workspace with a `backend` discriminator and a JSON `config`, resolved by an in-tree adapter registry at Chat-turn time — rather than as a Provider variant, an MCP server, or a generic plugin system. State (filesystem, environment) is keyed on `(orgId, workspaceId)` and is expected to persist across Chat turns; this is what makes Hermes/Claude-Code-style workflows possible. Scope is Workspace-only in v1.

--- a/docs/adr/0002-sandbox-fixed-five-tool-core.md
+++ b/docs/adr/0002-sandbox-fixed-five-tool-core.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # Sandbox interface is a fixed five-tool core with stateless shell semantics
 
 The `SandboxBackend` interface defines exactly five tools — `shell.exec`, `fs.read`, `fs.write`, `fs.edit`, `fs.list` — with Platypus-defined parameter shapes, return shapes, and output bounds. Adapters cannot add tools, rename tools, or change signatures. `shell.exec` is stateless: each call gets a fresh shell with an explicit `cwd`, no session state survives between calls, and a mandatory timeout applies. The system prompt receives a fixed adapter-agnostic orientation block whenever the `"sandbox"` tool set is granted.

--- a/docs/adr/0003-docker-reference-sandbox-adapter-socket-mount.md
+++ b/docs/adr/0003-docker-reference-sandbox-adapter-socket-mount.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # Docker reference Sandbox adapter mounts the host Docker socket
 
 > **Update — superseded in part by [ADR-0013](0013-plugin-system-manifest-driven-in-process-extension-points.md):**

--- a/docs/adr/0004-sandbox-workspace-default-env-vars.md
+++ b/docs/adr/0004-sandbox-workspace-default-env-vars.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # Sandbox workspace-default env vars are Platypus-merged at exec time, opaque to the model
 
 A Sandbox carries a workspace-default `env: Record<string, string>` (top-level column on the `sandbox` row). On every `shell.exec`, the Sandbox route merges the workspace env on top of the model-provided `input.env` (workspace wins on key collision) and calls the adapter with the merged map. Values never appear in the system prompt, tool-call transcripts, or logs; the orientation block lists keys only. The motivating use case is API keys (`OPENAI_API_KEY`, `GITHUB_TOKEN`, …) so agent-written code can call third-party services without those values transiting the LLM.

--- a/docs/adr/0005-sandbox-host-reachability-is-admin-curated-default-deny.md
+++ b/docs/adr/0005-sandbox-host-reachability-is-admin-curated-default-deny.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # Sandbox host reachability is an admin-curated, default-deny capability bounded by an operator allowlist
 
 > **Update — see [ADR-0013](0013-plugin-system-manifest-driven-in-process-extension-points.md):**

--- a/docs/adr/0006-credential-and-reach-bearing-config-is-admin-managed.md
+++ b/docs/adr/0006-credential-and-reach-bearing-config-is-admin-managed.md
@@ -1,3 +1,7 @@
+---
+status: accepted
+---
+
 # Credential- and reach-bearing configuration is admin-managed; composition is owner-managed
 
 Resources that introduce credentials, external reach, or code execution — **Providers, Sandboxes, and MCPs** — are configured by an Org Admin by default. Resources that merely compose already-sanctioned capabilities — **Agents, Skills, Chats** — remain editable by the Workspace Owner. Because Workspaces are single-user, the Owner is exactly the actor (e.g. a contractor) the default is meant to constrain, so leaving credential-bearing config owner-editable would defeat the control.

--- a/docs/adr/0012-ssh-reference-sandbox-byo-host-adapter.md
+++ b/docs/adr/0012-ssh-reference-sandbox-byo-host-adapter.md
@@ -1,5 +1,5 @@
 ---
-Status: proposed
+status: accepted
 ---
 
 # SSH reference Sandbox adapter attaches to a pre-existing, operator-owned host

--- a/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md
+++ b/docs/adr/0013-plugin-system-manifest-driven-in-process-extension-points.md
@@ -1,5 +1,5 @@
 ---
-Status: proposed
+status: accepted
 ---
 
 # Plugins are manifest-driven, in-process bundles that fill core-owned extension points


### PR DESCRIPTION
## Summary

The ADR set had inconsistent (and in places stale/missing) `status` headers. This normalizes all 13 to a uniform lowercase `status: accepted`.

- **0012 (SSH sandbox adapter)** and **0013 (plugin system)** still read `Status: proposed`, but both have shipped — the plugin loader/registry and core plugins live under `apps/backend/src/plugins/` (`docker`, `ssh`, `tools-basic`, `tools-platform`, `web-fetch`), and the SSH adapter under `apps/backend/src/plugins/ssh/`. Flipped to `accepted`.
- **0001–0006** were missing a frontmatter status header entirely. Added `status: accepted`.
- Normalized on the lowercase `status:` convention already used by 0007–0011 (0012/0013 previously used capitalized `Status:`).

## Verification

```
$ for f in docs/adr/0*.md; do head -3 "$f" | grep -i "status:"; done
```

All 13 ADRs now report `status: accepted`.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)