### PR TITLE
feat: add the web-search backend Extension point

### DIFF
--- a/apps/backend/index.ts
+++ b/apps/backend/index.ts
@@ -67,8 +67,9 @@ const main = async () => {
         origin: p.origin,
         toolSets: p.toolSetIds,
         sandboxBackends: p.sandboxBackendIds,
+        webBackends: p.webBackendIds,
       },
-      `Loaded plugin ${p.name}@${p.version} (${p.origin}): ${p.toolSetIds.length} tool set(s), ${p.sandboxBackendIds.length} sandbox backend(s)`,
+      `Loaded plugin ${p.name}@${p.version} (${p.origin}): ${p.toolSetIds.length} tool set(s), ${p.sandboxBackendIds.length} sandbox backend(s), ${p.webBackendIds.length} web backend(s)`,
     );
   }
   setLoadedPlugins(loadedPlugins);

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -737,6 +737,51 @@ describe("loadPlugins — web-search backends", () => {
     ).rejects.toThrow(/@platypus\/searx.*"searx".*createExecutors/s);
   });
 
+  it("aborts (fail-loud) on a contribution with no backend id, before namespacing it", async () => {
+    const { register } = makeRegister();
+    // Namespacing an absent id first would mint `"@platypus/searx.undefined"`
+    // and register it, turning a missing field into a mystery catalog entry.
+    const nameless = {
+      name: "SearXNG",
+      createExecutors: () => ({
+        web_search: () => ({ query: "", results: [] }),
+      }),
+    } as unknown as ReturnType<typeof webBackend>;
+
+    await expect(
+      loadPlugins({
+        pluginNames: ["@platypus/searx"],
+        builtinPlugins: {
+          "@platypus/searx": () =>
+            Promise.resolve({
+              plugin: webManifest("@platypus/searx", [nameless]),
+            }),
+        },
+        register,
+        registerWeb: () => {},
+      }),
+    ).rejects.toThrow(/@platypus\/searx.*non-empty "backend" id/s);
+  });
+
+  it("aborts (fail-loud) on a contribution with a blank display name", async () => {
+    const { register } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@platypus/searx"],
+        builtinPlugins: {
+          "@platypus/searx": () =>
+            Promise.resolve({
+              plugin: webManifest("@platypus/searx", [
+                { ...webBackend("searx"), name: "   " },
+              ]),
+            }),
+        },
+        register,
+        registerWeb: () => {},
+      }),
+    ).rejects.toThrow(/@platypus\/searx.*"searx".*non-empty "name"/s);
+  });
+
   it("refuses an over-ceiling timeoutMs at boot rather than clamping it", async () => {
     const { register } = makeRegister();
     await expect(

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -713,6 +713,33 @@ describe("loadPlugins — web-search backends", () => {
     ).rejects.toThrow(/@bad\/plugin.*webBackends.*array/s);
   });
 
+  it("aborts (fail-loud, plugin-named) on a non-object web backend entry", async () => {
+    // `webBackends` being an array is checked; a third-party JS plugin can
+    // still put `null` inside it, which would otherwise throw an unattributed
+    // "Cannot read properties of null" reading `.backend` next.
+    const { register } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@platypus/searx"],
+        builtinPlugins: {
+          "@platypus/searx": () =>
+            Promise.resolve({
+              plugin: {
+                name: "@platypus/searx",
+                version: "0.1.0",
+                apiVersion: 1,
+                contributes: { webBackends: [null] },
+              },
+            }),
+        },
+        register,
+        registerWeb: () => {},
+      }),
+    ).rejects.toThrow(
+      /@platypus\/searx.*web backend contribution must be an object/s,
+    );
+  });
+
   it("aborts (fail-loud) when a contribution has no createExecutors function", async () => {
     const { register } = makeRegister();
     // The TS type requires it; a third-party JS plugin can still omit it, and

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -8,7 +8,12 @@ import {
   type SandboxBackend,
   type SandboxBackendContribution,
   type ToolSetContribution,
+  type WebBackendContribution,
 } from "@platypuschat/plugin-sdk";
+import {
+  MAX_WEB_TIMEOUT_MS,
+  type WebBackendRegistration,
+} from "../web-backends/index.ts";
 import { loadPlugins, parsePluginConfig, parsePluginList } from "./loader.ts";
 import { plugin as examplePlugin } from "./example/index.ts";
 import { registerToolSet, getToolSet } from "../tools/index.ts";
@@ -57,6 +62,34 @@ const toolSet = (id: string): ToolSetContribution => ({
   name: id,
   category: "Test",
   tools: {},
+});
+
+// A capturing `registerWeb` for the Web-search-backend extension point. It takes
+// core's composed registration, not the raw contribution.
+const makeWebRegister = () => {
+  const calls: WebBackendRegistration[] = [];
+  const registerWeb = (registration: WebBackendRegistration) => {
+    calls.push(registration);
+  };
+  return { registerWeb, calls };
+};
+
+const webManifest = (
+  name: string,
+  webBackends: WebBackendContribution[],
+): PlatypusPlugin => ({
+  name,
+  version: "0.1.0",
+  apiVersion: 1,
+  contributes: { webBackends },
+});
+
+const webBackend = (backend: string): WebBackendContribution => ({
+  backend,
+  name: backend,
+  createExecutors: () => ({
+    web_search: () => ({ query: "", results: [] }),
+  }),
 });
 
 const sandboxBackend = (backend: string): SandboxBackendContribution => ({
@@ -194,6 +227,7 @@ describe("loadPlugins", () => {
         origin: "core",
         toolSetIds: ["math-conversions", "time"],
         sandboxBackendIds: [],
+        webBackendIds: [],
       },
     ]);
   });
@@ -411,6 +445,7 @@ describe("loadPlugins — sandbox backends", () => {
         origin: "core",
         toolSetIds: [],
         sandboxBackendIds: ["docker"],
+        webBackendIds: [],
       },
     ]);
   });
@@ -563,6 +598,231 @@ describe("loadPlugins — sandbox backends", () => {
 
     // A plain schema passes through by identity — append-only compatibility.
     expect(calls[0].configSchema).toBe(plain);
+  });
+});
+
+describe("loadPlugins — web-search backends", () => {
+  it("registers a web-backend contribution and reports its id", async () => {
+    const { register } = makeRegister();
+    const { registerWeb, calls } = makeWebRegister();
+    const loaded = await loadPlugins({
+      pluginNames: ["@platypus/searx"],
+      builtinPlugins: {
+        "@platypus/searx": () =>
+          Promise.resolve({
+            plugin: webManifest("@platypus/searx", [webBackend("searx")]),
+          }),
+      },
+      register,
+      registerWeb,
+    });
+
+    expect(calls.map((c) => c.backend)).toEqual(["searx"]);
+    // What lands in the registry is core's composed builder, not the raw
+    // contribution: the model-facing surface is core-owned (ADR-0014).
+    expect(typeof calls[0].buildTurnTools).toBe("function");
+    expect(loaded[0]).toMatchObject({
+      name: "@platypus/searx",
+      origin: "core",
+      webBackendIds: ["searx"],
+    });
+  });
+
+  it("prefixes a third-party web-backend id with the manifest name", async () => {
+    const { register } = makeRegister();
+    const { registerWeb, calls } = makeWebRegister();
+    const loaded = await loadPlugins({
+      pluginNames: ["@acme/platypus-search"],
+      builtinPlugins: {},
+      importPlugin: () =>
+        Promise.resolve({
+          plugin: webManifest("acme", [webBackend("web")]),
+        }),
+      register,
+      registerWeb,
+    });
+
+    expect(calls.map((c) => c.backend)).toEqual(["acme.web"]);
+    expect(loaded[0].webBackendIds).toEqual(["acme.web"]);
+  });
+
+  it("aborts (fail-loud) on a duplicate web backend id, naming both plugins", async () => {
+    const { register } = makeRegister();
+    const { registerWeb } = makeWebRegister();
+    // Two core plugins keep bare backend ids, so a shared `searx` collides.
+    const builtinPlugins = {
+      "@a/plugin": () =>
+        Promise.resolve({
+          plugin: webManifest("@a/plugin", [webBackend("searx")]),
+        }),
+      "@b/plugin": () =>
+        Promise.resolve({
+          plugin: webManifest("@b/plugin", [webBackend("searx")]),
+        }),
+    };
+
+    await expect(
+      loadPlugins({
+        pluginNames: ["@a/plugin", "@b/plugin"],
+        builtinPlugins,
+        register,
+        registerWeb,
+      }),
+    ).rejects.toThrow(/"searx".*"@a\/plugin".*"@b\/plugin"/s);
+  });
+
+  it("re-throws a registry collision with plugin attribution", async () => {
+    const { register } = makeRegister();
+    const registerWeb = () => {
+      throw new Error("Web backend 'searx' has already been registered.");
+    };
+
+    await expect(
+      loadPlugins({
+        pluginNames: ["@platypus/collides"],
+        builtinPlugins: {
+          "@platypus/collides": () =>
+            Promise.resolve({
+              plugin: webManifest("@platypus/collides", [webBackend("searx")]),
+            }),
+        },
+        register,
+        registerWeb,
+      }),
+    ).rejects.toThrow(/@platypus\/collides.*"searx".*already been registered/s);
+  });
+
+  it("aborts (fail-loud) when webBackends is not an array", async () => {
+    const { register } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@bad/plugin"],
+        builtinPlugins: {},
+        importPlugin: () =>
+          Promise.resolve({
+            plugin: {
+              name: "bad",
+              version: "0.1.0",
+              apiVersion: 1,
+              contributes: { webBackends: {} },
+            },
+          }),
+        register,
+        registerWeb: () => {},
+      }),
+    ).rejects.toThrow(/@bad\/plugin.*webBackends.*array/s);
+  });
+
+  it("aborts (fail-loud) when a contribution has no createExecutors function", async () => {
+    const { register } = makeRegister();
+    // The TS type requires it; a third-party JS plugin can still omit it, and
+    // boot — not a live turn — is where that is caught.
+    const broken = {
+      backend: "searx",
+      name: "SearXNG",
+    } as unknown as ReturnType<typeof webBackend>;
+
+    await expect(
+      loadPlugins({
+        pluginNames: ["@platypus/searx"],
+        builtinPlugins: {
+          "@platypus/searx": () =>
+            Promise.resolve({
+              plugin: webManifest("@platypus/searx", [broken]),
+            }),
+        },
+        register,
+        registerWeb: () => {},
+      }),
+    ).rejects.toThrow(/@platypus\/searx.*"searx".*createExecutors/s);
+  });
+
+  it("refuses an over-ceiling timeoutMs at boot rather than clamping it", async () => {
+    const { register } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@platypus/searx"],
+        builtinPlugins: {
+          "@platypus/searx": () =>
+            Promise.resolve({
+              plugin: webManifest("@platypus/searx", [
+                { ...webBackend("searx"), timeoutMs: MAX_WEB_TIMEOUT_MS + 1 },
+              ]),
+            }),
+        },
+        register,
+        registerWeb: () => {},
+      }),
+    ).rejects.toThrow(
+      new RegExp(
+        `@platypus/searx.*"searx".*timeoutMs.*${MAX_WEB_TIMEOUT_MS}`,
+        "s",
+      ),
+    );
+  });
+
+  it("accepts a timeoutMs at the ceiling", async () => {
+    const { register } = makeRegister();
+    const { registerWeb, calls } = makeWebRegister();
+    await loadPlugins({
+      pluginNames: ["@platypus/searx"],
+      builtinPlugins: {
+        "@platypus/searx": () =>
+          Promise.resolve({
+            plugin: webManifest("@platypus/searx", [
+              { ...webBackend("searx"), timeoutMs: MAX_WEB_TIMEOUT_MS },
+            ]),
+          }),
+      },
+      register,
+      registerWeb,
+    });
+
+    expect(calls).toHaveLength(1);
+  });
+
+  it("injects the shared plugin config block into createExecutors", async () => {
+    const { register } = makeRegister();
+    const { registerWeb, calls } = makeWebRegister();
+    const createExecutors = vi.fn(() => ({
+      web_search: () => ({ query: "q", results: [] }),
+    }));
+
+    await loadPlugins({
+      pluginNames: ["acme"],
+      builtinPlugins: {},
+      importPlugin: () =>
+        Promise.resolve({
+          plugin: {
+            name: "acme",
+            version: "0.1.0",
+            apiVersion: 1,
+            configSchema: z.object({ endpoint: z.string() }),
+            credentialsSchema: z.object({ apiKey: z.string() }),
+            contributes: {
+              webBackends: [
+                { backend: "web", name: "Acme Search", createExecutors },
+              ],
+            },
+          } satisfies PlatypusPlugin,
+        }),
+      register,
+      registerWeb,
+      pluginConfig: {
+        acme: {
+          config: { endpoint: "https://searx.internal" },
+          credentials: { apiKey: "sk-test" },
+        },
+      },
+    });
+
+    const ctx = { orgId: "org-1", workspaceId: "ws-1", userId: "user-1" };
+    await calls[0].buildTurnTools(ctx);
+
+    expect(createExecutors).toHaveBeenCalledWith(ctx, {
+      config: { endpoint: "https://searx.internal" },
+      credentials: { apiKey: "sk-test" },
+    });
   });
 });
 

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -479,6 +479,27 @@ export async function loadPlugins(
     const webBackendIds: string[] = [];
 
     for (const contribution of manifest.contributes.webBackends ?? []) {
+      // Identity is checked before it is namespaced: `contributionId(undefined)`
+      // would otherwise mint a plausible-looking `"acme.undefined"` and register
+      // it, so a JS plugin's missing field would surface as a mystery id in the
+      // catalog rather than a boot error naming the plugin.
+      if (
+        typeof contribution.backend !== "string" ||
+        contribution.backend.trim() === ""
+      ) {
+        throw new Error(
+          `Plugin "${manifest.name}": every web backend must declare a non-empty "backend" id.`,
+        );
+      }
+      if (
+        typeof contribution.name !== "string" ||
+        contribution.name.trim() === ""
+      ) {
+        throw new Error(
+          `Plugin "${manifest.name}": web backend "${contribution.backend}" must declare a non-empty "name".`,
+        );
+      }
+
       const effectiveBackend = contributionId(contribution.backend);
 
       const existingOwner = webOwners.get(effectiveBackend);
@@ -520,8 +541,15 @@ export async function loadPlugins(
       // Core wraps the executors here, binding the same shared plugin config that
       // every other contribution factory receives. What lands in the registry is
       // the finished, guarded builder — per-turn callers never see the executors.
+      //
+      // The contribution goes in by reference, with the namespaced id alongside
+      // it rather than spread over it: `createExecutors` must be called on the
+      // author's own object, or a class-instance contribution loses its
+      // prototype and its `this`. (The sandbox loop achieves the same by
+      // re-wrapping `create` around the original.)
       const registration = composeWebBackend({
-        contribution: { ...contribution, backend: effectiveBackend },
+        contribution,
+        backend: effectiveBackend,
         plugin: pluginCtx,
         pluginName: manifest.name,
       });

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -479,6 +479,16 @@ export async function loadPlugins(
     const webBackendIds: string[] = [];
 
     for (const contribution of manifest.contributes.webBackends ?? []) {
+      // A third-party JS plugin can put anything in this array — including
+      // `null` — and every other malformed case in this loop gets a
+      // plugin-named boot error, so this one does too rather than throwing an
+      // unattributed `Cannot read properties of null`.
+      if (typeof contribution !== "object" || contribution === null) {
+        throw new Error(
+          `Plugin "${manifest.name}": every web backend contribution must be an object.`,
+        );
+      }
+
       // Identity is checked before it is namespaced: `contributionId(undefined)`
       // would otherwise mint a plausible-looking `"acme.undefined"` and register
       // it, so a JS plugin's missing field would surface as a mystery id in the

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -12,6 +12,12 @@ import {
   registerSandboxBackend,
   type SandboxBackendRegistration,
 } from "../sandbox/index.ts";
+import {
+  composeWebBackend,
+  MAX_WEB_TIMEOUT_MS,
+  registerWebBackend,
+  type WebBackendRegistration,
+} from "../web-backends/index.ts";
 
 // Summary of one loaded plugin, for the boot log line and observability.
 export interface LoadedPlugin {
@@ -20,6 +26,7 @@ export interface LoadedPlugin {
   origin: "core" | "third-party";
   toolSetIds: string[];
   sandboxBackendIds: string[];
+  webBackendIds: string[];
   /**
    * The plugin's boot-resolved, Operator-owned deploy-time **config** (never
    * credentials), or `undefined` when the manifest declares no `configSchema`.
@@ -65,6 +72,13 @@ export interface LoadPluginsOptions {
   register?: (id: string, def: Omit<ToolSetContribution, "id">) => void;
   /** Registers one Sandbox-backend contribution. Defaults to core `registerSandboxBackend`. */
   registerSandbox?: (contribution: SandboxBackendContribution) => void;
+  /**
+   * Registers one Web-search backend. Takes the *composed* registration — core
+   * has already wrapped the contribution's executors in its own Tools — rather
+   * than the raw contribution, since a backend's model-facing surface is
+   * core-owned (ADR-0014). Defaults to core `registerWebBackend`.
+   */
+  registerWeb?: (registration: WebBackendRegistration) => void;
   /**
    * Deploy-time plugin config/credentials keyed by plugin name. Defaults to
    * parsing `PLATYPUS_PLUGIN_CONFIG` (see {@link parsePluginConfig}).
@@ -223,6 +237,14 @@ const validateManifest = (name: string, mod: PluginModule): PlatypusPlugin => {
       `Plugin "${name}": "contributes.sandboxBackends" must be an array.`,
     );
   }
+  if (
+    contributes.webBackends !== undefined &&
+    !Array.isArray(contributes.webBackends)
+  ) {
+    throw new Error(
+      `Plugin "${name}": "contributes.webBackends" must be an array.`,
+    );
+  }
   return p as PlatypusPlugin;
 };
 
@@ -291,14 +313,17 @@ export async function loadPlugins(
     ((name: string) => import(name) as Promise<PluginModule>);
   const register = opts.register ?? registerToolSet;
   const registerSandbox = opts.registerSandbox ?? registerSandboxBackend;
+  const registerWeb = opts.registerWeb ?? registerWebBackend;
   const pluginConfig =
     opts.pluginConfig ?? parsePluginConfig(process.env.PLATYPUS_PLUGIN_CONFIG);
 
   // Tracks contribution id -> owning plugin name for owner-attributed collisions.
-  // Tool sets and Sandbox backends live in separate registries, so each keeps
-  // its own owner map (a Tool set and a backend may share a bare id).
+  // Tool sets, Sandbox backends, and Web-search backends live in separate
+  // registries, so each keeps its own owner map (a Tool set and a backend may
+  // share a bare id).
   const owners = new Map<string, string>();
   const sandboxOwners = new Map<string, string>();
+  const webOwners = new Map<string, string>();
   const loaded: LoadedPlugin[] = [];
 
   for (const name of names) {
@@ -451,12 +476,80 @@ export async function loadPlugins(
       sandboxBackendIds.push(effectiveBackend);
     }
 
+    const webBackendIds: string[] = [];
+
+    for (const contribution of manifest.contributes.webBackends ?? []) {
+      const effectiveBackend = contributionId(contribution.backend);
+
+      const existingOwner = webOwners.get(effectiveBackend);
+      if (existingOwner) {
+        throw new Error(
+          `Web backend id "${effectiveBackend}" is contributed by both "${existingOwner}" and "${manifest.name}".`,
+        );
+      }
+
+      // A web backend supplies executors only — core builds the Tools — so a
+      // missing factory means the contribution can never serve a turn. The TS
+      // type says so; a third-party JS plugin can still ship it, and boot is
+      // where that is caught (ADR-0014's fail-loud boot posture).
+      if (typeof contribution.createExecutors !== "function") {
+        throw new Error(
+          `Plugin "${manifest.name}": web backend "${effectiveBackend}" must provide a "createExecutors" function.`,
+        );
+      }
+
+      // `timeoutMs` is static on the contribution, so an over-ceiling value is
+      // knowable now — refused with attribution rather than silently clamped at
+      // turn time, where an Operator would never see it.
+      if (contribution.timeoutMs !== undefined) {
+        const { timeoutMs } = contribution;
+        if (
+          typeof timeoutMs !== "number" ||
+          !Number.isFinite(timeoutMs) ||
+          timeoutMs <= 0 ||
+          timeoutMs > MAX_WEB_TIMEOUT_MS
+        ) {
+          throw new Error(
+            `Plugin "${manifest.name}": web backend "${effectiveBackend}" declares timeoutMs ${String(
+              timeoutMs,
+            )}, which must be a positive number no greater than ${MAX_WEB_TIMEOUT_MS}.`,
+          );
+        }
+      }
+
+      // Core wraps the executors here, binding the same shared plugin config that
+      // every other contribution factory receives. What lands in the registry is
+      // the finished, guarded builder — per-turn callers never see the executors.
+      const registration = composeWebBackend({
+        contribution: { ...contribution, backend: effectiveBackend },
+        plugin: pluginCtx,
+        pluginName: manifest.name,
+      });
+
+      try {
+        registerWeb(registration);
+      } catch (cause) {
+        // A collision with a backend registered outside the loader surfaces
+        // here — re-throw with plugin attribution.
+        throw new Error(
+          `Plugin "${manifest.name}": failed to register web backend "${effectiveBackend}" (${
+            cause instanceof Error ? cause.message : String(cause)
+          }).`,
+          { cause },
+        );
+      }
+
+      webOwners.set(effectiveBackend, manifest.name);
+      webBackendIds.push(effectiveBackend);
+    }
+
     loaded.push({
       name: manifest.name,
       version: manifest.version,
       origin,
       toolSetIds,
       sandboxBackendIds,
+      webBackendIds,
       // Carry the resolved deploy-time config (config only, never credentials)
       // so request handlers can read it via the registry (ADR-0013).
       config: pluginCtx.config,

--- a/apps/backend/src/plugins/registry.ts
+++ b/apps/backend/src/plugins/registry.ts
@@ -22,6 +22,7 @@ export const CORE_BUILTIN_OWNER = "core (built-in)";
 let loadedPlugins: readonly LoadedPlugin[] = [];
 let toolSetOwners = new Map<string, string>();
 let sandboxBackendOwners = new Map<string, string>();
+let webBackendOwners = new Map<string, string>();
 let pluginConfigs = new Map<string, unknown>();
 
 /**
@@ -33,10 +34,12 @@ export const setLoadedPlugins = (plugins: readonly LoadedPlugin[]): void => {
   loadedPlugins = plugins;
   toolSetOwners = new Map();
   sandboxBackendOwners = new Map();
+  webBackendOwners = new Map();
   pluginConfigs = new Map();
   for (const p of plugins) {
     for (const id of p.toolSetIds) toolSetOwners.set(id, p.name);
     for (const id of p.sandboxBackendIds) sandboxBackendOwners.set(id, p.name);
+    for (const id of p.webBackendIds) webBackendOwners.set(id, p.name);
     if (p.config !== undefined) pluginConfigs.set(p.name, p.config);
   }
 };
@@ -55,6 +58,10 @@ export const getToolSetPlugin = (toolSetId: string): string | undefined =>
 /** The plugin that contributed a Sandbox backend, or `undefined` if none. */
 export const getSandboxBackendPlugin = (backend: string): string | undefined =>
   sandboxBackendOwners.get(backend);
+
+/** The plugin that contributed a Web-search backend, or `undefined` if none. */
+export const getWebBackendPlugin = (backend: string): string | undefined =>
+  webBackendOwners.get(backend);
 
 /**
  * A plugin's boot-resolved, Operator-owned deploy-time **config** (never

--- a/apps/backend/src/routes/plugins.test.ts
+++ b/apps/backend/src/routes/plugins.test.ts
@@ -16,6 +16,7 @@ const LOADED: LoadedPlugin[] = [
     origin: "core",
     toolSetIds: ["math-conversions", "time"],
     sandboxBackendIds: [],
+    webBackendIds: [],
   },
   {
     name: "acme-sandbox",
@@ -23,6 +24,7 @@ const LOADED: LoadedPlugin[] = [
     origin: "third-party",
     toolSetIds: ["acme-sandbox.management"],
     sandboxBackendIds: ["acme-sandbox.sandbox"],
+    webBackendIds: ["acme-sandbox.search"],
   },
 ];
 
@@ -49,7 +51,11 @@ describe("Plugins Routes", () => {
           name: string;
           version: string;
           origin: string;
-          contributions: { toolSets: string[]; sandboxBackends: string[] };
+          contributions: {
+            toolSets: string[];
+            sandboxBackends: string[];
+            webBackends: string[];
+          };
         }>;
       };
 
@@ -61,6 +67,7 @@ describe("Plugins Routes", () => {
           contributions: {
             toolSets: ["math-conversions", "time"],
             sandboxBackends: [],
+            webBackends: [],
           },
         },
         {
@@ -70,6 +77,7 @@ describe("Plugins Routes", () => {
           contributions: {
             toolSets: ["acme-sandbox.management"],
             sandboxBackends: ["acme-sandbox.sandbox"],
+            webBackends: ["acme-sandbox.search"],
           },
         },
       ]);

--- a/apps/backend/src/routes/plugins.ts
+++ b/apps/backend/src/routes/plugins.ts
@@ -24,6 +24,7 @@ plugins.get("/", requireAuth, requireOrgAccess(["admin"]), (c) => {
     contributions: {
       toolSets: p.toolSetIds,
       sandboxBackends: p.sandboxBackendIds,
+      webBackends: p.webBackendIds,
     },
   }));
   return c.json({ results });

--- a/apps/backend/src/routes/sandbox.test.ts
+++ b/apps/backend/src/routes/sandbox.test.ts
@@ -66,6 +66,7 @@ describe("Sandbox Routes", () => {
           origin: "core",
           toolSetIds: [],
           sandboxBackendIds: [ANNOTATED_BACKEND],
+          webBackendIds: [],
         },
       ]);
 

--- a/apps/backend/src/routes/tool.test.ts
+++ b/apps/backend/src/routes/tool.test.ts
@@ -39,6 +39,7 @@ describe("Tool Routes", () => {
         origin: "core",
         toolSetIds: ["math"],
         sandboxBackendIds: [],
+        webBackendIds: [],
       },
     ]);
   });

--- a/apps/backend/src/web-backends/index.test.ts
+++ b/apps/backend/src/web-backends/index.test.ts
@@ -10,10 +10,12 @@ import {
   getWebBackends,
   isPresentableUrl,
   MAX_ANSWER_CHARS,
+  MAX_CONTENT_TYPE_CHARS,
   MAX_READ_URL_CONTENT_CHARS,
   MAX_SEARCH_RESULT_SCAN,
   MAX_SEARCH_RESULTS,
   MAX_SNIPPET_CHARS,
+  MAX_URL_CHARS,
   readUrlInputSchema,
   MAX_TITLE_CHARS,
   registerWebBackend,
@@ -109,6 +111,15 @@ describe("web-backend registry", () => {
     expect(getWebBackend("nope")).toBeUndefined();
   });
 
+  it("does not resolve Object.prototype members as registered backends", () => {
+    // A plain-object registry would return `Object.prototype.toString` here —
+    // truthy, but with no `buildTurnTools`. PR2 feeds this lookup from a
+    // nullable DB column, so this must stay undefined rather than throw later.
+    expect(getWebBackend("toString")).toBeUndefined();
+    expect(getWebBackend("constructor")).toBeUndefined();
+    expect(getWebBackend("__proto__")).toBeUndefined();
+  });
+
   it("throws on a duplicate registration", () => {
     registerWebBackend(registration("searx"));
     expect(() => registerWebBackend(registration("searx"))).toThrow(
@@ -159,6 +170,48 @@ describe("composeWebBackend — tool construction", () => {
     expect(mockLogger.warn).toHaveBeenCalledWith(
       { plugin: "@acme/searx", backend: "searx" },
       expect.stringContaining("no web_search executor"),
+    );
+  });
+
+  it("serves no tools (and warns, not rejects) when createExecutors throws", async () => {
+    const tools = await composeWebBackend({
+      contribution: contribution(
+        {},
+        {
+          createExecutors: () => {
+            throw new Error("could not construct client");
+          },
+        },
+      ),
+      pluginName: "@acme/searx",
+    }).buildTurnTools(CTX);
+
+    expect(tools).toEqual({});
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ plugin: "@acme/searx", backend: "searx" }),
+      expect.stringContaining("createExecutors threw"),
+    );
+  });
+
+  it("serves no tools (and warns, not hangs) when createExecutors outruns timeoutMs", async () => {
+    const tools = await composeWebBackend({
+      contribution: contribution(
+        {},
+        {
+          createExecutors: () =>
+            new Promise(() => {
+              /* never settles */
+            }),
+          timeoutMs: 20,
+        },
+      ),
+      pluginName: "@acme/searx",
+    }).buildTurnTools(CTX);
+
+    expect(tools).toEqual({});
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ plugin: "@acme/searx", backend: "searx" }),
+      expect.stringContaining("createExecutors timed out"),
     );
   });
 });
@@ -260,6 +313,50 @@ describe("web_search — core-owned caps", () => {
     expect(mockLogger.warn).toHaveBeenCalledWith(
       { backend: "searx", plugin: "@acme/searx", dropped: 3 },
       expect.stringContaining("not http(s)"),
+    );
+  });
+
+  it("drops a result URL that exceeds MAX_URL_CHARS", async () => {
+    const overlong = `https://example.com/${"x".repeat(MAX_URL_CHARS)}`;
+    const { web_search } = await buildTools({
+      web_search: () => ({
+        query: "q",
+        results: [
+          { title: "Too long", url: overlong },
+          { title: "Good", url: "https://example.com/ok" },
+        ],
+      }),
+    });
+
+    const result = await search(web_search, "q");
+    expect(result.results).toEqual([
+      { title: "Good", url: "https://example.com/ok" },
+    ]);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      { backend: "searx", plugin: "@acme/searx", dropped: 1 },
+      expect.stringContaining("not http(s)"),
+    );
+  });
+
+  it("does not warn about the scan bound when the result cap is what stopped the loop", async () => {
+    // 500 usable results, well past MAX_SEARCH_RESULT_SCAN — but the first 10
+    // are all usable, so the result cap (not the scan cap) ends the loop and
+    // nothing was actually lost to MAX_SEARCH_RESULT_SCAN.
+    const { web_search } = await buildTools({
+      web_search: () => ({
+        query: "q",
+        results: Array.from({ length: 500 }, (_v, i) => ({
+          title: `Result ${i}`,
+          url: `https://example.com/${i}`,
+        })),
+      }),
+    });
+
+    const result = await search(web_search, "q");
+    expect(result.results).toHaveLength(MAX_SEARCH_RESULTS);
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("more results than core will scan"),
     );
   });
 
@@ -500,6 +597,49 @@ describe("read_url — egress guard, capping, slicing", () => {
 
     const result = await read(read_url, { url: "https://example.com/page" });
     expect(result.url).toBe("https://example.com/page");
+  });
+
+  it("falls back to the requested URL when the resolved URL exceeds MAX_URL_CHARS", async () => {
+    const overlong = `https://example.com/${"x".repeat(MAX_URL_CHARS)}`;
+    const { read_url } = await buildTools({
+      web_search: () => ({ query: "q", results: [] }),
+      read_url: () => ({ content: "hi", url: overlong }),
+    });
+
+    const result = await read(read_url, { url: "https://example.com/page" });
+    expect(result.url).toBe("https://example.com/page");
+  });
+
+  it("truncates an oversized content_type", async () => {
+    const { read_url } = await buildTools({
+      web_search: () => ({ query: "q", results: [] }),
+      read_url: () => ({
+        content: "hi",
+        url: "https://example.com/page",
+        contentType: "x".repeat(MAX_CONTENT_TYPE_CHARS + 100),
+      }),
+    });
+
+    const result = await read(read_url, { url: "https://example.com/page" });
+    expect(result.content_type).toBe(`${"x".repeat(MAX_CONTENT_TYPE_CHARS)}…`);
+  });
+
+  it("warns when the backend's content is missing or the wrong type", async () => {
+    const { read_url } = await buildTools({
+      web_search: () => ({ query: "q", results: [] }),
+      read_url: () => ({ url: "https://example.com/page" }) as never,
+    });
+
+    const result = await read(read_url, { url: "https://example.com/page" });
+    expect(result.content).toBe("");
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "searx",
+        plugin: "@acme/searx",
+        url: "https://example.com/page",
+      }),
+      expect.stringContaining("returned no content"),
+    );
   });
 
   it("honours timeoutMs", async () => {

--- a/apps/backend/src/web-backends/index.test.ts
+++ b/apps/backend/src/web-backends/index.test.ts
@@ -11,8 +11,10 @@ import {
   isPresentableUrl,
   MAX_ANSWER_CHARS,
   MAX_READ_URL_CONTENT_CHARS,
+  MAX_SEARCH_RESULT_SCAN,
   MAX_SEARCH_RESULTS,
   MAX_SNIPPET_CHARS,
+  readUrlInputSchema,
   MAX_TITLE_CHARS,
   registerWebBackend,
   type ReadUrlToolResult,
@@ -261,12 +263,64 @@ describe("web_search — core-owned caps", () => {
     );
   });
 
+  it("stops scanning past MAX_SEARCH_RESULT_SCAN even when nothing is usable", async () => {
+    // Every entry is unpresentable, so the result cap never trips and only the
+    // scan bound stops the loop — otherwise core parses the whole array.
+    const { web_search } = await buildTools({
+      web_search: () => ({
+        query: "q",
+        results: Array.from(
+          { length: MAX_SEARCH_RESULT_SCAN + 25 },
+          (_v, i) => ({ title: `x${i}`, url: "javascript:alert(1)" }),
+        ),
+      }),
+    });
+
+    const result = await search(web_search, "q");
+    expect(result.results).toEqual([]);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ dropped: MAX_SEARCH_RESULT_SCAN }),
+      expect.stringContaining("not http(s)"),
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        returned: MAX_SEARCH_RESULT_SCAN + 25,
+        scanned: MAX_SEARCH_RESULT_SCAN,
+      }),
+      expect.stringContaining("more results than core will scan"),
+    );
+  });
+
   it("tolerates a malformed executor payload rather than throwing", async () => {
     const { web_search } = await buildTools({
       web_search: () => ({}) as never,
     });
 
     expect(await search(web_search, "q")).toEqual({ query: "q", results: [] });
+  });
+
+  it("keeps a usable entry whose sibling fields are the wrong type", async () => {
+    // The URL is the only field an entry is dropped over; a non-string title or
+    // snippet is narrowed away rather than coerced, so no `[object Object]` or
+    // stringified number reaches the model.
+    const { web_search } = await buildTools({
+      web_search: () =>
+        ({
+          query: "q",
+          results: [
+            {
+              title: { nested: true },
+              url: "https://example.com/a",
+              snippet: 42,
+            },
+          ],
+        }) as never,
+    });
+
+    const result = await search(web_search, "q");
+    expect(result.results).toEqual([
+      { title: "", url: "https://example.com/a" },
+    ]);
   });
 
   it("returns an error result (not a rejection) when the executor throws", async () => {
@@ -418,8 +472,14 @@ describe("read_url — egress guard, capping, slicing", () => {
     });
 
     // The slice covers the whole capped string, so there is nothing to continue
-    // to — but the cap did cut, so `truncated` still says so.
-    expect(result.content).toHaveLength(MAX_READ_URL_CONTENT_CHARS);
+    // to — but the cap did cut, so `truncated` says so and the content spells
+    // out why there is no continuation index to follow.
+    expect(
+      result.content.startsWith("x".repeat(MAX_READ_URL_CONTENT_CHARS)),
+    ).toBe(true);
+    expect(result.content).toContain(
+      `exceeded the ${MAX_READ_URL_CONTENT_CHARS}-character limit`,
+    );
     expect(result.truncated).toBe(true);
     expect(result).not.toHaveProperty("next_start_index");
     expect(mockLogger.warn).toHaveBeenCalledWith(
@@ -471,6 +531,85 @@ describe("read_url — egress guard, capping, slicing", () => {
     const result = await read(read_url, { url: "https://example.com/page" });
     expect(result.error).toBe(
       "The web backend could not complete this read_url request.",
+    );
+  });
+});
+
+describe("readUrlInputSchema — the fetchUrl-mirroring defaults", () => {
+  // `callTool` invokes `execute` directly, so the tests above never exercise the
+  // schema. ADR-0014 requires this input to mirror `fetchUrl` byte-for-byte, and
+  // the defaults are the half of that contract nothing else covers.
+  it("defaults max_length to 5000 and start_index to 0", () => {
+    expect(readUrlInputSchema.parse({ url: "https://example.com/" })).toEqual({
+      url: "https://example.com/",
+      max_length: 5_000,
+      start_index: 0,
+    });
+  });
+
+  it("rejects a non-URL, a zero max_length, and a negative start_index", () => {
+    expect(readUrlInputSchema.safeParse({ url: "not a url" }).success).toBe(
+      false,
+    );
+    expect(
+      readUrlInputSchema.safeParse({
+        url: "https://example.com/",
+        max_length: 0,
+      }).success,
+    ).toBe(false);
+    expect(
+      readUrlInputSchema.safeParse({
+        url: "https://example.com/",
+        start_index: -1,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("composeWebBackend — the contribution is not copied", () => {
+  it("calls createExecutors on the author's own object, so `this` survives", async () => {
+    // A class-instance contribution: `createExecutors` is a prototype method and
+    // reaches sibling state through `this`. Spreading the contribution into a
+    // copy would drop both.
+    class AcmeBackend {
+      backend = "searx";
+      name = "SearXNG";
+      hits = [{ title: "From this", url: "https://example.com/1" }];
+
+      createExecutors(): WebBackendExecutors {
+        return {
+          web_search: () => ({ query: "q", results: this.hits }),
+        };
+      }
+    }
+
+    const registration = composeWebBackend({
+      contribution: new AcmeBackend(),
+      // The loader's namespaced id rides alongside, not over, the contribution.
+      backend: "acme.searx",
+      pluginName: "@acme/searx",
+    });
+
+    expect(registration.backend).toBe("acme.searx");
+
+    const { web_search } = await registration.buildTurnTools(CTX);
+    const result = await search(web_search, "q");
+    expect(result.results).toEqual([
+      { title: "From this", url: "https://example.com/1" },
+    ]);
+  });
+
+  it("binds web_search to the executor object so a method executor keeps `this`", async () => {
+    const executors = {
+      answer: "from the executor object",
+      web_search(this: { answer: string }) {
+        return { query: "q", results: [], answer: this.answer };
+      },
+    };
+
+    const { web_search } = await buildTools(executors);
+    expect((await search(web_search, "q")).answer).toBe(
+      "from the executor object",
     );
   });
 });

--- a/apps/backend/src/web-backends/index.test.ts
+++ b/apps/backend/src/web-backends/index.test.ts
@@ -293,7 +293,7 @@ describe("web_search — core-owned caps", () => {
     expect(await search(web_search, "q")).not.toHaveProperty("answer");
   });
 
-  it("drops results whose URL is not http(s) and warns once", async () => {
+  it("drops results whose URL is not http(s) and logs the count once", async () => {
     const { web_search } = await buildTools({
       web_search: () => ({
         query: "q",
@@ -310,19 +310,27 @@ describe("web_search — core-owned caps", () => {
     expect(result.results).toEqual([
       { title: "Good", url: "https://example.com/ok" },
     ]);
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      { backend: "searx", plugin: "@acme/searx", dropped: 3 },
-      expect.stringContaining("not http(s)"),
+    // `debug`, not `warn`: expected steady state for an upstream that mixes in
+    // unusable results, and the line is per-call and model-triggerable.
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      {
+        backend: "searx",
+        plugin: "@acme/searx",
+        droppedScheme: 3,
+        droppedLength: 0,
+      },
+      expect.stringContaining("unusable URL"),
     );
   });
 
-  it("drops a result URL that exceeds MAX_URL_CHARS", async () => {
+  it("drops a result URL that exceeds MAX_URL_CHARS, counted apart from a bad scheme", async () => {
     const overlong = `https://example.com/${"x".repeat(MAX_URL_CHARS)}`;
     const { web_search } = await buildTools({
       web_search: () => ({
         query: "q",
         results: [
           { title: "Too long", url: overlong },
+          { title: "XSS", url: "javascript:alert(1)" },
           { title: "Good", url: "https://example.com/ok" },
         ],
       }),
@@ -332,9 +340,16 @@ describe("web_search — core-owned caps", () => {
     expect(result.results).toEqual([
       { title: "Good", url: "https://example.com/ok" },
     ]);
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      { backend: "searx", plugin: "@acme/searx", dropped: 1 },
-      expect.stringContaining("not http(s)"),
+    // The two reasons are separately attributed: an unusable scheme is a backend
+    // bug, an over-length URL is routine noise from some upstreams.
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      {
+        backend: "searx",
+        plugin: "@acme/searx",
+        droppedScheme: 1,
+        droppedLength: 1,
+      },
+      expect.stringContaining("unusable URL"),
     );
   });
 
@@ -375,9 +390,9 @@ describe("web_search — core-owned caps", () => {
 
     const result = await search(web_search, "q");
     expect(result.results).toEqual([]);
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ dropped: MAX_SEARCH_RESULT_SCAN }),
-      expect.stringContaining("not http(s)"),
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ droppedScheme: MAX_SEARCH_RESULT_SCAN }),
+      expect.stringContaining("unusable URL"),
     );
     expect(mockLogger.warn).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -610,7 +625,7 @@ describe("read_url — egress guard, capping, slicing", () => {
     expect(result.url).toBe("https://example.com/page");
   });
 
-  it("truncates an oversized content_type", async () => {
+  it("shortens an oversized content_type without a truncation marker", async () => {
     const { read_url } = await buildTools({
       web_search: () => ({ query: "q", results: [] }),
       read_url: () => ({
@@ -621,7 +636,10 @@ describe("read_url — egress guard, capping, slicing", () => {
     });
 
     const result = await read(read_url, { url: "https://example.com/page" });
-    expect(result.content_type).toBe(`${"x".repeat(MAX_CONTENT_TYPE_CHARS)}…`);
+    // Sliced bare: `truncate`'s `…` marker would leave an invalid MIME type in a
+    // machine-readable field, unlike a snippet a model reads.
+    expect(result.content_type).toBe("x".repeat(MAX_CONTENT_TYPE_CHARS));
+    expect(result.content_type).not.toContain("…");
   });
 
   it("warns when the backend's content is missing or the wrong type", async () => {
@@ -701,6 +719,34 @@ describe("readUrlInputSchema — the fetchUrl-mirroring defaults", () => {
       readUrlInputSchema.safeParse({
         url: "https://example.com/",
         start_index: -1,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("caps url at MAX_URL_CHARS, so the read_url fallback cannot exceed the cap", () => {
+    // `result.url` falls back to this input when the backend's resolved URL is
+    // over-length, so capping it here is what makes MAX_URL_CHARS an invariant on
+    // that field rather than a bound on one of its two sources.
+    const overlong = `https://example.com/${"x".repeat(MAX_URL_CHARS)}`;
+    expect(readUrlInputSchema.safeParse({ url: overlong }).success).toBe(false);
+    expect(
+      readUrlInputSchema.safeParse({ url: "https://example.com/ok" }).success,
+    ).toBe(true);
+  });
+
+  it("caps max_length at MAX_READ_URL_CONTENT_CHARS", () => {
+    // The schema references the constant directly now, so this asserts the bound
+    // rather than a hand-copied number that could drift from it.
+    expect(
+      readUrlInputSchema.safeParse({
+        url: "https://example.com/",
+        max_length: MAX_READ_URL_CONTENT_CHARS,
+      }).success,
+    ).toBe(true);
+    expect(
+      readUrlInputSchema.safeParse({
+        url: "https://example.com/",
+        max_length: MAX_READ_URL_CONTENT_CHARS + 1,
       }).success,
     ).toBe(false);
   });

--- a/apps/backend/src/web-backends/index.test.ts
+++ b/apps/backend/src/web-backends/index.test.ts
@@ -1,0 +1,492 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Tool } from "ai";
+import { callTool } from "../test-utils.ts";
+import { EGRESS_BLOCKED_MESSAGE } from "../utils/egress-guard.ts";
+import { logger } from "../logger.ts";
+import {
+  clearWebBackends,
+  composeWebBackend,
+  getWebBackend,
+  getWebBackends,
+  isPresentableUrl,
+  MAX_ANSWER_CHARS,
+  MAX_READ_URL_CONTENT_CHARS,
+  MAX_SEARCH_RESULTS,
+  MAX_SNIPPET_CHARS,
+  MAX_TITLE_CHARS,
+  registerWebBackend,
+  type ReadUrlToolResult,
+  type WebBackendContribution,
+  type WebBackendExecutors,
+  type WebSearchToolResult,
+  type WebToolError,
+} from "./index.ts";
+
+vi.mock("../logger.ts", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockLogger = vi.mocked(logger);
+
+const CTX = { orgId: "org-1", workspaceId: "ws-1", userId: "user-1" };
+
+// A public address for the injected resolver, so the real egress guard stays in
+// the path (these tests assert core's guarding, not DNS).
+const resolvePublic = () => Promise.resolve(["93.184.216.34"]);
+
+const contribution = (
+  executors: Partial<WebBackendExecutors>,
+  overrides: Partial<WebBackendContribution> = {},
+): WebBackendContribution => ({
+  backend: "searx",
+  name: "SearXNG",
+  createExecutors: () => executors as WebBackendExecutors,
+  ...overrides,
+});
+
+const buildTools = (
+  executors: Partial<WebBackendExecutors>,
+  overrides: Partial<WebBackendContribution> = {},
+): Promise<Record<string, Tool>> =>
+  composeWebBackend({
+    contribution: contribution(executors, overrides),
+    pluginName: "@acme/searx",
+    resolveHostname: resolvePublic,
+  }).buildTurnTools(CTX);
+
+const search = (tool: Tool, query: string) =>
+  callTool(tool, { query }) as Promise<WebSearchToolResult & WebToolError>;
+
+const read = (
+  tool: Tool,
+  input: { url: string; max_length?: number; start_index?: number },
+) =>
+  callTool(tool, {
+    max_length: 5_000,
+    start_index: 0,
+    ...input,
+  }) as Promise<ReadUrlToolResult & WebToolError>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearWebBackends();
+});
+
+describe("web-backend registry", () => {
+  const registration = (backend: string) =>
+    composeWebBackend({
+      contribution: contribution(
+        { web_search: () => ({ query: "", results: [] }) },
+        { backend },
+      ),
+      pluginName: "@acme/searx",
+    });
+
+  it("registers a backend and serves it by its discriminator", () => {
+    registerWebBackend(registration("searx"));
+
+    const found = getWebBackend("searx");
+    expect(found?.backend).toBe("searx");
+    expect(found?.name).toBe("SearXNG");
+    expect(typeof found?.buildTurnTools).toBe("function");
+  });
+
+  it("lists every registered backend", () => {
+    registerWebBackend(registration("searx"));
+    registerWebBackend(registration("brave"));
+
+    expect(getWebBackends().map((r) => r.backend)).toEqual(["searx", "brave"]);
+  });
+
+  it("returns undefined for an unregistered discriminator", () => {
+    expect(getWebBackend("nope")).toBeUndefined();
+  });
+
+  it("throws on a duplicate registration", () => {
+    registerWebBackend(registration("searx"));
+    expect(() => registerWebBackend(registration("searx"))).toThrow(
+      /'searx' has already been registered/,
+    );
+  });
+});
+
+describe("composeWebBackend — tool construction", () => {
+  it("builds only web_search when the backend supplies no read_url", async () => {
+    const tools = await buildTools({
+      web_search: () => ({ query: "q", results: [] }),
+    });
+
+    expect(Object.keys(tools)).toEqual(["web_search"]);
+  });
+
+  it("builds both tools when the backend supplies read_url", async () => {
+    const tools = await buildTools({
+      web_search: () => ({ query: "q", results: [] }),
+      read_url: () => ({ content: "", url: "https://example.com/" }),
+    });
+
+    expect(Object.keys(tools).sort()).toEqual(["read_url", "web_search"]);
+  });
+
+  it("passes the turn context and the plugin config block into createExecutors", async () => {
+    const createExecutors = vi.fn(() => ({
+      web_search: () => ({ query: "q", results: [] }),
+    }));
+    const plugin = { config: { region: "eu" }, credentials: { apiKey: "k" } };
+
+    await composeWebBackend({
+      contribution: contribution({}, { createExecutors }),
+      plugin,
+      pluginName: "@acme/searx",
+    }).buildTurnTools(CTX);
+
+    expect(createExecutors).toHaveBeenCalledWith(CTX, plugin);
+  });
+
+  it("serves no tools (and warns) when the executor object has no web_search", async () => {
+    // The TS type forbids this, but a third-party JS plugin can still return it:
+    // boot is fail-loud, turn-time resolution degrades gracefully.
+    const tools = await buildTools({});
+
+    expect(tools).toEqual({});
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      { plugin: "@acme/searx", backend: "searx" },
+      expect.stringContaining("no web_search executor"),
+    );
+  });
+});
+
+describe("web_search — core-owned caps", () => {
+  const hit = (n: number) => ({
+    title: `Result ${n}`,
+    url: `https://example.com/${n}`,
+    snippet: `Snippet ${n}`,
+  });
+
+  it("echoes the model's query and passes results through", async () => {
+    const { web_search } = await buildTools({
+      web_search: () => ({ query: "backend rewrote this", results: [hit(1)] }),
+    });
+
+    const result = await search(web_search, "original query");
+    expect(result.query).toBe("original query");
+    expect(result.results).toEqual([
+      {
+        title: "Result 1",
+        url: "https://example.com/1",
+        snippet: "Snippet 1",
+      },
+    ]);
+  });
+
+  it("slices results to MAX_SEARCH_RESULTS", async () => {
+    const { web_search } = await buildTools({
+      web_search: () => ({
+        query: "q",
+        results: Array.from({ length: MAX_SEARCH_RESULTS + 5 }, (_v, i) =>
+          hit(i),
+        ),
+      }),
+    });
+
+    const result = await search(web_search, "q");
+    expect(result.results).toHaveLength(MAX_SEARCH_RESULTS);
+  });
+
+  it("truncates title and snippet", async () => {
+    const { web_search } = await buildTools({
+      web_search: () => ({
+        query: "q",
+        results: [
+          {
+            title: "t".repeat(MAX_TITLE_CHARS + 50),
+            url: "https://example.com/",
+            snippet: "s".repeat(MAX_SNIPPET_CHARS + 50),
+          },
+        ],
+      }),
+    });
+
+    const [only] = (await search(web_search, "q")).results;
+    expect(only.title).toBe(`${"t".repeat(MAX_TITLE_CHARS)}…`);
+    expect(only.snippet).toBe(`${"s".repeat(MAX_SNIPPET_CHARS)}…`);
+  });
+
+  it("truncates the answer box — free upstream text is not passed through unbounded", async () => {
+    const { web_search } = await buildTools({
+      web_search: () => ({
+        query: "q",
+        results: [],
+        answer: "a".repeat(MAX_ANSWER_CHARS + 500),
+      }),
+    });
+
+    const result = await search(web_search, "q");
+    expect(result.answer).toBe(`${"a".repeat(MAX_ANSWER_CHARS)}…`);
+  });
+
+  it("omits answer entirely when the backend supplies none", async () => {
+    const { web_search } = await buildTools({
+      web_search: () => ({ query: "q", results: [] }),
+    });
+
+    expect(await search(web_search, "q")).not.toHaveProperty("answer");
+  });
+
+  it("drops results whose URL is not http(s) and warns once", async () => {
+    const { web_search } = await buildTools({
+      web_search: () => ({
+        query: "q",
+        results: [
+          { title: "XSS", url: "javascript:alert(1)" },
+          { title: "Data", url: "data:text/html,<script>" },
+          { title: "Junk", url: "not a url" },
+          { title: "Good", url: "https://example.com/ok" },
+        ],
+      }),
+    });
+
+    const result = await search(web_search, "q");
+    expect(result.results).toEqual([
+      { title: "Good", url: "https://example.com/ok" },
+    ]);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      { backend: "searx", plugin: "@acme/searx", dropped: 3 },
+      expect.stringContaining("not http(s)"),
+    );
+  });
+
+  it("tolerates a malformed executor payload rather than throwing", async () => {
+    const { web_search } = await buildTools({
+      web_search: () => ({}) as never,
+    });
+
+    expect(await search(web_search, "q")).toEqual({ query: "q", results: [] });
+  });
+
+  it("returns an error result (not a rejection) when the executor throws", async () => {
+    const { web_search } = await buildTools({
+      web_search: () => {
+        throw new Error("upstream 500 for https://api.example.com/?key=secret");
+      },
+    });
+
+    const result = await search(web_search, "q");
+    // The cause is logged, never handed to the model: a backend's error text
+    // routinely embeds a credentialed upstream URL.
+    expect(result.error).toBe(
+      "The web backend could not complete this web_search request.",
+    );
+    expect(result.error).not.toContain("secret");
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "searx",
+        plugin: "@acme/searx",
+        tool: "web_search",
+        outcome: "error",
+      }),
+      expect.any(String),
+    );
+  });
+
+  it("times out a hanging executor and reports the timeout", async () => {
+    const { web_search } = await buildTools(
+      {
+        web_search: () =>
+          new Promise(() => {
+            /* never settles */
+          }),
+      },
+      { timeoutMs: 20 },
+    );
+
+    const result = await search(web_search, "q");
+    expect(result.error).toBe(
+      "The web backend did not respond within 20ms (web_search).",
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: "web_search", outcome: "timeout" }),
+      expect.any(String),
+    );
+  });
+
+  it("logs one debug line per successful call, without the query", async () => {
+    const { web_search } = await buildTools({
+      web_search: () => ({ query: "q", results: [] }),
+    });
+
+    await search(web_search, "secret internal term");
+
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "searx",
+        plugin: "@acme/searx",
+        tool: "web_search",
+        outcome: "ok",
+        durationMs: expect.any(Number) as unknown,
+      }),
+      "Web backend executor call",
+    );
+    // The query itself is user content: debug only, never on the outcome line.
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("read_url — egress guard, capping, slicing", () => {
+  const page = (content: string, url = "https://example.com/page") => ({
+    web_search: () => ({ query: "q", results: [] }),
+    read_url: () => ({ content, url, contentType: "text/markdown" }),
+  });
+
+  it("blocks a model-supplied URL that resolves into a denied range", async () => {
+    const read_url_executor = vi.fn(() => ({
+      content: "internal",
+      url: "http://169.254.169.254/latest/meta-data",
+    }));
+    const { read_url } = await buildTools({
+      web_search: () => ({ query: "q", results: [] }),
+      read_url: read_url_executor,
+    });
+
+    const result = await read(read_url, {
+      url: "http://169.254.169.254/latest/meta-data",
+    });
+
+    expect(result.error).toBe(EGRESS_BLOCKED_MESSAGE);
+    expect(read_url_executor).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: "read_url", outcome: "blocked" }),
+      expect.any(String),
+    );
+  });
+
+  it("returns the post-redirect URL and content type on an allowed read", async () => {
+    const { read_url } = await buildTools(
+      page("Hello", "https://example.com/final"),
+    );
+
+    const result = await read(read_url, { url: "https://example.com/start" });
+    expect(result.content).toBe("Hello");
+    expect(result.url).toBe("https://example.com/final");
+    expect(result.content_type).toBe("text/markdown");
+    expect(result.truncated).toBe(false);
+    expect(result).not.toHaveProperty("next_start_index");
+  });
+
+  it("slices by max_length and emits the fetchUrl continuation hint", async () => {
+    const { read_url } = await buildTools(page("abcdefghij"));
+
+    const result = await read(read_url, {
+      url: "https://example.com/page",
+      max_length: 4,
+      start_index: 0,
+    });
+
+    expect(result.content).toBe(
+      "abcd\n\n[Content truncated. Pass start_index=4 to continue reading.]",
+    );
+    expect(result.truncated).toBe(true);
+    expect(result.next_start_index).toBe(4);
+  });
+
+  it("serves a continuation read from start_index", async () => {
+    const { read_url } = await buildTools(page("abcdefghij"));
+
+    const result = await read(read_url, {
+      url: "https://example.com/page",
+      max_length: 6,
+      start_index: 4,
+    });
+
+    expect(result.content).toBe("efghij");
+    expect(result.truncated).toBe(false);
+  });
+
+  it("caps content at MAX_READ_URL_CONTENT_CHARS before slicing, and warns", async () => {
+    const oversized = "x".repeat(MAX_READ_URL_CONTENT_CHARS + 100);
+    const { read_url } = await buildTools(page(oversized));
+
+    const result = await read(read_url, {
+      url: "https://example.com/page",
+      max_length: MAX_READ_URL_CONTENT_CHARS,
+      start_index: 0,
+    });
+
+    // The slice covers the whole capped string, so there is nothing to continue
+    // to — but the cap did cut, so `truncated` still says so.
+    expect(result.content).toHaveLength(MAX_READ_URL_CONTENT_CHARS);
+    expect(result.truncated).toBe(true);
+    expect(result).not.toHaveProperty("next_start_index");
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backend: "searx",
+        url: "https://example.com/page",
+        length: oversized.length,
+      }),
+      expect.stringContaining("exceeded the core cap"),
+    );
+  });
+
+  it("falls back to the requested URL when the backend returns an unusable one", async () => {
+    const { read_url } = await buildTools({
+      web_search: () => ({ query: "q", results: [] }),
+      read_url: () => ({ content: "hi", url: "javascript:alert(1)" }),
+    });
+
+    const result = await read(read_url, { url: "https://example.com/page" });
+    expect(result.url).toBe("https://example.com/page");
+  });
+
+  it("honours timeoutMs", async () => {
+    const { read_url } = await buildTools(
+      {
+        web_search: () => ({ query: "q", results: [] }),
+        read_url: () =>
+          new Promise(() => {
+            /* never settles */
+          }),
+      },
+      { timeoutMs: 20 },
+    );
+
+    const result = await read(read_url, { url: "https://example.com/page" });
+    expect(result.error).toBe(
+      "The web backend did not respond within 20ms (read_url).",
+    );
+  });
+
+  it("returns an error result (not a rejection) when the executor throws", async () => {
+    const { read_url } = await buildTools({
+      web_search: () => ({ query: "q", results: [] }),
+      read_url: () => {
+        throw new Error("browser service crashed");
+      },
+    });
+
+    const result = await read(read_url, { url: "https://example.com/page" });
+    expect(result.error).toBe(
+      "The web backend could not complete this read_url request.",
+    );
+  });
+});
+
+describe("isPresentableUrl", () => {
+  it("accepts http and https only", () => {
+    expect(isPresentableUrl("http://example.com/")).toBe(true);
+    expect(isPresentableUrl("https://example.com/")).toBe(true);
+  });
+
+  it("rejects other schemes, non-URLs, and non-strings", () => {
+    expect(isPresentableUrl("javascript:alert(1)")).toBe(false);
+    expect(isPresentableUrl("data:text/html,<script>")).toBe(false);
+    expect(isPresentableUrl("file:///etc/passwd")).toBe(false);
+    expect(isPresentableUrl("not a url")).toBe(false);
+    expect(isPresentableUrl(undefined)).toBe(false);
+    expect(isPresentableUrl(42)).toBe(false);
+  });
+});

--- a/apps/backend/src/web-backends/index.ts
+++ b/apps/backend/src/web-backends/index.ts
@@ -22,6 +22,12 @@ import {
 export const MAX_SEARCH_RESULTS = 10;
 export const MAX_SNIPPET_CHARS = 500;
 export const MAX_TITLE_CHARS = 200;
+// How many raw entries core will look at to fill those 10 slots. The cap alone
+// does not bound the work: entries with an unusable URL are dropped and skipped
+// over, so an executor returning a million `javascript:` hits would otherwise
+// have core parse a million URLs. Ten times the yield is ample slack for a
+// backend whose upstream mixes in results core cannot present.
+export const MAX_SEARCH_RESULT_SCAN = MAX_SEARCH_RESULTS * 10;
 // `answer` is free text from an upstream answer box (Brave, Tavily), so it is
 // capped like every other string a backend supplies. 10 results × 500 chars plus
 // a 4k answer is ~9k characters worst case — comparable to native search output.
@@ -79,6 +85,15 @@ export const clearWebBackends = (): void => {
 // model can tell a truncated snippet from a naturally short one.
 const truncate = (value: string, max: number): string =>
   value.length > max ? `${value.slice(0, max)}…` : value;
+
+// Everything an executor resolves is read through this, so the wrapper treats a
+// backend's payload as `unknown` and narrows field by field. The SDK types say
+// what a well-behaved backend returns; a third-party JS plugin is under no
+// obligation to honour them, and core must not fall over on the difference.
+const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : {};
 
 /**
  * Whether a URL may be presented to the model (and, in the frontend, rendered as
@@ -145,8 +160,20 @@ const failureMessage = (toolName: string): string =>
   `The web backend could not complete this ${toolName} request.`;
 
 export interface ComposeWebBackendOptions {
-  /** The contribution, with its id already namespaced by the loader. */
+  /**
+   * The contribution exactly as its author wrote it. Passed through untouched —
+   * never spread into a copy — so `createExecutors` is invoked with the author's
+   * own object as its receiver and a class-instance contribution keeps both its
+   * prototype methods and its `this`. The namespaced id rides {@link backend}
+   * instead, which is why this stays the original reference.
+   */
   contribution: WebBackendContribution;
+  /**
+   * The loader's namespaced discriminator, overriding `contribution.backend`.
+   * Omitted outside the loader (tests, core registrations), where the
+   * contribution's own bare id is already the effective one.
+   */
+  backend?: string;
   /** The plugin's boot-resolved deploy-time config/credentials (ADR-0013). */
   plugin?: PluginConfigContext;
   /** Owning plugin's manifest name, for attribution in every log line. */
@@ -172,13 +199,16 @@ export const composeWebBackend = (
   options: ComposeWebBackendOptions,
 ): WebBackendRegistration => {
   const { contribution, plugin, pluginName, resolveHostname } = options;
-  const backend = contribution.backend;
+  const backend = options.backend ?? contribution.backend;
   const timeoutMs = contribution.timeoutMs ?? DEFAULT_WEB_TIMEOUT_MS;
 
   // One line per executor call (ADR-0014 observability). `debug` when it worked,
   // `warn` when it did not, cause attached on failure. Queries and URLs are user
-  // content and can carry sensitive terms, so they never reach this line — they
-  // are logged separately at `debug`.
+  // content and can carry sensitive terms, so they never reach *this* line; the
+  // model's query appears only on the `debug` line below. A model-supplied URL
+  // does reach `warn` on the two paths that cannot be diagnosed without it — an
+  // egress block and a content-cap hit — which is what D3 and the egress-guard
+  // contract call for.
   const logCall = (
     toolName: string,
     outcome: "ok" | "timeout" | "blocked" | "error",
@@ -199,7 +229,9 @@ export const composeWebBackend = (
     }
   };
 
-  const buildSearchTool = (executors: WebBackendExecutors): Tool =>
+  const buildSearchTool = (
+    webSearch: WebBackendExecutors["web_search"],
+  ): Tool =>
     tool({
       description: WEB_SEARCH_DESCRIPTION,
       inputSchema: webSearchInputSchema,
@@ -212,12 +244,9 @@ export const composeWebBackend = (
           "web_search query",
         );
 
-        let raw;
+        let raw: unknown;
         try {
-          raw = await withTimeout(
-            () => executors.web_search({ query }),
-            timeoutMs,
-          );
+          raw = await withTimeout(() => webSearch({ query }), timeoutMs);
         } catch (cause) {
           const timedOut = cause instanceof WebBackendTimeoutError;
           logCall(
@@ -233,16 +262,29 @@ export const composeWebBackend = (
           };
         }
 
+        const payload = asRecord(raw);
+        const entries: readonly unknown[] = Array.isArray(payload.results)
+          ? payload.results
+          : [];
+
         const results: WebSearchToolResult["results"] = [];
         let dropped = 0;
-        for (const entry of Array.isArray(raw?.results) ? raw.results : []) {
+        // Bounded on both ends: `MAX_SEARCH_RESULTS` on what is kept, and
+        // `MAX_SEARCH_RESULT_SCAN` on what is even looked at, so a pathological
+        // result array cannot spend core's CPU parsing URLs it will discard.
+        const scanned = entries.slice(0, MAX_SEARCH_RESULT_SCAN);
+        for (const candidate of scanned) {
           if (results.length >= MAX_SEARCH_RESULTS) break;
-          if (!isPresentableUrl(entry?.url)) {
+          const entry = asRecord(candidate);
+          if (!isPresentableUrl(entry.url)) {
             dropped += 1;
             continue;
           }
           const hit: WebSearchToolResult["results"][number] = {
-            title: truncate(String(entry.title ?? ""), MAX_TITLE_CHARS),
+            title: truncate(
+              typeof entry.title === "string" ? entry.title : "",
+              MAX_TITLE_CHARS,
+            ),
             url: entry.url,
           };
           if (typeof entry.snippet === "string") {
@@ -256,12 +298,23 @@ export const composeWebBackend = (
             "Dropped web_search results whose URL was not http(s)",
           );
         }
+        if (entries.length > scanned.length) {
+          logger.warn(
+            {
+              backend,
+              plugin: pluginName,
+              returned: entries.length,
+              scanned: scanned.length,
+            },
+            "Web backend returned more results than core will scan; the tail was ignored",
+          );
+        }
 
         // `query` is echoed from the model's own input, never from the executor:
         // core owns this shape, so a backend cannot substitute text here.
         const result: WebSearchToolResult = { query, results };
-        if (typeof raw?.answer === "string") {
-          result.answer = truncate(raw.answer, MAX_ANSWER_CHARS);
+        if (typeof payload.answer === "string") {
+          result.answer = truncate(payload.answer, MAX_ANSWER_CHARS);
         }
 
         logCall("web_search", "ok", startedAt);
@@ -295,7 +348,7 @@ export const composeWebBackend = (
           return { error: EGRESS_BLOCKED_MESSAGE };
         }
 
-        let raw;
+        let raw: unknown;
         try {
           raw = await withTimeout(() => readUrl({ url }), timeoutMs);
         } catch (cause) {
@@ -310,7 +363,8 @@ export const composeWebBackend = (
 
         // Cap first, then slice within the capped string: the cap bounds what core
         // ever holds, the slice serves this page of it.
-        const full = typeof raw?.content === "string" ? raw.content : "";
+        const payload = asRecord(raw);
+        const full = typeof payload.content === "string" ? payload.content : "";
         const capped = full.length > MAX_READ_URL_CONTENT_CHARS;
         if (capped) {
           logger.warn(
@@ -326,15 +380,23 @@ export const composeWebBackend = (
         const hasMore = start_index + max_length < content.length;
         const next_start_index = start_index + max_length;
 
+        // Same hint text as `fetchUrl`, so a continuation read reads identically
+        // whichever page-reader the model reached for. At the tail of a capped
+        // page there is nothing to continue *to*, and `truncated: true` with no
+        // `next_start_index` would read as an unexplained dead end — so the cut
+        // is spelled out instead of left for the model to infer.
+        let body = slice;
+        if (hasMore) {
+          body += `\n\n[Content truncated. Pass start_index=${next_start_index} to continue reading.]`;
+        } else if (capped) {
+          body += `\n\n[Content truncated: the page exceeded the ${MAX_READ_URL_CONTENT_CHARS}-character limit and the remainder cannot be read.]`;
+        }
+
         const result: ReadUrlToolResult = {
-          // Same hint text as `fetchUrl`, so a continuation read reads identically
-          // whichever page-reader the model reached for.
-          content: hasMore
-            ? `${slice}\n\n[Content truncated. Pass start_index=${next_start_index} to continue reading.]`
-            : slice,
-          url: isPresentableUrl(raw?.url) ? raw.url : url,
+          content: body,
+          url: isPresentableUrl(payload.url) ? payload.url : url,
           content_type:
-            typeof raw?.contentType === "string" ? raw.contentType : "",
+            typeof payload.contentType === "string" ? payload.contentType : "",
           // True when *anything* was cut — the core cap or this slice.
           truncated: hasMore || capped,
         };
@@ -365,8 +427,10 @@ export const composeWebBackend = (
         return {};
       }
 
+      // Both executors are bound to the object that supplied them, so a backend
+      // may write them as methods reaching sibling state through `this`.
       const tools: Record<string, Tool> = {
-        web_search: buildSearchTool(executors),
+        web_search: buildSearchTool(executors.web_search.bind(executors)),
       };
       if (typeof executors.read_url === "function") {
         tools.read_url = buildReadUrlTool(executors.read_url.bind(executors));

--- a/apps/backend/src/web-backends/index.ts
+++ b/apps/backend/src/web-backends/index.ts
@@ -32,6 +32,13 @@ export const MAX_SEARCH_RESULT_SCAN = MAX_SEARCH_RESULTS * 10;
 // capped like every other string a backend supplies. 10 results × 500 chars plus
 // a 4k answer is ~9k characters worst case — comparable to native search output.
 export const MAX_ANSWER_CHARS = 4_000;
+// A result/read URL is capped like every other backend-supplied string. Unlike
+// title/snippet/content_type, an over-length URL is *dropped* rather than
+// truncated: a cut URL is a broken link, worse than no link at all. 2048 is
+// generous relative to common browser/server URL-length limits.
+export const MAX_URL_CHARS = 2_048;
+// `content_type` is metadata, not a link, so truncation (not dropping) is fine.
+export const MAX_CONTENT_TYPE_CHARS = 200;
 // Mirrors sandbox MAX_READ_BYTES. Accepted limit, stated rather than implied: the
 // executor hands core an already-materialised string, so this bounds *context and
 // CPU*, not backend memory — a backend that buffers a 500 MB response does so
@@ -53,8 +60,15 @@ const READ_URL_DESCRIPTION =
   "Read the contents of a web page as text. Supports pagination for large pages via start_index.";
 
 // The registry, mirroring `sandbox/index.ts`: a flat map keyed by the
-// discriminator stored in `provider.webBackend`.
-const WEB_BACKEND_REGISTRY: Record<string, WebBackendRegistration> = {};
+// discriminator stored in `provider.webBackend`. `Object.create(null)` — not
+// `{}` — so a discriminator that collides with an `Object.prototype` member
+// (`"toString"`, `"constructor"`…) cannot false-hit `in` or shadow a real
+// registration; PR2 feeds this from a nullable DB column, so an unguarded
+// object would let a stale value throw mid-turn instead of degrading cleanly.
+const WEB_BACKEND_REGISTRY = Object.create(null) as Record<
+  string,
+  WebBackendRegistration
+>;
 
 export const registerWebBackend = (
   registration: WebBackendRegistration,
@@ -74,7 +88,14 @@ export const getWebBackend = (
 export const getWebBackends = (): ReadonlyArray<WebBackendRegistration> =>
   Object.values(WEB_BACKEND_REGISTRY);
 
-/** Test-only reset. Boot registers once; nothing in production unregisters. */
+/**
+ * Test-only reset. Boot registers once; nothing in production unregisters.
+ * `sandbox/index.test.ts` has no equivalent — it sidesteps the same
+ * module-level-state problem by giving every test a unique backend id instead.
+ * This module resets explicitly so most tests can reuse the same discriminator
+ * (`"searx"`), which reads closer to a real registration than a fresh id per
+ * `it()` would.
+ */
 export const clearWebBackends = (): void => {
   for (const key of Object.keys(WEB_BACKEND_REGISTRY)) {
     delete WEB_BACKEND_REGISTRY[key];
@@ -276,7 +297,13 @@ export const composeWebBackend = (
         for (const candidate of scanned) {
           if (results.length >= MAX_SEARCH_RESULTS) break;
           const entry = asRecord(candidate);
-          if (!isPresentableUrl(entry.url)) {
+          // A URL that fails the scheme check, or one so long it would blow the
+          // context/DOM budget the other caps exist to hold, is unusable either
+          // way — dropped, not truncated, since a cut URL is a broken link.
+          if (
+            !isPresentableUrl(entry.url) ||
+            entry.url.length > MAX_URL_CHARS
+          ) {
             dropped += 1;
             continue;
           }
@@ -295,10 +322,18 @@ export const composeWebBackend = (
         if (dropped > 0) {
           logger.warn(
             { backend, plugin: pluginName, dropped },
-            "Dropped web_search results whose URL was not http(s)",
+            "Dropped web_search results whose URL was not http(s) or exceeded MAX_URL_CHARS",
           );
         }
-        if (entries.length > scanned.length) {
+        // Only the *scan* bound warrants this warning: if the result cap already
+        // filled every slot (the `break` above), the unscanned tail was never
+        // needed and nothing was lost to `MAX_SEARCH_RESULT_SCAN`. Warn only when
+        // a slot was still open and there was more the scan bound kept us from
+        // looking at.
+        if (
+          results.length < MAX_SEARCH_RESULTS &&
+          entries.length > scanned.length
+        ) {
           logger.warn(
             {
               backend,
@@ -364,6 +399,15 @@ export const composeWebBackend = (
         // Cap first, then slice within the capped string: the cap bounds what core
         // ever holds, the slice serves this page of it.
         const payload = asRecord(raw);
+        if (typeof payload.content !== "string") {
+          // Every other narrowing path here warns; this one didn't, so a
+          // malformed payload previously read as a silent, successful empty
+          // page — indistinguishable from a page that is genuinely empty.
+          logger.warn(
+            { backend, plugin: pluginName, url },
+            "Web backend read_url returned no content",
+          );
+        }
         const full = typeof payload.content === "string" ? payload.content : "";
         const capped = full.length > MAX_READ_URL_CONTENT_CHARS;
         if (capped) {
@@ -392,11 +436,21 @@ export const composeWebBackend = (
           body += `\n\n[Content truncated: the page exceeded the ${MAX_READ_URL_CONTENT_CHARS}-character limit and the remainder cannot be read.]`;
         }
 
+        // Same drop-not-truncate treatment as a search result URL (D5): an
+        // over-length resolved URL falls back to the model-supplied one rather
+        // than being cut into a broken link.
+        const resolvedUrl =
+          isPresentableUrl(payload.url) && payload.url.length <= MAX_URL_CHARS
+            ? payload.url
+            : url;
+
         const result: ReadUrlToolResult = {
           content: body,
-          url: isPresentableUrl(payload.url) ? payload.url : url,
+          url: resolvedUrl,
           content_type:
-            typeof payload.contentType === "string" ? payload.contentType : "",
+            typeof payload.contentType === "string"
+              ? truncate(payload.contentType, MAX_CONTENT_TYPE_CHARS)
+              : "",
           // True when *anything* was cut — the core cap or this slice.
           truncated: hasMore || capped,
         };
@@ -413,7 +467,27 @@ export const composeWebBackend = (
     backend,
     name: contribution.name,
     buildTurnTools: async (ctx: WebBackendContext) => {
-      const executors = await contribution.createExecutors(ctx, plugin);
+      // A factory that throws or hangs must degrade exactly like the
+      // missing-`web_search` case below, not reject/pin the turn: ADR-0014's
+      // "runtime resolution graceful" and the timeout's "a backend cannot pin a
+      // turn open" both apply to the factory call, not just the executors it
+      // returns.
+      let executors: WebBackendExecutors | undefined;
+      try {
+        executors = await withTimeout(
+          () => contribution.createExecutors(ctx, plugin),
+          timeoutMs,
+        );
+      } catch (cause) {
+        const timedOut = cause instanceof WebBackendTimeoutError;
+        logger.warn(
+          { plugin: pluginName, backend, cause },
+          timedOut
+            ? "Web backend's createExecutors timed out; serving no tools this turn"
+            : "Web backend's createExecutors threw; serving no tools this turn",
+        );
+        return {};
+      }
 
       // The TS type makes `web_search` required, but a third-party JS plugin can
       // return anything. Boot stays fail-loud (the loader rejects a missing

--- a/apps/backend/src/web-backends/index.ts
+++ b/apps/backend/src/web-backends/index.ts
@@ -1,0 +1,379 @@
+import { tool, type Tool } from "ai";
+import type { PluginConfigContext } from "@platypuschat/plugin-sdk";
+import { logger } from "../logger.ts";
+import { checkEgress, EGRESS_BLOCKED_MESSAGE } from "../utils/egress-guard.ts";
+import {
+  readUrlInputSchema,
+  webSearchInputSchema,
+  type ReadUrlToolResult,
+  type WebBackendContext,
+  type WebBackendContribution,
+  type WebBackendExecutors,
+  type WebBackendRegistration,
+  type WebSearchToolResult,
+  type WebToolError,
+} from "./types.ts";
+
+// Output bounds for Web-search backends, fixed by Platypus and identical across
+// every backend — the mirror of `sandbox/index.ts`'s MAX_* set (ADR-0002/0014).
+// Backends never truncate: they return full results and core caps, so getting
+// truncation wrong once cannot drop a multi-hundred-kilobyte response into the
+// context window.
+export const MAX_SEARCH_RESULTS = 10;
+export const MAX_SNIPPET_CHARS = 500;
+export const MAX_TITLE_CHARS = 200;
+// `answer` is free text from an upstream answer box (Brave, Tavily), so it is
+// capped like every other string a backend supplies. 10 results × 500 chars plus
+// a 4k answer is ~9k characters worst case — comparable to native search output.
+export const MAX_ANSWER_CHARS = 4_000;
+// Mirrors sandbox MAX_READ_BYTES. Accepted limit, stated rather than implied: the
+// executor hands core an already-materialised string, so this bounds *context and
+// CPU*, not backend memory — a backend that buffers a 500 MB response does so
+// before core sees it, and the per-call timeout is the only lever there.
+export const MAX_READ_URL_CONTENT_CHARS = 1_000_000;
+
+// Per-call executor timeouts. The default applies when a contribution omits
+// `timeoutMs`; the ceiling is refused at boot by the plugin loader (fail-loud,
+// plugin-named) rather than silently clamped here, because `timeoutMs` is static
+// on the contribution and therefore knowable at load. 120s covers a cold
+// headless-browser render with headroom.
+export const DEFAULT_WEB_TIMEOUT_MS = 30_000;
+export const MAX_WEB_TIMEOUT_MS = 120_000;
+
+const WEB_SEARCH_DESCRIPTION =
+  "Search the web for current information. Returns a list of results with titles, URLs and snippets, and sometimes a direct answer.";
+
+const READ_URL_DESCRIPTION =
+  "Read the contents of a web page as text. Supports pagination for large pages via start_index.";
+
+// The registry, mirroring `sandbox/index.ts`: a flat map keyed by the
+// discriminator stored in `provider.webBackend`.
+const WEB_BACKEND_REGISTRY: Record<string, WebBackendRegistration> = {};
+
+export const registerWebBackend = (
+  registration: WebBackendRegistration,
+): void => {
+  if (registration.backend in WEB_BACKEND_REGISTRY) {
+    throw new Error(
+      `Web backend '${registration.backend}' has already been registered.`,
+    );
+  }
+  WEB_BACKEND_REGISTRY[registration.backend] = registration;
+};
+
+export const getWebBackend = (
+  backend: string,
+): WebBackendRegistration | undefined => WEB_BACKEND_REGISTRY[backend];
+
+export const getWebBackends = (): ReadonlyArray<WebBackendRegistration> =>
+  Object.values(WEB_BACKEND_REGISTRY);
+
+/** Test-only reset. Boot registers once; nothing in production unregisters. */
+export const clearWebBackends = (): void => {
+  for (const key of Object.keys(WEB_BACKEND_REGISTRY)) {
+    delete WEB_BACKEND_REGISTRY[key];
+  }
+};
+
+// Cut a backend-supplied string to a core-owned bound, marking the cut so the
+// model can tell a truncated snippet from a naturally short one.
+const truncate = (value: string, max: number): string =>
+  value.length > max ? `${value.slice(0, max)}…` : value;
+
+/**
+ * Whether a URL may be presented to the model (and, in the frontend, rendered as
+ * a clickable Sources pill). The egress guard covers **model-supplied** URLs going
+ * *into* `read_url`; this covers **backend-supplied** URLs coming *out* of
+ * `web_search`, which nothing else checks — a `javascript:` or `data:` href in a
+ * pill is a live hole, and dropping the entry also keeps garbage out of the
+ * context window.
+ */
+export const isPresentableUrl = (value: unknown): value is string => {
+  if (typeof value !== "string") return false;
+  try {
+    const { protocol } = new URL(value);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+/** Raised when an executor outruns its per-call timeout. */
+class WebBackendTimeoutError extends Error {}
+
+/**
+ * Race an executor against its timeout.
+ *
+ * The loser is not cancelled: the v1 executor contract carries no `AbortSignal`,
+ * so a hung upstream call keeps running in the background until its own socket
+ * timeout. What the timeout guarantees is that the *turn* is not pinned open —
+ * which is the property the ceiling exists to protect.
+ */
+const withTimeout = async <T>(
+  run: () => Promise<T> | T,
+  timeoutMs: number,
+): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve(run()),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new WebBackendTimeoutError(
+                `executor timed out after ${timeoutMs}ms`,
+              ),
+            ),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+};
+
+// The model-facing failure text. Deliberately fixed rather than the upstream
+// cause: a backend's error message routinely embeds the URL it called, which for
+// a hosted search API carries the Operator's API key as a query parameter. The
+// cause goes to the log line instead.
+const timeoutMessage = (toolName: string, timeoutMs: number): string =>
+  `The web backend did not respond within ${timeoutMs}ms (${toolName}).`;
+
+const failureMessage = (toolName: string): string =>
+  `The web backend could not complete this ${toolName} request.`;
+
+export interface ComposeWebBackendOptions {
+  /** The contribution, with its id already namespaced by the loader. */
+  contribution: WebBackendContribution;
+  /** The plugin's boot-resolved deploy-time config/credentials (ADR-0013). */
+  plugin?: PluginConfigContext;
+  /** Owning plugin's manifest name, for attribution in every log line. */
+  pluginName: string;
+  /**
+   * Hostname resolver handed to the egress guard. Injected by tests so the guard
+   * itself stays in the path; production uses its DNS default.
+   */
+  resolveHostname?: (hostname: string) => Promise<string[]>;
+}
+
+/**
+ * Wrap one Web-search-backend contribution into the registration core stores.
+ *
+ * This is where core takes ownership of everything except the upstream call
+ * itself (ADR-0014): fixed input schemas and descriptions, result-count caps and
+ * string truncation, `read_url` content capping plus `max_length` / `start_index`
+ * slicing with a `next_start_index` continuation hint, the egress guard on the
+ * model-supplied URL, the per-call timeout, the throw→error-string contract, and
+ * one observability line per executor call.
+ */
+export const composeWebBackend = (
+  options: ComposeWebBackendOptions,
+): WebBackendRegistration => {
+  const { contribution, plugin, pluginName, resolveHostname } = options;
+  const backend = contribution.backend;
+  const timeoutMs = contribution.timeoutMs ?? DEFAULT_WEB_TIMEOUT_MS;
+
+  // One line per executor call (ADR-0014 observability). `debug` when it worked,
+  // `warn` when it did not, cause attached on failure. Queries and URLs are user
+  // content and can carry sensitive terms, so they never reach this line — they
+  // are logged separately at `debug`.
+  const logCall = (
+    toolName: string,
+    outcome: "ok" | "timeout" | "blocked" | "error",
+    startedAt: number,
+    cause?: unknown,
+  ): void => {
+    const line = {
+      backend,
+      plugin: pluginName,
+      tool: toolName,
+      durationMs: Date.now() - startedAt,
+      outcome,
+    };
+    if (outcome === "ok") {
+      logger.debug(line, "Web backend executor call");
+    } else {
+      logger.warn({ ...line, cause }, "Web backend executor call failed");
+    }
+  };
+
+  const buildSearchTool = (executors: WebBackendExecutors): Tool =>
+    tool({
+      description: WEB_SEARCH_DESCRIPTION,
+      inputSchema: webSearchInputSchema,
+      execute: async ({
+        query,
+      }): Promise<WebSearchToolResult | WebToolError> => {
+        const startedAt = Date.now();
+        logger.debug(
+          { backend, plugin: pluginName, query },
+          "web_search query",
+        );
+
+        let raw;
+        try {
+          raw = await withTimeout(
+            () => executors.web_search({ query }),
+            timeoutMs,
+          );
+        } catch (cause) {
+          const timedOut = cause instanceof WebBackendTimeoutError;
+          logCall(
+            "web_search",
+            timedOut ? "timeout" : "error",
+            startedAt,
+            cause,
+          );
+          return {
+            error: timedOut
+              ? timeoutMessage("web_search", timeoutMs)
+              : failureMessage("web_search"),
+          };
+        }
+
+        const results: WebSearchToolResult["results"] = [];
+        let dropped = 0;
+        for (const entry of Array.isArray(raw?.results) ? raw.results : []) {
+          if (results.length >= MAX_SEARCH_RESULTS) break;
+          if (!isPresentableUrl(entry?.url)) {
+            dropped += 1;
+            continue;
+          }
+          const hit: WebSearchToolResult["results"][number] = {
+            title: truncate(String(entry.title ?? ""), MAX_TITLE_CHARS),
+            url: entry.url,
+          };
+          if (typeof entry.snippet === "string") {
+            hit.snippet = truncate(entry.snippet, MAX_SNIPPET_CHARS);
+          }
+          results.push(hit);
+        }
+        if (dropped > 0) {
+          logger.warn(
+            { backend, plugin: pluginName, dropped },
+            "Dropped web_search results whose URL was not http(s)",
+          );
+        }
+
+        // `query` is echoed from the model's own input, never from the executor:
+        // core owns this shape, so a backend cannot substitute text here.
+        const result: WebSearchToolResult = { query, results };
+        if (typeof raw?.answer === "string") {
+          result.answer = truncate(raw.answer, MAX_ANSWER_CHARS);
+        }
+
+        logCall("web_search", "ok", startedAt);
+        return result;
+      },
+    });
+
+  const buildReadUrlTool = (
+    readUrl: NonNullable<WebBackendExecutors["read_url"]>,
+  ): Tool =>
+    tool({
+      description: READ_URL_DESCRIPTION,
+      inputSchema: readUrlInputSchema,
+      execute: async ({
+        url,
+        max_length,
+        start_index,
+      }): Promise<ReadUrlToolResult | WebToolError> => {
+        const startedAt = Date.now();
+        logger.debug({ backend, plugin: pluginName, url }, "read_url target");
+
+        // The URL comes from the model, so it is vetted before anything reaches
+        // the network — the whole reason core, not the backend, owns this Tool.
+        const egress = await checkEgress(url, { resolve: resolveHostname });
+        if (!egress.allowed) {
+          logger.warn(
+            { tool: "read_url", backend, url, reason: egress.reason },
+            "Blocked a model-supplied URL by network policy",
+          );
+          logCall("read_url", "blocked", startedAt);
+          return { error: EGRESS_BLOCKED_MESSAGE };
+        }
+
+        let raw;
+        try {
+          raw = await withTimeout(() => readUrl({ url }), timeoutMs);
+        } catch (cause) {
+          const timedOut = cause instanceof WebBackendTimeoutError;
+          logCall("read_url", timedOut ? "timeout" : "error", startedAt, cause);
+          return {
+            error: timedOut
+              ? timeoutMessage("read_url", timeoutMs)
+              : failureMessage("read_url"),
+          };
+        }
+
+        // Cap first, then slice within the capped string: the cap bounds what core
+        // ever holds, the slice serves this page of it.
+        const full = typeof raw?.content === "string" ? raw.content : "";
+        const capped = full.length > MAX_READ_URL_CONTENT_CHARS;
+        if (capped) {
+          logger.warn(
+            { backend, url, length: full.length },
+            "Web backend read_url content exceeded the core cap and was truncated",
+          );
+        }
+        const content = capped
+          ? full.slice(0, MAX_READ_URL_CONTENT_CHARS)
+          : full;
+
+        const slice = content.slice(start_index, start_index + max_length);
+        const hasMore = start_index + max_length < content.length;
+        const next_start_index = start_index + max_length;
+
+        const result: ReadUrlToolResult = {
+          // Same hint text as `fetchUrl`, so a continuation read reads identically
+          // whichever page-reader the model reached for.
+          content: hasMore
+            ? `${slice}\n\n[Content truncated. Pass start_index=${next_start_index} to continue reading.]`
+            : slice,
+          url: isPresentableUrl(raw?.url) ? raw.url : url,
+          content_type:
+            typeof raw?.contentType === "string" ? raw.contentType : "",
+          // True when *anything* was cut — the core cap or this slice.
+          truncated: hasMore || capped,
+        };
+        if (hasMore) {
+          result.next_start_index = next_start_index;
+        }
+
+        logCall("read_url", "ok", startedAt);
+        return result;
+      },
+    });
+
+  return {
+    backend,
+    name: contribution.name,
+    buildTurnTools: async (ctx: WebBackendContext) => {
+      const executors = await contribution.createExecutors(ctx, plugin);
+
+      // The TS type makes `web_search` required, but a third-party JS plugin can
+      // return anything. Boot stays fail-loud (the loader rejects a missing
+      // `createExecutors`); runtime resolution stays graceful, so a malformed
+      // executor object costs the turn its search tools, not the turn.
+      if (typeof executors?.web_search !== "function") {
+        logger.warn(
+          { plugin: pluginName, backend },
+          "Web backend returned no web_search executor; serving no search tools this turn",
+        );
+        return {};
+      }
+
+      const tools: Record<string, Tool> = {
+        web_search: buildSearchTool(executors),
+      };
+      if (typeof executors.read_url === "function") {
+        tools.read_url = buildReadUrlTool(executors.read_url.bind(executors));
+      }
+      return tools;
+    },
+  };
+};
+
+export * from "./types.ts";

--- a/apps/backend/src/web-backends/index.ts
+++ b/apps/backend/src/web-backends/index.ts
@@ -3,6 +3,8 @@ import type { PluginConfigContext } from "@platypuschat/plugin-sdk";
 import { logger } from "../logger.ts";
 import { checkEgress, EGRESS_BLOCKED_MESSAGE } from "../utils/egress-guard.ts";
 import {
+  MAX_READ_URL_CONTENT_CHARS,
+  MAX_URL_CHARS,
   readUrlInputSchema,
   webSearchInputSchema,
   type ReadUrlToolResult,
@@ -32,18 +34,14 @@ export const MAX_SEARCH_RESULT_SCAN = MAX_SEARCH_RESULTS * 10;
 // capped like every other string a backend supplies. 10 results × 500 chars plus
 // a 4k answer is ~9k characters worst case — comparable to native search output.
 export const MAX_ANSWER_CHARS = 4_000;
-// A result/read URL is capped like every other backend-supplied string. Unlike
-// title/snippet/content_type, an over-length URL is *dropped* rather than
-// truncated: a cut URL is a broken link, worse than no link at all. 2048 is
-// generous relative to common browser/server URL-length limits.
-export const MAX_URL_CHARS = 2_048;
-// `content_type` is metadata, not a link, so truncation (not dropping) is fine.
+// `content_type` is metadata, not a link, so it is shortened rather than dropped —
+// but sliced bare, without `truncate`'s `…` marker: the marker suits prose a model
+// reads, where a machine-readable MIME type carrying one is invalid rather than
+// honestly-shortened.
 export const MAX_CONTENT_TYPE_CHARS = 200;
-// Mirrors sandbox MAX_READ_BYTES. Accepted limit, stated rather than implied: the
-// executor hands core an already-materialised string, so this bounds *context and
-// CPU*, not backend memory — a backend that buffers a 500 MB response does so
-// before core sees it, and the per-call timeout is the only lever there.
-export const MAX_READ_URL_CONTENT_CHARS = 1_000_000;
+// `MAX_URL_CHARS` and `MAX_READ_URL_CONTENT_CHARS` live in `./types.ts` — the input
+// schemas there reference them — and are re-exported from this module by the
+// `export *` at the bottom, so they read as part of this MAX_* set either way.
 
 // Per-call executor timeouts. The default applies when a contribution omits
 // `timeoutMs`; the ceiling is refused at boot by the plugin loader (fail-loud,
@@ -289,7 +287,11 @@ export const composeWebBackend = (
           : [];
 
         const results: WebSearchToolResult["results"] = [];
-        let dropped = 0;
+        // Counted apart, not as one `dropped` total: an unusable *scheme* is a bug
+        // (or worse) in the backend, an over-length URL is routine noise from some
+        // upstreams, and an Operator reading the line needs to tell them apart.
+        let droppedLength = 0;
+        let droppedScheme = 0;
         // Bounded on both ends: `MAX_SEARCH_RESULTS` on what is kept, and
         // `MAX_SEARCH_RESULT_SCAN` on what is even looked at, so a pathological
         // result array cannot spend core's CPU parsing URLs it will discard.
@@ -297,14 +299,21 @@ export const composeWebBackend = (
         for (const candidate of scanned) {
           if (results.length >= MAX_SEARCH_RESULTS) break;
           const entry = asRecord(candidate);
-          // A URL that fails the scheme check, or one so long it would blow the
-          // context/DOM budget the other caps exist to hold, is unusable either
-          // way — dropped, not truncated, since a cut URL is a broken link.
+          // Length before scheme, deliberately: `isPresentableUrl` parses the whole
+          // string with `new URL()`, and the CPU argument behind
+          // `MAX_SEARCH_RESULT_SCAN` applies just as much to a URL core is about to
+          // discard — otherwise a scan's worth of multi-megabyte hrefs gets fully
+          // parsed on the way to being dropped. Both cases drop rather than
+          // truncate: a cut URL is a broken link, worse than no link.
           if (
-            !isPresentableUrl(entry.url) ||
+            typeof entry.url !== "string" ||
             entry.url.length > MAX_URL_CHARS
           ) {
-            dropped += 1;
+            droppedLength += 1;
+            continue;
+          }
+          if (!isPresentableUrl(entry.url)) {
+            droppedScheme += 1;
             continue;
           }
           const hit: WebSearchToolResult["results"][number] = {
@@ -319,10 +328,15 @@ export const composeWebBackend = (
           }
           results.push(hit);
         }
-        if (dropped > 0) {
-          logger.warn(
-            { backend, plugin: pluginName, dropped },
-            "Dropped web_search results whose URL was not http(s) or exceeded MAX_URL_CHARS",
+        // `debug`, not `warn`: this is per-call and model-triggerable, and for some
+        // upstreams (Brave and Tavily both mix in results core cannot present) it is
+        // expected steady state rather than a fault — at `warn` a healthy backend
+        // would log on every search a user runs. The two lines below stay at `warn`
+        // because both mean the *backend* is misbehaving, not merely noisy.
+        if (droppedLength > 0 || droppedScheme > 0) {
+          logger.debug(
+            { backend, plugin: pluginName, droppedLength, droppedScheme },
+            "Dropped web_search results with an unusable URL",
           );
         }
         // Only the *scan* bound warrants this warning: if the result cap already
@@ -438,18 +452,26 @@ export const composeWebBackend = (
 
         // Same drop-not-truncate treatment as a search result URL (D5): an
         // over-length resolved URL falls back to the model-supplied one rather
-        // than being cut into a broken link.
+        // than being cut into a broken link. Length before scheme for the same
+        // reason as the search loop — `isPresentableUrl` parses the whole string.
+        // The fallback is bounded too: `readUrlInputSchema` caps `url` at
+        // `MAX_URL_CHARS`, so this field cannot exceed the cap by either route.
         const resolvedUrl =
-          isPresentableUrl(payload.url) && payload.url.length <= MAX_URL_CHARS
+          typeof payload.url === "string" &&
+          payload.url.length <= MAX_URL_CHARS &&
+          isPresentableUrl(payload.url)
             ? payload.url
             : url;
 
         const result: ReadUrlToolResult = {
           content: body,
           url: resolvedUrl,
+          // Sliced bare rather than through `truncate`: a `…` marker is right for
+          // prose a model reads, but `content_type` is machine-readable and a
+          // marked cut yields an invalid MIME type instead of a shortened one.
           content_type:
             typeof payload.contentType === "string"
-              ? truncate(payload.contentType, MAX_CONTENT_TYPE_CHARS)
+              ? payload.contentType.slice(0, MAX_CONTENT_TYPE_CHARS)
               : "",
           // True when *anything* was cut — the core cap or this slice.
           truncated: hasMore || capped,
@@ -472,6 +494,12 @@ export const composeWebBackend = (
       // "runtime resolution graceful" and the timeout's "a backend cannot pin a
       // turn open" both apply to the factory call, not just the executors it
       // returns.
+      //
+      // This window is *additive* to the executors': `buildTurnTools` runs once
+      // per turn and each tool call gets its own `timeoutMs`, so the worst case a
+      // turn can spend inside a backend is `(1 + calls) × timeoutMs` — 240s for a
+      // single search at the 120s boot ceiling. Still bounded, which is the
+      // property the ceiling exists to protect, but no longer one window.
       let executors: WebBackendExecutors | undefined;
       try {
         executors = await withTimeout(

--- a/apps/backend/src/web-backends/types.ts
+++ b/apps/backend/src/web-backends/types.ts
@@ -13,6 +13,27 @@ export type {
   WebSearchResults,
 } from "@platypuschat/plugin-sdk";
 
+// Two of the output bounds live here rather than beside their siblings in
+// `index.ts`: the input schemas below reference them, and `index.ts` imports this
+// module, so keeping them there forced the schemas to restate the numbers and
+// trust a comment to keep the copies in sync. `index.ts` re-exports this module,
+// so every existing `MAX_URL_CHARS` / `MAX_READ_URL_CONTENT_CHARS` import from
+// there still resolves.
+//
+// A URL is capped like every other string core hands the model. Unlike
+// title/snippet/content_type, an over-length URL is *dropped* rather than
+// truncated: a cut URL is a broken link, worse than no link at all. 2048 is
+// generous relative to common browser/server URL-length limits. Capping the
+// `read_url` input at the same number is what makes the bound an invariant —
+// the tool's own `url` field is the fallback when a backend's resolved URL is
+// rejected, so an uncapped input would let that fallback exceed the cap.
+export const MAX_URL_CHARS = 2_048;
+// Mirrors sandbox MAX_READ_BYTES. Accepted limit, stated rather than implied: the
+// executor hands core an already-materialised string, so this bounds *context and
+// CPU*, not backend memory — a backend that buffers a 500 MB response does so
+// before core sees it, and the per-call timeout is the only lever there.
+export const MAX_READ_URL_CONTENT_CHARS = 1_000_000;
+
 // Core-owned, fixed input schemas (ADR-0014). A backend supplies executors only,
 // so every Web-search backend presents the *same* model-facing signature and an
 // Agent prompt does not couple to whichever backend an Operator configured.
@@ -30,15 +51,14 @@ export type WebSearchInput = z.infer<typeof webSearchInputSchema>;
 // Mirrors `fetchUrl`'s pagination inputs byte-for-byte (max_length default 5000,
 // start_index default 0) so a continuation read reads identically on both tools.
 export const readUrlInputSchema = z.object({
-  url: z.string().url().describe("URL to read"),
+  // Capped so the model cannot hand core a URL longer than the one core would
+  // accept back from a backend — see MAX_URL_CHARS above.
+  url: z.string().url().max(MAX_URL_CHARS).describe("URL to read"),
   max_length: z
     .number()
     .int()
     .min(1)
-    // Mirrors `MAX_READ_URL_CONTENT_CHARS` in `index.ts`, which can't be
-    // imported here without a circular dependency (`index.ts` imports this
-    // module). Keep the two numbers in sync by hand.
-    .max(1_000_000)
+    .max(MAX_READ_URL_CONTENT_CHARS)
     .default(5_000)
     .describe("Maximum number of characters to return"),
   start_index: z

--- a/apps/backend/src/web-backends/types.ts
+++ b/apps/backend/src/web-backends/types.ts
@@ -35,6 +35,9 @@ export const readUrlInputSchema = z.object({
     .number()
     .int()
     .min(1)
+    // Mirrors `MAX_READ_URL_CONTENT_CHARS` in `index.ts`, which can't be
+    // imported here without a circular dependency (`index.ts` imports this
+    // module). Keep the two numbers in sync by hand.
     .max(1_000_000)
     .default(5_000)
     .describe("Maximum number of characters to return"),

--- a/apps/backend/src/web-backends/types.ts
+++ b/apps/backend/src/web-backends/types.ts
@@ -1,0 +1,93 @@
+import type { Tool } from "ai";
+import { z } from "zod";
+import type { WebBackendContext } from "@platypuschat/plugin-sdk";
+
+// The SDK is the single home of the executor-facing contract; core re-exports the
+// types its internal callers need so nothing below imports the SDK directly.
+export type {
+  ReadUrlResult,
+  WebBackendContext,
+  WebBackendContribution,
+  WebBackendExecutors,
+  WebSearchResult,
+  WebSearchResults,
+} from "@platypuschat/plugin-sdk";
+
+// Core-owned, fixed input schemas (ADR-0014). A backend supplies executors only,
+// so every Web-search backend presents the *same* model-facing signature and an
+// Agent prompt does not couple to whichever backend an Operator configured.
+//
+// Tool names are snake_case — a deliberate, documented exception to the repo's
+// camelCase tools (`fetchUrl`, `fsRead`…). These fill the slot provider-native
+// search occupies, where the vocabulary is already `web_search`, and models carry
+// strong priors on that name from the hosted OpenAI/Anthropic tools.
+
+export const webSearchInputSchema = z.object({
+  query: z.string().min(1).describe("The search query"),
+});
+export type WebSearchInput = z.infer<typeof webSearchInputSchema>;
+
+// Mirrors `fetchUrl`'s pagination inputs byte-for-byte (max_length default 5000,
+// start_index default 0) so a continuation read reads identically on both tools.
+export const readUrlInputSchema = z.object({
+  url: z.string().url().describe("URL to read"),
+  max_length: z
+    .number()
+    .int()
+    .min(1)
+    .max(1_000_000)
+    .default(5_000)
+    .describe("Maximum number of characters to return"),
+  start_index: z
+    .number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe("Start character index for pagination"),
+});
+export type ReadUrlInput = z.infer<typeof readUrlInputSchema>;
+
+// Model-facing returns. snake_case here, camelCase in the SDK types: this side
+// must match `fetchUrl` exactly (see readUrlInputSchema above).
+
+export type WebSearchToolResult = {
+  query: string;
+  results: Array<{ title: string; url: string; snippet?: string }>;
+  answer?: string;
+};
+
+export type ReadUrlToolResult = {
+  content: string;
+  url: string;
+  content_type: string;
+  truncated: boolean;
+  next_start_index?: number;
+};
+
+/**
+ * What a Tool returns to the model when the call could not be served — a blocked
+ * URL, a timeout, or a backend throw. A returned error object, not a rejection:
+ * an executor throw must not surface as an AI-SDK tool error and abort the turn
+ * (ADR-0014).
+ */
+export type WebToolError = { error: string };
+
+/**
+ * One registered Web-search backend. The discriminator string lives in the
+ * `provider.webBackend` column.
+ *
+ * `buildTurnTools` is the finished, guarded builder produced by
+ * {@link composeWebBackend}: it resolves the backend's executors for this turn
+ * and returns core-built `Tool`s with the caps, slicing, timeout, egress guard,
+ * and error contract already applied. Per-turn callers just `Object.assign` its
+ * output onto the turn's tool map.
+ *
+ * It is `buildTurnTools`, not `createTools`, on purpose: `createTools` is the
+ * exact identifier ADR-0014 **rejects** for the contribution factory, so reusing
+ * it on core's side of the seam would read as the rejected shape.
+ */
+export interface WebBackendRegistration {
+  backend: string;
+  name: string;
+  buildTurnTools(ctx: WebBackendContext): Promise<Record<string, Tool>>;
+}

--- a/apps/frontend/components/plugins-list.tsx
+++ b/apps/frontend/components/plugins-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import useSWR from "swr";
-import { Blocks, Container, Wrench } from "lucide-react";
+import { Blocks, Container, Globe, Wrench } from "lucide-react";
 import { useAuth } from "@/components/auth-provider";
 import { useBackendUrl } from "@/app/client-context";
 import { cn, fetcher, joinUrl } from "@/lib/utils";
@@ -23,8 +23,8 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 
 // Mirrors the read-only `GET /organizations/:orgId/plugins` payload (ADR-0013).
-// Contributions are the ids the plugin registered — tool sets and sandbox
-// backends tie back to their originating plugin here.
+// Contributions are the ids the plugin registered — tool sets, sandbox
+// backends, and web backends all tie back to their originating plugin here.
 interface InstalledPlugin {
   name: string;
   version: string;
@@ -32,6 +32,7 @@ interface InstalledPlugin {
   contributions: {
     toolSets: string[];
     sandboxBackends: string[];
+    webBackends: string[];
   };
 }
 
@@ -109,6 +110,7 @@ const PluginsList = ({
       {plugins.map((plugin) => {
         const toolSets = plugin.contributions.toolSets ?? [];
         const sandboxBackends = plugin.contributions.sandboxBackends ?? [];
+        const webBackends = plugin.contributions.webBackends ?? [];
 
         return (
           <li key={plugin.name} className="mb-2">
@@ -126,7 +128,9 @@ const PluginsList = ({
                     {plugin.origin === "core" ? "Core" : "Third-party"}
                   </Badge>
                 </ItemTitle>
-                {toolSets.length === 0 && sandboxBackends.length === 0 ? (
+                {toolSets.length === 0 &&
+                sandboxBackends.length === 0 &&
+                webBackends.length === 0 ? (
                   <ItemDescription>No contributions.</ItemDescription>
                 ) : (
                   <div className="flex flex-col gap-2 mt-1">
@@ -152,6 +156,22 @@ const PluginsList = ({
                           <Container className="size-3" /> Sandbox backends
                         </span>
                         {sandboxBackends.map((id) => (
+                          <Badge
+                            key={id}
+                            variant="outline"
+                            className="font-mono font-normal"
+                          >
+                            {id}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+                    {webBackends.length > 0 && (
+                      <div className="flex flex-wrap items-center gap-1.5">
+                        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground mr-1">
+                          <Globe className="size-3" /> Web backends
+                        </span>
+                        {webBackends.map((id) => (
                           <Badge
                             key={id}
                             variant="outline"

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -6,8 +6,8 @@
 The plugin SDK for [Platypus](https://github.com/willdady/platypus) — the
 compile-time contract third-party plugins are built against.
 
-Platypus loads its extensions — **Tool sets** and **Sandbox backends** — as
-plugins. This package is the typed surface they depend on: the `PlatypusPlugin`
+Platypus loads its extensions — **Tool sets**, **Sandbox backends**, and
+**Web-search backends** — as plugins. This package is the typed surface they depend on: the `PlatypusPlugin`
 manifest type, the contribution types, and the `PLUGIN_API_VERSION` constant. A
 plugin is an npm package that exports a manifest built against these types; an
 Operator installs it by adding the package to the `PLATYPUS_PLUGINS` list at
@@ -82,9 +82,69 @@ plugin-named error.
 - **Sandbox backends** (`contributes.sandboxBackends`) — shell/filesystem
   execution backends for the Platypus Sandbox (e.g. the built-in Docker and SSH
   backends).
+- **Web-search backends** (`contributes.webBackends`) — see below.
 
 Plugins may also declare deploy-time, Operator-owned `configSchema` /
 `credentialsSchema`, supplied via `PLATYPUS_PLUGIN_CONFIG` and validated at boot.
+
+## Web-search backends
+
+A Web-search backend fills the chat **web-search toggle** for Providers without
+working native search (self-hosted OpenAI-compatible servers: vLLM, LiteLLM,
+SGLang…). An Operator selects one **per Provider**; its tools are injected only
+while the toggle is on, and gone when it is off.
+
+Your backend supplies **executors** — plain functions — not tools. Core builds the
+`web_search` / `read_url` tools around them and owns the input schemas, the
+model-facing descriptions, result caps and snippet truncation, `max_length` /
+`start_index` slicing with a continuation hint, the per-call timeout, the
+throw→error contract, and an egress guard on the model-supplied URL. That keeps
+one fixed model-facing signature across every backend, and it is the only place
+those limits can actually be enforced.
+
+```ts
+import type { PlatypusPlugin } from "@platypuschat/plugin-sdk";
+import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+
+export const plugin: PlatypusPlugin = {
+  name: "acme-search",
+  version: "0.1.0",
+  apiVersion: PLUGIN_API_VERSION,
+  // A backend's endpoint and API key are deploy-time plugin config, not
+  // per-Provider settings — declare them with the plugin-level schemas.
+  contributes: {
+    webBackends: [
+      {
+        backend: "searx", // registers as `acme-search.searx`
+        name: "SearXNG",
+        timeoutMs: 5_000, // optional; core defaults to 30_000 and caps at 120_000
+        createExecutors: (ctx, plugin) => ({
+          // Mandatory. Return results; never truncate or paginate — core does.
+          web_search: async ({ query }) => ({
+            query,
+            results: [{ title: "…", url: "https://…", snippet: "…" }],
+            // Optional: an upstream answer box (Brave, Tavily) survives here.
+            answer: undefined,
+          }),
+          // Optional. Omit it and the model just gets search that turn.
+          read_url: async ({ url }) => ({
+            content: "the page's FULL text — core slices it",
+            url, // the post-redirect final URL, so the model cites where it landed
+            contentType: "text/markdown",
+          }),
+        }),
+      },
+    ],
+  },
+};
+```
+
+Note the casing: SDK types are camelCase (`contentType`), while the tool names and
+the model-facing return fields are snake_case (`web_search`, `read_url`,
+`content_type`, `next_start_index`) to match provider-native search and Platypus's
+own `fetchUrl`. There are deliberately no per-contribution config schemas — a web
+backend has no per-Provider row to validate, so its credentials ride the
+plugin-level `credentialsSchema` and arrive as `plugin.credentials`.
 
 ## Documentation
 

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -7,11 +7,11 @@ The plugin SDK for [Platypus](https://github.com/willdady/platypus) — the
 compile-time contract third-party plugins are built against.
 
 Platypus loads its extensions — **Tool sets**, **Sandbox backends**, and
-**Web-search backends** — as plugins. This package is the typed surface they depend on: the `PlatypusPlugin`
-manifest type, the contribution types, and the `PLUGIN_API_VERSION` constant. A
-plugin is an npm package that exports a manifest built against these types; an
-Operator installs it by adding the package to the `PLATYPUS_PLUGINS` list at
-deploy time.
+**Web-search backends** — as plugins. This package is the typed surface they
+depend on: the `PlatypusPlugin` manifest type, the contribution types, and the
+`PLUGIN_API_VERSION` constant. A plugin is an npm package that exports a
+manifest built against these types; an Operator installs it by adding the
+package to the `PLATYPUS_PLUGINS` list at deploy time.
 
 ## Install
 

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -97,8 +97,10 @@ while the toggle is on, and gone when it is off.
 Your backend supplies **executors** — plain functions — not tools. Core builds the
 `web_search` / `read_url` tools around them and owns the input schemas, the
 model-facing descriptions, result caps and snippet truncation, `max_length` /
-`start_index` slicing with a continuation hint, the per-call timeout, the
-throw→error contract, and an egress guard on the model-supplied URL. That keeps
+`start_index` slicing with a continuation hint, the timeout on both your factory
+and every executor call, the throw→error contract, and an egress guard on the
+model-supplied URL. Core also _drops_ any result whose `url` is not `http(s)` or
+is longer than 2048 characters, since neither can be presented as a link. That keeps
 one fixed model-facing signature across every backend, and it is the only place
 those limits can actually be enforced.
 
@@ -117,7 +119,11 @@ export const plugin: PlatypusPlugin = {
       {
         backend: "searx", // registers as `acme-search.searx`
         name: "SearXNG",
-        timeoutMs: 5_000, // optional; core defaults to 30_000 and caps at 120_000
+        // Optional; core defaults to 30_000 and caps at 120_000. It bounds
+        // `createExecutors` as well as each executor call, so budget for any lazy
+        // work the factory does — a factory that outruns it, or throws, serves no
+        // web tools that turn (warn-logged, never fatal).
+        timeoutMs: 5_000,
         createExecutors: (ctx, plugin) => ({
           // Mandatory. Return results; never truncate or paginate — core does.
           web_search: async ({ query }) => ({

--- a/packages/plugin-sdk/index.test.ts
+++ b/packages/plugin-sdk/index.test.ts
@@ -8,6 +8,7 @@ import {
   type PluginConfigContext,
   type SandboxBackendContribution,
   type ToolSetContribution,
+  type WebBackendContribution,
 } from "./index.ts";
 
 describe("@platypuschat/plugin-sdk", () => {
@@ -119,5 +120,62 @@ describe("@platypuschat/plugin-sdk", () => {
       },
     };
     backend.create({}, {}, shared);
+  });
+
+  it("accepts a web-backend contribution supplying executors only", async () => {
+    const contribution: WebBackendContribution = {
+      backend: "searx",
+      name: "SearXNG",
+      timeoutMs: 5_000,
+      createExecutors: (ctx, plugin) => {
+        expect(ctx.workspaceId).toBe("w");
+        expect(plugin?.credentials).toEqual({ apiKey: "k" });
+        return {
+          web_search: ({ query }) => ({
+            query,
+            results: [{ title: "Hit", url: "https://example.com/" }],
+            answer: "42",
+          }),
+          read_url: ({ url }) => ({
+            content: "page",
+            url,
+            contentType: "text/markdown",
+          }),
+        };
+      },
+    };
+
+    const plugin: PlatypusPlugin = {
+      name: "acme",
+      version: "0.1.0",
+      apiVersion: PLUGIN_API_VERSION,
+      contributes: { webBackends: [contribution] },
+    };
+    expect(plugin.contributes.webBackends).toHaveLength(1);
+
+    // The executors are plain functions, not AI SDK Tools: core owns the schemas,
+    // the caps, the slicing, the timeout, and the egress guard (ADR-0014).
+    const executors = await contribution.createExecutors(
+      { orgId: "o", workspaceId: "w", userId: "u" },
+      { config: {}, credentials: { apiKey: "k" } },
+    );
+    expect((await executors.web_search({ query: "q" })).results).toHaveLength(
+      1,
+    );
+    expect(typeof executors.read_url).toBe("function");
+  });
+
+  it("accepts a search-only web backend (read_url is optional)", () => {
+    const contribution: WebBackendContribution = {
+      backend: "searx",
+      name: "SearXNG",
+      // No read_url: a search-only Operator (no browser service) omits it and the
+      // model simply gets search that turn.
+      createExecutors: () => ({
+        web_search: () => ({ query: "q", results: [] }),
+      }),
+    };
+
+    expect(contribution.timeoutMs).toBeUndefined();
   });
 });

--- a/packages/plugin-sdk/index.ts
+++ b/packages/plugin-sdk/index.ts
@@ -347,11 +347,18 @@ export interface WebBackendContribution {
   backend: string;
   name: string;
   /**
-   * Per-call timeout for this backend's executors. Its author knows their
-   * upstream — a LAN metasearch should answer in ~2s where a headless-browser
-   * render legitimately needs 60 — which is why this is a contribution field and
-   * not one global env var. Core defaults to 30000 when absent and **refuses at
-   * boot** anything above its hard ceiling, so a backend cannot pin a turn open.
+   * Timeout applied to {@link createExecutors} **and** to each executor call it
+   * returns. Its author knows their upstream — a LAN metasearch should answer in
+   * ~2s where a headless-browser render legitimately needs 60 — which is why this
+   * is a contribution field and not one global env var. Core defaults to 30000
+   * when absent and **refuses at boot** anything above its hard ceiling, so a
+   * backend cannot pin a turn open.
+   *
+   * Budget for the factory, not just the calls: if `createExecutors` does lazy
+   * work — a token fetch, a health probe, a browser-pool warm-up — a value tuned
+   * only to the search call will time the *factory* out, and the turn then gets no
+   * web tools at all (warn-logged; see below). The windows are additive, so the
+   * worst case a turn spends inside a backend is `(1 + calls) × timeoutMs`.
    */
   timeoutMs?: number;
   /**
@@ -360,6 +367,12 @@ export interface WebBackendContribution {
    * contributions (ADR-0013) — where a backend's endpoint and API key live. It is
    * appended and optional so a single-argument factory keeps working unchanged
    * (append-only compatibility); core always supplies it.
+   *
+   * Boot is fail-loud, runtime is graceful: a contribution that omits this
+   * function is rejected at load by plugin name, but a factory that *throws* or
+   * outruns {@link timeoutMs} at turn time only costs that turn its web tools —
+   * warn-logged, never surfaced to the model, never fatal to the turn. A backend
+   * whose tools silently stop appearing is that warn line, not an error.
    */
   createExecutors(
     ctx: WebBackendContext,

--- a/packages/plugin-sdk/index.ts
+++ b/packages/plugin-sdk/index.ts
@@ -257,6 +257,117 @@ export interface SandboxBackendContribution<
 }
 
 /**
+ * Runtime scope handed to a Web-search backend's executor factory at Chat-turn
+ * time. Mirrors {@link SandboxContext} deliberately: `userId` is the Workspace
+ * owner, carried for audit/attribution, not isolation. No `userEmail` and no
+ * signed identity token — a backend that wants to attribute to its *own*
+ * upstream does so as its own implementation detail, using its own Plugin
+ * credentials (ADR-0014).
+ */
+export interface WebBackendContext {
+  orgId: string;
+  workspaceId: string;
+  userId: string;
+}
+
+/** One search hit. Core caps the count and truncates the strings (ADR-0014). */
+export interface WebSearchResult {
+  title: string;
+  url: string;
+  snippet?: string;
+}
+
+/**
+ * What a `web_search` executor resolves. Structured rather than rendered text so
+ * core can cap result counts and the frontend can lift `url` into the Sources
+ * row; `answer` is the escape hatch for upstreams with an answer box (Brave,
+ * Tavily) so that content is not simply discarded.
+ *
+ * `query` is part of the shape for symmetry with the model-facing return, but
+ * **core echoes the model's own query** in the Tool result — a backend cannot
+ * substitute text there.
+ */
+export interface WebSearchResults {
+  query: string;
+  results: WebSearchResult[];
+  answer?: string;
+}
+
+/**
+ * What a `read_url` executor resolves. `content` is the page's **full** content:
+ * backends never paginate or truncate, because core owns `max_length` /
+ * `start_index` slicing and the continuation hint (ADR-0014). `url` is the
+ * post-redirect final URL, so the model cites where it actually landed.
+ *
+ * Casing seam, deliberate: SDK types follow repo camelCase (`contentType`), while
+ * the model-facing Tool return is snake_case (`content_type`, `next_start_index`)
+ * to mirror `fetchUrl` byte-for-byte — the tool *names* `web_search` / `read_url`
+ * are already a documented snake_case exception.
+ */
+export interface ReadUrlResult {
+  content: string;
+  url: string;
+  contentType?: string;
+}
+
+/**
+ * The executors a Web-search backend supplies — plain functions, **not** `Tool`s.
+ * Core builds the `Tool` objects around these: it owns the input schemas, the
+ * model-facing descriptions, result caps, slicing, the per-call timeout, the
+ * error contract, and the egress guard on the model-supplied `read_url` URL. A
+ * backend that owned the `Tool` would put the model-supplied URL out of core's
+ * reach, leaving nowhere to enforce any of that (ADR-0014).
+ *
+ * `web_search` is mandatory — a Web-search backend that cannot search is
+ * meaningless. `read_url` is optional: a search-only Operator (SearXNG, no
+ * browser service) omits it and the model simply gets search that turn.
+ */
+export interface WebBackendExecutors {
+  web_search: (input: {
+    query: string;
+  }) => Promise<WebSearchResults> | WebSearchResults;
+  read_url?: (input: { url: string }) => Promise<ReadUrlResult> | ReadUrlResult;
+}
+
+/**
+ * A single Web-search-backend contribution — the fourth Extension point, filling
+ * core's request-gated web-search toggle slot (ADR-0014). `backend` is the
+ * discriminator stored in the `provider.webBackend` column (auto-namespaced for
+ * third parties, flat for core, per ADR-0013); `name` is the display label shown
+ * in the catalog and the Provider selector.
+ *
+ * There is deliberately **no** per-contribution `configSchema` /
+ * `credentialsSchema`: those exist on a Sandbox backend to validate real
+ * per-Workspace jsonb columns, and a web backend has no such row — the schema
+ * lives where the row lives. A backend's API key and endpoint ride the
+ * **plugin-level** schemas via `PLATYPUS_PLUGIN_CONFIG`, boot-validated and
+ * injected here as `plugin.credentials`.
+ */
+export interface WebBackendContribution {
+  backend: string;
+  name: string;
+  /**
+   * Per-call timeout for this backend's executors. Its author knows their
+   * upstream — a LAN metasearch should answer in ~2s where a headless-browser
+   * render legitimately needs 60 — which is why this is a contribution field and
+   * not one global env var. Core defaults to 30000 when absent and **refuses at
+   * boot** anything above its hard ceiling, so a backend cannot pin a turn open.
+   */
+  timeoutMs?: number;
+  /**
+   * Build this backend's executors for one Chat turn. `plugin` is the deploy-time
+   * {@link PluginConfigContext} shared across every one of the plugin's
+   * contributions (ADR-0013) — where a backend's endpoint and API key live. It is
+   * appended and optional so a single-argument factory keeps working unchanged
+   * (append-only compatibility); core always supplies it.
+   */
+  createExecutors(
+    ctx: WebBackendContext,
+    plugin?: PluginConfigContext,
+  ): WebBackendExecutors | Promise<WebBackendExecutors>;
+}
+
+/**
  * The `contributes` block: keyed by Extension-point type (core-owned, fixed).
  * Adding an Extension point (e.g. a messaging gateway) is a purely additive,
  * minor API bump — a new optional key here.
@@ -264,6 +375,7 @@ export interface SandboxBackendContribution<
 export interface PluginContributions {
   toolSets?: ToolSetContribution[];
   sandboxBackends?: SandboxBackendContribution[];
+  webBackends?: WebBackendContribution[];
 }
 
 /**

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platypuschat/plugin-sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Plugin SDK for Platypus — the manifest type and extension-point surface third-party plugins depend on.",
   "license": "MIT",
   "author": "Will Dady",


### PR DESCRIPTION
Implements the plumbing layer of [ADR-0014](docs/adr/0014-web-search-backend-extension-point.md) — the
fourth core-owned Extension point, filling the request-gated web-search toggle for Providers without
working native search (self-hosted vLLM / LiteLLM / SGLang). Part 1 of 4 for #329; **no chat behaviour
changes yet** — nothing resolves a backend until PR2 adds the `provider.webBackend` column and the
turn-time gate.

Builds on #358 (the shared egress guard) and #357 (the amended ADR).

## What's here

- **`packages/plugin-sdk`** — `webBackends?` on `PluginContributions`, plus `WebBackendContribution`,
  `WebBackendExecutors`, `WebBackendContext`, `WebSearchResults`, `ReadUrlResult`. Append-only, so
  `PLUGIN_API_VERSION` stays **1** and `OLDEST_SUPPORTED_API_VERSION` is untouched; package `0.1.1 →
0.2.0`, README gains a "Web-search backends" section. (Publishing stays your release step.)
- **`apps/backend/src/web-backends/`** — the registry (a direct mirror of `sandbox/index.ts`), the
  core-owned limits as named exported constants, and `composeWebBackend`: the wrapper that turns a
  contribution into `{ backend, name, buildTurnTools(ctx) }`.
- **Loader** — registration loop with the usual id namespacing (core flat, third-party `${name}.${id}`)
  and plugin-attributed collision errors; `registerWeb?` injection point; `webBackendIds` on
  `LoadedPlugin`.
- **Registry / `GET /plugins` / boot log** — each plugin's web backends are reported like its tool sets
  and sandbox backends.

A backend supplies **executors**, not `Tool`s. Core owns the input schemas, the descriptions, the caps,
the slicing, the timeout, the error contract, and the egress guard — per the ADR's enforceability
argument: a backend that owned the `Tool` would put the model-supplied URL out of core's reach.

`read_url` mirrors `fetchUrl` exactly — same `max_length` / `start_index` defaults, same
`{ content, url, content_type, truncated, next_start_index? }` return, same trailing
`[Content truncated. Pass start_index=… to continue reading.]` hint — so a continuation read reads
identically whichever page-reader the model reached for. No robots.txt, per the ADR.

One case has no `fetchUrl` counterpart to mirror: `fetchUrl` has no core content cap, so nothing there
corresponds to reaching the tail of a page that `MAX_READ_URL_CONTENT_CHARS` already cut. Left alone,
that read returns `truncated: true` with no `next_start_index` — an unexplained dead end. Core emits a
distinct terminal line instead, saying the remainder cannot be read. The paging hint above is unchanged
and still byte-identical.

## Calls the ADR left open

Each is one constant or one helper, so revising any of them later is a one-line edit plus a test.

| Decision                                                                                                                                                                  | Why                                                                                                                                                                                                                                                                                                                   |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `MAX_SEARCH_RESULTS=10`, `MAX_SNIPPET_CHARS=500`, `MAX_TITLE_CHARS=200`, **`MAX_ANSWER_CHARS=4000`**                                                                      | The ADR names result-count capping and snippet truncation, which left `answer` — free text from Brave/Tavily — unbounded, reopening the context-blowup hole `createExecutors` exists to close.                                                                                                                        |
| **`MAX_SEARCH_RESULT_SCAN = MAX_SEARCH_RESULTS * 10`** — how many raw entries core will look at to fill its 10 slots, with a warn-log naming what was ignored             | The result cap alone does not bound the work: unusable entries are dropped and skipped _past_, so an executor returning a million `javascript:` hits would have core parse a million URLs. Same category as the two bounds above — a limit the ADR is silent on, fixed as a named constant rather than left implicit. |
| **`MAX_READ_URL_CONTENT_CHARS=1_000_000`**, applied before slicing                                                                                                        | Mirrors sandbox `MAX_READ_BYTES`. Stated limit: the executor hands core a materialised string, so this bounds context and CPU, not backend memory — the timeout is the only lever there.                                                                                                                              |
| **`timeoutMs` ceiling 120_000, refused at boot** (default 30_000)                                                                                                         | ADR wording is "refuses anything above a hard ceiling"; `timeoutMs` is static on the contribution, so it is knowable at load, and boot posture is fail-loud everywhere else. Not a silent clamp.                                                                                                                      |
| **Result URLs are `http(s)`-only** (`isPresentableUrl`), non-conforming entries dropped with a warn-log                                                                   | The egress guard covers URLs going _into_ `read_url`; nothing covered the ones coming _out of_ `web_search`. PR3 makes these clickable, and `javascript:`/`data:` in a pill is a real hole.                                                                                                                           |
| **Mandatory `web_search` enforced twice** — boot rejects a missing `createExecutors`; turn time warns and serves `{}` if the executor object has no `web_search`          | The TS type makes it required, but a third-party JS plugin can return `{}`. Boot fail-loud, runtime graceful — the ADR's split posture.                                                                                                                                                                               |
| **`buildTurnTools(ctx)`**, not `createTools(ctx)`                                                                                                                         | `createTools` is the identifier the ADR **rejects** for the contribution factory; reusing it on core's side would read as the rejected shape.                                                                                                                                                                         |
| **Casing seam:** SDK types camelCase (`contentType`), model-facing returns snake_case (`content_type`)                                                                    | SDK types follow repo convention; the return must match `fetchUrl` byte-for-byte, and the tool _names_ are already a documented snake_case exception.                                                                                                                                                                 |
| **Observability** is a defined line: `{ backend, plugin, tool, durationMs, outcome }`, `outcome ∈ ok \| timeout \| blocked \| error` — `debug` for `ok`, `warn` otherwise | Queries and URLs are user content and can carry sensitive terms, so they are logged at `debug` only, never on the outcome line.                                                                                                                                                                                       |
| **Model-facing failure text is fixed, not the upstream cause**                                                                                                            | A backend's error message routinely embeds the URL it called, which for a hosted search API carries the Operator's API key. The cause goes to the log line.                                                                                                                                                           |

Two seams worth a reviewer's eye:

- **`query` is echoed from the model's input**, not from the executor's returned `query` — core owns the
  result shape, so a backend cannot substitute text there. The field stays in the SDK type because the
  ADR defines the executor return that way.
- **`isPresentableUrl` lives in `web-backends/`** for now. PR3 needs the same check in the frontend
  before rendering a Sources pill; happy to lift it into `@platypus/schemas` there (or here, if you'd
  rather it land with the definition).

## Verification

- New: 34 tests in `web-backends/index.test.ts`, 11 in `plugins/loader.test.ts`, 2 in the SDK's
  `index.test.ts`. Covers the caps and the scan bound, the `javascript:` drop, egress blocking (real
  guard, injected resolver), slicing + both truncation messages, the content cap, timeouts, executor
  throws, boot refusals, the `fetchUrl`-mirroring schema defaults, and plugin-config injection.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` all green across the workspace — backend 1320, frontend 26,
  schemas 60, plugin-sdk 7, example-plugin 3.

## Review pass on this branch

A self-review found nine items, all fixed here and all covered by the tests above. Three are worth a
reviewer knowing about, since they change behaviour rather than tidy it:

- **The contribution is passed to `composeWebBackend` by reference, never spread into a copy.** The
  namespaced id rides alongside it as a separate `backend` field. Spreading would invoke
  `createExecutors` on the copy, so a class-instance contribution would lose both its prototype and its
  `this` — the sandbox loop avoids the same trap by re-wrapping `create` around the original. Both
  executors are also bound to the object that supplied them, so a backend may write them as methods.
- **Executor payloads are read as `unknown` and narrowed field by field.** The SDK types say what a
  well-behaved backend returns; a third-party JS plugin is under no obligation to honour them. One
  visible consequence: a non-string `title` now narrows to `""` rather than being `String()`-coerced, so
  `[object Object]` cannot reach the model.
- **`backend` and `name` are validated before the id is namespaced.** Namespacing first would mint a
  plausible-looking `"acme.undefined"` and register it, turning a missing field into a mystery catalog
  entry instead of a boot error naming the plugin.

## Reporting surfaces — what this PR does and does not cover

`GET /plugins` reports `webBackends`, and the admin installed-plugins list renders them: its
`InstalledPlugin` type and its "No contributions." emptiness check both account for web backends, so a
plugin contributing only one no longer renders as contributing nothing.

The **docs site is deliberately not covered here.** `apps/docs/content/extending/index.mdx` documents
Sandbox backends and Tool sets and has no web-backend section, and `packages/plugin-sdk/README.md` links
to that page as the full contribution reference. That page describes what an Operator can actually use,
and until the Provider selector lands (PR3) there is no way to select a backend — so it goes with the
docs work in PR4 rather than describing an extension point nobody can reach. The SDK README, which ships
with the package an author builds against, _is_ updated here.

## Follows

PR2 predicate + `webBackend` column + turn-time resolution · PR3 catalog route, Provider selector,
`canSearch` rework, Sources rendering · PR4 ADR → `accepted` + docs, including the `extending` page's
web-backend section.

Refs #329 — part 1 of 4, so this does not close it.

## Related

#388 fixes the same two flaws in the Sandbox extension point — the `Object.prototype` registry and the
unvalidated contribution entry — which the review on this PR flagged as shared and asked to keep
separate. Based on `main`, independent of this branch.
