### PR TITLE
chore(docs): link good first issues from README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ Please be respectful and constructive in all interactions. We are committed to p
 
 ## Getting Started
 
+Looking for something to work on? Browse our [good first issues](https://github.com/willdady/platypus/contribute) — scoped, newcomer-friendly tasks that are a great starting point.
+
 1. **Fork the repository** and clone your fork locally.
 2. **Set up your development environment** by following [Local Development](#local-development) below.
 3. **Create a branch** from `main` for your changes (see [Branch Naming](#branch-naming) below).

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ lands well.
 
 Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) for details on local development, branch naming, commit conventions, and how to submit a pull request.
 
+**New here?** Browse our [good first issues](https://github.com/willdady/platypus/contribute) — scoped, newcomer-friendly tasks that are a great way to make your first contribution.
+
 ---
 
 Platypus logo by [Thiings.co](https://www.thiings.co/things)


### PR DESCRIPTION
## Summary

Adds pointers to the repo's [`/contribute`](https://github.com/willdady/platypus/contribute) page — which surfaces `good first issue`–labelled tickets — from two places newcomers actually look:

- **README.md** — a "New here?" callout under the Contributing section.
- **CONTRIBUTING.md** — a line at the top of Getting Started.

## Why

GitHub barely links the `/contribute` page from the repo UI, so contributors rarely stumble onto it. Linking it from the README and contributing guide makes our scoped, newcomer-friendly issues (e.g. the new iframe widget, #346) discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)