### PR TITLE
chore(docs): document the composed system prompt and rename field references

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,10 +29,18 @@ The plain text pulled out of a binary document (PDF, DOCX) that the target model
 _Avoid_: parsed text, converted file, OCR (Platypus does not OCR).
 
 **Agent**:
-A configurable preset that pins a Provider, model, system prompt, generation parameters, Tools, Skills, and sub-Agents. Selecting an Agent on a Chat turn replaces direct Provider/model selection.
+A configurable preset that pins a Provider, model, Instructions, generation parameters, Tools, Skills, and sub-Agents. Selecting an Agent on a Chat turn replaces direct Provider/model selection.
 
 **Sub-Agent**:
 An Agent referenced by a parent Agent and exposed to it as a delegate Tool.
+
+**Instructions**:
+The free-text behaviour brief a User writes on an Agent — or on a Chat with no Agent. One input to the System prompt rather than the whole of it: it renders as the first fragment and cannot suppress the Platypus-owned fragments that follow.
+_Avoid_: system prompt (that names the composed artefact), prompt, persona.
+
+**System prompt**:
+The single string Platypus composes per Chat turn and sends to the model, assembled from an ordered set of fragments that Platypus owns. Instructions render first and the Provider's security guardrails last; the fragments in between carry Organization, Workspace, User and Agent state. A User authors only the Instructions fragment and cannot suppress the others (ADR-0016). `FRAGMENTS` in `apps/backend/src/system-prompt.ts` is the authority on the order; `apps/docs/content/concepts/system-prompt.mdx` documents it for Users. A Sub-Agent invocation is the exception — it receives only Instructions plus guardrails.
+_Avoid_: prompt, preamble, prompt template.
 
 **Provider**:
 A configured connection to an AI vendor (OpenAI, OpenRouter, Bedrock, Anthropic, Google, …). Carries credentials, base URL, the enabled `modelIds`, and a `taskModelId` for one-shot tasks. Lives at either Organization or Workspace scope.
@@ -132,6 +140,7 @@ The record binding a Conversation locus to a Chat (which carries the Workspace +
 - A **Workspace** has many **Chats**, **Agents**, **MCPs**, and **Skills**, and zero-or-one **Sandbox**.
 - A **Chat** is produced by a sequence of **Chat turns**.
 - A **Chat turn** uses either an **Agent** or a direct **Provider** + model selection.
+- A **Chat turn** renders one **System prompt**, whose first fragment is the **Instructions** of the selected **Agent** — or of the **Chat** itself, where no Agent is selected.
 - An **Agent** references one **Provider**, zero-or-more **Tool sets** (static or **MCP**-backed), zero-or-more **Skills**, and zero-or-more **Sub-Agents**.
 - A **Provider** belongs to either an **Organization** (shared) or a **Workspace** (private).
 - An **Agent**, **Skill**, **MCP**, or **Provider** is a **Scoped resource**: its row carries either an `organizationId` or a `workspaceId`, never both. Resolved relative to a **Workspace**, an Organization-scoped one is a **Shared resource**, visible only through an **Attachment**; a Sandbox-backed **Tool set** instead rebinds to the invoking **Workspace**'s **Sandbox** at Chat-turn time.

--- a/apps/docs/content/building-with-platypus/agents.mdx
+++ b/apps/docs/content/building-with-platypus/agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agents & sub-agents
-description: Create and configure an Agent — pin a Provider and model, write a system prompt, tune generation parameters, grant tools and Skills, and compose sub-agents.
+description: Create and configure an Agent — pin a Provider and model, write its Instructions, tune generation parameters, grant tools and Skills, and compose sub-agents.
 ---
 
 import { Callout, Steps } from "nextra/components";
@@ -8,7 +8,7 @@ import { Callout, Steps } from "nextra/components";
 # Agents & sub-agents
 
 An **Agent** is a reusable preset for how the assistant behaves: a Provider and
-model, a system prompt, generation settings, and the tools, Skills, and
+model, its Instructions, generation settings, and the tools, Skills, and
 sub-agents it's allowed to use. Build it once, then select it on any Chat. For
 the concept, see [Agents & sub-agents](/concepts/agents); this page is the
 build.
@@ -30,11 +30,17 @@ From your Workspace, go to the **Agents** section and click **Create agent**.
   input when this Agent is selected.
 - **Avatar** _(optional)_ — click to upload or paste an image.
 
-### Write the system prompt
+### Write the Instructions
 
-The **System prompt** field shapes the Agent's personality and instructions. It's
+The **Instructions** field shapes the Agent's personality and behaviour. It's
 optional, but it's the single biggest lever on behaviour — e.g. _"You are a
 concise research assistant. Cite sources and prefer primary documents."_
+
+Platypus builds the full system prompt around what you write, adding the
+Workspace and user context, Memories, the Skills and sub-agent catalogues, and
+your Provider's security guardrails. [The system
+prompt](/concepts/system-prompt) lists every part in order — check it before
+writing anything long, so you don't restate what Platypus already supplies.
 
 ### Pin a Provider and model
 
@@ -105,7 +111,7 @@ to delegate to.
 
 At run time each selected sub-agent is exposed to the parent as a **delegate
 tool** named `delegateTo<AgentName>` — calling it runs the sub-agent (with its
-own model, prompt, and tools) and returns the result. This lets a coordinator
+own model, Instructions, and tools) and returns the result. This lets a coordinator
 Agent stay focused while specialists do the detailed work.
 
 <Callout type="warning">

--- a/apps/docs/content/building-with-platypus/index.mdx
+++ b/apps/docs/content/building-with-platypus/index.mdx
@@ -14,7 +14,7 @@ Everything you build lives inside your **Workspace** (your scoped environment �
 see [The big picture](/concepts)). A typical build goes in this order:
 
 1. **[Agents & sub-agents](/building-with-platypus/agents)** — create an Agent:
-   pin a Provider and model, write its system prompt, tune generation, and grant
+   pin a Provider and model, write its Instructions, tune generation, and grant
    it tools. Compose specialists as sub-agents.
 2. **[Skills](/building-with-platypus/skills)** — author named, on-demand
    know-how and attach it to an Agent.

--- a/apps/docs/content/building-with-platypus/skills.mdx
+++ b/apps/docs/content/building-with-platypus/skills.mdx
@@ -10,7 +10,7 @@ import { Callout, Steps } from "nextra/components";
 A **Skill** is packaged know-how you attach to an Agent: a name, a description,
 and a body of instructions for doing one thing well. The Agent sees only the
 name and description up front and pulls in the full body _on demand_ — keeping
-its everyday prompt short. For the concept, see [Skills](/concepts/skills); this
+the system prompt short. For the concept, see [Skills](/concepts/skills); this
 page is how to author one.
 
 ## Author a Skill

--- a/apps/docs/content/concepts/_meta.ts
+++ b/apps/docs/content/concepts/_meta.ts
@@ -9,6 +9,7 @@ const meta = {
   sandboxes: "Sandboxes",
   skills: "Skills",
   "memory-and-context": "Memory & context",
+  "system-prompt": "The system prompt",
   sharing: "Sharing across workspaces",
 };
 

--- a/apps/docs/content/concepts/agents.mdx
+++ b/apps/docs/content/concepts/agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agents & sub-agents
-description: Agents are reusable presets that pin a model, prompt, tools, and skills. Sub-agents let one agent delegate to another.
+description: Agents are reusable presets that pin a model, Instructions, tools, and skills. Sub-agents let one agent delegate to another.
 ---
 
 # Agents & sub-agents
@@ -8,14 +8,14 @@ description: Agents are reusable presets that pin a model, prompt, tools, and sk
 ## Agent
 
 An **Agent** is a saved configuration for how the assistant should behave. Rather
-than choosing a model and writing a system prompt every time you start a
+than choosing a model and writing instructions every time you start a
 conversation, you set it all up once on an Agent and then just pick that Agent on
 a Chat.
 
 An Agent pins together:
 
 - a **Provider** and a specific **model** to run on,
-- a **system prompt** that shapes its personality and instructions,
+- **Instructions** that shape its personality and behaviour,
 - **generation parameters** (such as temperature),
 - the **tools** it's allowed to use (see [Tools, tool sets & MCP](/concepts/tools)),
 - any **[Skills](/concepts/skills)** it can draw on,
@@ -24,10 +24,15 @@ An Agent pins together:
 When you select an Agent on a Chat turn, that selection takes the place of
 choosing a Provider and model by hand — the Agent already carries those choices.
 
+Your Instructions are the first part of the system prompt the model receives, not
+all of it: Platypus composes the rest from the Workspace, your Context, the
+Agent's Skills and tools, and its Provider. [The system
+prompt](/concepts/system-prompt) lists every part in order.
+
 **Why you'd use one:** consistency and reuse. A "Research assistant" Agent, a
 "Code reviewer" Agent, and a "Friendly support bot" Agent can each have their own
-prompt, model, and tools. Build them once, use them across many Chats, and tweak
-them in one place.
+Instructions, model, and tools. Build them once, use them across many Chats, and
+tweak them in one place.
 
 ## Sub-agent
 
@@ -38,4 +43,4 @@ work to it — the sub-agent shows up to the parent as a tool it can invoke.
 **Why you'd use one:** to break a big job into specialists. A top-level Agent can
 stay focused on coordinating, then delegate research to one sub-agent, drafting to
 another, and fact-checking to a third. Each sub-agent is a full Agent in its own
-right, with its own model, prompt, and tools.
+right, with its own model, Instructions, and tools.

--- a/apps/docs/content/concepts/index.mdx
+++ b/apps/docs/content/concepts/index.mdx
@@ -60,10 +60,10 @@ reply — is a **Chat turn**. A turn runs against either an **Agent** or a direc
 ### Agent
 
 An **Agent** is a reusable preset for how the assistant should behave. Instead of
-picking a model and writing a system prompt every time, you configure an Agent
-once — its **Provider** and model, its system prompt, its tools, its **Skills**,
-and any **Sub-Agents** — and then select it on a Chat. Selecting an Agent
-replaces choosing a Provider and model by hand.
+picking a model and writing instructions every time, you configure an Agent
+once — its **Provider** and model, its **Instructions**, its tools, its
+**Skills**, and any **Sub-Agents** — and then select it on a Chat. Selecting an
+Agent replaces choosing a Provider and model by hand.
 
 Agents are the heart of building with Platypus. The
 [Agents & sub-agents](/concepts/agents) page goes deeper.
@@ -85,5 +85,7 @@ page in this section:
   demand.
 - **[Memory & context](/concepts/memory-and-context)** — how an Agent remembers
   past activity and the notes you give it.
+- **[The system prompt](/concepts/system-prompt)** — every fragment Platypus
+  composes into the prompt a model actually receives, in order.
 - **[Sharing across workspaces](/concepts/sharing)** — how an Organization
   reuses one resource across many Workspaces.

--- a/apps/docs/content/concepts/memory-and-context.mdx
+++ b/apps/docs/content/concepts/memory-and-context.mdx
@@ -12,7 +12,8 @@ activity, beyond the messages in the current Chat: **Memory** and **Context**.
 
 **Memory** is a running summary of your prior activity that an Agent can recall.
 It's kept per person, per **Workspace**, and when an Agent is configured to use
-it, that summary is folded into the Agent's instructions automatically.
+it, that summary is folded into the [system prompt](/concepts/system-prompt)
+automatically — you don't put it in the Agent's Instructions yourself.
 
 **Why you'd use it:** so the assistant doesn't start from scratch every time.
 With Memory, an Agent can carry forward what it learned about your preferences,
@@ -29,9 +30,11 @@ You can set Context at two levels:
 - **global** — notes that apply everywhere you work, or
 - **per-Workspace** — notes specific to one Workspace.
 
-Whatever you put there is rendered into the Agent's instructions, so it's a
-direct way to tell the assistant standing facts: who you are, how you like
-answers formatted, what a project is about.
+Whatever you put there is rendered into the [system
+prompt](/concepts/system-prompt), so it's a direct way to tell the assistant
+standing facts: who you are, how you like answers formatted, what a project is
+about. It reaches every Agent you use, so there's no need to repeat it in any
+Agent's Instructions.
 
 **Memory vs. Context:** Memory is built up automatically from your activity;
 Context is written deliberately by you. They work together — Memory remembers,
@@ -40,9 +43,9 @@ Context instructs.
 ## Organization identity
 
 An **Organization** carries an optional free-text **identity / context** field,
-set by an Org Admin. Whatever you write there is folded into the Agent's
-instructions **early** — as framing, alongside the Workspace context — for every
-chat across the Organization.
+set by an Org Admin. Whatever you write there is folded into the system prompt
+**early** — as framing, alongside the Workspace context — for every chat across
+the Organization.
 
 Use it for standing facts about the organization itself: who you are, what you
 do, house tone, standard terminology. It's the org-wide counterpart to the

--- a/apps/docs/content/concepts/providers.mdx
+++ b/apps/docs/content/concepts/providers.mdx
@@ -98,9 +98,11 @@ steering. Put the guarding where the weakness is.
   authentication](/self-hosting/providers-and-auth) for the three-layer model.
 </Callout>
 
-The field is **append-only and non-suppressible**: an Agent's own system prompt
-cannot opt out of it. The escape hatch is to point the Agent at a different
-Provider.
+The field is **append-only and non-suppressible**: an Agent's own **Instructions**
+cannot opt out of it — they are the _first_ fragment of the composed system
+prompt, and this is the last (see [The system
+prompt](/concepts/system-prompt)). The escape hatch is to point the Agent at a
+different Provider.
 
 ### Starter snippets
 

--- a/apps/docs/content/concepts/sharing.mdx
+++ b/apps/docs/content/concepts/sharing.mdx
@@ -23,7 +23,7 @@ level and _referenced_ by many Workspaces — not copied into each one. There's 
 single source of truth: only **Org Admins** edit it, and it shows up as **locked**
 to Workspace Owners, who can use it but not change it.
 
-**Why this matters:** when the Org Admin updates a Shared Agent's prompt or
+**Why this matters:** when the Org Admin updates a Shared Agent's Instructions or
 rotates a Shared Provider's credentials, every Workspace using it gets the change
 at once. No drift, no copy-paste.
 

--- a/apps/docs/content/concepts/skills.mdx
+++ b/apps/docs/content/concepts/skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Skills
-description: A Skill is packaged know-how an agent can pull in on demand, keeping its instructions lean until the skill is actually needed.
+description: A Skill is packaged know-how an agent can pull in on demand, keeping its Instructions lean until the skill is actually needed.
 ---
 
 # Skills
@@ -9,16 +9,17 @@ description: A Skill is packaged know-how an agent can pull in on demand, keepin
 
 A **Skill** is a named capability you attach to an **Agent** — a description plus
 a set of instructions for doing something well. Rather than stuffing every
-possible instruction into the Agent's system prompt, you give the Agent Skills it
-can reach for when the moment calls for it.
+possible instruction into the Agent's **Instructions**, you give the Agent Skills
+it can reach for when the moment calls for it.
 
 Here's the clever part: the Agent only sees each Skill's _name and description_
 up front. When it decides a Skill is relevant, it requests that Skill's full
-instructions on demand. This keeps the Agent's everyday prompt short and focused,
-while still giving it deep know-how the instant it's needed.
+instructions on demand. Only the names and descriptions reach the [system
+prompt](/concepts/system-prompt), so it stays short and focused while the Agent
+still has deep know-how the instant it's needed.
 
 **Why you'd use one:** to teach an Agent how to handle specific situations
-without bloating its prompt. A "Write a release note" Skill, a "Triage a bug
+without bloating its Instructions. A "Write a release note" Skill, a "Triage a bug
 report" Skill, a "Format data as a table" Skill — each stays tucked away until the
 Agent recognises it should use it.
 

--- a/apps/docs/content/concepts/system-prompt.mdx
+++ b/apps/docs/content/concepts/system-prompt.mdx
@@ -1,0 +1,88 @@
+---
+title: The system prompt
+description: What Platypus actually sends the model — the ordered fragments it composes into the system prompt, and where your Instructions sit among them.
+---
+
+import { Callout } from "nextra/components";
+
+# The system prompt
+
+The **Instructions** you write on an Agent are not the whole system prompt.
+They're the first of up to twelve fragments that Platypus assembles, in a fixed
+order, on every Chat turn. The rest come from the Organization, the Workspace,
+you, the Agent's tools, and its Provider.
+
+This page is the canonical list. Read it once before you write long Instructions,
+because several of these fragments already supply things people commonly restate
+by hand.
+
+## The order
+
+Fragments render top to bottom in the order below. Any fragment with nothing to
+contribute is skipped rather than emitted empty, so a plain Agent in a plain
+Workspace produces a short prompt — only fragments 1, 4 and 5 are always present.
+
+| #      | Fragment                  | When it appears                                 | What it contributes                                                                                                                                                                                                                |
+| ------ | ------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1**  | **Instructions**          | Always                                          | Your text, verbatim, from the Agent's [Instructions](/building-with-platypus/agents) field — or the Chat's, on a Chat with no Agent. Left blank, it falls back to "You are a helpful AI assistant."                                |
+| **2**  | **Agent identity**        | Unattended runs only, with an Agent             | The Agent's own name and id, so it can identify itself to tools that need one — assigning a card to itself, for instance.                                                                                                          |
+| **3**  | **Organization identity** | When the Organization has an identity / context | The Org Admin's [Organization identity](/concepts/memory-and-context#organization-identity) text, as framing.                                                                                                                      |
+| **4**  | **Workspace**             | Always                                          | The Workspace id, which tools need, plus the Workspace's Context if it has one (a [Blueprint](/concepts/sharing) can set that at provisioning).                                                                                    |
+| **5**  | **User**                  | Always                                          | Your name and id. On an unattended run this becomes on-behalf-of framing instead, telling the model there's nobody to address.                                                                                                     |
+| **6**  | **User Contexts**         | When you've written Context                     | Your global and per-Workspace [Context](/concepts/memory-and-context#context) notes.                                                                                                                                               |
+| **7**  | **Memories**              | When there are Memories to recall               | The [Memory](/concepts/memory-and-context#memory) summaries retrieved for you in this Workspace.                                                                                                                                   |
+| **8**  | **Memory tools**          | When the Agent has the memory tool set          | A note that `memorySearch` and `memoryGet` are available for looking up memories beyond any summaries above.                                                                                                                       |
+| **9**  | **Skills**                | When the Agent has Skills                       | The name and description of each [Skill](/concepts/skills) — not its body, which the model requests on demand via `loadSkill`.                                                                                                     |
+| **10** | **Sub-Agents**            | When the Agent has sub-agents                   | Each [sub-agent](/concepts/agents#sub-agent), its delegate tool name, its description, and the rule that a delegated task must be self-contained.                                                                                  |
+| **11** | **Sandbox**               | When the Agent has the sandbox tool set         | How the [Sandbox](/concepts/sandboxes) works: the `/workspace` root, that files persist between turns, that each shell call starts fresh, output limits, timeouts, and the _names_ of any Workspace-default environment variables. |
+| **12** | **Security guardrails**   | When the run's Provider has guardrails          | The Provider's [security guardrails](/concepts/providers#security-guardrails), verbatim and last.                                                                                                                                  |
+
+<Callout type="info">
+  "Unattended" means a [Trigger](/building-with-platypus/triggers) run — fired
+  by a schedule or an event, on behalf of the Workspace Owner, with nobody
+  watching. Those runs pin one Agent for their whole duration, which is why the
+  Agent can be named in fragment 2 and why nobody is addressed in fragment 5.
+</Callout>
+
+<Callout type="warning">
+  This is the composition for a **Chat turn**. A sub-agent invoked through a
+  delegate tool is not a Chat turn: it receives its own Instructions plus its
+  Provider's security guardrails, and none of the fragments in between. Write a
+  sub-agent's Instructions so they stand on their own.
+</Callout>
+
+## Why the order matters
+
+The two ends of the prompt are deliberate.
+
+Your Instructions come first, where a model reads them as its brief. The
+Provider's security guardrails come last, where a model reads them as its final
+standing orders — recency is what makes them hold up against a prompt-injection
+attempt buried in a tool result halfway through a conversation.
+
+The Organization identity sits early, near the Workspace Context, because it's
+framing rather than a defence. That separation is on purpose: see
+[Providers & models](/concepts/providers#security-guardrails) for why identity and
+guardrails live at opposite ends.
+
+## What this means for your Instructions
+
+Your Instructions are one input to a prompt Platypus owns. Two consequences:
+
+**You don't need to restate what's already there.** The Workspace Context, your
+name, your Context notes, your Memories, the Skills catalogue and the sub-agent
+catalogue all arrive on their own. Describing a Skill inside your Instructions, or
+writing "the user you're talking to is Sam", spends context on something Platypus
+supplies anyway — and goes stale the moment either changes.
+
+**You can't switch the other fragments off.** Instructions add to the prompt; they
+don't replace or reorder it. Instructions telling the model to ignore its
+guardrails, or to forget the Workspace Context, will not remove those fragments —
+both are still in the prompt the model reads. If a Provider's guardrails are wrong
+for your Agent, point the Agent at a different Provider.
+
+<Callout type="info">
+  There's no in-app viewer for the assembled prompt. This page and the helper
+  text under the Instructions field are the reference. On a deployment you run
+  yourself, the backend logs the composed prompt at `debug` level.
+</Callout>

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -191,8 +191,8 @@ from, and layers above, the per-Workspace Sandbox `config` / `credentials`
 
 A **Sandbox** is a persistent, Workspace-keyed execution environment that
 exposes a fixed set of shell and filesystem tools to Agents. The contract every
-backend implements is small and fixed on purpose: an Agent's prompt should not
-care _which_ backend it's running on, so you can swap the reference Docker
+backend implements is small and fixed on purpose: an Agent's Instructions should
+not care _which_ backend it's running on, so you can swap the reference Docker
 adapter for Modal or Daytona without re-prompting.
 
 > See [ADR-0001](https://github.com/willdady/platypus/blob/main/docs/adr/0001-sandbox-as-workspace-keyed-execution-environment.md)

--- a/apps/docs/content/getting-started/index.mdx
+++ b/apps/docs/content/getting-started/index.mdx
@@ -130,11 +130,12 @@ From the dashboard's **Agents** section, click **Create agent**.
 - **Name** — what to call the agent.
 - **Model** — pick one of the models you enabled on your Provider (the dropdown
   groups models under each Provider).
-- **System prompt** _(optional)_ — instructions that shape its behaviour, e.g.
-  _"You are a concise, helpful assistant."_
+- **Instructions** _(optional)_ — how the assistant should behave, e.g. _"You are
+  a concise, helpful assistant."_ Platypus composes the system prompt around
+  this; see [The system prompt](/concepts/system-prompt).
 
-Click **Save**. An **Agent** pins a Provider, model, and prompt (and, later,
-Tools, Skills, and Sub-Agents) into a reusable preset.
+Click **Save**. An **Agent** pins a Provider, model, and Instructions (and,
+later, Tools, Skills, and Sub-Agents) into a reusable preset.
 
 ### Start a Chat and send a message
 


### PR DESCRIPTION
Closes #367. Rebased onto `main` after ADR-0016 (#375) landed.

With no in-app viewer of the composed prompt, the documentation is the only place anyone can learn what Platypus actually sends the model. This gives it a canonical account, and finishes the #366 / #374 rename on the prose side.

## The new page

`apps/docs/content/concepts/system-prompt.mdx` — a Concepts page listing all twelve fragments in the order `FRAGMENTS` renders them (`apps/backend/src/system-prompt.ts:177`), each with the condition under which it appears, plus why Instructions come first and guardrails last, and what that means for someone writing Instructions. Added to the Concepts nav after Memory & context, so every noun it references has already been introduced by the time a reader arrives.

Written against `FRAGMENTS` directly, then checked row by row against ADR-0016's Consequences list — order, conditions and the sub-agent exception all agree. This page is the User-facing counterpart to that ADR: the ADR fixes the contract, this documents the list.

## The rename boundary

Prose naming the *field* now says Instructions. Prose describing the *composed artefact* still says "system prompt" — that distinction is the whole point of #364, so the docs reinforce it rather than blurring it.

**Renamed:** both Agents pages, both Skills pages, `concepts/index.mdx`, `building-with-platypus/index.mdx`, `getting-started/index.mdx`, `sharing.mdx`, `extending/index.mdx`, and the `CONTEXT.md` Agent definition.

**Kept:** `concepts/providers.mdx:83`, the verbatim guardrail snippet at `:134`, `self-hosting/providers-and-auth.mdx:38`, the Chat-turn description at `getting-started/index.mdx:147`, and the `CONTEXT.md` example dialogue.

**Two judgement calls worth a reviewer's eye:**

- `providers.mdx:101` — "an Agent's own *system prompt* cannot opt out of it" became Instructions. Post-rename an Agent owns no system prompt; the sentence now names the first fragment and the last explicitly. ADR-0016 uses the same framing: "Instructions are an **input to** the system prompt, never the system prompt itself".
- `memory-and-context.mdx` and the Skills pages moved *toward* "system prompt", because the rename would otherwise have made accurate prose wrong. Memory, User Context and Organization identity are folded into the composed prompt, not into the user-editable Instructions field; and loading a Skill on demand keeps the *system prompt* short, since only names and descriptions are ever rendered.

## Glossary

`CONTEXT.md` gains **Instructions** and **System prompt** as terms, and its Agent definition says Instructions. The System prompt entry cites ADR-0016 and defers the fragment order to the renderer and the new page rather than restating it, so adding a fragment doesn't need three synchronised edits.

## Verification

- `pnpm --filter @platypus/docs build` passes; Pagefind indexes 29 pages.
- Every new internal link and anchor resolves against a built page.
- Checked in a browser against the built site: searching "system prompt" returns the new page plus Providers & models, Getting Started, providers-and-auth and the Agents build page — so a reader's existing vocabulary isn't stranded.

## Follow-ups

- **#377** — the four `apps/website` marketing-copy hits. #367 scopes "the documentation site"; the website is a separate app that no issue owned.
- **Sub-agent composition** — a sub-agent receives its Instructions plus its Provider's guardrails and none of the other ten fragments (`apps/backend/src/tools/sub-agent.ts:74`). The page carries a callout saying so. ADR-0016 records this split as current-behaviour-not-target-state and names closing it as separate work, so no issue is needed from this PR; noting it because it reads as a contradiction of #364's user story 21 until you get to the ADR.
- **`CONTEXT.md:76` and `concepts/memory-and-context.mdx:21` are inaccurate about Memory**, pre-existing on `main`: both say Memories reach the prompt only when the memory tool set is granted, but `getRecentMemories` (`chat-execution.ts:528`) runs unconditionally, and ADR-0016 states the condition as "when retrieved Memories format to a non-empty block". Left alone as out of scope; the new page's row 7 says "When there are Memories to recall" rather than contradicting them head-on. Worth a small follow-up.
- **Not done, one line if wanted:** ADR-0016 isn't in the Reference ADRs table on `extending/index.mdx`. It's arguably relevant there — the ADR answers "can a Plugin contribute a fragment?" — but that table is curated to extension ADRs, so I left it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)