### PR TITLE
fix(frontend): prevent chat input horizontal overflow on mobile

### DIFF
--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -526,8 +526,8 @@ export const Chat = ({
         <ConversationScrollButton />
       </Conversation>
       <div className="grid shrink-0 gap-4 p-4">
-        <div className="flex justify-center">
-          <div className="w-full xl:w-4/5 max-w-4xl">
+        <div className="flex justify-center min-w-0">
+          <div className="w-full xl:w-4/5 max-w-4xl min-w-0">
             {isWorkspaceOwner ? (
               <PromptInput
                 onSubmit={(message) => {


### PR DESCRIPTION
## Problem

On mobile, if a chat has content and you paste a long unbroken string (e.g. a URL) into the message box, the chat input grows horizontally and pushes the submit button off-screen.

## Root cause

The chat input's textarea uses `field-sizing: content`, which gives it an intrinsic **content width** equal to the pasted string. That width propagated up through the input area's CSS grid item, whose default `min-width: auto` refuses to shrink below its content. The whole input row grew wider than the viewport, and since the submit button is right-aligned (`justify-between`), it got pushed off-screen — `overflow-hidden` on the chat container clipped it from view rather than constraining it.

The message list uses the same centering pattern but sits inside a scroll container (`overflow-y-auto`), which already caps its min-content, so tool results alone never blew out. The pasted string in the `field-sizing` textarea was the real trigger.

## Fix

Add `min-w-0` to the input-area grid item so it can shrink below the textarea's intrinsic width. With the container width constrained, the textarea wraps long unbroken strings onto new lines instead of expanding the layout.

## Verification

Reproduced the exact DOM + compiled-utility CSS chain in an isolated HTML file rendered headless in Chrome at a 375px viewport:

- **Before:** submit button entirely off-screen, only the attachments button visible — matched the report.
- Tested candidates: `width:100%` on the textarea alone → no effect; `min-w-0` on the inner width-holder only → no effect; `min-w-0` on the grid item → button restored, layout contained.

Confirmed on-device: long unbroken strings now wrap within the chat input at the mobile breakpoint, and the submit button stays visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)