### PR TITLE
fix(backend): harden file-attachment normalizer and modelIds resolution

### DIFF
--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -572,21 +572,22 @@ export const prepareChatTurn = async (
       )
     : tools;
 
-  // Inline file URLs to `data:` bytes, then normalize any file part the target
-  // model can't ingest natively (issue #328): text-like files become annotated
-  // text; a native part is left untouched. The pre-persist gate
-  // (`validateTurnAttachments`) has already rejected unsupported binaries, so
-  // the normalizer here never throws.
+  // Inline file URLs to `data:` bytes when we have an origin, then ALWAYS
+  // normalize (issue #328): text-like files become annotated text, native
+  // files pass through untouched, and any part that couldn't be inlined — a
+  // storage miss, or a headless turn with no origin — is announced as
+  // unavailable rather than forwarded raw. Normalizing even without an origin
+  // keeps a stray file part on a headless turn from hard-failing conversion.
+  // The pre-persist gate (`validateTurnAttachments`) has already rejected
+  // unsupported binaries, so the normalizer here never throws.
   const passthroughFileTypes = passthroughFileTypesForModel(
     provider,
     resolvedModelId,
   );
-  const inlinedMessages = origin
-    ? normalizeFileParts(
-        await inlineFileUrls(messages, origin),
-        passthroughFileTypes,
-      )
-    : messages;
+  const inlinedMessages = normalizeFileParts(
+    origin ? await inlineFileUrls(messages, origin) : messages,
+    passthroughFileTypes,
+  );
 
   let disposed = false;
   const dispose = async () => {

--- a/apps/backend/src/services/file-gate.test.ts
+++ b/apps/backend/src/services/file-gate.test.ts
@@ -154,4 +154,59 @@ describe("normalizeFileParts", () => {
     expect(part.type).toBe("text");
     expect(part.text).toContain("report.pdf");
   });
+
+  it("announces a text-like file that never got inlined (storage:// survivor) as unavailable", () => {
+    const out = normalizeFileParts(
+      [
+        msg([
+          {
+            type: "file",
+            mediaType: "application/octet-stream",
+            filename: "notes.md",
+            url: "storage://abc123",
+          },
+        ]),
+      ],
+      chatPassthrough,
+    );
+    const part = out[0].parts[0] as { type: string; text: string };
+    expect(part.type).toBe("text");
+    expect(part.text).toContain("notes.md");
+    expect(part.text).toContain("unavailable");
+  });
+
+  it("announces a native file with an un-inlined storage:// URL as unavailable instead of forwarding it raw", () => {
+    const out = normalizeFileParts(
+      [
+        msg([
+          {
+            type: "file",
+            mediaType: "image/png",
+            filename: "a.png",
+            url: "storage://abc123",
+          },
+        ]),
+      ],
+      chatPassthrough,
+    );
+    const part = out[0].parts[0] as { type: string; text: string };
+    expect(part.type).toBe("text");
+    expect(part.text).toContain("a.png");
+    expect(part.text).toContain("unavailable");
+  });
+
+  it("leaves a native file with an external http(s) URL untouched (the model may fetch it)", () => {
+    const input = [
+      msg([
+        {
+          type: "file",
+          mediaType: "image/png",
+          filename: "a.png",
+          url: "https://example.com/a.png",
+        },
+      ]),
+    ];
+    const out = normalizeFileParts(input, chatPassthrough);
+    expect(out[0].parts[0]).toEqual(input[0].parts[0]);
+  });
 });

--- a/apps/backend/src/services/file-gate.ts
+++ b/apps/backend/src/services/file-gate.ts
@@ -105,6 +105,26 @@ const annotateInlinedText = (
 };
 
 /**
+ * A short text stand-in for a file that can't be sent. `unavailable` means we
+ * couldn't load its bytes (a storage miss, or a headless turn that skipped
+ * inlining); `unsupported` means a binary the model can't ingest slipped past
+ * the gate. Either way the part is announced, never forwarded raw.
+ */
+const omittedFilePlaceholder = (
+  filename: string | undefined,
+  reason: "unavailable" | "unsupported",
+) => {
+  const label = filename || "attachment";
+  return {
+    type: "text" as const,
+    text:
+      reason === "unavailable"
+        ? `[file unavailable: ${label}]`
+        : `[unsupported file omitted: ${label}]`,
+  };
+};
+
+/**
  * Rewrite non-native file parts into content the model can read. Runs at send
  * time, after file URLs are inlined (so `data:` bytes are available):
  *
@@ -114,8 +134,12 @@ const annotateInlinedText = (
  *   pre-persist gate should already have blocked it; never throws here, so a
  *   slipped-through part can't hard-fail conversion and re-brick the chat).
  *
- * A part whose bytes aren't available (e.g. a storage miss left it non-`data:`)
- * is left unchanged.
+ * A `storage://` URL (or a missing one) that reaches here never got inlined —
+ * a storage miss, or a headless turn with no origin to inline against. The
+ * model can't fetch it, so forwarding it raw would hard-fail conversion and
+ * re-brick the chat on every history replay (issue #328); it is announced as
+ * unavailable instead. External `http(s)` URLs are left alone — a model may
+ * still fetch those.
  */
 export const normalizeFileParts = (
   messages: PlatypusUIMessage[],
@@ -129,12 +153,20 @@ export const normalizeFileParts = (
       const url = typeof part.url === "string" ? part.url : "";
       const decoded = url.startsWith("data:") ? decodeDataUrl(url) : null;
       const bytes = decoded?.bytes;
+      // An internal storage URL that survived inlining is unreachable by the
+      // model; a missing URL likewise has nothing to send.
+      const unfetchable = url === "" || url.startsWith("storage://");
 
       const outcome = classifyFilePart(part, passthroughFileTypes, bytes);
-      if (outcome === "passthrough") return part;
+
+      if (outcome === "passthrough") {
+        return unfetchable
+          ? omittedFilePlaceholder(part.filename, "unavailable")
+          : part;
+      }
 
       if (outcome === "text") {
-        if (!bytes) return part;
+        if (!bytes) return omittedFilePlaceholder(part.filename, "unavailable");
         const content = new TextDecoder().decode(bytes);
         return {
           type: "text" as const,
@@ -142,10 +174,7 @@ export const normalizeFileParts = (
         };
       }
 
-      return {
-        type: "text" as const,
-        text: `[unsupported file omitted: ${part.filename || "attachment"}]`,
-      };
+      return omittedFilePlaceholder(part.filename, "unsupported");
     });
     return { ...message, parts };
   });

--- a/apps/backend/src/tools/agent-discovery.test.ts
+++ b/apps/backend/src/tools/agent-discovery.test.ts
@@ -38,6 +38,23 @@ describe("createAgentDiscoveryTools", () => {
         providers,
       );
     });
+
+    it("flattens per-model object modelIds to plain id strings", async () => {
+      mockDb.where.mockResolvedValue([
+        {
+          id: "p1",
+          name: "Provider 1",
+          modelIds: [
+            { id: "model-a", passthroughFileTypes: ["image/*"] },
+            { id: "model-b", passthroughFileTypes: [] },
+          ],
+        },
+      ]);
+
+      expect(await tools.listModelProviders.execute!({}, ctx)).toEqual([
+        { id: "p1", name: "Provider 1", modelIds: ["model-a", "model-b"] },
+      ]);
+    });
   });
 
   describe("listAgents", () => {

--- a/apps/backend/src/tools/agent-discovery.ts
+++ b/apps/backend/src/tools/agent-discovery.ts
@@ -9,6 +9,8 @@ import {
 } from "../db/schema.ts";
 import { getToolSets } from "../tools/index.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
+import { providerModelIds } from "../services/model-capability.ts";
+import type { Provider } from "@platypus/schemas";
 
 /**
  * Standalone factory for the listAgents tool so it can be shared across
@@ -86,12 +88,13 @@ export function createAgentDiscoveryTools(
           ),
         );
       // Advertise plain model-id strings regardless of whether the row stores
-      // the new per-model objects or a legacy `string[]` (issue #328).
+      // the new per-model objects or a legacy `string[]` (issue #328). Reuse the
+      // canonical resolver so this can't drift from the capability logic. Only
+      // `modelIds` is read for id extraction; the partial row is cast to satisfy
+      // its signature.
       return providers.map((p) => ({
         ...p,
-        modelIds: (p.modelIds as Array<string | { id: string }>).map((m) =>
-          typeof m === "string" ? m : m.id,
-        ),
+        modelIds: providerModelIds(p as unknown as Provider),
       }));
     },
   });

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -575,6 +575,13 @@ export type ProviderApiMode = z.infer<typeof providerApiModeSchema>;
 // legacy rows fall back to a provider-type default at resolve time on the
 // backend. This object is also the intended home for future per-model metadata
 // (e.g. max input/output tokens) — out of scope here.
+//
+// The universal wildcard (`*/*` or `*`) is an advanced escape hatch: it sends
+// EVERY attached file to the model raw. Values are deliberately NOT validated
+// as MIME patterns, so declaring a type the endpoint can't actually ingest is
+// the operator's responsibility — e.g. `*/*` on an OpenAI chat-completions
+// provider will forward a PDF raw and the endpoint will reject the turn. Use it
+// only on endpoints that genuinely accept those types natively.
 export const modelConfigSchema = z.object({
   id: z.string().min(1),
   passthroughFileTypes: z.array(z.string()).default([]),


### PR DESCRIPTION
Follow-up hardening on #343 (issue #328 Phase 1). A defect/regression pass over the merged per-model file-attachment gating — no new feature work.

## What changed

**Storage-miss / no-origin brick risk (the real bug)**
- `normalizeFileParts` now announces a file part that never got inlined as `[file unavailable: …]` instead of forwarding it raw. Previously, a `storage://` URL that survived inlining (a storage miss, an unparseable key, or a headless turn with no origin) was passed straight to `convertToModelMessages`, which hard-fails the turn and **re-bricks the chat on every history replay** — the exact failure mode #343 set out to kill.
- External `http(s)` URLs are deliberately left untouched (a model may still fetch them); only unreachable `storage://` / empty URLs are placeholdered.
- `prepareChatTurn` now **always** normalizes (previously only when `origin` was set), closing the headless/no-origin gap.

**modelIds resolution can't drift**
- `agent-discovery`'s `listModelProviders` reuses the canonical `providerModelIds()` resolver instead of its own inline `string | {id}` flatten.

**`*/*` footgun (left as designed)**
- Documented the universal wildcard in `modelConfigSchema` as an advanced escape hatch whose correctness is the operator's responsibility. No validation added — the design deliberately trusts the declared capability.

## Review notes
Also confirmed **safe-by-design, no change**: migration `0047` idempotency + default parity with `defaultPassthroughFileTypes`; empty-array→default inheritance; uncapped text inlining (Phase 2); gate silent-skip on model-resolution failure; all frontend `modelIds` consumers route through `getModelConfigs`/`getModelIds`.

`normalizeFileParts` now runs on every turn (including headless no-file turns) as a shallow map — negligible overhead, consistent with the interactive path which already did so, but it is a behavior change for headless callers worth flagging.

## Verification
- `pnpm --filter backend typecheck` — 0 errors
- `pnpm test` — 7/7 tasks (1173 backend + 44 schemas + 23 frontend + sdk/examples)
- `pnpm lint` — clean
- 4 new tests: `storage://` survivor → unavailable (text + native), external http URL untouched (regression guard), agent-discovery object-shape flatten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)