### PR TITLE
fix(backend): make the first-boot seed atomic and fail loudly

### DIFF
--- a/apps/backend/index.ts
+++ b/apps/backend/index.ts
@@ -1,16 +1,14 @@
 import { serve } from "@hono/node-server";
 import app from "./src/server.ts";
 import { db } from "./src/index.ts";
-import {
-  organization,
-  workspace,
-  organizationMember,
-  user,
-} from "./src/db/schema.ts";
-import { nanoid } from "nanoid";
-import { count, eq, sql } from "drizzle-orm";
+import { sql } from "drizzle-orm";
 import { auth } from "./src/auth.ts";
 import { logger } from "./src/logger.ts";
+import {
+  NonRetryableSeedError,
+  seedFirstBoot,
+  type AdminSignUp,
+} from "./src/db/seed.ts";
 import { startMemoryScheduler } from "./src/jobs/memory-scheduler.ts";
 import { startTriggerScheduler } from "./src/jobs/trigger-scheduler.ts";
 import { loadPlugins } from "./src/plugins/loader.ts";
@@ -18,90 +16,39 @@ import { setLoadedPlugins } from "./src/plugins/registry.ts";
 
 const PORT = process.env.PORT || "4001";
 
+/** The production admin-User creator handed to the seed: better-auth sign-up. */
+const signUpAdmin: AdminSignUp = async (input) => {
+  const result = await auth.api.signUpEmail({ body: input });
+  if (!result.user) {
+    throw new Error("Sign up returned no user");
+  }
+  return { id: result.user.id };
+};
+
 const main = async () => {
   logger.info(`Serving on port: ${PORT}`);
 
-  await exponentialBackoff(async () => {
-    // Enable pgvector extension for embedding storage (needed before drizzle-kit push in dev)
-    await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
+  // A seed that cannot complete must not reach `serve()`: an HTTP server nobody
+  // can authenticate against reports healthy while being unusable (#369). Retry
+  // the transient failures, then exit non-zero so the orchestrator says so.
+  try {
+    await exponentialBackoff(async () => {
+      // Enable pgvector extension for embedding storage (needed before drizzle-kit push in dev)
+      await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
 
-    const [orgCount] = await db.select({ value: count() }).from(organization);
-
-    if (orgCount.value === 0) {
-      logger.info("No organizations found. Creating initial organization...");
-      const orgId = nanoid();
-      await db.insert(organization).values({
-        id: orgId,
-        name: "Default Organization",
-      });
-      logger.info(`- Organization created: ${orgId}`);
-
-      logger.info("Creating default user...");
-      const defaultEmail = process.env.ADMIN_EMAIL;
-      const defaultPassword = process.env.ADMIN_PASSWORD;
-
-      if (!defaultEmail || !defaultPassword) {
-        throw new Error(
-          "ADMIN_EMAIL and ADMIN_PASSWORD environment variables are required for initial setup",
-        );
-      }
-
-      try {
-        const result = await auth.api.signUpEmail({
-          body: {
-            email: defaultEmail,
-            password: defaultPassword,
-            name: "Admin User",
-          },
-        });
-
-        if (!result.user) {
-          throw new Error("Failed to get user from sign up response");
-        }
-
-        logger.info(`- User created: ${defaultEmail}`);
-
-        // Update role to admin and verify email after creation
-        await db
-          .update(user)
-          .set({ role: "admin", emailVerified: true })
-          .where(eq(user.id, result.user.id));
-
-        logger.info(`- User upgraded to admin role`);
-
-        // Create organization membership with admin role
-        logger.info("Creating organization membership...");
-        await db.insert(organizationMember).values({
-          id: nanoid(),
-          organizationId: orgId,
-          userId: result.user.id,
-          role: "admin",
-        });
-        logger.info(`- Organization membership created for ${defaultEmail}`);
-
-        // Create default workspace owned by the admin user
-        logger.info("Creating initial workspace...");
-        const workspaceId = nanoid();
-        await db.insert(workspace).values({
-          id: workspaceId,
-          organizationId: orgId,
-          ownerId: result.user.id,
-          name: "Default Workspace",
-        });
-        logger.info(`- Workspace created: ${workspaceId}`);
-
-        logger.info(
-          `- Default credentials: ${defaultEmail} / ${defaultPassword}`,
-        );
-        logger.info(
-          "⚠️  Please change the default password after first login!",
-        );
-      } catch (error) {
-        logger.error({ error }, "Failed to create default user");
-        throw error;
-      }
-    }
-  });
+      await seedFirstBoot(db, { signUpAdmin });
+    });
+  } catch (error) {
+    // The message goes in the log line, not just the serialised error: it is
+    // the one thing the Operator has to work from (#369).
+    logger.fatal(
+      { err: error },
+      `Startup failed, not starting the HTTP server: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    process.exit(1);
+  }
 
   // Load plugins before the HTTP server accepts traffic so their Tool set
   // contributions are registered by the time Chat turns resolve tools. Fail-loud
@@ -145,9 +92,11 @@ const exponentialBackoff = async <T>(
   try {
     return await fn();
   } catch (error) {
-    if (retries > 0) {
+    // A missing environment variable or input better-auth rejected fails the
+    // same way every time — retrying only delays the message the Operator needs.
+    if (retries > 0 && !(error instanceof NonRetryableSeedError)) {
       logger.warn(
-        { error },
+        { err: error },
         `Operation failed, retrying in ${delay / 1000} seconds...`,
       );
       await new Promise((resolve) => setTimeout(resolve, delay));

--- a/apps/backend/src/db/seed.test.ts
+++ b/apps/backend/src/db/seed.test.ts
@@ -1,0 +1,459 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `eq` and `count` are replaced with introspectable markers so the in-memory
+ * fake database below can interpret a Drizzle condition without parsing SQL.
+ * Everything else (`pgTable` and friends, used by the schema module) comes from
+ * the real package.
+ */
+vi.mock("drizzle-orm", async () => {
+  const actual =
+    await vi.importActual<typeof import("drizzle-orm")>("drizzle-orm");
+  return {
+    ...actual,
+    eq: (column: { name: string }, value: unknown) => ({
+      column: column.name,
+      value,
+    }),
+    count: () => ({ isCount: true }),
+  };
+});
+
+// Reaches the real implementation through the `...actual` spread above.
+import { getTableName } from "drizzle-orm";
+import {
+  seedFirstBoot,
+  NonRetryableSeedError,
+  type SeedDatabase,
+  type AdminSignUp,
+} from "./seed.ts";
+import { logger } from "../logger.ts";
+
+type Row = Record<string, unknown>;
+
+/** The four tables the seed touches, keyed by their Postgres table name. */
+type Store = {
+  organization: Row[];
+  user: Row[];
+  organization_member: Row[];
+  workspace: Row[];
+};
+
+/** Snake-cased column names from `eq` map back onto camel-cased row keys. */
+const toCamel = (name: string) =>
+  name.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+
+type Condition = { column: string; value: unknown } | undefined;
+
+const matches = (row: Row, condition: Condition) =>
+  !condition ||
+  row[condition.column] === condition.value ||
+  row[toCamel(condition.column)] === condition.value;
+
+/**
+ * A minimal in-memory stand-in for the Drizzle handle covering only what the
+ * seed uses: counting, lookups by column, inserts, updates, deletes and — the
+ * reason this exists rather than the chainable mock in `test-utils` — a
+ * `transaction` that actually rolls back. Prior art in this repo mocks queries
+ * or mirrors logic in plain JS, neither of which can express "after a failed
+ * boot the database is back where it started", which is the assertion issue
+ * #369 turns on.
+ *
+ * `transaction` hands the callback a handle bound to a *staging copy* that is
+ * only merged back on success, mirroring the property that matters in
+ * production: writes issued against the outer handle inside the callback go to
+ * a different connection and survive the rollback. A refactor that used `db`
+ * where it means `tx` fails these tests rather than passing quietly.
+ */
+const createFakeDb = (options: { onInsert?: (table: string) => void } = {}) => {
+  const committed: Store = {
+    organization: [],
+    user: [],
+    organization_member: [],
+    workspace: [],
+  };
+
+  const nameOf = (table: unknown) =>
+    getTableName(table as Parameters<typeof getTableName>[0]);
+
+  const makeHandle = (store: Store) => {
+    const rowsFor = (table: unknown): Row[] => {
+      const name = nameOf(table);
+      const rows = store[name as keyof Store];
+      if (!rows) throw new Error(`Fake db has no table "${name}"`);
+      return rows;
+    };
+
+    return {
+      select(selection?: Record<string, unknown>) {
+        let table: unknown;
+        let condition: Condition;
+        let take = Infinity;
+        const builder = {
+          from(t: unknown) {
+            table = t;
+            return builder;
+          },
+          where(c: Condition) {
+            condition = c;
+            return builder;
+          },
+          limit(n: number) {
+            take = n;
+            return builder;
+          },
+          then(
+            onFulfilled: (rows: Row[]) => unknown,
+            onRejected?: () => unknown,
+          ) {
+            const rows = rowsFor(table)
+              .filter((row) => matches(row, condition))
+              .slice(0, take);
+            const isCount = Object.values(selection ?? {}).some(
+              (value) => (value as { isCount?: boolean })?.isCount,
+            );
+            const result = isCount
+              ? [
+                  Object.fromEntries(
+                    Object.keys(selection ?? {}).map((key) => [
+                      key,
+                      rows.length,
+                    ]),
+                  ),
+                ]
+              : rows.map((row) => ({ ...row }));
+            return Promise.resolve(result).then(onFulfilled, onRejected);
+          },
+        };
+        return builder;
+      },
+      insert(table: unknown) {
+        return {
+          values(values: Row) {
+            const name = nameOf(table);
+            options.onInsert?.(name);
+            // The real `user.email` is unique; model it so a leftover User
+            // makes a second sign-up fail the way Postgres would.
+            if (
+              name === "user" &&
+              store.user.some((row) => row.email === values.email)
+            ) {
+              throw new Error("duplicate key value violates unique constraint");
+            }
+            rowsFor(table).push({ ...values });
+            return Promise.resolve();
+          },
+        };
+      },
+      update(table: unknown) {
+        let patch: Row = {};
+        const builder = {
+          set(values: Row) {
+            patch = values;
+            return builder;
+          },
+          where(condition: Condition) {
+            for (const row of rowsFor(table)) {
+              if (matches(row, condition)) Object.assign(row, patch);
+            }
+            return Promise.resolve();
+          },
+        };
+        return builder;
+      },
+      delete(table: unknown) {
+        return {
+          where(condition: Condition) {
+            const rows = rowsFor(table);
+            const kept = rows.filter((row) => !matches(row, condition));
+            rows.length = 0;
+            rows.push(...kept);
+            return Promise.resolve();
+          },
+        };
+      },
+      async transaction<T>(callback: (tx: unknown) => Promise<T>): Promise<T> {
+        const staged = structuredClone(store);
+        const result = await callback(makeHandle(staged));
+        for (const [name, rows] of Object.entries(staged)) {
+          const target = store[name as keyof Store];
+          target.length = 0;
+          target.push(...rows);
+        }
+        return result;
+      },
+    };
+  };
+
+  return { handle: makeHandle(committed), tables: committed };
+};
+
+const asSeedDb = (fake: { handle: unknown }) => fake.handle as SeedDatabase;
+
+/**
+ * Stands in for better-auth's `signUpEmail`: it writes the User row through its
+ * own database access, outside any transaction the seed opens — which is the
+ * whole reason the seed has to compensate rather than rely on rollback.
+ */
+const createSignUp = (
+  tables: Store,
+  behaviour: { fail?: Error } = {},
+): AdminSignUp => {
+  let n = 0;
+  return vi.fn(({ email, name }) => {
+    if (behaviour.fail) return Promise.reject(behaviour.fail);
+    if (tables.user.some((row) => row.email === email)) {
+      return Promise.reject(
+        new Error("duplicate key value violates unique constraint"),
+      );
+    }
+    const id = `user-${++n}`;
+    tables.user.push({
+      id,
+      email,
+      name,
+      role: "user",
+      emailVerified: false,
+    });
+    return Promise.resolve({ id });
+  });
+};
+
+const VALID_ENV = {
+  ADMIN_EMAIL: "admin@example.com",
+  ADMIN_PASSWORD: "s3cret!",
+};
+
+describe("seedFirstBoot", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("seeds an organization, admin user, membership and workspace on an empty database", async () => {
+    const fake = createFakeDb();
+    const signUpAdmin = createSignUp(fake.tables);
+
+    const result = await seedFirstBoot(asSeedDb(fake), {
+      signUpAdmin,
+      env: VALID_ENV,
+    });
+
+    expect(result.seeded).toBe(true);
+    expect(fake.tables.organization).toHaveLength(1);
+    expect(fake.tables.user).toHaveLength(1);
+    expect(fake.tables.organization_member).toHaveLength(1);
+    expect(fake.tables.workspace).toHaveLength(1);
+
+    const [admin] = fake.tables.user;
+    expect(admin).toMatchObject({
+      email: VALID_ENV.ADMIN_EMAIL,
+      role: "admin",
+      emailVerified: true,
+    });
+    expect(fake.tables.organization_member[0]).toMatchObject({
+      organizationId: fake.tables.organization[0].id,
+      userId: admin.id,
+      role: "admin",
+    });
+    expect(fake.tables.workspace[0]).toMatchObject({
+      organizationId: fake.tables.organization[0].id,
+      ownerId: admin.id,
+      name: "Default Workspace",
+    });
+  });
+
+  it("writes nothing and names the missing variable when ADMIN_EMAIL is unset", async () => {
+    const fake = createFakeDb();
+    const signUpAdmin = createSignUp(fake.tables);
+
+    await expect(
+      seedFirstBoot(asSeedDb(fake), {
+        signUpAdmin,
+        env: { ADMIN_PASSWORD: "s3cret!" },
+      }),
+    ).rejects.toThrow(/ADMIN_EMAIL/);
+
+    expect(fake.tables.organization).toHaveLength(0);
+    expect(fake.tables.user).toHaveLength(0);
+    expect(signUpAdmin).not.toHaveBeenCalled();
+  });
+
+  it("names ADMIN_PASSWORD when it is the unset one, and does not retry", async () => {
+    const fake = createFakeDb();
+
+    const error = await seedFirstBoot(asSeedDb(fake), {
+      signUpAdmin: createSignUp(fake.tables),
+      env: { ADMIN_EMAIL: "admin@example.com" },
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(NonRetryableSeedError);
+    expect((error as Error).message).toMatch(/ADMIN_PASSWORD/);
+    expect(fake.tables.organization).toHaveLength(0);
+  });
+
+  it("leaves no organization behind when a write after the organization insert fails", async () => {
+    const fake = createFakeDb({
+      onInsert: (table) => {
+        if (table === "workspace") throw new Error("connection terminated");
+      },
+    });
+
+    await expect(
+      seedFirstBoot(asSeedDb(fake), {
+        signUpAdmin: createSignUp(fake.tables),
+        env: VALID_ENV,
+      }),
+    ).rejects.toThrow(/connection terminated/);
+
+    expect(fake.tables.organization).toHaveLength(0);
+    expect(fake.tables.organization_member).toHaveLength(0);
+    expect(fake.tables.workspace).toHaveLength(0);
+    // The User is written by better-auth outside the transaction, so rollback
+    // cannot remove it — the seed compensates explicitly.
+    expect(fake.tables.user).toHaveLength(0);
+  });
+
+  it("seeds successfully on a retry after a failed attempt (regression: #369)", async () => {
+    let failing = true;
+    const fake = createFakeDb({
+      onInsert: (table) => {
+        if (failing && table === "workspace") {
+          throw new Error("connection terminated");
+        }
+      },
+    });
+    const signUpAdmin = createSignUp(fake.tables);
+
+    await expect(
+      seedFirstBoot(asSeedDb(fake), { signUpAdmin, env: VALID_ENV }),
+    ).rejects.toThrow(/connection terminated/);
+
+    failing = false;
+
+    const result = await seedFirstBoot(asSeedDb(fake), {
+      signUpAdmin,
+      env: VALID_ENV,
+    });
+
+    expect(result.seeded).toBe(true);
+    expect(fake.tables.organization).toHaveLength(1);
+    expect(fake.tables.user).toHaveLength(1);
+    expect(fake.tables.organization_member).toHaveLength(1);
+    expect(fake.tables.workspace).toHaveLength(1);
+  });
+
+  it("refuses to promote a User that already holds ADMIN_EMAIL", async () => {
+    const fake = createFakeDb();
+    // Compensation can itself fail — the database is the thing that broke — so
+    // a leftover User is reachable. Promoting whoever holds the address would
+    // be an escalation; the seed stops and says which row to delete.
+    fake.tables.user.push({
+      id: "leftover-user",
+      email: VALID_ENV.ADMIN_EMAIL,
+      name: "Admin User",
+      role: "user",
+      emailVerified: false,
+    });
+    const signUpAdmin = createSignUp(fake.tables);
+
+    const error = await seedFirstBoot(asSeedDb(fake), {
+      signUpAdmin,
+      env: VALID_ENV,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(NonRetryableSeedError);
+    expect((error as Error).message).toMatch(VALID_ENV.ADMIN_EMAIL);
+    expect((error as Error).message).toMatch(/Delete that user/);
+    expect(signUpAdmin).not.toHaveBeenCalled();
+    expect(fake.tables.user[0]).toMatchObject({ role: "user" });
+    expect(fake.tables.organization).toHaveLength(0);
+    expect(fake.tables.organization_member).toHaveLength(0);
+  });
+
+  it("is a quiet no-op against an already-seeded database", async () => {
+    const fake = createFakeDb();
+    const signUpAdmin = createSignUp(fake.tables);
+    await seedFirstBoot(asSeedDb(fake), { signUpAdmin, env: VALID_ENV });
+
+    const warn = vi.spyOn(logger, "warn");
+    const error = vi.spyOn(logger, "error");
+
+    const result = await seedFirstBoot(asSeedDb(fake), {
+      signUpAdmin,
+      env: VALID_ENV,
+    });
+
+    expect(result).toEqual({ seeded: false });
+    expect(fake.tables.organization).toHaveLength(1);
+    expect(fake.tables.user).toHaveLength(1);
+    expect(fake.tables.workspace).toHaveLength(1);
+    expect(warn).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it("requires no admin config to skip an already-seeded database", async () => {
+    const fake = createFakeDb();
+    await seedFirstBoot(asSeedDb(fake), {
+      signUpAdmin: createSignUp(fake.tables),
+      env: VALID_ENV,
+    });
+
+    await expect(
+      seedFirstBoot(asSeedDb(fake), {
+        signUpAdmin: createSignUp(fake.tables),
+        env: {},
+      }),
+    ).resolves.toEqual({ seeded: false });
+  });
+
+  it("reports a deterministic better-auth rejection as non-retryable", async () => {
+    const fake = createFakeDb();
+    const rejection = Object.assign(new Error("Password too short"), {
+      statusCode: 400,
+    });
+
+    const error = await seedFirstBoot(asSeedDb(fake), {
+      signUpAdmin: createSignUp(fake.tables, { fail: rejection }),
+      env: VALID_ENV,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(NonRetryableSeedError);
+    expect((error as Error).message).toMatch(/Password too short/);
+    expect(fake.tables.organization).toHaveLength(0);
+    expect(fake.tables.user).toHaveLength(0);
+  });
+
+  it("retries a transient better-auth failure rather than giving up", async () => {
+    const fake = createFakeDb();
+
+    const error = await seedFirstBoot(asSeedDb(fake), {
+      signUpAdmin: createSignUp(fake.tables, {
+        fail: new Error("socket hang up"),
+      }),
+      env: VALID_ENV,
+    }).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(NonRetryableSeedError);
+    expect(fake.tables.organization).toHaveLength(0);
+  });
+
+  it("flags a database left half-seeded by an older release", async () => {
+    const fake = createFakeDb();
+    fake.tables.organization.push({
+      id: "org-1",
+      name: "Default Organization",
+    });
+    const error = vi.spyOn(logger, "error");
+
+    const result = await seedFirstBoot(asSeedDb(fake), {
+      signUpAdmin: createSignUp(fake.tables),
+      env: VALID_ENV,
+    });
+
+    expect(result).toEqual({ seeded: false });
+    expect(error).toHaveBeenCalled();
+    expect(fake.tables.organization).toHaveLength(1);
+    expect(fake.tables.user).toHaveLength(0);
+  });
+});

--- a/apps/backend/src/db/seed.ts
+++ b/apps/backend/src/db/seed.ts
@@ -1,0 +1,255 @@
+import { count, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import type { db } from "../index.ts";
+import { logger } from "../logger.ts";
+import { organization, organizationMember, workspace, user } from "./schema.ts";
+
+/** The Drizzle handle the seed writes through. */
+export type SeedDatabase = typeof db;
+
+/** Environment variables the seed reads. */
+export type SeedEnv = {
+  ADMIN_EMAIL?: string;
+  ADMIN_PASSWORD?: string;
+};
+
+/**
+ * Creates the admin User and returns its id. In production this is
+ * better-auth's `signUpEmail`, which owns its own database access and so writes
+ * outside any transaction the seed opens — the reason `seedFirstBoot`
+ * compensates for the User explicitly instead of relying on rollback.
+ */
+export type AdminSignUp = (input: {
+  email: string;
+  password: string;
+  name: string;
+}) => Promise<{ id: string }>;
+
+export type SeedDeps = {
+  signUpAdmin: AdminSignUp;
+  /** Defaults to `process.env`. */
+  env?: SeedEnv;
+};
+
+export type SeedResult =
+  | { seeded: false }
+  | {
+      seeded: true;
+      organizationId: string;
+      userId: string;
+      workspaceId: string;
+    };
+
+/**
+ * A seed failure no amount of retrying can fix — missing configuration, or
+ * input better-auth rejected outright. Startup surfaces this immediately rather
+ * than burning the backoff schedule on a deterministic error.
+ */
+export class NonRetryableSeedError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "NonRetryableSeedError";
+  }
+}
+
+/**
+ * better-auth rejects invalid input (a password below its minimum length, an
+ * email already taken) with a 4xx `APIError`. Those are deterministic; 5xx and
+ * plain transport errors are not.
+ */
+const isDeterministicRejection = (error: unknown): boolean => {
+  const status = (error as { statusCode?: unknown } | null)?.statusCode;
+  return typeof status === "number" && status >= 400 && status < 500;
+};
+
+const errorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
+/**
+ * Bootstraps an empty database with the Default Organization, the admin User
+ * from `ADMIN_EMAIL` / `ADMIN_PASSWORD`, that User's Organization membership and
+ * the Default Workspace.
+ *
+ * The invariant is that no partially seeded state survives a failure (#369).
+ * Configuration is validated before anything is written; the Organization,
+ * membership and Workspace are written in one transaction; and the User — which
+ * better-auth writes outside that transaction — is deleted again if the
+ * transaction fails. A database that already has an Organization is left
+ * untouched and nothing is logged, so restarts stay a silent no-op.
+ */
+export const seedFirstBoot = async (
+  database: SeedDatabase,
+  deps: SeedDeps,
+): Promise<SeedResult> => {
+  const env = deps.env ?? process.env;
+
+  const [orgCount] = await database
+    .select({ value: count() })
+    .from(organization);
+
+  if ((orgCount?.value ?? 0) > 0) {
+    await warnIfHalfSeeded(database);
+    return { seeded: false };
+  }
+
+  // Validate before writing: a missing variable must cost nothing, so that the
+  // operator's next attempt starts from a clean database.
+  const missing = (["ADMIN_EMAIL", "ADMIN_PASSWORD"] as const).filter(
+    (name) => !env[name],
+  );
+  if (missing.length > 0) {
+    const names = missing.join(" and ");
+    const isAre =
+      missing.length > 1
+        ? "environment variables are"
+        : "environment variable is";
+    throw new NonRetryableSeedError(
+      `${names} ${isAre} required to seed the initial admin user. Set ${names} and restart.`,
+    );
+  }
+  const email = env.ADMIN_EMAIL!;
+  const password = env.ADMIN_PASSWORD!;
+
+  logger.info("No organizations found. Seeding initial data...");
+
+  const adminId = await createAdminUser(database, deps.signUpAdmin, {
+    email,
+    password,
+  });
+
+  try {
+    const result = await database.transaction(async (tx) => {
+      const organizationId = nanoid();
+      await tx.insert(organization).values({
+        id: organizationId,
+        name: "Default Organization",
+      });
+
+      await tx
+        .update(user)
+        .set({ role: "admin", emailVerified: true })
+        .where(eq(user.id, adminId));
+
+      await tx.insert(organizationMember).values({
+        id: nanoid(),
+        organizationId,
+        userId: adminId,
+        role: "admin",
+      });
+
+      const workspaceId = nanoid();
+      await tx.insert(workspace).values({
+        id: workspaceId,
+        organizationId,
+        ownerId: adminId,
+        name: "Default Workspace",
+      });
+
+      return {
+        seeded: true as const,
+        organizationId,
+        userId: adminId,
+        workspaceId,
+      };
+    });
+
+    logger.info(
+      {
+        organizationId: result.organizationId,
+        workspaceId: result.workspaceId,
+        userId: result.userId,
+      },
+      "Seeded Default Organization, admin user, membership and Default Workspace",
+    );
+    logger.info(`- Default credentials: ${email} / ${password}`);
+    logger.info("⚠️  Please change the default password after first login!");
+
+    return result;
+  } catch (error) {
+    // The transaction rolled back, but better-auth's User row is outside it.
+    // Remove it so the next attempt starts from an empty database.
+    await compensateUser(database, adminId);
+    throw error;
+  }
+};
+
+/**
+ * Creates the admin User through better-auth and returns its id.
+ *
+ * A User already holding `ADMIN_EMAIL` stops the seed rather than being adopted:
+ * compensation runs against the database that just failed, so it can fail too,
+ * and the account left behind is not necessarily one the Operator created —
+ * promoting whoever holds that address to admin is an escalation, not a
+ * recovery. Deleting one row is a cheap fix; the message says so.
+ */
+const createAdminUser = async (
+  database: SeedDatabase,
+  signUpAdmin: AdminSignUp,
+  credentials: { email: string; password: string },
+): Promise<string> => {
+  const [existing] = await database
+    .select({ id: user.id })
+    .from(user)
+    .where(eq(user.email, credentials.email))
+    .limit(1);
+
+  if (existing) {
+    throw new NonRetryableSeedError(
+      `A user already exists for ${credentials.email} in a database with no organizations, most likely left behind by a first boot that failed. Refusing to seed rather than promote an existing account to admin. Delete that user (or point ADMIN_EMAIL at a different address) and restart.`,
+    );
+  }
+
+  try {
+    const created = await signUpAdmin({
+      email: credentials.email,
+      password: credentials.password,
+      name: "Admin User",
+    });
+    logger.info(`- User created: ${credentials.email}`);
+    return created.id;
+  } catch (error) {
+    if (isDeterministicRejection(error)) {
+      throw new NonRetryableSeedError(
+        `Could not create the admin user for ${credentials.email}: ${errorMessage(
+          error,
+        )}. Fix ADMIN_EMAIL / ADMIN_PASSWORD and restart.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+};
+
+/** Best-effort removal of the User created before the failed transaction. */
+const compensateUser = async (database: SeedDatabase, userId: string) => {
+  try {
+    await database.delete(user).where(eq(user.id, userId));
+    logger.warn(
+      { userId },
+      "Seed failed — removed the admin user created before the failure so the next attempt starts clean",
+    );
+  } catch (error) {
+    logger.error(
+      { err: error, userId },
+      "Seed failed and the admin user created before the failure could not be removed. Delete that user before the next attempt, which will otherwise refuse to seed over it.",
+    );
+  }
+};
+
+/**
+ * A database seeded by a release that wrote the Organization outside a
+ * transaction can hold an Organization with no members — a stack nobody can
+ * sign into, which every restart since has skipped silently. Say so, once, on
+ * every boot: it is the only diagnostic such an operator gets.
+ */
+const warnIfHalfSeeded = async (database: SeedDatabase) => {
+  const [memberCount] = await database
+    .select({ value: count() })
+    .from(organizationMember);
+
+  if ((memberCount?.value ?? 0) === 0) {
+    logger.error(
+      'This database has an organization but no organization members, so nobody can sign in. A first boot failed partway through, before seeding was atomic. To recover, either delete the empty organization ("DELETE FROM organization;" against a database with no other data) and restart so this seed runs again, or start over with "docker compose down -v".',
+    );
+  }
+};


### PR DESCRIPTION
Closes #369

## The bug

The startup seed inserted the Default Organization, then read `ADMIN_EMAIL` / `ADMIN_PASSWORD`, then created the admin User, membership and Workspace — all outside a transaction. Any failure after the Organization insert left that row committed. The throw reached `exponentialBackoff`, which logged one `warn` and retried; on the retry `orgCount` was 1, so the seed was skipped entirely. `main()` returned normally, the HTTP server started, the container reported healthy — and nobody could sign in, on that boot or any boot after. The only recovery was `docker compose down -v`.

## The fix

The seed moves out of the anonymous closure in `main()` into `seedFirstBoot(db, deps)` in `apps/backend/src/db/seed.ts` — a named seam callable without standing up the HTTP server — and gains three guarantees:

- **Validate before writing.** `ADMIN_EMAIL` / `ADMIN_PASSWORD` are checked before the first write, so a missing variable costs nothing and the error names the variable.
- **Write atomically.** Organization, admin role, membership and Workspace go in one transaction. The User — which better-auth's `signUpEmail` writes through its own database access, outside that transaction — is deleted again if the transaction fails.
- **Don't reach `serve()`.** Once retries are exhausted, startup logs `fatal` and exits non-zero. Failures no retry can fix (missing config, input better-auth rejects with a 4xx) skip the backoff entirely rather than burning ~31s to reach the same message.

Also: error log fields moved from `{ error }` to `{ err }`, because pino only serializes errors under `err` — without it the fatal line printed `{"name": "NonRetryableSeedError"}` and no message, which is the diagnostic the Operator needs.

## Two judgement calls

**The guard stays the Organization count.** With the writes atomic, an Organization can no longer exist without the rest of the seed, so the skip is now correct rather than accidentally so — no schema change, no seed marker. A database *already* broken by the old path can't self-heal, so every boot logs an error saying what happened and how to recover; silence is what made this expensive.

**A User already holding `ADMIN_EMAIL` stops the boot rather than being adopted.** Compensation runs against the database that just failed, so it can fail too, leaving a User behind. The first cut adopted that User for zero-touch recovery; review caught the shape — sign-up is public, the account isn't necessarily one the Operator created, and promoting whoever holds the address is an escalation, not a recovery. The error names the row to delete, so the fix is one row rather than the database.

## Testing

`apps/backend/src/db/seed.test.ts` — 11 tests covering the five cases the issue enumerates, over an in-memory fake whose `transaction` really rolls back (prior art mocks queries or mirrors logic in plain JS; neither can express "after a failed boot the database is back where it started"). The fake hands the callback a handle bound to a staging copy, so a refactor using `db` where it means `tx` fails the tests instead of passing quietly.

Both rollback tests were mutation-checked: remove the transaction and the retry-after-failure regression test reproduces the original bug.

**Verified against real Postgres**, on a throwaway database, since the fake can't prove Drizzle's transaction semantics or the better-auth interplay:

| Scenario | Result |
| --- | --- |
| `ADMIN_EMAIL` unset | exit 1, message names the variable, zero rows, no retries |
| Password below better-auth's minimum | exit 1, message carries the rejection, zero rows |
| `CHECK (false)` injected on `workspace` | rollback + User/account compensation on all five retries, zero rows |
| Constraint removed, reboot | seeds fully, sign-in returns HTTP 200 |
| Leftover User holding `ADMIN_EMAIL` | exit 1, role stays `user`, error names the row |
| Restart against seeded database | silent no-op, zero warnings |

`pnpm test` (1264 backend, 26 frontend, 3 example), `pnpm typecheck` and `pnpm lint` all pass.

## Docs coordination

Per the issue's last Implementation Decision: **this landed first.** The existing claim on `self-hosting/docker-compose.mdx` that the backend "refuses to seed if `ADMIN_EMAIL` and `ADMIN_PASSWORD` are unset — it logs an error and exits" is accurate as of this change, so that page needs no `down -v` recovery section. Documentation changes are out of scope here and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)