### PR TITLE
chore(docs): call the Agent field Instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Platypus is an open-source, full-stack application designed to help you build AI
 ## ✨ Key Features
 
 - **🏢 Multi-Tenancy:** Built-in support for Organizations and Workspaces to isolate data and manage teams.
-- **🤖 Agentic Workflows:** Create sophisticated agents with custom system prompts, model configurations, and tool assignments.
+- **🤖 Agentic Workflows:** Create sophisticated agents with custom Instructions, model configurations, and tool assignments.
 - **✨ Skills:** Create reusable instruction sets that agents can dynamically load on-demand to handle specialized tasks.
 - **🧩 Sub-Agents:** Agents can delegate specialized tasks to other agents, enabling hierarchical multi-agent workflows with isolated contexts and result streaming.
 - **📱 Responsive Design:** A fully responsive interface that works seamlessly across desktop, tablet, and mobile devices.


### PR DESCRIPTION
The README's Key Features list was the last non-historical surface describing the Agent's user-authored field as a "system prompt". Per [ADR-0016](../blob/main/docs/adr/0016-system-prompt-composition-contract.md), Instructions are *an input to* the system prompt — the first of twelve fragments Platypus composes — never the prompt itself.

No linked issue. This closes the last item on the follow-up list in #379, found while triaging #377 (closed as a duplicate of #376).

## Change

One line, `README.md:25`:

| Before | After |
|---|---|
| "Create sophisticated agents with custom **system prompts**, model configurations…" | "Create sophisticated agents with custom **Instructions**, model configurations…" |

Capitalised, diverging from #379's lowercase choice on the marketing site. That PR's reasoning was that `apps/website/app/page.tsx` lowercases every domain noun; the README does the opposite — "Organizations and Workspaces", "Agents, Skills, MCPs, Providers", "Blueprint" — and the very next bullet already uses a generic "reusable instruction sets" for Skills, which lowercase would blur against.

## #379's follow-up list was stale

It was written against a tree that predated #378 by four minutes, so it read as a wider gap than it was. Re-checked against `fffe74f`:

- **`CONTEXT.md` — already done by #378.** Line 32 reads "pins a Provider, model, Instructions"; the **Instructions** glossary entry exists at 37–39 with `_Avoid_: system prompt (that names the composed artefact)`, alongside a **System prompt** entry citing ADR-0016. The glossary does not trail the copy.
- **`apps/docs` — already done by #378.** Every line #379 cited now names the field Instructions: `building-with-platypus/agents.mdx` has a "Write the Instructions" step, `concepts/agents.mdx:18` lists "**Instructions** that shape its personality", `concepts/index.mdx:64` and `getting-started/index.mdx:133` both say **Instructions**.

Every surviving "system prompt" across `CONTEXT.md` and `apps/docs` denotes the composite and is correct as written, per ADR-0016: *"names that genuinely denote the composite keep saying system prompt."*

`CHANGELOG.md` and `plans/*.md` also match, and are deliberately untouched — historical records.

## Verification

Prettier clean. No test or build consumes the README, so nothing else applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)