### PR TITLE
chore(backend): type chat message metadata and narrow the tool type surface

### DIFF
--- a/.agents/skills/tools/SKILL.md
+++ b/.agents/skills/tools/SKILL.md
@@ -268,14 +268,20 @@ The `ChatMessage` component in `apps/frontend/components/chat-message.tsx` check
 **Steps to add custom tool UI:**
 
 1. **Create component** in `/apps/frontend/components/your-tool.tsx`
-2. **Add conditional rendering** in `chat-message.tsx` (before the generic `tool-*` fallback):
+2. **Add the tool to `CustomUITools`** in `apps/backend/src/types.ts`. That type
+   enumerates only the tools with bespoke UI — being listed there is what gives
+   your tool part real `input`/`output` types instead of `unknown`.
+3. **Add conditional rendering** in `chat-message.tsx` (before the generic `tool-*` fallback):
    ```typescript
    else if (part.type === "tool-yourToolName") {
-     return <YourToolComponent toolPart={part as ToolUIPart} />;
+     return <YourToolComponent toolPart={part} />;
    }
    ```
-3. **Import component** at top of `chat-message.tsx`
-4. **Handle tool states**: `input-streaming`, `input-available`, `output-available`, `output-error`
+   No cast is needed — matching the literal `type` narrows the part. The generic
+   fallback branches use the `isToolUIPart` guard from `ai`, since plugin- and
+   MCP-contributed tools aren't known at compile time.
+4. **Import component** at top of `chat-message.tsx`
+5. **Handle tool states**: `input-streaming`, `input-available`, `output-available`, `output-error`
 
 **Existing custom tool components** (check `apps/frontend/components/` for current list):
 

--- a/apps/backend/src/types.ts
+++ b/apps/backend/src/types.ts
@@ -1,33 +1,36 @@
-import {
-  type UIMessage,
-  type InferUITool,
-  type InferUITools,
-  type UIDataTypes,
-} from "ai";
-import * as mathTools from "./tools/math.ts";
-import * as timeTools from "./tools/time.ts";
-import { createWebFetchTools } from "./tools/fetch.ts";
+import { type UIMessage, type InferUITool, type UIDataTypes } from "ai";
 import { createLoadSkillTool } from "./tools/skill.ts";
-import { createTriggerTools } from "./tools/trigger.ts";
 
-export type MathTools = InferUITools<typeof mathTools>;
-export type TimeTools = InferUITools<typeof timeTools>;
-export type FetchTools = InferUITools<ReturnType<typeof createWebFetchTools>>;
+/**
+ * Metadata the run pipeline attaches to a streamed assistant message.
+ *
+ * Omitted entirely for runs that resolved no agent (a direct provider/model
+ * chat), which is why `UIMessage["metadata"]` stays optional rather than the
+ * fields inside it.
+ */
+export type ChatMessageMetadata = {
+  /** Agent the run resolved; the chat UI renders its name and avatar. */
+  agentId: string;
+};
 
-export type SkillTools = {
+/**
+ * Tools whose input/output shapes are consumed by bespoke chat UI.
+ *
+ * Deliberately not the whole tool surface, and it cannot be one: the native
+ * tool sets are plugins loaded at runtime (ADR-0013), third-party plugins
+ * contribute tools under namespaced contribution ids, and MCP tools are
+ * unknown until connect time. Add an entry only when a component needs that
+ * tool's typed input or output — every other tool renders through the generic
+ * `ToolUIPart` path. Sub-agent delegate tools cannot be listed either: their
+ * names are generated per sub-agent, so the renderer matches on the
+ * `tool-delegateTo` prefix instead of a static key.
+ */
+export type CustomUITools = {
   loadSkill: InferUITool<ReturnType<typeof createLoadSkillTool>>;
 };
 
-export type TriggerTools = {
-  [K in keyof ReturnType<typeof createTriggerTools>]: InferUITool<
-    ReturnType<typeof createTriggerTools>[K]
-  >;
-};
-
-export type PlatypusTools = MathTools &
-  TimeTools &
-  FetchTools &
-  SkillTools &
-  TriggerTools;
-
-export type PlatypusUIMessage = UIMessage<unknown, UIDataTypes, PlatypusTools>;
+export type PlatypusUIMessage = UIMessage<
+  ChatMessageMetadata,
+  UIDataTypes,
+  CustomUITools
+>;

--- a/apps/frontend/components/chat-message.test.tsx
+++ b/apps/frontend/components/chat-message.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Agent } from "@platypus/schemas";
+import type { PlatypusUIMessage } from "@platypus/backend/src/types";
+
+// Streamdown pulls in shiki and a worker-ish runtime that jsdom can't host;
+// the assertions here only care about the avatar rendered beside the message.
+vi.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+import { ChatMessage } from "./chat-message";
+
+const agents: Agent[] = [
+  {
+    id: "agent-1",
+    name: "Research Agent",
+    avatarUrl: "https://example.com/agent-1.png",
+  } as unknown as Agent,
+];
+
+const assistantMessage = (
+  metadata?: PlatypusUIMessage["metadata"],
+): PlatypusUIMessage => ({
+  id: "m1",
+  role: "assistant",
+  metadata,
+  parts: [{ type: "text", text: "Hello" }],
+});
+
+function renderMessage(message: PlatypusUIMessage) {
+  return render(
+    <ChatMessage
+      message={message}
+      isLastMessage
+      status="ready"
+      isEditing={false}
+      editContent=""
+      editTextareaRef={{ current: null }}
+      agents={agents}
+      setEditContent={vi.fn()}
+      onEditStart={vi.fn()}
+      onEditCancel={vi.fn()}
+      onEditSubmit={vi.fn()}
+      onMessageDelete={vi.fn()}
+      onRegenerate={vi.fn()}
+      onCopyMessage={vi.fn()}
+      copiedMessageId={null}
+    />,
+  );
+}
+
+describe("ChatMessage agent attribution", () => {
+  it("renders the agent avatar when the message is attributed to an agent", () => {
+    renderMessage(assistantMessage({ agentId: "agent-1" }));
+
+    const avatar = screen.getByAltText("Research Agent");
+    expect(avatar).toHaveAttribute("src", "https://example.com/agent-1.png");
+  });
+
+  it("falls back to the generic bot avatar for a run with no attribution", () => {
+    const { container } = renderMessage(assistantMessage());
+
+    expect(screen.queryByAltText("Research Agent")).toBeNull();
+    expect(container.querySelector("svg.lucide-bot")).not.toBeNull();
+  });
+
+  it("falls back to the generic bot avatar when the agent is unknown", () => {
+    const { container } = renderMessage(assistantMessage({ agentId: "gone" }));
+
+    expect(screen.queryByAltText("Research Agent")).toBeNull();
+    expect(container.querySelector("svg.lucide-bot")).not.toBeNull();
+  });
+});

--- a/apps/frontend/components/chat-message.test.tsx
+++ b/apps/frontend/components/chat-message.test.tsx
@@ -13,13 +13,15 @@ vi.mock("streamdown", () => ({
 
 import { ChatMessage } from "./chat-message";
 
-const agents: Agent[] = [
-  {
+const makeAgent = (overrides: Partial<Agent>): Agent =>
+  ({
     id: "agent-1",
     name: "Research Agent",
     avatarUrl: "https://example.com/agent-1.png",
-  } as unknown as Agent,
-];
+    ...overrides,
+  }) as Agent;
+
+const agents = [makeAgent({})];
 
 const assistantMessage = (
   metadata?: PlatypusUIMessage["metadata"],
@@ -60,17 +62,17 @@ describe("ChatMessage agent attribution", () => {
     expect(avatar).toHaveAttribute("src", "https://example.com/agent-1.png");
   });
 
-  it("falls back to the generic bot avatar for a run with no attribution", () => {
-    const { container } = renderMessage(assistantMessage());
+  // A direct provider/model run carries no attribution; an agentId that no
+  // longer resolves (deleted agent) has to degrade the same way.
+  it.each([
+    ["a run with no attribution", undefined],
+    ["an agentId that resolves to no agent", { agentId: "gone" }],
+  ] as const)("falls back to the generic bot avatar for %s", (_, metadata) => {
+    const { container } = renderMessage(assistantMessage(metadata));
 
     expect(screen.queryByAltText("Research Agent")).toBeNull();
-    expect(container.querySelector("svg.lucide-bot")).not.toBeNull();
-  });
-
-  it("falls back to the generic bot avatar when the agent is unknown", () => {
-    const { container } = renderMessage(assistantMessage({ agentId: "gone" }));
-
-    expect(screen.queryByAltText("Research Agent")).toBeNull();
-    expect(container.querySelector("svg.lucide-bot")).not.toBeNull();
+    // The fallback is our own `bg-muted` circle wrapping an icon — asserted
+    // via markup we own rather than a lucide-generated class name.
+    expect(container.querySelector("div.bg-muted > svg")).not.toBeNull();
   });
 });

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -30,9 +30,9 @@ import {
 import { DynamicToolHeader } from "./dynamic-tool-header";
 import {
   DynamicToolUIPart,
-  ToolUIPart,
   FileUIPart,
   TextUIPart,
+  isToolUIPart,
   type ChatStatus,
 } from "ai";
 import { Agent } from "@platypus/schemas";
@@ -48,18 +48,6 @@ import {
 import { Textarea } from "./ui/textarea";
 import { LoadSkillTool } from "./load-skill-tool";
 import { SubAgentTool } from "./sub-agent-tool";
-
-/**
- * Re-type a `tool-` prefixed message part as a tool part.
- *
- * Only tools with bespoke UI are enumerated in the message's static part union
- * (see `CustomUITools` in the backend types); plugin- and MCP-contributed
- * tools are not known at compile time, so the runtime `tool-` prefix is the
- * only signal we have. Intersecting keeps the assertion honest — the result is
- * still the part we were handed.
- */
-const asToolUIPart = <T extends { type: string }>(part: T) =>
-  part as T & ToolUIPart;
 
 interface ChatMessageProps {
   /** The message object to render */
@@ -234,39 +222,29 @@ export const ChatMessage = memo(function ChatMessage({
             </Tool>
           );
         } else if (part.type === "tool-loadSkill") {
-          return (
-            <LoadSkillTool
-              key={`${message.id}-${i}`}
-              toolPart={part as ToolUIPart}
-            />
-          );
-        } else if (part.type.startsWith("tool-delegateTo")) {
+          return <LoadSkillTool key={`${message.id}-${i}`} toolPart={part} />;
+        } else if (
+          isToolUIPart(part) &&
+          part.type.startsWith("tool-delegateTo")
+        ) {
           // Sub-agent tools get custom UI with robot icon and nested chat
-          return (
-            <SubAgentTool
-              key={`${message.id}-${i}`}
-              toolPart={asToolUIPart(part)}
-            />
-          );
-        } else if (part.type.startsWith("tool-")) {
-          const toolPart = asToolUIPart(part);
-          const toolInput = toolPart.input as
-            Record<string, unknown> | undefined;
+          return <SubAgentTool key={`${message.id}-${i}`} toolPart={part} />;
+        } else if (isToolUIPart(part)) {
+          // Plugin- and MCP-contributed tools aren't enumerated in the part
+          // union (see `CustomUITools`), so they land on the generic renderer.
+          const toolInput = part.input as Record<string, unknown> | undefined;
           const toolLabel = (toolInput?.label ?? toolInput?.name) as
             string | undefined;
           return (
             <Tool key={`${message.id}-${i}`}>
               <ToolHeader
-                state={toolPart.state}
-                type={toolPart.type}
+                state={part.state}
+                type={part.type}
                 label={toolLabel}
               />
               <ToolContent>
-                <ToolInput input={toolPart.input} />
-                <ToolOutput
-                  output={toolPart.output}
-                  errorText={toolPart.errorText}
-                />
+                <ToolInput input={part.input} />
+                <ToolOutput output={part.output} errorText={part.errorText} />
               </ToolContent>
             </Tool>
           );

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -49,6 +49,18 @@ import { Textarea } from "./ui/textarea";
 import { LoadSkillTool } from "./load-skill-tool";
 import { SubAgentTool } from "./sub-agent-tool";
 
+/**
+ * Re-type a `tool-` prefixed message part as a tool part.
+ *
+ * Only tools with bespoke UI are enumerated in the message's static part union
+ * (see `CustomUITools` in the backend types); plugin- and MCP-contributed
+ * tools are not known at compile time, so the runtime `tool-` prefix is the
+ * only signal we have. Intersecting keeps the assertion honest — the result is
+ * still the part we were handed.
+ */
+const asToolUIPart = <T extends { type: string }>(part: T) =>
+  part as T & ToolUIPart;
+
 interface ChatMessageProps {
   /** The message object to render */
   message: PlatypusUIMessage;
@@ -99,8 +111,7 @@ export const ChatMessage = memo(function ChatMessage({
   onCopyMessage,
   copiedMessageId,
 }: ChatMessageProps) {
-  const messageAgentId = (message.metadata as Record<string, unknown>)
-    ?.agentId as string | undefined;
+  const messageAgentId = message.metadata?.agentId;
   const messageAgent = messageAgentId
     ? agents.find((a) => a.id === messageAgentId)
     : undefined;
@@ -234,11 +245,11 @@ export const ChatMessage = memo(function ChatMessage({
           return (
             <SubAgentTool
               key={`${message.id}-${i}`}
-              toolPart={part as ToolUIPart}
+              toolPart={asToolUIPart(part)}
             />
           );
         } else if (part.type.startsWith("tool-")) {
-          const toolPart = part as ToolUIPart;
+          const toolPart = asToolUIPart(part);
           const toolInput = toolPart.input as
             Record<string, unknown> | undefined;
           const toolLabel = (toolInput?.label ?? toolInput?.name) as

--- a/apps/frontend/components/load-skill-tool.tsx
+++ b/apps/frontend/components/load-skill-tool.tsx
@@ -41,16 +41,23 @@ const getStatusBadge = (status: ToolUIPart["state"]) => {
   );
 };
 
+/**
+ * `loadSkill` is enumerated in `CustomUITools`, so its part carries real
+ * input/output types — no assertion needed to read them.
+ */
+type LoadSkillToolPart = Extract<
+  ToolUIPart<CustomUITools>,
+  { type: "tool-loadSkill" }
+>;
+
 interface LoadSkillToolProps {
-  toolPart: ToolUIPart;
+  toolPart: LoadSkillToolPart;
 }
 
 export const LoadSkillTool = ({ toolPart }: LoadSkillToolProps) => {
-  const input = toolPart.input as CustomUITools["loadSkill"]["input"];
-  const output = toolPart.output as CustomUITools["loadSkill"]["output"];
+  const { input, output } = toolPart;
   const errorText =
-    toolPart.errorText ||
-    (output && "error" in output ? (output.error as string) : null);
+    toolPart.errorText || (output && "error" in output ? output.error : null);
 
   return (
     <div className="not-prose mb-4 w-full rounded-md border">

--- a/apps/frontend/components/load-skill-tool.tsx
+++ b/apps/frontend/components/load-skill-tool.tsx
@@ -10,7 +10,7 @@ import {
 import type { ToolUIPart } from "ai";
 import type { ReactNode } from "react";
 import { Badge } from "@/components/ui/badge";
-import { type PlatypusTools } from "@platypus/backend/src/types";
+import { type CustomUITools } from "@platypus/backend/src/types";
 
 const getStatusBadge = (status: ToolUIPart["state"]) => {
   const labels: Record<ToolUIPart["state"], string> = {
@@ -46,8 +46,8 @@ interface LoadSkillToolProps {
 }
 
 export const LoadSkillTool = ({ toolPart }: LoadSkillToolProps) => {
-  const input = toolPart.input as PlatypusTools["loadSkill"]["input"];
-  const output = toolPart.output as PlatypusTools["loadSkill"]["output"];
+  const input = toolPart.input as CustomUITools["loadSkill"]["input"];
+  const output = toolPart.output as CustomUITools["loadSkill"]["output"];
   const errorText =
     toolPart.errorText ||
     (output && "error" in output ? (output.error as string) : null);


### PR DESCRIPTION
Closes #355

Two type-hygiene fixes in the shared chat message types. No runtime behaviour change, no schema change.

## 1. Chat message metadata is now typed

`ChatMessageMetadata` (`{ agentId: string }`) is applied as the metadata generic on `PlatypusUIMessage`. The whole object stays optional on `UIMessage` because runs that resolve no agent — a direct provider/model chat — omit it entirely.

This closes the gap between the two ends. Verified empirically: renaming `agentId` → `agentIdX` in the `messageMetadata` producer now fails with

```
TS2322: Property 'agentId' is missing in type '{ agentIdX: string; }'
        but required in type 'ChatMessageMetadata'
```

The read site in `chat-message.tsx` drops its `as Record<string, unknown>` assertion and is simply `message.metadata?.agentId`.

## 2. `PlatypusTools` → `CustomUITools`

The old intersection claimed an exhaustive tool surface it could not deliver — its five entries were just the ones predating pluginisation. It is now narrowed to the tools with bespoke UI (today only `loadSkill`), renamed to say so, with a comment recording why it stays partial: native tool sets are runtime-loaded plugins (ADR-0013), third-party plugins contribute under namespaced contribution ids, MCP tools are unknown until connect time, and sub-agent delegate tool names are generated per sub-agent so the renderer matches the `tool-delegateTo` prefix instead.

The now-unused `MathTools` / `TimeTools` / `FetchTools` / `SkillTools` / `TriggerTools` aliases are removed — nothing outside `types.ts` referenced them.

## Fallout, as the issue anticipated

Narrowing the generic drops plugin tool parts from the message part union, so `part as ToolUIPart` in the prefix-matched branches became a `TS2352` no-overlap error. Those branches now use `isToolUIPart` from `ai` — a real type guard, so they narrow with no assertion.

Because `loadSkill` is the one statically enumerated tool part, matching its literal type narrows it properly, so `LoadSkillTool` takes the typed part and reads `input`/`output` off it directly. That removed both `CustomUITools[...]` assertions and the `as string` on the error branch — the compile-time checking the narrowing was for, rather than casting past it.

The tools skill still taught `part as ToolUIPart`; it now documents the guard and the `CustomUITools` entry a tool needs to get typed parts.

## Testing

`pnpm typecheck`, `pnpm lint`, `pnpm test` (1174 backend + 26 frontend) all pass. `apps/frontend` has no `typecheck` script, so `tsc --noEmit` was run there manually (clean) plus a full `next build`.

New `chat-message.test.tsx` covers agent attribution rendering: attributed, unattributed, and an `agentId` that resolves to no agent.

## Two known gaps

1. **The live-chat acceptance criterion is unverified.** There is no local application database to drive the app against, so the render path is covered by component tests rather than a live run. The two touched lines compile to equivalent JS (an optional-chained property read, and a removed identity call), so runtime equivalence is structural, but this criterion is not literally ticked.

2. **`apps/frontend` is not in the `pnpm typecheck` CI gate**, so the frontend half of this change is only caught by `next build`. Adding the script is a two-line change but puts a new gate on CI — left as a separate policy call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)