### PR TITLE
fix(frontend): surface agent form validation errors (#331)

### DIFF
--- a/apps/frontend/components/agent-form.test.tsx
+++ b/apps/frontend/components/agent-form.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { Provider } from "@platypus/schemas";
+
+// --- Module mocks ------------------------------------------------------------
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "u1" } }),
+}));
+
+const toastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: vi.fn(),
+  },
+}));
+
+const mutate = vi.fn();
+const provider: Provider = {
+  id: "p1",
+  name: "OpenAI",
+  modelIds: ["gpt-4o"],
+} as Provider;
+
+// Stable references so re-renders don't churn identity (which would retrigger
+// useResetOnChange and loop).
+const providersResponse = { data: { results: [provider] }, isLoading: false };
+const emptyListResponse = { data: { results: [] }, isLoading: false };
+const nullResponse = { data: undefined, isLoading: false };
+
+// useSWR is called for providers, skills, agents, and (when editing) the agent.
+// Key off the request URL so each call gets the right payload. A null key means
+// SWR would not fetch — mirror that by returning no data.
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (!key) return nullResponse;
+    if (typeof key === "string" && key.endsWith("/providers")) {
+      return providersResponse;
+    }
+    return emptyListResponse;
+  },
+  useSWRConfig: () => ({ mutate }),
+}));
+
+import { AgentForm } from "./agent-form";
+
+// --- Helpers -----------------------------------------------------------------
+
+function mockFailedSave(error: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    json: async () => ({ error }),
+  } as unknown as Response);
+}
+
+function renderCreateForm() {
+  return render(
+    <AgentForm orgId="org1" workspaceId="ws1" toolSets={[]} agents={[]} />,
+  );
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe("AgentForm validation error surfacing", () => {
+  beforeEach(() => {
+    push.mockReset();
+    toastError.mockReset();
+    mutate.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders an inline error and marks the Model control invalid when the server rejects modelId", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFailedSave([{ path: ["modelId"], message: "Model is required" }]),
+    );
+
+    renderCreateForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Model is required")).toBeInTheDocument(),
+    );
+
+    // The Model select trigger is marked invalid for assistive tech.
+    const trigger = screen.getByRole("combobox");
+    expect(trigger).toHaveAttribute("aria-invalid", "true");
+
+    // A validation failure is never silent.
+    expect(toastError).toHaveBeenCalled();
+  });
+
+  it("shows a generic error toast when the failure maps to no inline field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFailedSave("something went wrong on the server"),
+    );
+
+    renderCreateForm();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith("Failed to save agent"),
+    );
+  });
+
+  it("clears a field's error and re-enables Save once the field is edited", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFailedSave([{ path: ["maxSteps"], message: "Invalid max steps" }]),
+    );
+
+    renderCreateForm();
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
+
+    await waitFor(() =>
+      expect(screen.getByText("Invalid max steps")).toBeInTheDocument(),
+    );
+    // An unshown error must not silently disable the button — but a shown one
+    // does, until the user corrects the field.
+    expect(saveButton).toBeDisabled();
+
+    // Editing the offending field clears its error and re-enables Save.
+    fireEvent.change(screen.getByLabelText("Max steps"), {
+      target: { value: "10" },
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByText("Invalid max steps")).not.toBeInTheDocument(),
+    );
+    expect(saveButton).not.toBeDisabled();
+  });
+});

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -211,19 +211,25 @@ const AgentForm = ({
     }
   });
 
+  // Drop the stored server validation error for the given field(s) so a
+  // corrected field stops rendering its error and re-enables the Save button.
+  const clearValidationErrors = useCallback((...ids: string[]) => {
+    setValidationErrors((prev) => {
+      if (!ids.some((id) => id in prev)) return prev;
+      const newErrors = { ...prev };
+      for (const id of ids) {
+        delete newErrors[id];
+      }
+      return newErrors;
+    });
+  }, []);
+
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     const { id, value } = e.target;
 
-    // Clear validation error for this field
-    if (validationErrors[id]) {
-      setValidationErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[id];
-        return newErrors;
-      });
-    }
+    clearValidationErrors(id);
 
     setFormData((prevData) => ({
       ...prevData,
@@ -232,6 +238,7 @@ const AgentForm = ({
   };
 
   const handleNumberChange = (id: string, value: string) => {
+    clearValidationErrors(id);
     setFormData((prevData) => ({
       ...prevData,
       [id]: value === "" ? undefined : parseInt(value),
@@ -239,6 +246,7 @@ const AgentForm = ({
   };
 
   const handleFloatChange = (id: string, value: string) => {
+    clearValidationErrors(id);
     setFormData((prevData) => ({
       ...prevData,
       [id]: value === "" ? undefined : parseFloat(value),
@@ -296,6 +304,7 @@ const AgentForm = ({
       // Provider/model selected
       const [, newProviderId, ...modelIdParts] = value.split(":");
       const newModelId = modelIdParts.join(":");
+      clearValidationErrors("providerId", "modelId");
       setFormData((prevData) => ({
         ...prevData,
         providerId: newProviderId,
@@ -377,7 +386,15 @@ const AgentForm = ({
       } else {
         // Parse standardschema.dev validation errors
         const errorData = await response.json();
-        setValidationErrors(parseValidationErrors(errorData));
+        const errors = parseValidationErrors(errorData);
+        setValidationErrors(errors);
+        // Surface a user-visible signal even when the failure maps to a field
+        // without an inline error, so a rejected save is never silent (#331).
+        toast.error(
+          Object.keys(errors).length > 0
+            ? "Please fix the highlighted fields and try again"
+            : "Failed to save agent",
+        );
         console.error("Failed to save agent");
       }
     } catch (error) {
@@ -580,7 +597,7 @@ const AgentForm = ({
               <FieldError>{validationErrors.inputPlaceholder}</FieldError>
             )}
           </Field>
-          <Field>
+          <Field data-invalid={!!validationErrors.systemPrompt}>
             <ExpandableTextarea
               id="systemPrompt"
               label="System prompt"
@@ -589,36 +606,51 @@ const AgentForm = ({
               onChange={handleChange}
               disabled={isSubmitting || readOnly}
               className="!font-mono"
+              aria-invalid={!!validationErrors.systemPrompt}
+              error={validationErrors.systemPrompt}
             />
           </Field>
-          <Field>
-            <FieldLabel>Model</FieldLabel>
-            <Select
-              value={`provider:${formData.providerId}:${formData.modelId}`}
-              onValueChange={handleModelChange}
-              disabled={isSubmitting || readOnly}
-            >
-              <SelectTrigger disabled={isSubmitting || readOnly}>
-                <SelectValue placeholder="Select a model" />
-              </SelectTrigger>
-              <SelectContent>
-                {providers.map((provider) => (
-                  <SelectGroup key={provider.id}>
-                    <SelectLabel>{provider.name}</SelectLabel>
-                    {provider.modelIds.map((modelId) => (
-                      <SelectItem
-                        key={`provider:${provider.id}:${modelId}`}
-                        value={`provider:${provider.id}:${modelId}`}
-                      >
-                        {modelId}
-                      </SelectItem>
+          {/* Provider and model are chosen from one control, so surface either
+              field's server error on the single Model field. */}
+          {(() => {
+            const modelError =
+              validationErrors.modelId || validationErrors.providerId;
+            return (
+              <Field data-invalid={!!modelError}>
+                <FieldLabel htmlFor="modelId">Model</FieldLabel>
+                <Select
+                  value={`provider:${formData.providerId}:${formData.modelId}`}
+                  onValueChange={handleModelChange}
+                  disabled={isSubmitting || readOnly}
+                >
+                  <SelectTrigger
+                    id="modelId"
+                    disabled={isSubmitting || readOnly}
+                    aria-invalid={!!modelError}
+                  >
+                    <SelectValue placeholder="Select a model" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {providers.map((provider) => (
+                      <SelectGroup key={provider.id}>
+                        <SelectLabel>{provider.name}</SelectLabel>
+                        {provider.modelIds.map((modelId) => (
+                          <SelectItem
+                            key={`provider:${provider.id}:${modelId}`}
+                            value={`provider:${provider.id}:${modelId}`}
+                          >
+                            {modelId}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
                     ))}
-                  </SelectGroup>
-                ))}
-              </SelectContent>
-            </Select>
-          </Field>
-          <Field className="w-1/2">
+                  </SelectContent>
+                </Select>
+                {modelError && <FieldError>{modelError}</FieldError>}
+              </Field>
+            );
+          })()}
+          <Field className="w-1/2" data-invalid={!!validationErrors.maxSteps}>
             <FieldLabel htmlFor="maxSteps">Max steps</FieldLabel>
             <Input
               id="maxSteps"
@@ -627,11 +659,15 @@ const AgentForm = ({
               value={formData.maxSteps}
               onChange={(e) => handleNumberChange("maxSteps", e.target.value)}
               disabled={isSubmitting || readOnly}
+              aria-invalid={!!validationErrors.maxSteps}
             />
             <FieldDescription>
               Controls when a tool-calling loop should stop based on the number
               of steps executed
             </FieldDescription>
+            {validationErrors.maxSteps && (
+              <FieldError>{validationErrors.maxSteps}</FieldError>
+            )}
           </Field>
         </FieldGroup>
 
@@ -816,7 +852,7 @@ const AgentForm = ({
           </CollapsibleTrigger>
           <CollapsibleContent className="mb-6">
             <FieldGroup className="grid grid-cols-2">
-              <Field>
+              <Field data-invalid={!!validationErrors.temperature}>
                 <FieldLabel htmlFor="temperature">Temperature</FieldLabel>
                 <Input
                   id="temperature"
@@ -828,9 +864,13 @@ const AgentForm = ({
                     handleFloatChange("temperature", e.target.value)
                   }
                   disabled={isSubmitting || readOnly}
+                  aria-invalid={!!validationErrors.temperature}
                 />
+                {validationErrors.temperature && (
+                  <FieldError>{validationErrors.temperature}</FieldError>
+                )}
               </Field>
-              <Field>
+              <Field data-invalid={!!validationErrors.seed}>
                 <FieldLabel htmlFor="seed">Seed</FieldLabel>
                 <Input
                   id="seed"
@@ -838,9 +878,13 @@ const AgentForm = ({
                   value={formData.seed ?? ""}
                   onChange={(e) => handleNumberChange("seed", e.target.value)}
                   disabled={isSubmitting || readOnly}
+                  aria-invalid={!!validationErrors.seed}
                 />
+                {validationErrors.seed && (
+                  <FieldError>{validationErrors.seed}</FieldError>
+                )}
               </Field>
-              <Field>
+              <Field data-invalid={!!validationErrors.topP}>
                 <FieldLabel htmlFor="topP">Top-p</FieldLabel>
                 <Input
                   id="topP"
@@ -851,9 +895,13 @@ const AgentForm = ({
                   value={formData.topP ?? ""}
                   onChange={(e) => handleFloatChange("topP", e.target.value)}
                   disabled={isSubmitting || readOnly}
+                  aria-invalid={!!validationErrors.topP}
                 />
+                {validationErrors.topP && (
+                  <FieldError>{validationErrors.topP}</FieldError>
+                )}
               </Field>
-              <Field>
+              <Field data-invalid={!!validationErrors.topK}>
                 <FieldLabel htmlFor="topK">Top-k</FieldLabel>
                 <Input
                   id="topK"
@@ -862,9 +910,13 @@ const AgentForm = ({
                   value={formData.topK ?? ""}
                   onChange={(e) => handleNumberChange("topK", e.target.value)}
                   disabled={isSubmitting || readOnly}
+                  aria-invalid={!!validationErrors.topK}
                 />
+                {validationErrors.topK && (
+                  <FieldError>{validationErrors.topK}</FieldError>
+                )}
               </Field>
-              <Field>
+              <Field data-invalid={!!validationErrors.presencePenalty}>
                 <FieldLabel htmlFor="presencePenalty">
                   Presence Penalty
                 </FieldLabel>
@@ -879,9 +931,13 @@ const AgentForm = ({
                     handleFloatChange("presencePenalty", e.target.value)
                   }
                   disabled={isSubmitting || readOnly}
+                  aria-invalid={!!validationErrors.presencePenalty}
                 />
+                {validationErrors.presencePenalty && (
+                  <FieldError>{validationErrors.presencePenalty}</FieldError>
+                )}
               </Field>
-              <Field>
+              <Field data-invalid={!!validationErrors.frequencyPenalty}>
                 <FieldLabel htmlFor="frequencyPenalty">
                   Frequency Penalty
                 </FieldLabel>
@@ -896,7 +952,11 @@ const AgentForm = ({
                     handleFloatChange("frequencyPenalty", e.target.value)
                   }
                   disabled={isSubmitting || readOnly}
+                  aria-invalid={!!validationErrors.frequencyPenalty}
                 />
+                {validationErrors.frequencyPenalty && (
+                  <FieldError>{validationErrors.frequencyPenalty}</FieldError>
+                )}
               </Field>
             </FieldGroup>
           </CollapsibleContent>


### PR DESCRIPTION
Closes #331

## Problem

The agent create/edit form validated only on the server and rendered inline errors for just `name`, `description`, and `inputPlaceholder`. A non-OK save produced only a `console.error` — no toast — so a rejected save (notably a missing **Model**) silently disabled the Save button with nothing telling the user why. The Model select's change handler also never cleared a stored Model error, so it stuck and kept the button disabled even after picking a valid model.

## Changes

- **Inline errors for every validated field** — Model (`modelId`/`providerId`), `systemPrompt`, `maxSteps`, and the advanced sampling fields (`temperature`, `topP`, `topK`, `seed`, `presencePenalty`, `frequencyPenalty`) now render `<FieldError>` with `aria-invalid`/`data-invalid` on the control, consistent with the existing `name`/`description`/`inputPlaceholder` fields.
- **Clear-on-change** — a shared `clearValidationErrors(...ids)` helper replaces the inline delete logic and is wired into `handleChange`, `handleNumberChange`, `handleFloatChange`, and `handleModelChange`, so correcting any field (including the Model select) clears its error and re-enables Save.
- **Never silent** — a non-OK save now always raises an error toast (a field-specific "Please fix the highlighted fields" message when errors map to fields, generic "Failed to save agent" otherwise).

No schema changes; `modelId` stays required as-is (out of scope per the issue).

## Tests

New `apps/frontend/components/agent-form.test.tsx` (3 tests):
- inline Model error + `aria-invalid` + toast on a rejected `modelId`
- generic toast fallback for a failure that maps to no field
- editing a field clears its error and re-enables Save

`tsc --noEmit` (frontend) clean, eslint clean, full suite passes (backend 1121, frontend 19). Two-axis code review (Standards + Spec) returned no blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)