### PR TITLE
fix(frontend): populate edit forms from SWR warm cache

### DIFF
--- a/apps/frontend/hooks/use-reset-on-change.test.tsx
+++ b/apps/frontend/hooks/use-reset-on-change.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useResetOnChange } from "./use-reset-on-change";
+
+describe("useResetOnChange", () => {
+  it("runs reset on the first render when the key is already present (warm cache)", () => {
+    const reset = vi.fn();
+    const agent = { id: "agent-1" }; // identity-stable, as SWR returns
+    renderHook(() => useResetOnChange(agent, reset));
+    // Previously this failed: prevKey seeded to the first-render value meant the
+    // key never "changed" and reset never fired — an empty form on warm cache.
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs reset once even when the key is undefined on first render (cold load)", () => {
+    const reset = vi.fn();
+    renderHook(() => useResetOnChange(undefined, reset));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-runs reset when the key changes after the first render", () => {
+    const reset = vi.fn();
+    const { rerender } = renderHook(({ key }) => useResetOnChange(key, reset), {
+      initialProps: { key: undefined as { id: string } | undefined },
+    });
+    expect(reset).toHaveBeenCalledTimes(1); // first render
+
+    const agent = { id: "agent-1" };
+    rerender({ key: agent });
+    expect(reset).toHaveBeenCalledTimes(2); // key became available
+
+    // Same identity on re-render must not clobber in-progress edits.
+    rerender({ key: agent });
+    expect(reset).toHaveBeenCalledTimes(2);
+
+    // A genuinely new source (e.g. navigating to a different agent) re-syncs.
+    rerender({ key: { id: "agent-2" } });
+    expect(reset).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not re-run reset on re-renders when the key is stable", () => {
+    const reset = vi.fn();
+    const key = { id: "agent-1" };
+    const { rerender } = renderHook(() => useResetOnChange(key, reset));
+    rerender();
+    rerender();
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/hooks/use-reset-on-change.ts
+++ b/apps/frontend/hooks/use-reset-on-change.ts
@@ -1,14 +1,28 @@
 import { useState } from "react";
 
+// Sentinel that no real key can ever equal, so the very first render always
+// counts as a "change" and fires `reset`. Seeding `prevKey` with the first
+// render's key instead (the old behaviour) meant that when the synced source
+// was already available synchronously — e.g. served from SWR's warm in-memory
+// cache after client-side navigation — the key never subsequently changed and
+// `reset` never ran, leaving the form on its empty defaults (#332).
+const UNINITIALIZED = Symbol("useResetOnChange:uninitialized");
+
 /**
  * Re-initialises local state whenever `key` changes, using React's documented
  * "adjust state during render" pattern instead of a `setState`-in-effect.
  *
- * `reset` is invoked synchronously during render (only when `key` differs from
- * the previous render), so React discards the in-progress render and restarts
- * with the new state — no cascading effect-triggered re-render. Use this for
- * editable fields that should track a server/prop value until the user edits
- * them, then re-sync when that value changes.
+ * `reset` is invoked synchronously during render — on the first render and
+ * whenever `key` differs from the previous render — so React discards the
+ * in-progress render and restarts with the new state, with no cascading
+ * effect-triggered re-render. Use this for editable fields that should track a
+ * server/prop value until the user edits them, then re-sync when that value
+ * changes.
+ *
+ * Because it also runs on the first render, `reset` fires whether the source
+ * is present synchronously (warm cache) or arrives later (cold load). Guard the
+ * callback against a not-yet-loaded source (`if (source) { … }`) so the initial
+ * run is a harmless no-op when there is nothing to sync yet.
  *
  * @param key   A primitive (or identity-stable) value that changes when the
  *              synced source changes — e.g. `widget.title` or
@@ -16,7 +30,7 @@ import { useState } from "react";
  * @param reset Applies the latest source values to local state.
  */
 export function useResetOnChange(key: unknown, reset: () => void) {
-  const [prevKey, setPrevKey] = useState(key);
+  const [prevKey, setPrevKey] = useState<unknown>(UNINITIALIZED);
   if (key !== prevKey) {
     setPrevKey(key);
     reset();


### PR DESCRIPTION
Closes #332

## Problem

Opening an agent's editor via **3-dots → Edit** often showed an empty form (blank name, description, system prompt, provider/model, etc.). A full page refresh populated it correctly.

## Root cause

`useResetOnChange(key, reset)` seeded its `prevKey` state with the value present on the **first** render:

```ts
const [prevKey, setPrevKey] = useState(key); // seeds to first-render value
```

There is no `<SWRConfig>` provider, so SWR uses a process-global in-memory cache that survives client-side navigation. When an agent had already been fetched earlier in the session, `useSWR` returned it **synchronously on the form's first render** — so `prevKey` was seeded to that object, the key never subsequently *changed*, `reset()` never fired, and the empty `useState` defaults rendered. A hard refresh cleared the cache, forcing the cold path (data arrives later → key changes → reset fires → form fills), which is why refreshing "fixed" it.

## Fix

Seed `prevKey` with a `Symbol` sentinel that no real key can ever equal, so `reset` fires on the first render (warm **or** cold) and again on genuine key changes — while still not re-firing when the key is stable across re-renders, so in-progress user edits aren't clobbered. Callbacks are already guarded against a not-yet-loaded source (`if (source) { … }`), so the initial run is a harmless no-op when there's nothing to sync yet.

Fixing the hook itself resolves all three affected call sites at once — `agent-form`, `trigger-form`, and `workspace-context-form` all share it.

## Acceptance criteria

- [x] Editing an agent populates all fields on warm-cache client-side navigation and on cold load (hard refresh)
- [x] Opening one agent, navigating back, then opening a different agent shows the second agent's data
- [x] The create-agent form (no `agentId`) still renders empty defaults (callback guarded by `if (agent)`)
- [x] In-progress edits are not overwritten by re-renders that don't represent a genuine source change
- [x] `trigger-form` and `workspace-context-form` fixed transitively (both guard with `if (trigger)` / `if (contextData)`)

## Testing

- New `use-reset-on-change.test.tsx` (TDD, red → green): warm-cache first render, cold-load `undefined` first render, genuine key change, stable-identity no-clobber — 4/4 pass
- Full frontend suite: 20/20 pass. `typecheck`, `tsc --noEmit`, and `lint` all clean
- Regression audit: since `reset` now fires on first render for all ~20 call sites, verified each either guards with `if (source)` or re-applies its own initial `useState` value (a no-op React bails on) — confirmed no clobber

## Out of scope (per issue)

No `<SWRConfig>` provider, no react-hook-form conversion, no UI redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)