### PR TITLE
chore(website): call the Agent field Instructions, not system prompt

### DIFF
--- a/apps/website/app/page.tsx
+++ b/apps/website/app/page.tsx
@@ -68,7 +68,7 @@ const STEPS = [
   },
   {
     title: "Create an agent",
-    body: "Pin a provider, model, and system prompt, then grant it skills and MCP tool sets.",
+    body: "Pin a provider, model, and instructions, then grant it skills and MCP tool sets.",
   },
   {
     title: "Start a chat & send a message",
@@ -229,9 +229,9 @@ export default function HomePage() {
           icon={Bot}
           eyebrow="Agents"
           title="Agents that reason, act, and delegate"
-          body="Give an agent a provider, model, and system prompt, then arm it with tool sets, skills, and sub-agents. It plans, calls tools in a loop to get the job done, and hands off to specialist agents when a task calls for them."
+          body="Give an agent a provider, model, and instructions, then arm it with tool sets, skills, and sub-agents. It plans, calls tools in a loop to get the job done, and hands off to specialist agents when a task calls for them."
           points={[
-            "Pair any provider and model with a system prompt that shapes how it behaves",
+            "Pair any provider and model with instructions that shape how it behaves",
             "Grant tool sets and skills, and cap the tool-calling loop with max steps",
             "Compose agents from sub-agents, each exposed to the parent as a delegate tool",
           ]}
@@ -279,7 +279,7 @@ export default function HomePage() {
               },
               {
                 name: "Agent",
-                body: "A configured worker: provider, model, prompt, tools, skills, and sub-agents.",
+                body: "A configured worker: provider, model, instructions, tools, skills, and sub-agents.",
               },
             ].map((node, i, arr) => (
               <Fragment key={node.name}>


### PR DESCRIPTION
Closes #376

The marketing homepage was the last surface describing the Agent's user-authored field as a "system prompt" — teaching the exact mental model the #374 rename exists to fix. Per [ADR-0016](../blob/main/docs/adr/0016-system-prompt-composition-contract.md), Instructions are *an input to* the system prompt: the first of twelve fragments Platypus composes, never the prompt itself.

## Changes

Copy only, all in `apps/website/app/page.tsx`:

| Line | Before | After |
|---|---|---|
| 71 | "provider, model, and system prompt" | "provider, model, and instructions" |
| 232 | "a provider, model, and system prompt" | "a provider, model, and instructions" |
| 234 | "a system prompt that shapes how it behaves" | "instructions that shape how it behaves" |
| 282 | "provider, model, prompt, tools…" | "provider, model, instructions, tools…" |

Line 56 ("memory and free-text context are rendered into the system prompt") is deliberately unchanged — it denotes the composite, and ADR-0016 keeps that name for exactly those cases: *"Names that genuinely denote the composite keep saying system prompt."*

## Beyond the ticket's list

Line 282 is a fourth occurrence the issue didn't enumerate — the Agent glossary card read "provider, model, **prompt**", missing the ticket's search only because it omits "system". Same file, same user-authored field, and the highest-leverage spot for the mental model, so it's included here. Revert that one line if you'd rather keep the change to the three specified.

Lowercase "instructions" rather than the UI's capital-I label: the page lowercases every domain noun ("provider", "model", "workspace", "agents"), reserving capitals for headings.

## Follow-ups (not touched — AC 3 scopes this to marketing copy)

The issue's premise that the website is "the last surface" doesn't hold:

- `apps/docs` still calls it "System prompt" — `building-with-platypus/agents.mdx:3,11,33,35`, `getting-started/index.mdx:133`, `concepts/agents.mdx:18`, `concepts/index.mdx:64`
- `README.md:25`
- `CONTEXT.md:32` still says "pins a Provider, model, system prompt" and has no **Instructions** glossary entry, so the glossary now trails the copy

## Verification

ESLint, Prettier, `pnpm typecheck`, and `pnpm test` (101 files / 1253 tests) all clean. `apps/website` has no test suite and this is static copy, so no tests were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)