### PR TITLE
fix: centralize file classification

### DIFF
--- a/apps/backend/src/services/file-classification.ts
+++ b/apps/backend/src/services/file-classification.ts
@@ -15,14 +15,19 @@
  * browser-supplied media type, which is an unreliable, OS-specific lottery
  * (`.py` → `text/x-python` but `.md` → `application/octet-stream`).
  */
-import { isTextLikeExtension, mediaTypeMatches } from "@platypus/schemas";
+import {
+  classifyFile,
+  isTextLikeExtension,
+  mediaTypeMatches,
+  type FileClassification,
+} from "@platypus/schemas";
 
 // The media-type matcher and the text-extension test live in @platypus/schemas
 // so the backend gate and the frontend warning share one copy. Re-exported so
 // this module remains the single classification import surface (incl. tests).
 export { isTextLikeExtension, mediaTypeMatches };
 
-export type FilePartClass = "passthrough" | "text" | "reject";
+export type FilePartClass = FileClassification;
 
 /** How many leading bytes to sniff for the NUL-byte binary heuristic. */
 const SNIFF_BYTES = 8_000;
@@ -46,11 +51,9 @@ export const classifyFilePart = (
   passthroughFileTypes: string[],
   bytes?: Uint8Array,
 ): FilePartClass => {
-  if (mediaTypeMatches(part.mediaType, passthroughFileTypes)) {
-    return "passthrough";
-  }
-  if (isTextLikeExtension(part.filename) && !(bytes && looksBinary(bytes))) {
-    return "text";
-  }
-  return "reject";
+  return classifyFile(
+    part,
+    passthroughFileTypes,
+    bytes ? looksBinary(bytes) : false,
+  );
 };

--- a/apps/frontend/lib/model-config.ts
+++ b/apps/frontend/lib/model-config.ts
@@ -1,7 +1,6 @@
 import {
+  classifyFile,
   defaultPassthroughFileTypes,
-  isTextLikeExtension,
-  mediaTypeMatches,
   type Provider,
 } from "@platypus/schemas";
 
@@ -62,10 +61,4 @@ export const getPassthroughFileTypes = (
 export const classifyAttachment = (
   file: { mediaType?: string; filename?: string },
   passthroughFileTypes: string[],
-): "passthrough" | "text" | "reject" => {
-  if (mediaTypeMatches(file.mediaType, passthroughFileTypes)) {
-    return "passthrough";
-  }
-  if (isTextLikeExtension(file.filename)) return "text";
-  return "reject";
-};
+) => classifyFile(file, passthroughFileTypes);

--- a/apps/frontend/lib/model-config.ts
+++ b/apps/frontend/lib/model-config.ts
@@ -6,8 +6,8 @@ import {
 
 /**
  * Client-side per-model file capability helpers (issue #328). The pure logic
- * (`defaultPassthroughFileTypes`, `mediaTypeMatches`, `isTextLikeExtension`) is
- * shared with the backend via @platypus/schemas so the two never drift; this
+ * (`defaultPassthroughFileTypes`, `classifyFile`) is shared with the backend
+ * via @platypus/schemas so the two never drift; this
  * module adds the frontend-only view helpers over a provider's `modelIds`,
  * which may be the new per-model objects or a legacy `string[]`.
  */

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -15,6 +15,7 @@ import {
   SANDBOX_ENV_MAX_ENTRIES,
   SANDBOX_ENV_MAX_VALUE_BYTES,
   providerCreateSchema,
+  classifyFile,
 } from "./index";
 
 describe("Organization Schema", () => {
@@ -462,5 +463,47 @@ describe("sandboxEnvSchema", () => {
     const tooMany: Record<string, string> = {};
     for (let i = 0; i <= SANDBOX_ENV_MAX_ENTRIES; i++) tooMany[`K${i}`] = "v";
     expect(sandboxEnvSchema.safeParse(tooMany).success).toBe(false);
+  });
+});
+
+describe("classifyFile", () => {
+  const passthroughFileTypes = ["image/*"];
+
+  it("prioritizes native passthrough media types", () => {
+    expect(
+      classifyFile(
+        { mediaType: "image/png", filename: "image.png" },
+        passthroughFileTypes,
+        true,
+      ),
+    ).toBe("passthrough");
+  });
+
+  it("classifies text-like files when content is not binary", () => {
+    expect(
+      classifyFile(
+        { mediaType: "application/octet-stream", filename: "notes.md" },
+        passthroughFileTypes,
+      ),
+    ).toBe("text");
+  });
+
+  it("rejects binary content even when the extension is text-like", () => {
+    expect(
+      classifyFile(
+        { mediaType: "application/octet-stream", filename: "notes.md" },
+        passthroughFileTypes,
+        true,
+      ),
+    ).toBe("reject");
+  });
+
+  it("rejects unsupported binary file types", () => {
+    expect(
+      classifyFile(
+        { mediaType: "application/pdf", filename: "report.pdf" },
+        passthroughFileTypes,
+      ),
+    ).toBe("reject");
   });
 });

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -759,6 +759,27 @@ export const mediaTypeMatches = (
   });
 };
 
+export type FileClassification = "passthrough" | "text" | "reject";
+
+/**
+ * Classify a file from metadata shared by the frontend and backend. The
+ * backend can additionally provide its byte-sniff result when content is
+ * available.
+ */
+export const classifyFile = (
+  file: { mediaType?: string; filename?: string },
+  passthroughFileTypes: string[],
+  contentLooksBinary = false,
+): FileClassification => {
+  if (mediaTypeMatches(file.mediaType, passthroughFileTypes)) {
+    return "passthrough";
+  }
+  if (isTextLikeExtension(file.filename) && !contentLooksBinary) {
+    return "text";
+  }
+  return "reject";
+};
+
 const providerBaseSchema = z.object({
   id: z.string(),
   organizationId: z.string().optional(),


### PR DESCRIPTION
## Summary

Closes #347.

Moves the shared passthrough / text / reject cascade into
`@platypus/schemas` so the frontend warning and backend enforcement use one
classifier.

## Changes

- adds `classifyFile` and `FileClassification` to the shared schemas package
- keeps the backend-only NUL-byte sniff in `classifyFilePart`
- delegates frontend metadata classification directly to the shared function
- adds shared regression coverage for passthrough priority, text files, binary
  sniffing, and unsupported files

The current behavior is preserved: backend bytes can override a text-like
extension, while native passthrough still wins before content sniffing.

## Testing

- `pnpm --filter @platypus/schemas test` - 48 tests passed
- `pnpm --filter @platypus/backend test -- file-classification.test.ts` -
  1,174 backend tests passed
- `pnpm --filter @platypus/frontend test` - 23 tests passed
- `pnpm typecheck`
- `pnpm --filter @platypus/frontend lint`
- Prettier check for all changed TypeScript files
- `git diff --check`
