### PR TITLE
fix: gate unsupported file attachments per-model (#328)

### DIFF
--- a/apps/backend/drizzle/0047_backfill_model_configs.sql
+++ b/apps/backend/drizzle/0047_backfill_model_configs.sql
@@ -1,0 +1,32 @@
+-- Backfill provider.modelIds from a legacy string[] to per-model config objects
+-- (issue #328). Each string id becomes { "id": <id>, "passthroughFileTypes": [...] }
+-- with the passthrough set defaulted by provider type:
+--   Anthropic / Google / Bedrock, and OpenAI on the Responses API → images + PDF
+--   OpenAI chat-completions and everything else                   → images only
+--
+-- Only rows still holding string elements are rewritten, so this is idempotent
+-- and a no-op once every row is object-shaped. The backend also normalizes
+-- either shape at read time, so an un-run migration (e.g. dev push) is harmless.
+UPDATE "provider" p
+SET "modelIds" = (
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', elem,
+      'passthroughFileTypes',
+      CASE
+        WHEN p."provider_type" IN ('Anthropic', 'Google', 'Bedrock')
+          THEN '["image/*","application/pdf"]'::jsonb
+        WHEN p."provider_type" = 'OpenAI' AND p."api_mode" <> 'chat'
+          THEN '["image/*","application/pdf"]'::jsonb
+        ELSE '["image/*"]'::jsonb
+      END
+    )
+  )
+  FROM jsonb_array_elements_text(p."modelIds") AS elem
+)
+WHERE jsonb_typeof(p."modelIds") = 'array'
+  AND EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(p."modelIds") AS e
+    WHERE jsonb_typeof(e) = 'string'
+  );

--- a/apps/backend/drizzle/meta/0047_snapshot.json
+++ b/apps/backend/drizzle/meta/0047_snapshot.json
@@ -1,0 +1,4303 @@
+{
+  "id": "66e541e1-8fe3-4f8d-9054-f33945cb945b",
+  "prevId": "83f5152e-d97b-4306-b848-a31fe481a3a7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_set_ids": {
+          "name": "tool_set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "skill_ids": {
+          "name": "skill_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "sub_agent_ids": {
+          "name": "sub_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "input_placeholder": {
+          "name": "input_placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_workspace_id": {
+          "name": "idx_agent_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agent_organization_id": {
+          "name": "idx_agent_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_agent_provider_id": {
+          "name": "idx_agent_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_workspace_id_workspace_id_fk": {
+          "name": "agent_workspace_id_workspace_id_fk",
+          "tableFrom": "agent",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "agent_provider_id_provider_id_fk": {
+          "name": "agent_provider_id_provider_id_fk",
+          "tableFrom": "agent",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "tableTo": "provider",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_agent_name_org": {
+          "name": "unique_agent_name_org",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment": {
+      "name": "attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_attachment_workspace": {
+          "name": "idx_attachment_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_attachment_resource": {
+          "name": "idx_attachment_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "attachment_workspace_id_workspace_id_fk": {
+          "name": "attachment_workspace_id_workspace_id_fk",
+          "tableFrom": "attachment",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_attachment": {
+          "name": "unique_attachment",
+          "columns": [
+            "workspace_id",
+            "resource_type",
+            "resource_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blueprint": {
+      "name": "blueprint",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_model_provider_id": {
+          "name": "task_model_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_provider_id": {
+          "name": "memory_extraction_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_embedding_provider_id": {
+          "name": "memory_embedding_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blueprint_organization_id": {
+          "name": "idx_blueprint_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "blueprint_organization_id_organization_id_fk": {
+          "name": "blueprint_organization_id_organization_id_fk",
+          "tableFrom": "blueprint",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "blueprint_task_model_provider_id_provider_id_fk": {
+          "name": "blueprint_task_model_provider_id_provider_id_fk",
+          "tableFrom": "blueprint",
+          "columnsFrom": [
+            "task_model_provider_id"
+          ],
+          "tableTo": "provider",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "blueprint_memory_extraction_provider_id_provider_id_fk": {
+          "name": "blueprint_memory_extraction_provider_id_provider_id_fk",
+          "tableFrom": "blueprint",
+          "columnsFrom": [
+            "memory_extraction_provider_id"
+          ],
+          "tableTo": "provider",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "blueprint_memory_embedding_provider_id_provider_id_fk": {
+          "name": "blueprint_memory_embedding_provider_id_provider_id_fk",
+          "tableFrom": "blueprint",
+          "columnsFrom": [
+            "memory_embedding_provider_id"
+          ],
+          "tableTo": "provider",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_blueprint_name_org": {
+          "name": "unique_blueprint_name_org",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blueprint_item": {
+      "name": "blueprint_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blueprint_item_blueprint": {
+          "name": "idx_blueprint_item_blueprint",
+          "columns": [
+            {
+              "expression": "blueprint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_blueprint_item_resource": {
+          "name": "idx_blueprint_item_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "blueprint_item_blueprint_id_blueprint_id_fk": {
+          "name": "blueprint_item_blueprint_id_blueprint_id_fk",
+          "tableFrom": "blueprint_item",
+          "columnsFrom": [
+            "blueprint_id"
+          ],
+          "tableTo": "blueprint",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_blueprint_item": {
+          "name": "unique_blueprint_item",
+          "columns": [
+            "blueprint_id",
+            "resource_type",
+            "resource_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_memory_processed_at": {
+          "name": "last_memory_processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_status": {
+          "name": "memory_extraction_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_workspace_id": {
+          "name": "idx_chat_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_chat_tags": {
+          "name": "idx_chat_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "idx_chat_memory_processing": {
+          "name": "idx_chat_memory_processing",
+          "columns": [
+            {
+              "expression": "memory_extraction_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_memory_processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "chat_workspace_id_workspace_id_fk": {
+          "name": "chat_workspace_id_workspace_id_fk",
+          "tableFrom": "chat",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context": {
+      "name": "context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_context_user_id": {
+          "name": "idx_context_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_context_workspace_id": {
+          "name": "idx_context_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "context_user_id_user_id_fk": {
+          "name": "context_user_id_user_id_fk",
+          "tableFrom": "context",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "context_workspace_id_workspace_id_fk": {
+          "name": "context_workspace_id_workspace_id_fk",
+          "tableFrom": "context",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_context_user_workspace": {
+          "name": "unique_context_user_workspace",
+          "columns": [
+            "user_id",
+            "workspace_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard": {
+      "name": "dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desktop_layout": {
+          "name": "desktop_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mobile_layout": {
+          "name": "mobile_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_dashboard_workspace_id": {
+          "name": "idx_dashboard_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_dashboard_workspace_name": {
+          "name": "uq_dashboard_workspace_name",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "dashboard_workspace_id_workspace_id_fk": {
+          "name": "dashboard_workspace_id_workspace_id_fk",
+          "tableFrom": "dashboard",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitation_email": {
+          "name": "idx_invitation_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_invitation_org_id": {
+          "name": "idx_invitation_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "invitation_invited_by_user_id_fk": {
+          "name": "invitation_invited_by_user_id_fk",
+          "tableFrom": "invitation",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_invitation_org_email": {
+          "name": "unique_invitation_org_email",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_blueprint": {
+      "name": "invitation_blueprint",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitation_blueprint_invitation": {
+          "name": "idx_invitation_blueprint_invitation",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_invitation_blueprint_blueprint": {
+          "name": "idx_invitation_blueprint_blueprint",
+          "columns": [
+            {
+              "expression": "blueprint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_blueprint_invitation_id_invitation_id_fk": {
+          "name": "invitation_blueprint_invitation_id_invitation_id_fk",
+          "tableFrom": "invitation_blueprint",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "tableTo": "invitation",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "invitation_blueprint_blueprint_id_blueprint_id_fk": {
+          "name": "invitation_blueprint_blueprint_id_blueprint_id_fk",
+          "tableFrom": "invitation_blueprint",
+          "columnsFrom": [
+            "blueprint_id"
+          ],
+          "tableTo": "blueprint",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_invitation_blueprint": {
+          "name": "unique_invitation_blueprint",
+          "columns": [
+            "invitation_id",
+            "blueprint_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_board": {
+      "name": "kanban_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_board_workspace_id": {
+          "name": "idx_kanban_board_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "kanban_board_workspace_id_workspace_id_fk": {
+          "name": "kanban_board_workspace_id_workspace_id_fk",
+          "tableFrom": "kanban_board",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_kanban_board_name_workspace": {
+          "name": "unique_kanban_board_name_workspace",
+          "columns": [
+            "workspace_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card": {
+      "name": "kanban_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_ids": {
+          "name": "label_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "assignees": {
+          "name": "assignees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_user_id": {
+          "name": "last_edited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_agent_id": {
+          "name": "last_edited_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_column_id": {
+          "name": "idx_kanban_card_column_id",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_kanban_card_label_ids": {
+          "name": "idx_kanban_card_label_ids",
+          "columns": [
+            {
+              "expression": "label_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "idx_kanban_card_assignees": {
+          "name": "idx_kanban_card_assignees",
+          "columns": [
+            {
+              "expression": "assignees",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "gin",
+          "concurrently": false
+        },
+        "idx_kanban_card_due_date": {
+          "name": "idx_kanban_card_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_kanban_card_priority": {
+          "name": "idx_kanban_card_priority",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_kanban_card_column_position": {
+          "name": "idx_kanban_card_column_position",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_column_id_kanban_column_id_fk": {
+          "name": "kanban_card_column_id_kanban_column_id_fk",
+          "tableFrom": "kanban_card",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "tableTo": "kanban_column",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "kanban_card_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "kanban_card_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "tableTo": "agent",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "kanban_card_last_edited_by_user_id_user_id_fk": {
+          "name": "kanban_card_last_edited_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "columnsFrom": [
+            "last_edited_by_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "kanban_card_last_edited_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_last_edited_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "columnsFrom": [
+            "last_edited_by_agent_id"
+          ],
+          "tableTo": "agent",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card_comment": {
+      "name": "kanban_card_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_comment_card_id": {
+          "name": "idx_kanban_card_comment_card_id",
+          "columns": [
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_comment_card_id_kanban_card_id_fk": {
+          "name": "kanban_card_comment_card_id_kanban_card_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "tableTo": "kanban_card",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "kanban_card_comment_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_comment_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "kanban_card_comment_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_comment_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "tableTo": "agent",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_column": {
+      "name": "kanban_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_column_board_id": {
+          "name": "idx_kanban_column_board_id",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "kanban_column_board_id_kanban_board_id_fk": {
+          "name": "kanban_column_board_id_kanban_board_id_fk",
+          "tableFrom": "kanban_column",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "tableTo": "kanban_board",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp": {
+      "name": "mcp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_access_token": {
+          "name": "oauth_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_refresh_token": {
+          "name": "oauth_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_expires_at": {
+          "name": "oauth_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_requested_scope": {
+          "name": "oauth_requested_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_workspace_id": {
+          "name": "idx_mcp_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_mcp_organization_id": {
+          "name": "idx_mcp_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_organization_id_organization_id_fk": {
+          "name": "mcp_organization_id_organization_id_fk",
+          "tableFrom": "mcp",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "mcp_workspace_id_workspace_id_fk": {
+          "name": "mcp_workspace_id_workspace_id_fk",
+          "tableFrom": "mcp",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_mcp_name_org": {
+          "name": "unique_mcp_name_org",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        },
+        "unique_mcp_name_workspace": {
+          "name": "unique_mcp_name_workspace",
+          "columns": [
+            "workspace_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_state": {
+      "name": "mcp_oauth_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_oauth_state_mcp_id": {
+          "name": "idx_mcp_oauth_state_mcp_id",
+          "columns": [
+            {
+              "expression": "mcp_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_state_mcp_id_mcp_id_fk": {
+          "name": "mcp_oauth_state_mcp_id_mcp_id_fk",
+          "tableFrom": "mcp_oauth_state",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "tableTo": "mcp",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_daily_summary": {
+      "name": "memory_daily_summary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_date": {
+          "name": "summary_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_summary_user_workspace": {
+          "name": "idx_daily_summary_user_workspace",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_daily_summary_date": {
+          "name": "idx_daily_summary_date",
+          "columns": [
+            {
+              "expression": "summary_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "memory_daily_summary_user_id_user_id_fk": {
+          "name": "memory_daily_summary_user_id_user_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "memory_daily_summary_workspace_id_workspace_id_fk": {
+          "name": "memory_daily_summary_workspace_id_workspace_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_daily_summary_user_workspace_date": {
+          "name": "unique_daily_summary_user_workspace_date",
+          "columns": [
+            "user_id",
+            "workspace_id",
+            "summary_date"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_workspace_id": {
+          "name": "idx_notification_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_notification_agent_id": {
+          "name": "idx_notification_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_notification_created_at": {
+          "name": "idx_notification_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_workspace_id_workspace_id_fk": {
+          "name": "notification_workspace_id_workspace_id_fk",
+          "tableFrom": "notification",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notification_agent_id_agent_id_fk": {
+          "name": "notification_agent_id_agent_id_fk",
+          "tableFrom": "notification",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agent",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_read": {
+      "name": "notification_read",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_read_user_id": {
+          "name": "idx_notification_read_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_notification_read_notification_id": {
+          "name": "idx_notification_read_notification_id",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notification_read_notification_id_notification_id_fk": {
+          "name": "notification_read_notification_id_notification_id_fk",
+          "tableFrom": "notification_read",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "tableTo": "notification",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "notification_read_user_id_user_id_fk": {
+          "name": "notification_read_user_id_user_id_fk",
+          "tableFrom": "notification_read",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_notification_read": {
+          "name": "unique_notification_read",
+          "columns": [
+            "notification_id",
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_context": {
+          "name": "identity_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_member": {
+      "name": "organization_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_member_org_id": {
+          "name": "idx_org_member_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_org_member_user_id": {
+          "name": "idx_org_member_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "organization_member_organization_id_organization_id_fk": {
+          "name": "organization_member_organization_id_organization_id_fk",
+          "tableFrom": "organization_member",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "organization_member_user_id_user_id_fk": {
+          "name": "organization_member_user_id_user_id_fk",
+          "tableFrom": "organization_member",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraBody": {
+          "name": "extraBody",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_mode": {
+          "name": "api_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'responses'"
+        },
+        "native_search_enabled": {
+          "name": "native_search_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "security_guardrails": {
+          "name": "security_guardrails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modelIds": {
+          "name": "modelIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_model_id": {
+          "name": "task_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_extraction_model_id": {
+          "name": "memory_extraction_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_workspace_id": {
+          "name": "idx_provider_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_provider_organization_id": {
+          "name": "idx_provider_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "provider_organization_id_organization_id_fk": {
+          "name": "provider_organization_id_organization_id_fk",
+          "tableFrom": "provider",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_provider_name_org": {
+          "name": "unique_provider_name_org",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        },
+        "unique_provider_name_workspace": {
+          "name": "unique_provider_name_workspace",
+          "columns": [
+            "workspace_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox": {
+      "name": "sandbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "admin_env": {
+          "name": "admin_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_env": {
+          "name": "user_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_sandbox_workspace_id": {
+          "name": "unique_sandbox_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sandbox_workspace_id_workspace_id_fk": {
+          "name": "sandbox_workspace_id_workspace_id_fk",
+          "tableFrom": "sandbox",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_teardown_failure": {
+      "name": "sandbox_teardown_failure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_teardown_failure_workspace_id": {
+          "name": "idx_sandbox_teardown_failure_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill": {
+      "name": "skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_workspace_id": {
+          "name": "idx_skill_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_skill_organization_id": {
+          "name": "idx_skill_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "skill_organization_id_organization_id_fk": {
+          "name": "skill_organization_id_organization_id_fk",
+          "tableFrom": "skill",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "skill_workspace_id_workspace_id_fk": {
+          "name": "skill_workspace_id_workspace_id_fk",
+          "tableFrom": "skill",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_skill_name_workspace": {
+          "name": "unique_skill_name_workspace",
+          "columns": [
+            "workspace_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        },
+        "unique_skill_name_org": {
+          "name": "unique_skill_name_org",
+          "columns": [
+            "organization_id",
+            "name"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger": {
+      "name": "trigger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_runs_to_keep": {
+          "name": "max_runs_to_keep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "search": {
+          "name": "search",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_workspace_id": {
+          "name": "idx_trigger_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_trigger_next_run_at": {
+          "name": "idx_trigger_next_run_at",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_trigger_type": {
+          "name": "idx_trigger_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "trigger_workspace_id_workspace_id_fk": {
+          "name": "trigger_workspace_id_workspace_id_fk",
+          "tableFrom": "trigger",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "trigger_agent_id_agent_id_fk": {
+          "name": "trigger_agent_id_agent_id_fk",
+          "tableFrom": "trigger",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "tableTo": "agent",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_run": {
+      "name": "trigger_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_run_trigger_id": {
+          "name": "idx_trigger_run_trigger_id",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_trigger_run_started_at": {
+          "name": "idx_trigger_run_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "trigger_run_trigger_id_trigger_id_fk": {
+          "name": "trigger_run_trigger_id_trigger_id_fk",
+          "tableFrom": "trigger_run",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "tableTo": "trigger",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Webhook'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_secret": {
+          "name": "signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhook_workspace_id": {
+          "name": "idx_webhook_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_workspace_id_workspace_id_fk": {
+          "name": "webhook_workspace_id_workspace_id_fk",
+          "tableFrom": "webhook",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "tableTo": "workspace",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget": {
+      "name": "widget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_widget_dashboard_id": {
+          "name": "idx_widget_dashboard_id",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uq_widget_dashboard_title": {
+          "name": "uq_widget_dashboard_title",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "widget_dashboard_id_dashboard_id_fk": {
+          "name": "widget_dashboard_id_dashboard_id_fk",
+          "tableFrom": "widget",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "tableTo": "dashboard",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace": {
+      "name": "workspace",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_model_provider_id": {
+          "name": "task_model_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_provider_id": {
+          "name": "memory_extraction_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_embedding_provider_id": {
+          "name": "memory_embedding_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_daily_summaries": {
+          "name": "max_daily_summaries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 90
+        },
+        "provider_self_management": {
+          "name": "provider_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mcp_self_management": {
+          "name": "mcp_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_organization_id": {
+          "name": "idx_workspace_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_workspace_owner_id": {
+          "name": "idx_workspace_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "workspace_organization_id_organization_id_fk": {
+          "name": "workspace_organization_id_organization_id_fk",
+          "tableFrom": "workspace",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "tableTo": "organization",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "workspace_owner_id_user_id_fk": {
+          "name": "workspace_owner_id_user_id_fk",
+          "tableFrom": "workspace",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "workspace_task_model_provider_id_provider_id_fk": {
+          "name": "workspace_task_model_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "columnsFrom": [
+            "task_model_provider_id"
+          ],
+          "tableTo": "provider",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "workspace_memory_extraction_provider_id_provider_id_fk": {
+          "name": "workspace_memory_extraction_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "columnsFrom": [
+            "memory_extraction_provider_id"
+          ],
+          "tableTo": "provider",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "workspace_memory_embedding_provider_id_provider_id_fk": {
+          "name": "workspace_memory_embedding_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "columnsFrom": [
+            "memory_embedding_provider_id"
+          ],
+          "tableTo": "provider",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1783498140025,
       "tag": "0046_brave_smasher",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1784345318833,
+      "tag": "0047_backfill_model_configs",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -69,7 +69,13 @@ export const provider = pgTable(
     // every run on this provider (and sub-agent runs resolved to it). Nullable
     // — existing providers are unchanged.
     securityGuardrails: t.text("security_guardrails"),
-    modelIds: t.jsonb().$type<string[]>().notNull(),
+    // Per-model config (see `modelConfigSchema` in @platypus/schemas). Legacy
+    // rows may still hold a bare `string[]`; the backend normalizes both shapes
+    // via `resolveProviderModels`, and migration 0047 backfills stored rows.
+    modelIds: t
+      .jsonb()
+      .$type<Array<{ id: string; passthroughFileTypes: string[] }> | string[]>()
+      .notNull(),
     taskModelId: t.text("task_model_id").notNull(),
     memoryExtractionModelId: t.text("memory_extraction_model_id").notNull(),
     embeddingModelId: t.text("embedding_model_id"),

--- a/apps/backend/src/routes/chat.test.ts
+++ b/apps/backend/src/routes/chat.test.ts
@@ -25,6 +25,7 @@ vi.mock("../services/chat-execution.ts", () => {
   }
   return {
     prepareChatTurn: mockPrepareChatTurn,
+    validateTurnAttachments: vi.fn(),
     ValidationError,
     NotFoundError,
     drizzleChatTurnQueries: {},

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { db } from "../index.ts";
 import { chat as chatTable } from "../db/schema.ts";
 import { NotFoundError, ValidationError } from "../services/chat-execution.ts";
+import { FileValidationError } from "../services/file-gate.ts";
 import { chatSubmitSchema, chatUpdateSchema } from "@platypus/schemas";
 import { and, count, desc, eq, or, sql } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
@@ -156,6 +157,11 @@ chat.post(
         },
       });
     } catch (error) {
+      // A rejected attachment (issue #328) fails before the sink persists, so
+      // the chat is never bricked; surface it as a 400 naming the file(s).
+      if (error instanceof FileValidationError) {
+        return c.json({ message: error.message, files: error.files }, 400);
+      }
       if (error instanceof ValidationError) {
         return c.json({ message: error.message }, 400);
       }

--- a/apps/backend/src/routes/org-provider.ts
+++ b/apps/backend/src/routes/org-provider.ts
@@ -6,7 +6,7 @@ import { provider as providerTable } from "../db/schema.ts";
 import { providerCreateSchema, providerUpdateSchema } from "@platypus/schemas";
 import { eq, and } from "drizzle-orm";
 import { handleEmbeddingConfigChange } from "../services/embedding-invalidation.ts";
-import { dedupeArray } from "../utils.ts";
+import { dedupeModelConfigs } from "../services/model-capability.ts";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { requireSharedDeletable } from "../services/scoped-resource.ts";
@@ -26,7 +26,7 @@ orgProvider.post(
     const data = c.req.valid("json");
 
     if (data.modelIds) {
-      data.modelIds = dedupeArray(data.modelIds).sort();
+      data.modelIds = dedupeModelConfigs(data.modelIds);
     }
 
     // A duplicate name surfaces as a Postgres unique violation, mapped to 409
@@ -91,7 +91,7 @@ orgProvider.put(
     const data = c.req.valid("json");
 
     if (data.modelIds) {
-      data.modelIds = dedupeArray(data.modelIds).sort();
+      data.modelIds = dedupeModelConfigs(data.modelIds);
     }
 
     // Detect and handle embedding config changes before the update

--- a/apps/backend/src/routes/provider.ts
+++ b/apps/backend/src/routes/provider.ts
@@ -6,7 +6,7 @@ import { provider as providerTable } from "../db/schema.ts";
 import { providerCreateSchema, providerUpdateSchema } from "@platypus/schemas";
 import { eq, and } from "drizzle-orm";
 import { handleEmbeddingConfigChange } from "../services/embedding-invalidation.ts";
-import { dedupeArray } from "../utils.ts";
+import { dedupeModelConfigs } from "../services/model-capability.ts";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
@@ -37,7 +37,7 @@ provider.post(
   async (c) => {
     const data = c.req.valid("json");
     if (data.modelIds) {
-      data.modelIds = dedupeArray(data.modelIds).sort();
+      data.modelIds = dedupeModelConfigs(data.modelIds);
     }
     // A duplicate name surfaces as a Postgres unique violation, mapped to 409
     // by the central onError (ADR-0010).
@@ -104,7 +104,7 @@ provider.put(
     const providerId = c.req.param("providerId");
     const data = c.req.valid("json");
     if (data.modelIds) {
-      data.modelIds = dedupeArray(data.modelIds).sort();
+      data.modelIds = dedupeModelConfigs(data.modelIds);
     }
 
     // A Shared Provider is a single source of truth edited only on the

--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -1,59 +1,65 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-const { mockPrepareChatTurn, mockGenerateText, mockStreamText, streamHarness } =
-  vi.hoisted(() => {
-    // A minimal, manually-driven async iterable standing in for the server-side
-    // snapshot branch of the UI message stream. The test pushes partial
-    // messages and ends it explicitly so timing is deterministic.
-    class AsyncQueue {
-      items: unknown[] = [];
-      resolvers: ((r: { value: unknown; done: boolean }) => void)[] = [];
-      ended = false;
-      push(item: unknown) {
-        const r = this.resolvers.shift();
-        if (r) r({ value: item, done: false });
-        else this.items.push(item);
-      }
-      end() {
-        this.ended = true;
-        let r;
-        while ((r = this.resolvers.shift()))
-          r({ value: undefined, done: true });
-      }
-      [Symbol.asyncIterator]() {
-        return {
-          next: () => {
-            if (this.items.length)
-              return Promise.resolve({
-                value: this.items.shift(),
-                done: false,
-              });
-            if (this.ended)
-              return Promise.resolve({ value: undefined, done: true });
-            return new Promise((res) => this.resolvers.push(res));
-          },
-        };
-      }
+const {
+  mockPrepareChatTurn,
+  mockValidateTurnAttachments,
+  mockGenerateText,
+  mockStreamText,
+  streamHarness,
+} = vi.hoisted(() => {
+  // A minimal, manually-driven async iterable standing in for the server-side
+  // snapshot branch of the UI message stream. The test pushes partial
+  // messages and ends it explicitly so timing is deterministic.
+  class AsyncQueue {
+    items: unknown[] = [];
+    resolvers: ((r: { value: unknown; done: boolean }) => void)[] = [];
+    ended = false;
+    push(item: unknown) {
+      const r = this.resolvers.shift();
+      if (r) r({ value: item, done: false });
+      else this.items.push(item);
     }
-    return {
-      mockPrepareChatTurn: vi.fn(),
-      mockGenerateText: vi.fn(),
-      mockStreamText: vi.fn(),
-      streamHarness: {
-        AsyncQueue,
-        queue: null as InstanceType<typeof AsyncQueue> | null,
-        // The AI SDK callbacks the runner registers; captured so the test can
-        // drive step-completion and stream-completion by hand.
-        onStepFinish: undefined as ((step: unknown) => void) | undefined,
-        onFinish: undefined as
-          ((ctx: { messages: unknown[] }) => Promise<void> | void) | undefined,
-        responseSentinel: { __isResponse: true },
-      },
-    };
-  });
+    end() {
+      this.ended = true;
+      let r;
+      while ((r = this.resolvers.shift())) r({ value: undefined, done: true });
+    }
+    [Symbol.asyncIterator]() {
+      return {
+        next: () => {
+          if (this.items.length)
+            return Promise.resolve({
+              value: this.items.shift(),
+              done: false,
+            });
+          if (this.ended)
+            return Promise.resolve({ value: undefined, done: true });
+          return new Promise((res) => this.resolvers.push(res));
+        },
+      };
+    }
+  }
+  return {
+    mockPrepareChatTurn: vi.fn(),
+    mockValidateTurnAttachments: vi.fn(),
+    mockGenerateText: vi.fn(),
+    mockStreamText: vi.fn(),
+    streamHarness: {
+      AsyncQueue,
+      queue: null as InstanceType<typeof AsyncQueue> | null,
+      // The AI SDK callbacks the runner registers; captured so the test can
+      // drive step-completion and stream-completion by hand.
+      onStepFinish: undefined as ((step: unknown) => void) | undefined,
+      onFinish: undefined as
+        ((ctx: { messages: unknown[] }) => Promise<void> | void) | undefined,
+      responseSentinel: { __isResponse: true },
+    },
+  };
+});
 
 vi.mock("../services/chat-execution.ts", () => ({
   prepareChatTurn: mockPrepareChatTurn,
+  validateTurnAttachments: mockValidateTurnAttachments,
 }));
 
 vi.mock("ai", async () => {

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -11,6 +11,7 @@ import {
 } from "ai";
 import {
   prepareChatTurn,
+  validateTurnAttachments,
   type ChatTurn,
   type ToolActivityEvent,
 } from "../services/chat-execution.ts";
@@ -230,6 +231,18 @@ export class AgentRunner {
     unattended?: boolean;
   }) {
     const { scope, input, sink } = params;
+
+    // File gate (issue #328): reject a turn carrying a file the target model
+    // can't handle BEFORE the sink persists anything, so a bad attachment can
+    // never brick the chat. Runs only when the turn has file parts; throws
+    // `FileValidationError`, which propagates to the route as a 400.
+    await validateTurnAttachments({
+      request: input.request,
+      messages: input.messages,
+      orgId: scope.orgId,
+      workspaceId: scope.workspaceId,
+    });
+
     await sink.onStart({ runId: input.runId, messages: input.messages });
 
     const state: RunState = {

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -67,6 +67,7 @@ vi.mock("@ai-sdk/mcp", () => ({
 
 import {
   prepareChatTurn,
+  validateTurnAttachments,
   NotFoundError,
   ValidationError,
   createToolHeartbeat,
@@ -74,7 +75,9 @@ import {
   wrapToolsWithBump,
   normalizeToolResult,
 } from "./chat-execution.ts";
+import { FileValidationError } from "./file-gate.ts";
 import { createInMemoryChatTurnQueries } from "./chat-execution.test-fixtures.ts";
+import type { PlatypusUIMessage } from "../types.ts";
 
 const baseProvider = {
   id: "p1",
@@ -82,7 +85,7 @@ const baseProvider = {
   organizationId: "org-1",
   workspaceId: "ws-1",
   providerType: "OpenAI" as const,
-  modelIds: ["gpt-4"],
+  modelIds: [{ id: "gpt-4", passthroughFileTypes: [] }],
   apiKey: "sk-test",
   apiMode: "chat" as const,
   nativeSearchEnabled: true,
@@ -405,7 +408,12 @@ describe("chat-execution", () => {
     it("throws ValidationError when the model id is not enabled on the Provider", async () => {
       const queries = createInMemoryChatTurnQueries({
         workspaces: [baseWorkspace],
-        providers: [{ ...baseProvider, modelIds: ["gpt-3.5"] }],
+        providers: [
+          {
+            ...baseProvider,
+            modelIds: [{ id: "gpt-3.5", passthroughFileTypes: [] }],
+          },
+        ],
       });
 
       await expect(
@@ -763,5 +771,74 @@ describe("chat-execution", () => {
       expect(onStart).toHaveBeenCalledTimes(1);
       expect(onEnd).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe("validateTurnAttachments", () => {
+  // baseProvider is OpenAI apiMode:"chat" → resolves to images-only passthrough.
+  const queries = () =>
+    createInMemoryChatTurnQueries({
+      workspaces: [baseWorkspace],
+      providers: [baseProvider],
+    });
+
+  const fileMessage = (mediaType: string, filename: string) =>
+    ({
+      id: "m1",
+      role: "user",
+      parts: [{ type: "file", mediaType, filename, url: "data:," }],
+    }) as unknown as PlatypusUIMessage;
+
+  const request = { providerId: "p1", modelId: "gpt-4" };
+
+  it("rejects a PDF the chat-completions model can't ingest natively", async () => {
+    await expect(
+      validateTurnAttachments(
+        {
+          request,
+          messages: [fileMessage("application/pdf", "report.pdf")],
+          orgId: "org-1",
+          workspaceId: "ws-1",
+        },
+        queries(),
+      ),
+    ).rejects.toBeInstanceOf(FileValidationError);
+  });
+
+  it("allows a text-like file (inlined later) and a native image", async () => {
+    await expect(
+      validateTurnAttachments(
+        {
+          request,
+          messages: [
+            fileMessage("application/octet-stream", "notes.md"),
+            fileMessage("image/png", "a.png"),
+          ],
+          orgId: "org-1",
+          workspaceId: "ws-1",
+        },
+        queries(),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("is a no-op when the turn carries no file parts", async () => {
+    await expect(
+      validateTurnAttachments(
+        {
+          request,
+          messages: [
+            {
+              id: "m1",
+              role: "user",
+              parts: [{ type: "text", text: "hi" }],
+            } as unknown as PlatypusUIMessage,
+          ],
+          orgId: "org-1",
+          workspaceId: "ws-1",
+        },
+        queries(),
+      ),
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -32,6 +32,15 @@ import type { LanguageModel, Tool } from "ai";
 import { logger } from "../logger.ts";
 import { buildMcpTransportConfig } from "./mcp-oauth-provider.ts";
 import { inlineFileUrls } from "../storage/utils.ts";
+import {
+  passthroughFileTypesForModel,
+  providerHasModel,
+} from "./model-capability.ts";
+import {
+  assertFilePartsSupported,
+  messagesHaveFileParts,
+  normalizeFileParts,
+} from "./file-gate.ts";
 import type { PlatypusUIMessage } from "../types.ts";
 
 /**
@@ -563,8 +572,20 @@ export const prepareChatTurn = async (
       )
     : tools;
 
+  // Inline file URLs to `data:` bytes, then normalize any file part the target
+  // model can't ingest natively (issue #328): text-like files become annotated
+  // text; a native part is left untouched. The pre-persist gate
+  // (`validateTurnAttachments`) has already rejected unsupported binaries, so
+  // the normalizer here never throws.
+  const passthroughFileTypes = passthroughFileTypesForModel(
+    provider,
+    resolvedModelId,
+  );
   const inlinedMessages = origin
-    ? await inlineFileUrls(messages, origin)
+    ? normalizeFileParts(
+        await inlineFileUrls(messages, origin),
+        passthroughFileTypes,
+      )
     : messages;
 
   let disposed = false;
@@ -613,6 +634,49 @@ export const prepareChatTurn = async (
     },
     dispose,
   };
+};
+
+/**
+ * Pre-persist file gate (issue #328). Resolves the target model's declared
+ * `passthroughFileTypes` and rejects the turn — before anything is persisted —
+ * if any attached file (fresh upload or history) is neither natively accepted
+ * nor text-like. Throws `FileValidationError`, which the chat route maps to a
+ * 400 naming the offending file(s).
+ *
+ * A no-op when the turn carries no file parts (the common case, including all
+ * headless runs), so it adds no lookups there. If model resolution itself fails
+ * (unknown agent/provider/model), it silently returns and lets the normal
+ * `prepareChatTurn` path surface that error unchanged — this gate only adds the
+ * file-rejection behavior, it never preempts existing error handling.
+ */
+export const validateTurnAttachments = async (
+  args: {
+    request: ChatTurnRequest;
+    messages: PlatypusUIMessage[];
+    orgId: string;
+    workspaceId: string;
+  },
+  queries: ChatTurnQueries = drizzleChatTurnQueries,
+): Promise<void> => {
+  if (!messagesHaveFileParts(args.messages)) return;
+
+  let passthroughFileTypes: string[];
+  try {
+    const context = await resolveChatContext(
+      queries,
+      args.request,
+      args.orgId,
+      args.workspaceId,
+    );
+    passthroughFileTypes = passthroughFileTypesForModel(
+      context.provider,
+      context.resolvedModelId,
+    );
+  } catch {
+    return;
+  }
+
+  assertFilePartsSupported(args.messages, passthroughFileTypes);
 };
 
 // --- Private helpers ---
@@ -830,7 +894,7 @@ const resolveChatContext = async (
     );
   }
 
-  if (!provider.modelIds.includes(resolvedModelId)) {
+  if (!providerHasModel(provider, resolvedModelId)) {
     throw new ValidationError(
       `Model id '${resolvedModelId}' not enabled for provider '${resolvedProviderId}'`,
     );

--- a/apps/backend/src/services/embedding.test.ts
+++ b/apps/backend/src/services/embedding.test.ts
@@ -17,7 +17,7 @@ const baseProvider: Provider = {
   organizationId: "org-1",
   workspaceId: "ws-1",
   providerType: "OpenAI",
-  modelIds: ["text-embedding-3-small"],
+  modelIds: [{ id: "text-embedding-3-small", passthroughFileTypes: [] }],
   apiKey: "sk-test",
   apiMode: "chat",
   nativeSearchEnabled: true,

--- a/apps/backend/src/services/file-classification.test.ts
+++ b/apps/backend/src/services/file-classification.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import {
+  mediaTypeMatches,
+  isTextLikeExtension,
+  looksBinary,
+  classifyFilePart,
+} from "./file-classification.ts";
+
+describe("mediaTypeMatches", () => {
+  it("matches an exact media type", () => {
+    expect(mediaTypeMatches("application/pdf", ["application/pdf"])).toBe(true);
+    expect(mediaTypeMatches("application/pdf", ["image/png"])).toBe(false);
+  });
+
+  it("matches a type/* wildcard", () => {
+    expect(mediaTypeMatches("image/png", ["image/*"])).toBe(true);
+    expect(mediaTypeMatches("image/jpeg", ["image/*"])).toBe(true);
+    expect(mediaTypeMatches("application/pdf", ["image/*"])).toBe(false);
+  });
+
+  it("matches the */* wildcard", () => {
+    expect(mediaTypeMatches("anything/here", ["*/*"])).toBe(true);
+  });
+
+  it("is case-insensitive and tolerates parameters", () => {
+    expect(mediaTypeMatches("IMAGE/PNG", ["image/*"])).toBe(true);
+    expect(mediaTypeMatches("text/plain; charset=utf-8", ["text/plain"])).toBe(
+      true,
+    );
+  });
+
+  it("returns false for an empty pattern list or missing type", () => {
+    expect(mediaTypeMatches("image/png", [])).toBe(false);
+    expect(mediaTypeMatches(undefined, ["image/*"])).toBe(false);
+  });
+});
+
+describe("isTextLikeExtension", () => {
+  it("recognizes code and text extensions regardless of case", () => {
+    for (const name of ["notes.md", "data.JSON", "run.sh", "a.py", "x.csv"]) {
+      expect(isTextLikeExtension(name)).toBe(true);
+    }
+  });
+
+  it("rejects binary document and unknown extensions", () => {
+    for (const name of ["report.pdf", "sheet.xlsx", "slides.pptx", "a.bin"]) {
+      expect(isTextLikeExtension(name)).toBe(false);
+    }
+  });
+
+  it("returns false when there is no filename or extension", () => {
+    expect(isTextLikeExtension(undefined)).toBe(false);
+    expect(isTextLikeExtension("Makefile")).toBe(false);
+  });
+});
+
+describe("looksBinary", () => {
+  it("flags content containing a NUL byte", () => {
+    expect(looksBinary(new Uint8Array([104, 105, 0, 116]))).toBe(true);
+  });
+
+  it("treats NUL-free content as text", () => {
+    expect(looksBinary(new TextEncoder().encode("hello world"))).toBe(false);
+  });
+
+  it("treats empty content as text", () => {
+    expect(looksBinary(new Uint8Array([]))).toBe(false);
+  });
+});
+
+describe("classifyFilePart", () => {
+  const chatPassthrough = ["image/*"];
+  const nativePassthrough = ["image/*", "application/pdf"];
+
+  it("passes through a file whose media type the model accepts natively", () => {
+    expect(
+      classifyFilePart(
+        { mediaType: "image/png", filename: "a.png" },
+        chatPassthrough,
+      ),
+    ).toBe("passthrough");
+    expect(
+      classifyFilePart(
+        { mediaType: "application/pdf", filename: "a.pdf" },
+        nativePassthrough,
+      ),
+    ).toBe("passthrough");
+  });
+
+  it("inlines a text-like file the model can't take natively", () => {
+    // .md mis-tagged as octet-stream by the OS is still text by extension.
+    expect(
+      classifyFilePart(
+        { mediaType: "application/octet-stream", filename: "notes.md" },
+        chatPassthrough,
+      ),
+    ).toBe("text");
+  });
+
+  it("rejects a binary document the model can't take natively", () => {
+    expect(
+      classifyFilePart(
+        { mediaType: "application/pdf", filename: "report.pdf" },
+        chatPassthrough,
+      ),
+    ).toBe("reject");
+  });
+
+  it("uses byte-sniffing to override a text extension that is actually binary", () => {
+    expect(
+      classifyFilePart(
+        { mediaType: "application/octet-stream", filename: "notes.md" },
+        chatPassthrough,
+        new Uint8Array([0, 1, 2]),
+      ),
+    ).toBe("reject");
+  });
+
+  it("does not let byte-sniffing affect the native passthrough decision", () => {
+    // Passthrough wins before any text/binary consideration.
+    expect(
+      classifyFilePart(
+        { mediaType: "image/png", filename: "a.png" },
+        chatPassthrough,
+        new Uint8Array([0, 1, 2]),
+      ),
+    ).toBe("passthrough");
+  });
+});

--- a/apps/backend/src/services/file-classification.ts
+++ b/apps/backend/src/services/file-classification.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure classification of a file message part against a model's declared
+ * `passthroughFileTypes` (issue #328). The gate and the send-time normalizer
+ * share this logic so the reject decision and the transform decision never
+ * drift.
+ *
+ * Three outcomes:
+ * - `passthrough` — the model ingests this media type natively; send unchanged.
+ * - `text`        — not native, but the file is textual; inline it as text.
+ * - `reject`      — not native and not textual (a binary document); the turn is
+ *                   rejected (Phase 1) or extracted to text (Phase 2).
+ *
+ * Text-vs-binary is decided from the file's *real nature* — its extension plus,
+ * when bytes are available, a NUL-byte content sniff — never from the
+ * browser-supplied media type, which is an unreliable, OS-specific lottery
+ * (`.py` → `text/x-python` but `.md` → `application/octet-stream`).
+ */
+import { isTextLikeExtension, mediaTypeMatches } from "@platypus/schemas";
+
+// The media-type matcher and the text-extension test live in @platypus/schemas
+// so the backend gate and the frontend warning share one copy. Re-exported so
+// this module remains the single classification import surface (incl. tests).
+export { isTextLikeExtension, mediaTypeMatches };
+
+export type FilePartClass = "passthrough" | "text" | "reject";
+
+/** How many leading bytes to sniff for the NUL-byte binary heuristic. */
+const SNIFF_BYTES = 8_000;
+
+/** Whether content looks binary — a NUL byte in the sniffed prefix. */
+export const looksBinary = (bytes: Uint8Array): boolean => {
+  const end = Math.min(bytes.length, SNIFF_BYTES);
+  for (let i = 0; i < end; i++) {
+    if (bytes[i] === 0) return true;
+  }
+  return false;
+};
+
+/**
+ * Classify a file part. `bytes` (the decoded file content) is optional: the
+ * pre-persist gate classifies on metadata alone, while the send-time normalizer
+ * passes bytes so a text-extension file that is actually binary is caught.
+ */
+export const classifyFilePart = (
+  part: { mediaType?: string; filename?: string },
+  passthroughFileTypes: string[],
+  bytes?: Uint8Array,
+): FilePartClass => {
+  if (mediaTypeMatches(part.mediaType, passthroughFileTypes)) {
+    return "passthrough";
+  }
+  if (isTextLikeExtension(part.filename) && !(bytes && looksBinary(bytes))) {
+    return "text";
+  }
+  return "reject";
+};

--- a/apps/backend/src/services/file-gate.test.ts
+++ b/apps/backend/src/services/file-gate.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import type { PlatypusUIMessage } from "../types.ts";
+import {
+  FileValidationError,
+  messagesHaveFileParts,
+  assertFilePartsSupported,
+  normalizeFileParts,
+} from "./file-gate.ts";
+
+const textDataUrl = (text: string, mediaType = "application/octet-stream") =>
+  `data:${mediaType};base64,${Buffer.from(text, "utf8").toString("base64")}`;
+
+const binaryDataUrl = (bytes: number[], mediaType = "application/pdf") =>
+  `data:${mediaType};base64,${Buffer.from(bytes).toString("base64")}`;
+
+const msg = (parts: unknown[]): PlatypusUIMessage =>
+  ({ id: "m1", role: "user", parts }) as unknown as PlatypusUIMessage;
+
+describe("messagesHaveFileParts", () => {
+  it("detects a file part anywhere in the list", () => {
+    expect(
+      messagesHaveFileParts([
+        msg([{ type: "text", text: "hi" }]),
+        msg([{ type: "file", mediaType: "image/png", url: "data:..." }]),
+      ]),
+    ).toBe(true);
+  });
+
+  it("is false when there are no file parts", () => {
+    expect(messagesHaveFileParts([msg([{ type: "text", text: "hi" }])])).toBe(
+      false,
+    );
+  });
+});
+
+describe("assertFilePartsSupported", () => {
+  const chatPassthrough = ["image/*"];
+
+  it("passes when every file is native or text-like", () => {
+    expect(() =>
+      assertFilePartsSupported(
+        [
+          msg([{ type: "file", mediaType: "image/png", filename: "a.png" }]),
+          msg([
+            {
+              type: "file",
+              mediaType: "application/octet-stream",
+              filename: "notes.md",
+            },
+          ]),
+        ],
+        chatPassthrough,
+      ),
+    ).not.toThrow();
+  });
+
+  it("throws FileValidationError naming an unsupported binary file", () => {
+    let error: unknown;
+    try {
+      assertFilePartsSupported(
+        [
+          msg([
+            {
+              type: "file",
+              mediaType: "application/pdf",
+              filename: "report.pdf",
+            },
+          ]),
+        ],
+        chatPassthrough,
+      );
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(FileValidationError);
+    expect((error as FileValidationError).files).toEqual(["report.pdf"]);
+    expect((error as FileValidationError).message).toContain("report.pdf");
+  });
+
+  it("collects every offending file across the history", () => {
+    let error: unknown;
+    try {
+      assertFilePartsSupported(
+        [
+          msg([
+            { type: "file", mediaType: "application/pdf", filename: "a.pdf" },
+          ]),
+          msg([{ type: "text", text: "hello" }]),
+          msg([
+            {
+              type: "file",
+              mediaType: "application/vnd.ms-powerpoint",
+              filename: "b.pptx",
+            },
+          ]),
+        ],
+        chatPassthrough,
+      );
+    } catch (e) {
+      error = e;
+    }
+    expect((error as FileValidationError).files).toEqual(["a.pdf", "b.pptx"]);
+  });
+});
+
+describe("normalizeFileParts", () => {
+  const chatPassthrough = ["image/*"];
+
+  it("leaves natively-supported files untouched", () => {
+    const input = [
+      msg([
+        { type: "file", mediaType: "image/png", filename: "a.png", url: "u" },
+      ]),
+    ];
+    const out = normalizeFileParts(input, chatPassthrough);
+    expect(out[0].parts[0]).toEqual(input[0].parts[0]);
+  });
+
+  it("inlines a text-like file as an annotated text part", () => {
+    const out = normalizeFileParts(
+      [
+        msg([
+          {
+            type: "file",
+            mediaType: "application/octet-stream",
+            filename: "notes.md",
+            url: textDataUrl("# Hello\nbody"),
+          },
+        ]),
+      ],
+      chatPassthrough,
+    );
+    const part = out[0].parts[0] as { type: string; text: string };
+    expect(part.type).toBe("text");
+    expect(part.text).toContain("notes.md");
+    expect(part.text).toContain("# Hello");
+  });
+
+  it("replaces a slipped-through binary with a placeholder rather than throwing", () => {
+    const out = normalizeFileParts(
+      [
+        msg([
+          {
+            type: "file",
+            mediaType: "application/pdf",
+            filename: "report.pdf",
+            url: binaryDataUrl([0, 1, 2, 3]),
+          },
+        ]),
+      ],
+      chatPassthrough,
+    );
+    const part = out[0].parts[0] as { type: string; text: string };
+    expect(part.type).toBe("text");
+    expect(part.text).toContain("report.pdf");
+  });
+});

--- a/apps/backend/src/services/file-gate.ts
+++ b/apps/backend/src/services/file-gate.ts
@@ -1,0 +1,151 @@
+import type { PlatypusUIMessage } from "../types.ts";
+import { classifyFilePart } from "./file-classification.ts";
+
+/**
+ * The pre-persist validation gate and the send-time normalizer (issue #328).
+ *
+ * The gate (`assertFilePartsSupported`) runs over the whole outgoing message
+ * list — fresh upload and history — BEFORE the chat row is persisted, so a turn
+ * carrying a file the model can't handle is rejected upfront and writes nothing
+ * (it can never brick the chat). The normalizer (`normalizeFileParts`) runs at
+ * send time, after file URLs are inlined, and rewrites non-native text-like
+ * files into text the model can read.
+ *
+ * Kept free of any dependency on chat-execution so it can be imported there
+ * without a cycle.
+ */
+
+/** A file part in a UI message (the AI SDK's `FileUIPart`). */
+type FilePart = {
+  type: "file";
+  mediaType?: string;
+  filename?: string;
+  url?: string;
+};
+
+const isFilePart = (part: unknown): part is FilePart =>
+  typeof part === "object" &&
+  part !== null &&
+  (part as { type?: unknown }).type === "file";
+
+/**
+ * Thrown when an outgoing turn carries a file the target model can neither
+ * ingest natively nor have inlined as text. The route maps it to a 400 with a
+ * message naming the offending file(s). A standalone error (not a subclass of
+ * chat-execution's `ValidationError`) to avoid an import cycle — callers match
+ * on it explicitly.
+ */
+export class FileValidationError extends Error {
+  readonly files: string[];
+
+  constructor(files: string[]) {
+    const list = files.join(", ");
+    super(
+      files.length === 1
+        ? `This model can't read the attached file "${list}". Remove it, or switch to a model that accepts it.`
+        : `This model can't read these attached files: ${list}. Remove them, or switch to a model that accepts them.`,
+    );
+    this.name = "FileValidationError";
+    this.files = files;
+  }
+}
+
+/** Whether any message carries a file part (cheap short-circuit for the gate). */
+export const messagesHaveFileParts = (messages: PlatypusUIMessage[]): boolean =>
+  messages.some(
+    (message) => Array.isArray(message.parts) && message.parts.some(isFilePart),
+  );
+
+/**
+ * Reject the turn if any file part is neither natively accepted nor text-like.
+ * Classifies on metadata alone (extension + declared media type) — no bytes
+ * required — so it can run before persistence. Throws `FileValidationError`
+ * listing every offending file.
+ */
+export const assertFilePartsSupported = (
+  messages: PlatypusUIMessage[],
+  passthroughFileTypes: string[],
+): void => {
+  const offending: string[] = [];
+  for (const message of messages) {
+    if (!Array.isArray(message.parts)) continue;
+    for (const part of message.parts) {
+      if (!isFilePart(part)) continue;
+      if (classifyFilePart(part, passthroughFileTypes) === "reject") {
+        offending.push(part.filename || "attachment");
+      }
+    }
+  }
+  if (offending.length > 0) {
+    throw new FileValidationError(offending);
+  }
+};
+
+/** Parse a base64 (or URL-encoded) `data:` URL into its media type and bytes. */
+const decodeDataUrl = (
+  url: string,
+): { mediaType: string; bytes: Uint8Array } | null => {
+  const match = url.match(/^data:([^;,]*)(;base64)?,([\s\S]*)$/);
+  if (!match) return null;
+  const mediaType = match[1] || "application/octet-stream";
+  const body = match[3];
+  const bytes = match[2]
+    ? new Uint8Array(Buffer.from(body, "base64"))
+    : new Uint8Array(Buffer.from(decodeURIComponent(body), "utf8"));
+  return { mediaType, bytes };
+};
+
+/** Wrap decoded file text in a labelled fenced block so the model sees its origin. */
+const annotateInlinedText = (
+  filename: string | undefined,
+  content: string,
+): string => {
+  const label = filename || "attachment";
+  return `[file: ${label}]\n\n\`\`\`\n${content}\n\`\`\``;
+};
+
+/**
+ * Rewrite non-native file parts into content the model can read. Runs at send
+ * time, after file URLs are inlined (so `data:` bytes are available):
+ *
+ * - native passthrough → left byte-for-byte unchanged;
+ * - text-like → replaced with an annotated text part;
+ * - reject-class → replaced with a short placeholder (defensive: the
+ *   pre-persist gate should already have blocked it; never throws here, so a
+ *   slipped-through part can't hard-fail conversion and re-brick the chat).
+ *
+ * A part whose bytes aren't available (e.g. a storage miss left it non-`data:`)
+ * is left unchanged.
+ */
+export const normalizeFileParts = (
+  messages: PlatypusUIMessage[],
+  passthroughFileTypes: string[],
+): PlatypusUIMessage[] =>
+  messages.map((message) => {
+    if (!Array.isArray(message.parts)) return message;
+    const parts = message.parts.map((part) => {
+      if (!isFilePart(part)) return part;
+
+      const url = typeof part.url === "string" ? part.url : "";
+      const decoded = url.startsWith("data:") ? decodeDataUrl(url) : null;
+      const bytes = decoded?.bytes;
+
+      const outcome = classifyFilePart(part, passthroughFileTypes, bytes);
+      if (outcome === "passthrough") return part;
+
+      if (outcome === "text") {
+        if (!bytes) return part;
+        const content = new TextDecoder().decode(bytes);
+        return {
+          type: "text" as const,
+          text: annotateInlinedText(part.filename, content),
+        };
+      }
+
+      return {
+        type: "text" as const,
+        text: `[unsupported file omitted: ${part.filename || "attachment"}]`,
+      };
+    });
+    return { ...message, parts };
+  });

--- a/apps/backend/src/services/model-capability.test.ts
+++ b/apps/backend/src/services/model-capability.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import type { Provider } from "@platypus/schemas";
+import {
+  defaultPassthroughFileTypes,
+  resolveProviderModels,
+  providerModelIds,
+  providerHasModel,
+  passthroughFileTypesForModel,
+  dedupeModelConfigs,
+} from "./model-capability.ts";
+
+const provider = (over: Partial<Provider>): Provider => ({
+  id: "p1",
+  name: "Test",
+  workspaceId: "ws-1",
+  providerType: "OpenAI",
+  apiKey: "sk",
+  apiMode: "chat",
+  nativeSearchEnabled: true,
+  modelIds: [{ id: "m", passthroughFileTypes: [] }],
+  taskModelId: "m",
+  memoryExtractionModelId: "m",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...over,
+});
+
+describe("defaultPassthroughFileTypes", () => {
+  it("gives native-file providers images + PDF", () => {
+    for (const t of ["Anthropic", "Google", "Bedrock"] as const) {
+      expect(
+        defaultPassthroughFileTypes(provider({ providerType: t })),
+      ).toEqual(["image/*", "application/pdf"]);
+    }
+  });
+
+  it("gives OpenAI Responses images + PDF but chat-completions images only", () => {
+    expect(
+      defaultPassthroughFileTypes(
+        provider({ providerType: "OpenAI", apiMode: "responses" }),
+      ),
+    ).toEqual(["image/*", "application/pdf"]);
+    expect(
+      defaultPassthroughFileTypes(
+        provider({ providerType: "OpenAI", apiMode: "chat" }),
+      ),
+    ).toEqual(["image/*"]);
+  });
+
+  it("gives unknown/OpenRouter providers the images-only floor", () => {
+    expect(
+      defaultPassthroughFileTypes(provider({ providerType: "OpenRouter" })),
+    ).toEqual(["image/*"]);
+  });
+});
+
+describe("resolveProviderModels", () => {
+  it("coerces a legacy string[] to objects with provider-type defaults", () => {
+    const p = provider({
+      providerType: "Anthropic",
+      apiMode: "responses",
+      modelIds: ["claude-x", "claude-y"] as unknown as Provider["modelIds"],
+    });
+    expect(resolveProviderModels(p)).toEqual([
+      { id: "claude-x", passthroughFileTypes: ["image/*", "application/pdf"] },
+      { id: "claude-y", passthroughFileTypes: ["image/*", "application/pdf"] },
+    ]);
+  });
+
+  it("fills the default when an object declares no passthrough types", () => {
+    const p = provider({
+      providerType: "OpenAI",
+      apiMode: "chat",
+      modelIds: [{ id: "qwen", passthroughFileTypes: [] }],
+    });
+    // Empty array is treated as "declare none" → inherit the provider default.
+    expect(resolveProviderModels(p)[0].passthroughFileTypes).toEqual([
+      "image/*",
+    ]);
+  });
+
+  it("preserves an explicit passthrough declaration", () => {
+    const p = provider({
+      modelIds: [{ id: "qwen-vl", passthroughFileTypes: ["image/*"] }],
+    });
+    expect(resolveProviderModels(p)[0].passthroughFileTypes).toEqual([
+      "image/*",
+    ]);
+  });
+});
+
+describe("providerModelIds / providerHasModel", () => {
+  const p = provider({
+    modelIds: [
+      { id: "a", passthroughFileTypes: [] },
+      { id: "b", passthroughFileTypes: [] },
+    ],
+  });
+  it("lists ids in order", () => {
+    expect(providerModelIds(p)).toEqual(["a", "b"]);
+  });
+  it("reports membership", () => {
+    expect(providerHasModel(p, "b")).toBe(true);
+    expect(providerHasModel(p, "z")).toBe(false);
+  });
+});
+
+describe("passthroughFileTypesForModel", () => {
+  it("returns the model's resolved types, defaulting when unknown", () => {
+    const p = provider({
+      providerType: "Anthropic",
+      apiMode: "responses",
+      modelIds: [{ id: "claude", passthroughFileTypes: ["image/*"] }],
+    });
+    expect(passthroughFileTypesForModel(p, "claude")).toEqual(["image/*"]);
+    // Unknown model → provider default.
+    expect(passthroughFileTypesForModel(p, "ghost")).toEqual([
+      "image/*",
+      "application/pdf",
+    ]);
+  });
+});
+
+describe("dedupeModelConfigs", () => {
+  it("dedupes by id (first wins) and sorts by id", () => {
+    expect(
+      dedupeModelConfigs([
+        { id: "b", passthroughFileTypes: ["image/*"] },
+        { id: "a", passthroughFileTypes: [] },
+        { id: "b", passthroughFileTypes: [] },
+      ]),
+    ).toEqual([
+      { id: "a", passthroughFileTypes: [] },
+      { id: "b", passthroughFileTypes: ["image/*"] },
+    ]);
+  });
+});

--- a/apps/backend/src/services/model-capability.ts
+++ b/apps/backend/src/services/model-capability.ts
@@ -1,0 +1,91 @@
+import {
+  defaultPassthroughFileTypes,
+  type ModelConfig,
+  type Provider,
+} from "@platypus/schemas";
+
+// The provider-type default set is shared with the frontend via
+// @platypus/schemas; re-exported so this module stays the backend's single
+// capability import surface.
+export { defaultPassthroughFileTypes };
+
+/**
+ * Per-model file capability resolution.
+ *
+ * Capability is a property of the `(provider, model)` pair and is *declared*,
+ * not inferred (see issue #328). A model's `passthroughFileTypes` lists the
+ * media types it ingests natively; anything else is converted to text where
+ * possible (Phase 2) or, until then, cleanly rejected. This module is the
+ * single source of truth for turning a provider's stored models — which may be
+ * the new per-model objects OR a legacy `string[]` — into resolved
+ * `ModelConfig`s with sensible provider-type defaults filled in.
+ */
+
+/**
+ * Normalize a provider's stored models into resolved `ModelConfig`s.
+ *
+ * Tolerates both shapes so the runtime is correct regardless of migration
+ * state (dev `drizzle-kit push` skips the data backfill): a bare `string`
+ * entry, or an object with no `passthroughFileTypes`, inherits the
+ * provider-type default. An empty list also inherits the default — this keeps a
+ * newly-added model (whose types default to `[]`) from accidentally rejecting
+ * every file, including images; the trade-off is that "accept nothing natively"
+ * can't be expressed, which is fine (the images-only floor is already the
+ * minimum, and Phase 2 extracts the rest to text).
+ */
+export const resolveProviderModels = (provider: Provider): ModelConfig[] => {
+  const fallback = defaultPassthroughFileTypes(provider);
+  const raw = provider.modelIds as unknown as Array<
+    string | Partial<ModelConfig>
+  >;
+  return raw.map((entry) => {
+    if (typeof entry === "string") {
+      return { id: entry, passthroughFileTypes: fallback };
+    }
+    const declared = entry.passthroughFileTypes;
+    return {
+      id: entry.id ?? "",
+      passthroughFileTypes:
+        declared && declared.length > 0 ? declared : fallback,
+    };
+  });
+};
+
+/** The plain model-id list, preserving order — for existing `string[]` consumers. */
+export const providerModelIds = (provider: Provider): string[] =>
+  resolveProviderModels(provider).map((model) => model.id);
+
+/**
+ * Dedupe a provider payload's models by id (first entry wins, so an operator's
+ * explicit `passthroughFileTypes` is kept over a later duplicate) and sort by
+ * id for stable storage. Replaces the old `dedupeArray(modelIds).sort()` on the
+ * flat string list, which no longer works now that entries are objects.
+ */
+export const dedupeModelConfigs = (models: ModelConfig[]): ModelConfig[] => {
+  const byId = new Map<string, ModelConfig>();
+  for (const model of models) {
+    if (!byId.has(model.id)) byId.set(model.id, model);
+  }
+  return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+};
+
+/** Whether `modelId` is one of the provider's enabled models. */
+export const providerHasModel = (
+  provider: Provider,
+  modelId: string,
+): boolean => resolveProviderModels(provider).some((m) => m.id === modelId);
+
+/**
+ * The media types the given model ingests natively. Falls back to the
+ * provider-type default when the model isn't found (defensive — callers should
+ * validate the model id first).
+ */
+export const passthroughFileTypesForModel = (
+  provider: Provider,
+  modelId: string,
+): string[] => {
+  const model = resolveProviderModels(provider).find((m) => m.id === modelId);
+  return model
+    ? model.passthroughFileTypes
+    : defaultPassthroughFileTypes(provider);
+};

--- a/apps/backend/src/services/provider.test.ts
+++ b/apps/backend/src/services/provider.test.ts
@@ -75,7 +75,7 @@ const baseProvider: Provider = {
   organizationId: "org-1",
   workspaceId: "ws-1",
   providerType: "OpenAI",
-  modelIds: ["gpt-4"],
+  modelIds: [{ id: "gpt-4", passthroughFileTypes: [] }],
   apiKey: "sk-test",
   apiMode: "chat",
   nativeSearchEnabled: true,

--- a/apps/backend/src/tools/agent-discovery.ts
+++ b/apps/backend/src/tools/agent-discovery.ts
@@ -85,7 +85,14 @@ export function createAgentDiscoveryTools(
             eq(providerTable.organizationId, orgId),
           ),
         );
-      return providers;
+      // Advertise plain model-id strings regardless of whether the row stores
+      // the new per-model objects or a legacy `string[]` (issue #328).
+      return providers.map((p) => ({
+        ...p,
+        modelIds: (p.modelIds as Array<string | { id: string }>).map((m) =>
+          typeof m === "string" ? m : m.id,
+        ),
+      }));
     },
   });
 

--- a/apps/frontend/components/agent-form.test.tsx
+++ b/apps/frontend/components/agent-form.test.tsx
@@ -29,8 +29,8 @@ const mutate = vi.fn();
 const provider: Provider = {
   id: "p1",
   name: "OpenAI",
-  modelIds: ["gpt-4o"],
-} as Provider;
+  modelIds: [{ id: "gpt-4o", passthroughFileTypes: [] }],
+} as unknown as Provider;
 
 // Stable references so re-renders don't churn identity (which would retrigger
 // useResetOnChange and loop).

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -49,6 +49,7 @@ import {
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
 import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import { getModelIds } from "@/lib/model-config";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -176,7 +177,7 @@ const AgentForm = ({
       ) {
         setFormData((prevData) => ({
           ...prevData,
-          modelId: providers[0].modelIds[0],
+          modelId: getModelIds(providers[0])[0],
           providerId: providers[0].id,
         }));
       }
@@ -634,7 +635,7 @@ const AgentForm = ({
                     {providers.map((provider) => (
                       <SelectGroup key={provider.id}>
                         <SelectLabel>{provider.name}</SelectLabel>
-                        {provider.modelIds.map((modelId) => (
+                        {getModelIds(provider).map((modelId) => (
                           <SelectItem
                             key={`provider:${provider.id}:${modelId}`}
                             value={`provider:${provider.id}:${modelId}`}

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -39,6 +39,8 @@ import { fetcher, joinUrl } from "@/lib/utils";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useChatSettings } from "@/hooks/use-chat-settings";
 import { useModelSelection } from "@/hooks/use-model-selection";
+import { getPassthroughFileTypes } from "@/lib/model-config";
+import { FileCompatibilityWarning } from "./file-compatibility-warning";
 import { useMessageEditing } from "@/hooks/use-message-editing";
 import { useChatTitlePoll } from "@/hooks/use-chat-title-poll";
 import { useChatUI } from "@/hooks/use-chat-ui";
@@ -411,6 +413,14 @@ export const Chat = ({
     resolvedProvider.providerType !== "Bedrock" &&
     resolvedProvider.nativeSearchEnabled !== false;
 
+  // The media types the currently-selected model ingests natively (issue #328),
+  // used to warn about incompatible attachments. Empty when nothing resolves yet.
+  const resolvedModelId = agentId ? selectedAgent?.modelId : modelId;
+  const passthroughFileTypes =
+    resolvedProvider && resolvedModelId
+      ? getPassthroughFileTypes(resolvedProvider, resolvedModelId)
+      : [];
+
   // Treat a server-side run-in-progress as if we were locally streaming,
   // so a tab that reconnects mid-run (or an unrelated tab opened on the
   // same chat) can't kick off a second concurrent run. The submit button
@@ -530,6 +540,9 @@ export const Chat = ({
                 <PromptInputAttachments className="w-full">
                   {(attachment) => <PromptInputAttachment data={attachment} />}
                 </PromptInputAttachments>
+                <FileCompatibilityWarning
+                  passthroughFileTypes={passthroughFileTypes}
+                />
                 <PromptInputBody>
                   <PromptInputTextarea
                     ref={textareaRef}

--- a/apps/frontend/components/file-compatibility-warning.tsx
+++ b/apps/frontend/components/file-compatibility-warning.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { TriangleAlert } from "lucide-react";
+import { usePromptInputAttachments } from "./ai-elements/prompt-input";
+import { classifyAttachment } from "@/lib/model-config";
+
+/**
+ * Proactive, client-side warning (issue #328) shown when an attached file can't
+ * be read by the currently-selected model — it is neither ingested natively nor
+ * inlinable as text, so the backend gate would reject the turn. Rendered inside
+ * `<PromptInput>` so it can read the live attachment list from context. The
+ * backend remains the source of truth; this is only a heads-up.
+ */
+export const FileCompatibilityWarning = ({
+  passthroughFileTypes,
+}: {
+  passthroughFileTypes: string[];
+}) => {
+  const attachments = usePromptInputAttachments();
+
+  const blocked = attachments.files.filter(
+    (file) =>
+      classifyAttachment(
+        { mediaType: file.mediaType, filename: file.filename },
+        passthroughFileTypes,
+      ) === "reject",
+  );
+
+  if (blocked.length === 0) return null;
+
+  const names = blocked.map((f) => f.filename || "attachment").join(", ");
+
+  return (
+    <div
+      role="status"
+      className="mb-2 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-700 dark:text-amber-400"
+    >
+      <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+      <span>
+        The selected model can&apos;t read{" "}
+        <span className="font-medium">{names}</span>. Remove{" "}
+        {blocked.length === 1 ? "it" : "them"} or switch to a model that accepts{" "}
+        {blocked.length === 1 ? "it" : "them"}. This is a capability limit, not
+        a security filter.
+      </span>
+    </div>
+  );
+};

--- a/apps/frontend/components/model-selector-dialog.tsx
+++ b/apps/frontend/components/model-selector-dialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "./ai-elements/model-selector";
 import { AgentAvatar } from "./agent-avatar";
 import { Button } from "./ui/button";
+import { getModelIds } from "@/lib/model-config";
 
 const filterByKeywords = (
   _value: string,
@@ -88,7 +89,7 @@ export const ModelSelectorDialog = ({
           {/* Providers Group */}
           {providers.map((provider) => (
             <ModelSelectorGroup key={provider.id} heading={provider.name}>
-              {provider.modelIds.map((model) => (
+              {getModelIds(provider).map((model) => (
                 <ModelSelectorItem
                   key={`provider:${provider.id}:${model}`}
                   className="cursor-pointer"

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -29,6 +29,7 @@ import {
   Eye,
   EyeOff,
   OctagonX,
+  Plus,
   Trash2,
 } from "lucide-react";
 import {
@@ -47,6 +48,11 @@ import { useRouter } from "next/navigation";
 import { type Provider } from "@platypus/schemas";
 import useSWR from "swr";
 import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import {
+  getModelConfigs,
+  defaultPassthroughFileTypes,
+  type ModelConfigView,
+} from "@/lib/model-config";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -117,7 +123,6 @@ const ProviderForm = ({
   const [headersString, setHeadersString] = useState("{}");
   const [extraBodyError, setExtraBodyError] = useState<string | null>(null);
   const [extraBodyString, setExtraBodyString] = useState("{}");
-  const [modelIdsString, setModelIdsString] = useState("");
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -158,7 +163,7 @@ const ProviderForm = ({
         apiMode: provider.apiMode ?? "responses",
         nativeSearchEnabled: provider.nativeSearchEnabled ?? true,
         securityGuardrails: provider.securityGuardrails ?? "",
-        modelIds: provider.modelIds || [],
+        modelIds: provider.modelIds ? getModelConfigs(provider) : [],
         taskModelId: provider.taskModelId,
         memoryExtractionModelId: provider.memoryExtractionModelId,
         embeddingModelId: provider.embeddingModelId || "",
@@ -166,7 +171,6 @@ const ProviderForm = ({
       });
       setHeadersString(JSON.stringify(provider.headers || {}, null, 2));
       setExtraBodyString(JSON.stringify(provider.extraBody || {}, null, 2));
-      setModelIdsString((provider.modelIds || []).join("\n"));
       setSavedEmbeddingModelId(provider.embeddingModelId || null);
       setSavedEmbeddingDimensions(
         provider.embeddingDimensions?.toString() || null,
@@ -214,16 +218,6 @@ const ProviderForm = ({
       } catch {
         setExtraBodyError("Invalid JSON");
       }
-    } else if (id === "modelIds") {
-      setModelIdsString(value);
-      const parsed = value
-        .split("\n")
-        .map((line) => line.trim())
-        .filter((line) => line.length > 0);
-      setFormData((prevData) => ({
-        ...prevData,
-        modelIds: parsed,
-      }));
     } else {
       setFormData((prevData) => ({
         ...prevData,
@@ -248,6 +242,57 @@ const ProviderForm = ({
       return newData;
     });
   };
+
+  // --- Per-model config editing (issue #328) ---
+
+  const updateModel = (index: number, patch: Partial<ModelConfigView>) => {
+    setFormData((prev) => ({
+      ...prev,
+      modelIds: prev.modelIds.map((m, i) =>
+        i === index ? { ...m, ...patch } : m,
+      ),
+    }));
+  };
+
+  const addModel = () => {
+    if (validationErrors.modelIds) {
+      setValidationErrors((prev) => {
+        const next = { ...prev };
+        delete next.modelIds;
+        return next;
+      });
+    }
+    setFormData((prev) => ({
+      ...prev,
+      // New models default to the provider-type passthrough set; the operator
+      // can widen or narrow it. This is a capability router, not a security
+      // allow-list — see the field description.
+      modelIds: [
+        ...prev.modelIds,
+        {
+          id: "",
+          passthroughFileTypes: defaultPassthroughFileTypes({
+            providerType: formData.providerType,
+            apiMode: formData.apiMode,
+          }),
+        },
+      ],
+    }));
+  };
+
+  const removeModel = (index: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      modelIds: prev.modelIds.filter((_, i) => i !== index),
+    }));
+  };
+
+  // Passthrough types are edited as a comma-separated string of media types.
+  const parsePassthroughTypes = (value: string): string[] =>
+    value
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
 
   const hasEmbeddingConfigChanged = (): boolean => {
     if (!providerId) return false; // New provider, no existing embeddings
@@ -527,17 +572,75 @@ const ProviderForm = ({
           </Field>
 
           <Field data-invalid={!!validationErrors.modelIds}>
-            <FieldLabel htmlFor="modelIds">Model IDs</FieldLabel>
-            <Textarea
-              id="modelIds"
-              placeholder={["gpt-4", "gpt-3.5-turbo"].join("\n")}
-              value={modelIdsString}
-              onChange={handleChange}
-              disabled={isSubmitting || isReadOnly}
-              aria-invalid={!!validationErrors.modelIds}
-            />
+            <FieldLabel htmlFor="modelIds">Models</FieldLabel>
+            <div className="flex flex-col gap-3">
+              {formData.modelIds.length === 0 && (
+                <p className="text-sm text-muted-foreground">
+                  No models added yet.
+                </p>
+              )}
+              {formData.modelIds.map((model, index) => (
+                <div
+                  key={index}
+                  className="flex flex-col gap-2 rounded-md border p-3"
+                >
+                  <div className="flex items-center gap-2">
+                    <Input
+                      aria-label={`Model ID ${index + 1}`}
+                      placeholder="Model ID (e.g. gpt-4o)"
+                      value={model.id}
+                      onChange={(e) =>
+                        updateModel(index, { id: e.target.value })
+                      }
+                      disabled={isSubmitting || isReadOnly}
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="shrink-0"
+                      aria-label={`Remove model ${index + 1}`}
+                      onClick={() => removeModel(index)}
+                      disabled={isSubmitting || isReadOnly}
+                    >
+                      <Trash2 />
+                    </Button>
+                  </div>
+                  <Input
+                    aria-label={`Native file types for model ${index + 1}`}
+                    placeholder="image/*, application/pdf"
+                    value={model.passthroughFileTypes.join(", ")}
+                    onChange={(e) =>
+                      updateModel(index, {
+                        passthroughFileTypes: parsePassthroughTypes(
+                          e.target.value,
+                        ),
+                      })
+                    }
+                    disabled={isSubmitting || isReadOnly}
+                  />
+                </div>
+              ))}
+            </div>
+            {!isReadOnly && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2 w-fit"
+                onClick={addModel}
+                disabled={isSubmitting}
+              >
+                <Plus /> Add model
+              </Button>
+            )}
             <FieldDescription>
-              Model IDs to allow for this provider. One per line.
+              Models this provider exposes. For each model, list the file media
+              types it can ingest <strong>natively</strong> (comma-separated,
+              wildcards like <code>image/*</code> allowed). Files of other types
+              are converted to text where possible — this is a capability
+              setting, <strong>not a security filter</strong>. Leave the types
+              empty to use the provider-type default.
             </FieldDescription>
             {validationErrors.modelIds && (
               <FieldError>{validationErrors.modelIds}</FieldError>

--- a/apps/frontend/hooks/use-model-selection.ts
+++ b/apps/frontend/hooks/use-model-selection.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Provider, Agent, Chat } from "@platypus/schemas";
 import { setWithExpiry, getWithExpiry } from "@/lib/local-storage";
+import { getModelIds } from "@/lib/model-config";
 
 export interface ModelSelection {
   agentId: string;
@@ -74,7 +75,8 @@ export const useModelSelection = (
         const provider = providers.find((p) => p.id === persistedProviderId);
         if (provider) {
           // Check if the persisted model is still available for this provider
-          if (provider.modelIds.includes(persistedModelId)) {
+          const providerModelIds = getModelIds(provider);
+          if (providerModelIds.includes(persistedModelId)) {
             // Both provider and model are valid, restore them
             setProviderId(persistedProviderId);
             setModelId(persistedModelId);
@@ -85,7 +87,7 @@ export const useModelSelection = (
               `Model '${persistedModelId}' no longer available for provider '${persistedProviderId}', falling back to first model`,
             );
             setProviderId(persistedProviderId);
-            setModelId(provider.modelIds[0]);
+            setModelId(providerModelIds[0]);
             return;
           }
         } else {
@@ -124,7 +126,10 @@ export const useModelSelection = (
           const provider = providers.find(
             (p) => p.id === lastSelection.providerId,
           );
-          if (provider?.modelIds.includes(lastSelection.modelId)) {
+          if (
+            provider &&
+            getModelIds(provider).includes(lastSelection.modelId)
+          ) {
             setProviderId(lastSelection.providerId);
             setModelId(lastSelection.modelId);
             return;
@@ -135,7 +140,7 @@ export const useModelSelection = (
     }
 
     // PRIORITY 3: Fall back to first provider's first model (for new chats, invalid persisted data, or missing chatData)
-    setModelId(providers[0].modelIds[0]);
+    setModelId(getModelIds(providers[0])[0]);
     setProviderId(providers[0].id);
     /* eslint-enable react-hooks/set-state-in-effect */
   }, [

--- a/apps/frontend/lib/model-config.ts
+++ b/apps/frontend/lib/model-config.ts
@@ -1,0 +1,71 @@
+import {
+  defaultPassthroughFileTypes,
+  isTextLikeExtension,
+  mediaTypeMatches,
+  type Provider,
+} from "@platypus/schemas";
+
+/**
+ * Client-side per-model file capability helpers (issue #328). The pure logic
+ * (`defaultPassthroughFileTypes`, `mediaTypeMatches`, `isTextLikeExtension`) is
+ * shared with the backend via @platypus/schemas so the two never drift; this
+ * module adds the frontend-only view helpers over a provider's `modelIds`,
+ * which may be the new per-model objects or a legacy `string[]`.
+ */
+
+export { defaultPassthroughFileTypes };
+
+export type ModelConfigView = {
+  id: string;
+  passthroughFileTypes: string[];
+};
+
+/** Normalize a provider's models to objects, tolerating the legacy `string[]`. */
+export const getModelConfigs = (
+  provider: Pick<Provider, "modelIds">,
+): ModelConfigView[] =>
+  (
+    provider.modelIds as unknown as Array<
+      string | { id: string; passthroughFileTypes?: string[] }
+    >
+  ).map((m) =>
+    typeof m === "string"
+      ? { id: m, passthroughFileTypes: [] }
+      : { id: m.id, passthroughFileTypes: m.passthroughFileTypes ?? [] },
+  );
+
+/** The plain model-id list, order preserved. */
+export const getModelIds = (provider: Pick<Provider, "modelIds">): string[] =>
+  getModelConfigs(provider).map((m) => m.id);
+
+/** The resolved passthrough types for a model, filling the provider default. */
+export const getPassthroughFileTypes = (
+  provider: Pick<Provider, "modelIds" | "providerType" | "apiMode">,
+  modelId: string,
+): string[] => {
+  const model = getModelConfigs(provider).find((m) => m.id === modelId);
+  const declared = model?.passthroughFileTypes ?? [];
+  return declared.length > 0
+    ? declared
+    : defaultPassthroughFileTypes({
+        providerType: provider.providerType,
+        apiMode: provider.apiMode,
+      });
+};
+
+/**
+ * Classify an attachment against a model's passthrough set — the metadata-only
+ * mirror of the backend gate. `reject` is the case worth warning about: the
+ * turn would be blocked (Phase 1) because the file is neither native nor
+ * text-like.
+ */
+export const classifyAttachment = (
+  file: { mediaType?: string; filename?: string },
+  passthroughFileTypes: string[],
+): "passthrough" | "text" | "reject" => {
+  if (mediaTypeMatches(file.mediaType, passthroughFileTypes)) {
+    return "passthrough";
+  }
+  if (isTextLikeExtension(file.filename)) return "text";
+  return "reject";
+};

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -343,6 +343,54 @@ describe("Provider Create Schema", () => {
   });
 });
 
+describe("Provider modelIds (per-model config)", () => {
+  const base = {
+    organizationId: "org-123",
+    name: "Test Provider",
+    providerType: "OpenAI" as const,
+    apiKey: "sk-test",
+    taskModelId: "gpt-4",
+    memoryExtractionModelId: "gpt-4",
+  };
+
+  it("coerces a legacy string[] to per-model objects with empty passthrough", () => {
+    const result = providerCreateSchema.safeParse({
+      ...base,
+      modelIds: ["gpt-4", "gpt-4o"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelIds).toEqual([
+        { id: "gpt-4", passthroughFileTypes: [] },
+        { id: "gpt-4o", passthroughFileTypes: [] },
+      ]);
+    }
+  });
+
+  it("accepts per-model objects and defaults passthroughFileTypes to []", () => {
+    const result = providerCreateSchema.safeParse({
+      ...base,
+      modelIds: [
+        { id: "gpt-4o" },
+        { id: "qwen-vl", passthroughFileTypes: ["image/*"] },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelIds).toEqual([
+        { id: "gpt-4o", passthroughFileTypes: [] },
+        { id: "qwen-vl", passthroughFileTypes: ["image/*"] },
+      ]);
+    }
+  });
+
+  it("requires at least one model", () => {
+    expect(
+      providerCreateSchema.safeParse({ ...base, modelIds: [] }).success,
+    ).toBe(false);
+  });
+});
+
 describe("Organization identityContext", () => {
   it("accepts an organization when identityContext is omitted or null", () => {
     const base = {

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -565,6 +565,183 @@ export const providerApiModeSchema = z.enum(["chat", "responses"]);
 
 export type ProviderApiMode = z.infer<typeof providerApiModeSchema>;
 
+// Per-model configuration attached to a provider. Replaces the old free-form
+// `modelIds: string[]`; each enabled model now carries its own metadata.
+//
+// `passthroughFileTypes` lists the media types (wildcards like `image/*`
+// allowed) the model ingests NATIVELY. It is a capability ROUTER, not a
+// security allow-list: an attached file whose type is absent is converted to
+// text where possible (Phase 2) — it is never blocked for safety. Absent /
+// legacy rows fall back to a provider-type default at resolve time on the
+// backend. This object is also the intended home for future per-model metadata
+// (e.g. max input/output tokens) — out of scope here.
+export const modelConfigSchema = z.object({
+  id: z.string().min(1),
+  passthroughFileTypes: z.array(z.string()).default([]),
+});
+
+export type ModelConfig = z.infer<typeof modelConfigSchema>;
+
+// Provider `modelIds` payload schema. Accepts the new per-model objects and,
+// for backward compatibility with clients/rows predating per-model config, a
+// bare `string[]`; bare strings coerce to objects with an empty
+// `passthroughFileTypes` (defaults are applied on the backend at resolve time).
+export const modelIdsSchema = z
+  .array(z.union([z.string().min(1), modelConfigSchema]))
+  .min(1, "At least one model is required")
+  .transform((items) =>
+    items.map((item) =>
+      typeof item === "string"
+        ? { id: item, passthroughFileTypes: [] as string[] }
+        : item,
+    ),
+  );
+
+// --- Model file-capability helpers (issue #328) ---
+//
+// Framework-agnostic and dependency-free, so both the backend gate and the
+// frontend warning import the SAME logic instead of maintaining mirrored
+// copies. Provider-type strings are accepted loosely (`string`) so callers on
+// either side can pass their own provider shape.
+
+// Provider types that ingest documents (images + PDF) natively.
+const NATIVE_FILE_PROVIDER_TYPES: ReadonlySet<string> = new Set([
+  "Anthropic",
+  "Google",
+  "Bedrock",
+]);
+
+/**
+ * The passthrough set a model inherits when it declares none. Native-file
+ * providers, and OpenAI on the Responses API, take images and PDFs; OpenAI
+ * chat-completions endpoints and everything else get the images-only floor.
+ */
+export const defaultPassthroughFileTypes = (provider: {
+  providerType: string;
+  apiMode?: string;
+}): string[] => {
+  if (NATIVE_FILE_PROVIDER_TYPES.has(provider.providerType)) {
+    return ["image/*", "application/pdf"];
+  }
+  if (provider.providerType === "OpenAI" && provider.apiMode !== "chat") {
+    return ["image/*", "application/pdf"];
+  }
+  return ["image/*"];
+};
+
+/**
+ * Extensions whose bytes are plain text (source, config, data, markup). Used
+ * to decide the text-vs-binary split by the file's real nature rather than the
+ * unreliable browser-supplied media type. Binary document formats
+ * (pdf/docx/xlsx/pptx) are deliberately absent — those need extraction (Phase
+ * 2), not inlining.
+ */
+export const TEXT_LIKE_EXTENSIONS: ReadonlySet<string> = new Set([
+  "txt",
+  "text",
+  "md",
+  "markdown",
+  "mdx",
+  "rst",
+  "log",
+  "csv",
+  "tsv",
+  "json",
+  "jsonl",
+  "ndjson",
+  "yaml",
+  "yml",
+  "toml",
+  "ini",
+  "cfg",
+  "conf",
+  "env",
+  "properties",
+  "xml",
+  "html",
+  "htm",
+  "svg",
+  "css",
+  "scss",
+  "sass",
+  "less",
+  "js",
+  "mjs",
+  "cjs",
+  "jsx",
+  "ts",
+  "tsx",
+  "py",
+  "rb",
+  "go",
+  "rs",
+  "java",
+  "kt",
+  "kts",
+  "scala",
+  "c",
+  "h",
+  "cc",
+  "cpp",
+  "cxx",
+  "hpp",
+  "cs",
+  "php",
+  "swift",
+  "sh",
+  "bash",
+  "zsh",
+  "fish",
+  "ps1",
+  "bat",
+  "sql",
+  "graphql",
+  "gql",
+  "proto",
+  "dockerfile",
+  "makefile",
+  "gitignore",
+  "editorconfig",
+  "lua",
+  "pl",
+  "pm",
+  "r",
+  "jl",
+  "dart",
+  "vue",
+  "svelte",
+  "tf",
+  "hcl",
+]);
+
+/** Whether a filename's extension is a known plain-text/code/config format. */
+export const isTextLikeExtension = (filename: string | undefined): boolean => {
+  if (!filename) return false;
+  const base = filename.split(/[\\/]/).pop() ?? "";
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0) return false;
+  return TEXT_LIKE_EXTENSIONS.has(base.slice(dot + 1).toLowerCase());
+};
+
+/**
+ * Whether `mediaType` matches any pattern. A pattern may be exact
+ * (`application/pdf`), a subtype wildcard ("image slash star"), or the
+ * universal wildcard. Case-insensitive; media-type parameters are ignored.
+ */
+export const mediaTypeMatches = (
+  mediaType: string | undefined,
+  patterns: string[],
+): boolean => {
+  if (!mediaType || patterns.length === 0) return false;
+  const type = mediaType.split(";")[0].trim().toLowerCase();
+  return patterns.some((pattern) => {
+    const p = pattern.trim().toLowerCase();
+    if (p === "*/*" || p === "*") return true;
+    if (p.endsWith("/*")) return type.startsWith(p.slice(0, -1));
+    return type === p;
+  });
+};
+
 const providerBaseSchema = z.object({
   id: z.string(),
   organizationId: z.string().optional(),
@@ -601,7 +778,7 @@ const providerBaseSchema = z.object({
   // agent at a different provider. A prompt-level FLOOR, not a guarantee.
   // Length-bounded against abuse; nullable so existing providers are unchanged.
   securityGuardrails: z.string().max(8000).nullable().optional(),
-  modelIds: z.array(z.string()).min(1),
+  modelIds: modelIdsSchema,
   taskModelId: z.string(),
   memoryExtractionModelId: z.string(),
   embeddingModelId: z.string().nullable().optional(),


### PR DESCRIPTION
Implements **Phase 1** of #328. Fixes file attachments breaking chat-completions / proxied models, and stops one failed attachment from permanently bricking a chat.

## What changed

**Per-model file capability (declared, not inferred)**
- Provider `modelIds` goes from `string[]` to per-model objects `{ id, passthroughFileTypes }` (MIME strings, wildcards like `image/*` allowed). Legacy `string[]` rows/payloads are tolerated at read time and backfilled by migration `0047` with provider-type defaults (Anthropic/Google/Bedrock and OpenAI Responses → images + PDF; OpenAI chat-completions and others → images only).

**Pre-persist validation gate (fixes bricking)**
- `validateTurnAttachments` resolves the target model's `passthroughFileTypes` and scans the whole message list (fresh upload **and** history) **before** the chat sink's eager `onStart` upsert. A file the model can't ingest natively and isn't text-like is rejected with a typed `FileValidationError` → 400 naming the file(s); nothing is persisted, so a bad attachment can never brick the chat. Mid-chat switches to an incompatible model are blocked the same way.

**Send-time normalizer (fixes the media-type lottery)**
- Non-native text-like files are inlined as annotated text; native files pass through byte-for-byte. Text-vs-binary is decided by file extension + NUL-byte content sniff, **never** the unreliable browser media type — fixing `.py`-works-but-`.md`-fails.

**Frontend**
- Provider form edits per-model passthrough types; the chat input warns when the selected model can't accept an attachment. Copy makes clear this is a capability router, **not a security filter**.

**Shared helpers**
- Default passthrough sets, media-type matching, and the text-extension list live in `@platypus/schemas` so backend and frontend can't drift.

## Scope
PDF/DOCX text extraction is **Phase 2** (#342) and deliberately out of scope — such binaries are cleanly rejected here (better than today's brick / cryptic error).

## Verification
- Backend typecheck: 0 errors · Frontend `tsc --noEmit`: 0 errors
- Full test suite green (1169 backend + 44 schemas + frontend/examples/sdk); 34 new tests (classification, gate, capability, `validateTurnAttachments`, schema coercion)
- Lint clean across the monorepo

## Notes
- Empty `passthroughFileTypes` inherits the provider default (so "accept nothing natively" is inexpressible) — deliberate, to stop a new model from accidentally rejecting even images.
- Migration `0047` is data-only (jsonb→jsonb, no DDL), scaffolded via `drizzle-kit generate --custom` so the journal/snapshot chain stays consistent.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)