### PR TITLE
chore(docs): stop documentation drifting from code

### DIFF
--- a/.agents/skills/docs-audit/SKILL.md
+++ b/.agents/skills/docs-audit/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: docs-audit
+description: Audit one section of apps/docs/content against the code, and report what is wrong, stale, fragile, off-voice, or missing. Use when the user wants a documentation section checked for drift.
+disable-model-invocation: true
+---
+
+Audit one section of `apps/docs/content` against the source, and report every
+claim that no longer holds.
+
+`apps/docs/content/docs-contract.test.ts` already pins the claims with exactly
+one authoritative source — env tables, webhook events, core Plugin names, field
+limits, internal links, heading anchors. Assume those are green and do not
+re-check them. Your job is everything that needs judgement, above all the ~150
+bolded UI labels across `building-with-platypus/`, which nothing can see.
+
+**Never answer from memory.** Every verdict cites a file and a line in the code.
+A claim you did not open the source for is a claim you did not check.
+
+## Step 1 — Pick the section and build the suspect pool
+
+Audit **one** section per run: `getting-started/`, `self-hosting/`, `concepts/`,
+`building-with-platypus/`, `extending/`, or `reference/`. Ask the user which if
+they did not say.
+
+Find when the section was last touched, then list what changed in the code
+since:
+
+```bash
+git log -1 --format=%H -- apps/docs/content/<section>
+git log <that-sha>..HEAD --oneline -- apps/backend apps/frontend packages/schemas
+```
+
+Drift concentrates where code moved and docs did not, so read that commit list
+before you read the pages — it tells you which claims to distrust.
+
+**Done when:** you have the section, the last-touch SHA, and the commit list.
+
+## Step 2 — List every claim
+
+Read each page in the section **in full**. Then write out every falsifiable
+claim it makes, each with its `file:line`.
+
+A claim is anything a reader could act on and find wrong: a UI label, a field
+name, a menu path, a default, a limit, an ordering, a behaviour, a "this
+requires that", a "you cannot do X".
+
+List **every** claim, not a sample. Coverage has to be a property of the
+procedure, because it will not be a property of your attention. A page with
+sixty claims produces sixty rows.
+
+**Done when:** every page in the section has been read end to end and every
+claim is on the list with a line number.
+
+## Step 3 — Verify each claim against source
+
+For each claim, open the code that decides it and record the verdict as
+`doc file:line vs code file:line`.
+
+Where to look:
+
+- UI labels, fields, menu paths → `apps/frontend/app/**`, `apps/frontend/components/**`
+- limits, enums, required fields → `packages/schemas/index.ts`
+- endpoints, status codes, errors → `apps/backend/src/routes/**`
+- run behaviour, steps, timeouts → `apps/backend/src/runs/**`
+- plugins, Sandboxes, tool sets → `apps/backend/src/plugins/**`
+- deployment, env, first boot → `.env.example`, `compose*.yaml`, `apps/backend/index.ts`
+
+Check exhaustive lists **in both directions**: everything the code has appears
+in the doc, and everything the doc lists exists in the code. A missing row is
+invisible to a reader — they cannot miss what they were never shown.
+
+**Done when:** every claim has a verdict and a code citation.
+
+## Step 4 — Classify
+
+| Class       | Meaning                                                             |
+| ----------- | ------------------------------------------------------------------- |
+| **WRONG**   | Contradicts the code. A reader following it fails.                  |
+| **STALE**   | Was true, describes something that has since moved or been renamed. |
+| **FRAGILE** | True today, with no anchor — it will rot and nothing will notice.   |
+| **TONE**    | Accurate but off-voice against `VOICE.md`.                          |
+| **GAP**     | The code does something user-facing that no page mentions.          |
+
+## Step 5 — Report
+
+Rank by **reader cost**: what breaks a deployment first, then what wastes an
+hour, then what merely reads badly. Not by page order, and not by how easy the
+fix is.
+
+For each finding give the doc `file:line`, the code `file:line`, what the page
+says, what the code does, and the proposed edit.
+
+**FRAGILE defaults to deletion, not correction.** Correcting an anchorless claim
+resets the clock; deleting it stops the bleeding. Keep it only when it earns its
+maintenance — say why in the finding. Otherwise the audit's own output becomes
+next year's backlog.
+
+Close with the claim count, how many you verified, and what you could not
+check — a claim you could not resolve is a finding, not a silence.
+
+## The honest limit
+
+This skill is user-invoked only, so its value is bounded entirely by someone
+remembering to type it. Nothing schedules it and nothing reminds you. Pair it
+with a release checklist or `/loop`, or accept that the contract test is the
+only thing actually running.

--- a/.agents/skills/docs-audit/VOICE.md
+++ b/.agents/skills/docs-audit/VOICE.md
@@ -1,0 +1,80 @@
+# Docs voice
+
+House style for `apps/docs/content`. Used by `/docs-audit` to classify TONE
+findings, and by anyone editing a page.
+
+## Who is reading
+
+Self-hosters (Operators), Org Admins, and Workspace Owners. People running and
+using Platypus — not people building it.
+
+They arrive mid-task with a specific question. They are competent and short of
+time. They are not reading the section in order.
+
+## Write the task, not the implementation
+
+The reader cannot see the repository and will never open it.
+
+- No `apps/**` paths, no file names, no function or class names.
+- No ADR links and no ADR numbers.
+- No inlined TypeScript interfaces where a table of fields would do.
+- No "Status: implemented", no roadmap, no changelog.
+- No maintainer rationale unless it changes what the reader should do.
+
+The exception is a page whose subject genuinely is the source: the reference
+pages cite `.env.example` as their source of truth, and `extending/` shows the
+SDK surface a plugin author writes against.
+
+## Voice
+
+Second person, present tense, active. "Open the Webhook again and the **Signing
+Secret** field appears" — not "the field will then be displayed".
+
+Say what the thing is before what to do with it. Lead the page with the sentence
+a reader could quote to a colleague.
+
+Plain over formal, specific over hedged. Give the number, the default, the exact
+label. "Each attempt times out after **10 seconds**" beats "attempts time out
+promptly".
+
+Do not sell. No "powerful", "seamless", "simply", "just", "easily". If it were
+easy the page would be shorter.
+
+## Name the trap
+
+The strongest thing these docs do is call out the failure a reader is about to
+walk into, and say what to do instead:
+
+> Setting `TIMEZONE` and expecting a 9am Trigger to fire at 9am local is the
+> trap; set the zone on the Trigger.
+
+> A handler written against `data.notificationId` alone reads `undefined` on
+> every bulk event and drops the whole batch silently.
+
+State the wrong mental model, the symptom, then the fix. A `<Callout>` is the
+usual home for it. Do not soften it into "note that".
+
+## Conventions
+
+- **Domain nouns are capitalised**: Agent, Workspace, Organization, Chat, Skill,
+  Trigger, Board, Webhook, Sandbox, Plugin, Tool, Provider, Operator. Ordinary
+  words are not — a "card" on a Board is a card.
+- **UI labels are bold**, and menu paths use an arrow: **Settings → Webhooks**.
+  Bold the label exactly as it appears on screen.
+- **Code spans** for env vars, values, fields, and event names: `BACKEND_URL`,
+  `card.created`, `disk`.
+- `<Callout type="info">` for context a reader can skip;
+  `<Callout type="warning">` for something that costs them if missed.
+- `<Steps>` for an ordered procedure the reader performs once.
+- Tables for enumerations. A Required column earns its place; a Default column
+  states `_(none)_` or `_(unset)_` rather than leaving a blank.
+- Internal links are root-relative: `/self-hosting/configuration#plugins`.
+- End a task page with **Where to next** linking two or three real destinations.
+
+## Length
+
+Say it once, in the place the reader is standing. A claim repeated on three
+pages rots on two of them.
+
+Prefer deleting a paragraph to qualifying it. An anchorless claim that nothing
+verifies is a liability, and the shortest true page beats the fullest stale one.

--- a/.claude/skills/docs-audit
+++ b/.claude/skills/docs-audit
@@ -1,0 +1,1 @@
+../../.agents/skills/docs-audit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,35 @@ migrate`) but are skipped by the dev push flow. In dev, apply any needed data ch
 - **No TypeScript parameter properties.** Node's strip-only TS mode rejects `constructor(private x: T)` shorthand. Declare fields explicitly and assign in the constructor body.
 - Format with Prettier conventions.
 
+## Documentation
+
+Docs live in `apps/docs/content` and ship **in the same PR as the code**, never
+as a follow-up ticket. The follow-up ticket does not get filed; that is how
+`627cb1e` shipped a breaking Operator-facing change with no docs update.
+
+Check the table below against the paths in your own diff. If they intersect,
+the docs edit is part of this change:
+
+| You changed                                              | Update                                                               |
+| -------------------------------------------------------- | -------------------------------------------------------------------- |
+| any `.env.example`                                       | `reference/backend-configuration.mdx` / `frontend-configuration.mdx` |
+| a user-facing `min`/`max`/`z.enum` in `packages/schemas` | the matching `building-with-platypus/*.mdx` page                     |
+| `apps/backend/src/plugins/**`                            | `extending/index.mdx`, `self-hosting/configuration.mdx`              |
+| a visible label, field, or nav item in `apps/frontend`   | the `building-with-platypus/*.mdx` page for that feature             |
+
+When writing:
+
+- The audience is self-hosters and Workspace Owners, not maintainers.
+- Write the task, not the implementation — no `apps/**` paths, no ADR links, no
+  inlined interfaces, no status sections.
+- House style is `.agents/skills/docs-audit/VOICE.md`.
+
+`apps/docs/content/docs-contract.test.ts` mechanically pins the claims with a
+single authoritative source (env tables, webhook events, core Plugin names,
+field limits, internal links, heading anchors) and runs in the CI gate. It is a
+floor, not a gate — it cannot see the ~150 UI labels. Use `/docs-audit` for what
+needs judgement.
+
 ## Git Branch Standards
 
 Branch names MUST be prefixed `feature/`, `fix/`, or `chore/` only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,9 @@ When writing:
 `apps/docs/content/docs-contract.test.ts` mechanically pins the claims with a
 single authoritative source (env tables, webhook events, core Plugin names,
 field limits, internal links, heading anchors) and runs in the CI gate. It is a
-floor, not a gate — it cannot see the ~150 UI labels. Use `/docs-audit` for what
-needs judgement.
+floor, not a gate — it cannot see the ~150 UI labels. For what needs judgement,
+ask the user to run `/docs-audit`; the skill is user-invoked only, so you cannot
+start it yourself.
 
 ## Git Branch Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,9 +123,15 @@ chore(tests): add missing test coverage
 
 1. Ensure your code passes all tests (`pnpm test`) and is formatted (`pnpm format`).
 2. Write clear, descriptive commit messages following the conventions above.
-3. Open a pull request against the `main` branch.
-4. Provide a clear description of the changes and the motivation behind them.
-5. Link any related issues in your PR description.
+3. Update the docs in `apps/docs/content` in the same PR, not a follow-up one.
+   If you changed an `.env.example`, a user-facing limit or enum in
+   `packages/schemas`, anything under `apps/backend/src/plugins`, or a visible
+   label or field in the frontend, a page needs editing. `pnpm test` fails when
+   the reference tables, webhook events, core plugin names, field limits, or
+   internal links no longer match the code.
+4. Open a pull request against the `main` branch.
+5. Provide a clear description of the changes and the motivation behind them.
+6. Link any related issues in your PR description.
 
 ## Project Structure
 

--- a/apps/docs/content/docs-contract.test.ts
+++ b/apps/docs/content/docs-contract.test.ts
@@ -1,0 +1,791 @@
+/**
+ * Documentation contract test.
+ *
+ * Pins the documentation claims that have exactly one authoritative source, so
+ * that renaming an environment variable, adding a webhook event, registering a
+ * core Plugin, or changing a field limit fails CI instead of reaching an
+ * Operator at deploy time. Every failure names the doc file, the line, and the
+ * source of truth — an unattributable failure in a docs suite gets skipped.
+ *
+ * Only claims that can be checked without judgement live here. Anything that
+ * needs a reader's eye belongs in the `/docs-audit` skill instead. One noisy
+ * assertion trains everyone to ignore a red suite, which costs more than the
+ * assertion is worth.
+ *
+ * Known limits, stated so nobody mistakes this for coverage:
+ *
+ * - It only checks what someone encoded. The ~150 bolded UI labels across
+ *   `building-with-platypus/` have no anchor at all — rename a button and
+ *   nothing here complains. A green suite is not a correct docs site.
+ * - Text-matching MDX is brittle in boring ways. Dashes are normalised and
+ *   thousands separators stripped before comparison, but a rewritten sentence
+ *   can still move a claim out from under its anchor. When that happens the
+ *   failure says so explicitly rather than reporting a wrong number.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, posix, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import GithubSlugger from "github-slugger";
+import { describe, expect, it } from "vitest";
+import {
+  agentSchema,
+  dashboardCreateSchema,
+  DEFAULT_MAX_EXTRACTED_TEXT_CHARS,
+  kanbanBoardSchema,
+  mcpSchema,
+  skillSchema,
+  triggerSchema,
+  webhookEventSchema,
+} from "@platypus/schemas";
+
+const CONTENT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(CONTENT_DIR, "..", "..", "..");
+
+// --- reading -----------------------------------------------------------------
+
+const readRepoFile = (repoRelativePath: string): string =>
+  readFileSync(join(REPO_ROOT, repoRelativePath), "utf8");
+
+const readDoc = (contentRelativePath: string): string =>
+  readFileSync(join(CONTENT_DIR, contentRelativePath), "utf8");
+
+/** Every `.mdx` page under `content/`, as paths relative to `content/`. */
+const listDocs = (dir = CONTENT_DIR): string[] => {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const absolute = join(dir, entry);
+    if (statSync(absolute).isDirectory()) {
+      found.push(...listDocs(absolute));
+    } else if (entry.endsWith(".mdx")) {
+      found.push(relative(CONTENT_DIR, absolute).split(sep).join(posix.sep));
+    }
+  }
+  return found.sort();
+};
+
+const DOCS = listDocs();
+
+if (DOCS.length === 0) {
+  throw new Error(
+    `No .mdx pages found under ${CONTENT_DIR}. Every assertion below would pass vacuously.`,
+  );
+}
+
+/**
+ * Blank out fenced code blocks while preserving line numbering. Fences hold
+ * illustrative snippets — a Dockerfile `ARG`, an example payload — that are not
+ * claims about the current shape of anything.
+ */
+const withoutCodeFences = (content: string): string => {
+  let inFence = false;
+  return content
+    .split("\n")
+    .map((line) => {
+      if (/^\s*```/.test(line)) {
+        inFence = !inFence;
+        return "";
+      }
+      return inFence ? "" : line;
+    })
+    .join("\n");
+};
+
+type Located = { text: string; line: number };
+
+/** Inline `` `code` `` spans outside fenced blocks, with their line numbers. */
+const inlineCodeSpans = (content: string): Located[] => {
+  const spans: Located[] = [];
+  withoutCodeFences(content)
+    .split("\n")
+    .forEach((line, index) => {
+      for (const match of line.matchAll(/`([^`\n]+)`/g)) {
+        spans.push({ text: match[1], line: index + 1 });
+      }
+    });
+  return spans;
+};
+
+type MarkdownTable = { line: number; header: string[]; rows: string[][] };
+
+const splitRow = (line: string): string[] =>
+  line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((cell) => cell.trim());
+
+/** Every pipe table on the page, in document order. */
+const markdownTables = (content: string): MarkdownTable[] => {
+  const lines = withoutCodeFences(content).split("\n");
+  const tables: MarkdownTable[] = [];
+  for (let i = 0; i < lines.length - 1; i += 1) {
+    const isHeader = lines[i].trim().startsWith("|");
+    const isDivider = /^\s*\|[\s|:-]+\|\s*$/.test(lines[i + 1]);
+    if (!isHeader || !isDivider) continue;
+
+    const header = splitRow(lines[i]);
+    const rows: string[][] = [];
+    let cursor = i + 2;
+    while (cursor < lines.length && lines[cursor].trim().startsWith("|")) {
+      rows.push(splitRow(lines[cursor]));
+      cursor += 1;
+    }
+    tables.push({ line: i + 1, header, rows });
+    i = cursor;
+  }
+  return tables;
+};
+
+/** The table whose first header cell matches `label`, e.g. "Event". */
+const tableByFirstColumn = (
+  content: string,
+  label: string,
+): MarkdownTable | undefined =>
+  markdownTables(content).find((table) => table.header[0] === label);
+
+const firstCodeSpan = (cell: string): string | undefined =>
+  cell.match(/`([^`]+)`/)?.[1];
+
+// --- assertion plumbing ------------------------------------------------------
+
+/**
+ * Report every violation at once rather than the first. A docs failure is
+ * usually a batch — one rename touching six rows — and fixing them one CI run
+ * at a time is how people learn to skip the suite.
+ */
+const expectNoViolations = (violations: string[]) => {
+  expect(violations.join("\n\n"), "documentation contract violations").toBe("");
+};
+
+// --- environment variables ---------------------------------------------------
+
+const ENV_EXAMPLE_FILES = [
+  ".env.example",
+  "apps/backend/.env.example",
+  "apps/frontend/.env.example",
+];
+
+const ENV_REFERENCE_PAGES = [
+  "reference/backend-configuration.mdx",
+  "reference/frontend-configuration.mdx",
+];
+
+/**
+ * Variables the docs deliberately still name after they stopped existing,
+ * because a reader upgrading needs to be told where the setting went. Removing
+ * the migration note is what should retire the entry here.
+ */
+const REMOVED_VARS = new Set([
+  "FETCH_TOOL_IGNORE_ROBOTS_TXT",
+  "PLATYPUS_SANDBOX_DOCKER_ALLOWED_NETWORKS",
+]);
+
+/**
+ * Real variables that no `.env.example` ships, so the reference page is their
+ * only home. Both are read by the frontend (`next.config.ts` and the About
+ * page) and neither is something a deployment normally sets.
+ */
+const VARS_WITHOUT_ENV_EXAMPLE_ENTRY = new Set([
+  "ALLOWED_DEV_ORIGINS",
+  "NEXT_PUBLIC_APP_VERSION",
+]);
+
+/**
+ * Assignments in a `.env.example`, including commented-out ones — a `# VAR=`
+ * line is how the file documents an optional setting, so it is still a variable
+ * the reference page owes the reader a row for.
+ */
+const parseEnvExample = (content: string): Map<string, number> => {
+  const found = new Map<string, number>();
+  content.split("\n").forEach((line, index) => {
+    const match = line.match(/^\s*#?\s*([A-Z][A-Z0-9_]*)=/);
+    if (match && !found.has(match[1])) found.set(match[1], index + 1);
+  });
+  return found;
+};
+
+describe("environment variables", () => {
+  const declared = new Map<string, string>(); // VAR -> "file:line"
+  for (const file of ENV_EXAMPLE_FILES) {
+    for (const [name, line] of parseEnvExample(readRepoFile(file))) {
+      if (!declared.has(name)) declared.set(name, `${file}:${line}`);
+    }
+  }
+
+  // A bare uppercase word is only read as a variable claim when it really is
+  // one; without this `UTC` in a Default column would look like a phantom row.
+  const looksLikeVariable = (token: string) =>
+    /^[A-Z][A-Z0-9_]*$/.test(token) &&
+    (token.includes("_") || declared.has(token));
+
+  const documented = new Map<string, string>(); // VAR -> "page:line"
+  for (const page of ENV_REFERENCE_PAGES) {
+    for (const span of inlineCodeSpans(readDoc(page))) {
+      const token = span.text.split("=")[0].trim();
+      if (!looksLikeVariable(token)) continue;
+      if (!documented.has(token)) documented.set(token, `${page}:${span.line}`);
+    }
+  }
+
+  it("extracted variables from both sides", () => {
+    // An extractor that silently stops matching turns every assertion below
+    // green, which is worse than no test at all.
+    expect(
+      declared.size,
+      `parsed no assignments out of ${ENV_EXAMPLE_FILES.join(", ")}`,
+    ).toBeGreaterThan(20);
+    expect(
+      documented.size,
+      `parsed no variables out of ${ENV_REFERENCE_PAGES.join(", ")}`,
+    ).toBeGreaterThan(20);
+  });
+
+  it("documents every variable the .env.example files ship", () => {
+    const violations: string[] = [];
+    for (const [name, origin] of declared) {
+      if (documented.has(name)) continue;
+      violations.push(
+        `\`${name}\` is set in ${origin} but neither reference page mentions it.\n` +
+          `Add a row to apps/docs/content/${ENV_REFERENCE_PAGES.join(" or apps/docs/content/")}.`,
+      );
+    }
+    expectNoViolations(violations);
+  });
+
+  it("names no variable the .env.example files do not ship", () => {
+    const violations: string[] = [];
+    for (const [name, origin] of documented) {
+      if (declared.has(name)) continue;
+      if (REMOVED_VARS.has(name)) continue;
+      if (VARS_WITHOUT_ENV_EXAMPLE_ENTRY.has(name)) continue;
+      violations.push(
+        `apps/docs/content/${origin} names \`${name}\`, which no .env.example assigns.\n` +
+          `Source of truth: ${ENV_EXAMPLE_FILES.join(", ")}.\n` +
+          `If the variable was deliberately removed, add it to REMOVED_VARS in this file; ` +
+          `if it is real but no example file ships it, add it to VARS_WITHOUT_ENV_EXAMPLE_ENTRY.`,
+      );
+    }
+    expectNoViolations(violations);
+  });
+
+  it("keeps the variable allowlists honest", () => {
+    const violations: string[] = [];
+    for (const name of REMOVED_VARS) {
+      if (declared.has(name)) {
+        violations.push(
+          `\`${name}\` is listed in REMOVED_VARS but ${declared.get(name)} assigns it again.\n` +
+            `Drop it from REMOVED_VARS so the reference page is checked against the env files.`,
+        );
+      }
+    }
+    for (const name of [...REMOVED_VARS, ...VARS_WITHOUT_ENV_EXAMPLE_ENTRY]) {
+      if (!documented.has(name)) {
+        violations.push(
+          `\`${name}\` is allowlisted in this file but no reference page mentions it any more.\n` +
+            `Remove the allowlist entry.`,
+        );
+      }
+    }
+    expectNoViolations(violations);
+  });
+});
+
+// --- webhook events ----------------------------------------------------------
+
+describe("webhook events", () => {
+  const page = "building-with-platypus/webhooks.mdx";
+  const content = readDoc(page);
+  const table = tableByFirstColumn(content, "Event");
+  const source = "packages/schemas/index.ts (webhookEventSchema)";
+
+  it("has a subscribable-events table to check", () => {
+    expect(
+      table,
+      `apps/docs/content/${page} has no table whose first column is "Event". ` +
+        `The event list is checked against ${source}; restore the table or update this test.`,
+    ).toBeDefined();
+  });
+
+  it("matches webhookEventSchema in both directions", () => {
+    if (!table) return;
+
+    const documented = new Map<string, number>();
+    table.rows.forEach((row, index) => {
+      const name = firstCodeSpan(row[0]);
+      if (name) documented.set(name, table.line + 2 + index);
+    });
+    expect(
+      documented.size,
+      `parsed no event names out of the table at apps/docs/content/${page}:${table.line}`,
+    ).toBeGreaterThan(0);
+
+    const violations: string[] = [];
+    for (const event of webhookEventSchema.options) {
+      if (!documented.has(event)) {
+        violations.push(
+          `\`${event}\` is in ${source} but the events table at apps/docs/content/${page}:${table.line} has no row for it.\n` +
+            `An integrator cannot subscribe to an event they cannot find.`,
+        );
+      }
+    }
+    for (const [event, line] of documented) {
+      if (!webhookEventSchema.options.includes(event as never)) {
+        violations.push(
+          `apps/docs/content/${page}:${line} lists \`${event}\`, which is not in ${source}.\n` +
+            `That event never fires.`,
+        );
+      }
+    }
+    expectNoViolations(violations);
+  });
+});
+
+// --- core plugins ------------------------------------------------------------
+
+/**
+ * Read the plugin names out of the backend registry as text rather than
+ * importing it — the module pulls in the plugin SDK, and the docs package has
+ * no business depending on the backend to check a list of five strings.
+ */
+const BUILTIN_SOURCE = "apps/backend/src/plugins/builtin.ts";
+
+/** The literal between `declaration` and the `};` / `];` that closes it. */
+const literalAfter = (content: string, declaration: string): string => {
+  const body = content.slice(content.indexOf(declaration));
+  const end = body.search(/[}\]];/);
+  return body.slice(0, end);
+};
+
+const parseBuiltinPluginNames = (): string[] => {
+  const literal = literalAfter(readRepoFile(BUILTIN_SOURCE), "BUILTIN_PLUGINS");
+  return [...literal.matchAll(/"(@platypus\/[a-z0-9-]+)":/g)].map(
+    (match) => match[1],
+  );
+};
+
+const parseAlwaysOnPluginNames = (): string[] => {
+  const literal = literalAfter(
+    readRepoFile(BUILTIN_SOURCE),
+    "ALWAYS_ON_PLUGINS",
+  );
+  return [...literal.matchAll(/"(@platypus\/[a-z0-9-]+)"/g)].map(
+    (match) => match[1],
+  );
+};
+
+describe("core plugins", () => {
+  const registered = parseBuiltinPluginNames();
+  const alwaysOn = parseAlwaysOnPluginNames();
+
+  it("parsed the registry", () => {
+    expect(
+      registered.length,
+      `Parsed no plugin names out of ${BUILTIN_SOURCE} (BUILTIN_PLUGINS). The registry's shape changed; update this test.`,
+    ).toBeGreaterThan(0);
+    expect(
+      alwaysOn.length,
+      `Parsed no plugin names out of ${BUILTIN_SOURCE} (ALWAYS_ON_PLUGINS). The registry's shape changed; update this test.`,
+    ).toBeGreaterThan(0);
+  });
+
+  it("mentions every registered core plugin somewhere in the docs", () => {
+    const mentioned = new Map<string, string>(); // name -> "page:line"
+    for (const doc of DOCS) {
+      readDoc(doc)
+        .split("\n")
+        .forEach((line, index) => {
+          for (const match of line.matchAll(/@platypus\/[a-z0-9-]+/g)) {
+            if (!mentioned.has(match[0])) {
+              mentioned.set(match[0], `${doc}:${index + 1}`);
+            }
+          }
+        });
+    }
+
+    const violations: string[] = [];
+    for (const name of registered) {
+      if (!mentioned.has(name)) {
+        violations.push(
+          `\`${name}\` is registered in ${BUILTIN_SOURCE} but no page under apps/docs/content mentions it.\n` +
+            `An Operator cannot enable a plugin they have never heard of — document it in reference/backend-configuration.mdx and self-hosting/configuration.mdx.`,
+        );
+      }
+    }
+    for (const [name, origin] of mentioned) {
+      if (!registered.includes(name)) {
+        violations.push(
+          `apps/docs/content/${origin} mentions \`${name}\`, which ${BUILTIN_SOURCE} does not register.\n` +
+            `Either the plugin was renamed or removed, or the page invented it.`,
+        );
+      }
+    }
+    expectNoViolations(violations);
+  });
+
+  // A mention anywhere is a weak floor: a plugin named once in an upgrade note
+  // still leaves the Operator-facing list a row short. Configuration.mdx says
+  // "This page owns the list", so that table is checked row by row, tier
+  // included — which is the only thing pinning ALWAYS_ON_PLUGINS.
+  it("keeps the core-plugin table in step with the registry, tier included", () => {
+    const page = "self-hosting/configuration.mdx";
+    const table = tableByFirstColumn(readDoc(page), "Plugin");
+    expect(
+      table,
+      `apps/docs/content/${page} has no table whose first column is "Plugin". ` +
+        `The core plugin list is checked against ${BUILTIN_SOURCE}; restore the table or update this test.`,
+    ).toBeDefined();
+    if (!table) return;
+
+    const tierColumn = table.header.indexOf("Tier");
+    expect(
+      tierColumn,
+      `The core plugin table at apps/docs/content/${page}:${table.line} has no "Tier" column ` +
+        `to check against ALWAYS_ON_PLUGINS in ${BUILTIN_SOURCE}.`,
+    ).toBeGreaterThan(-1);
+
+    const listed = new Map<string, { tier: string; line: number }>();
+    table.rows.forEach((row, index) => {
+      const name = firstCodeSpan(row[0]);
+      if (name) {
+        listed.set(name, {
+          tier: row[tierColumn],
+          line: table.line + 2 + index,
+        });
+      }
+    });
+
+    const violations: string[] = [];
+    for (const name of registered) {
+      if (!listed.has(name)) {
+        violations.push(
+          `\`${name}\` is registered in ${BUILTIN_SOURCE} but the core plugin table at apps/docs/content/${page}:${table.line} has no row for it.\n` +
+            `A missing row is invisible — the Operator cannot deny or enable what the list never showed them.`,
+        );
+      }
+    }
+    for (const [name, row] of listed) {
+      if (!registered.includes(name)) {
+        violations.push(
+          `apps/docs/content/${page}:${row.line} lists \`${name}\`, which ${BUILTIN_SOURCE} does not register.\n` +
+            `That plugin cannot be loaded.`,
+        );
+        continue;
+      }
+      const expectedTier = alwaysOn.includes(name) ? "Always-on" : "Gate-able";
+      if (row.tier !== expectedTier) {
+        violations.push(
+          `apps/docs/content/${page}:${row.line} puts \`${name}\` in the "${row.tier}" tier, ` +
+            `but ALWAYS_ON_PLUGINS in ${BUILTIN_SOURCE} makes it "${expectedTier}".\n` +
+            `Listing an always-on plugin in PLATYPUS_PLUGINS is fail-loud at boot, so this misdirects an Operator into a backend that will not start.`,
+        );
+      }
+    }
+    expectNoViolations(violations);
+  });
+});
+
+// --- field limits ------------------------------------------------------------
+
+/**
+ * Unwrap `.optional()` / `.nullable()` so the string checks underneath are
+ * reachable.
+ */
+const unwrap = (
+  schema: unknown,
+): { minLength?: number; maxLength?: number } => {
+  let current = schema as { unwrap?: () => unknown };
+  while (typeof current?.unwrap === "function") {
+    current = current.unwrap() as { unwrap?: () => unknown };
+  }
+  return current as { minLength?: number; maxLength?: number };
+};
+
+/**
+ * The `min`/`max` a Zod string field enforces, whatever it is wrapped in.
+ *
+ * Throws rather than returning empty bounds. If Zod moves these accessors, an
+ * expectation of `{}` would satisfy every claim below and the whole section
+ * would go quietly green — the exact failure this file exists to prevent.
+ */
+const stringField = (
+  schema: { shape: Record<string, unknown> },
+  field: string,
+): { min?: number; max?: number } => {
+  const bounds = unwrap(schema.shape[field]);
+  const min = bounds.minLength ?? undefined;
+  const max = bounds.maxLength ?? undefined;
+  if (min === undefined && max === undefined) {
+    throw new Error(
+      `Read no min or max off the Zod field \`${field}\`. Either the schema stopped ` +
+        `bounding it, or Zod moved minLength/maxLength — fix this helper before trusting the suite.`,
+    );
+  }
+  return { min, max };
+};
+
+type LimitClaim = {
+  doc: string;
+  /** Unique substring identifying the block that makes the claim. */
+  anchor: string;
+  source: string;
+  expected: { min?: number; max?: number };
+};
+
+/**
+ * Only limits worth keeping are pinned. Where a page deliberately omits a bound
+ * — a Trigger instruction has a `min(1)` no reader will ever hit — the claim
+ * simply does not carry that number, and neither does the expectation.
+ */
+const LIMIT_CLAIMS: LimitClaim[] = [
+  {
+    doc: "building-with-platypus/agents.mdx",
+    anchor: "**Name** — what to call the Agent",
+    source: "packages/schemas/index.ts (agentSchema.name)",
+    expected: stringField(agentSchema, "name"),
+  },
+  {
+    doc: "building-with-platypus/agents.mdx",
+    anchor: "**Description** — a short summary",
+    source: "packages/schemas/index.ts (agentSchema.description)",
+    expected: stringField(agentSchema, "description"),
+  },
+  {
+    doc: "building-with-platypus/skills.mdx",
+    anchor: "**Name** — a kebab-case identifier",
+    source: "packages/schemas/index.ts (skillSchema.name)",
+    expected: stringField(skillSchema, "name"),
+  },
+  {
+    doc: "building-with-platypus/skills.mdx",
+    anchor: "**Description** — a brief summary of what the Skill does",
+    source: "packages/schemas/index.ts (skillSchema.description)",
+    expected: stringField(skillSchema, "description"),
+  },
+  {
+    doc: "building-with-platypus/skills.mdx",
+    anchor: "**Body** — the full instructions",
+    source: "packages/schemas/index.ts (skillSchema.body)",
+    expected: stringField(skillSchema, "body"),
+  },
+  {
+    doc: "building-with-platypus/mcp.mdx",
+    anchor: "**Name** — a label for this server",
+    source: "packages/schemas/index.ts (mcpSchema.name)",
+    expected: stringField(mcpSchema, "name"),
+  },
+  {
+    doc: "building-with-platypus/boards.mdx",
+    anchor: "**Name** — what to call the board",
+    source: "packages/schemas/index.ts (kanbanBoardSchema.name)",
+    expected: stringField(kanbanBoardSchema, "name"),
+  },
+  {
+    doc: "building-with-platypus/boards.mdx",
+    anchor: "**Description** _(optional)_ — up to",
+    source: "packages/schemas/index.ts (kanbanBoardSchema.description)",
+    expected: { max: stringField(kanbanBoardSchema, "description").max },
+  },
+  {
+    doc: "building-with-platypus/dashboards.mdx",
+    anchor: "**Name** — must be unique within the Workspace",
+    source: "packages/schemas/index.ts (dashboardCreateSchema.name)",
+    expected: stringField(dashboardCreateSchema, "name"),
+  },
+  {
+    doc: "building-with-platypus/dashboards.mdx",
+    anchor: "**Description** _(optional)_ — up to",
+    source: "packages/schemas/index.ts (dashboardCreateSchema.description)",
+    expected: { max: stringField(dashboardCreateSchema, "description").max },
+  },
+  {
+    doc: "building-with-platypus/triggers.mdx",
+    anchor: "**Instruction** — the message sent to the Agent",
+    source: "packages/schemas/index.ts (triggerSchema.instruction)",
+    expected: { max: stringField(triggerSchema, "instruction").max },
+  },
+  {
+    doc: "self-hosting/providers-and-auth.mdx",
+    anchor: "`maxExtractedTextChars`",
+    source: "packages/schemas/index.ts (DEFAULT_MAX_EXTRACTED_TEXT_CHARS)",
+    expected: { max: DEFAULT_MAX_EXTRACTED_TEXT_CHARS },
+  },
+];
+
+// A claim with no bound to compare is a test that always passes. Catch it here,
+// at module load, rather than letting it sit green in the report.
+for (const claim of LIMIT_CLAIMS) {
+  if (claim.expected.min === undefined && claim.expected.max === undefined) {
+    throw new Error(
+      `The limit claim "${claim.anchor}" in ${claim.doc} carries no expected bound, ` +
+        `so it would assert nothing. Its source is ${claim.source}.`,
+    );
+  }
+}
+
+/**
+ * The block making a claim: the anchor's line plus any continuation lines, so
+ * a limit that wrapped onto the next line is still found. Prose wraps; the
+ * claim should not have to care.
+ */
+const blockContaining = (
+  content: string,
+  anchor: string,
+): Located | undefined => {
+  // Fenced blocks are blanked first: an example snippet must not be mistaken
+  // for the page's claim about a real limit.
+  const lines = withoutCodeFences(content).split("\n");
+  const start = lines.findIndex((line) => line.includes(anchor));
+  if (start === -1) return undefined;
+
+  const collected = [lines[start]];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() === "" || /^\s*([-*+]\s|\||#|<|```)/.test(line)) break;
+    collected.push(line);
+  }
+  return { text: collected.join(" "), line: start + 1 };
+};
+
+/** Normalise en/em dashes and thousands separators before reading numbers. */
+const normaliseNumbers = (text: string): string =>
+  text
+    .replace(/[‒–—―]/g, "-") // figure, en, em, horizontal bar
+    // Lookahead rather than a capture: the match must not consume the digit a
+    // following separator needs, or `1,234,567` strips to `1234,567`.
+    .replace(/(\d),(?=\d)/g, "$1");
+
+const readClaimedLimits = (
+  text: string,
+): { min?: number; max?: number } | undefined => {
+  const normalised = normaliseNumbers(text);
+  const range = normalised.match(/(\d+)\s*-\s*(\d+)\s*characters/);
+  if (range) return { min: Number(range[1]), max: Number(range[2]) };
+  const upTo = normalised.match(/(?:up to|default)[^.]*?(\d+)\s*characters/);
+  if (upTo) return { max: Number(upTo[1]) };
+  return undefined;
+};
+
+describe("field limits", () => {
+  it.each(LIMIT_CLAIMS)("$doc — $anchor", (claim) => {
+    const content = readDoc(claim.doc);
+    const block = blockContaining(content, claim.anchor);
+    expect(
+      block,
+      `apps/docs/content/${claim.doc} no longer contains "${claim.anchor}". ` +
+        `The limit from ${claim.source} was pinned to that text — re-anchor this claim or drop it.`,
+    ).toBeDefined();
+    if (!block) return;
+
+    const claimed = readClaimedLimits(block.text);
+    expect(
+      claimed,
+      `apps/docs/content/${claim.doc}:${block.line} states no character limit, ` +
+        `but one was pinned to ${claim.source}. Restore the limit or drop this claim from the test.`,
+    ).toBeDefined();
+    if (!claimed) return;
+
+    const violations: string[] = [];
+    for (const bound of ["min", "max"] as const) {
+      const expected = claim.expected[bound];
+      if (expected === undefined) continue;
+      if (claimed[bound] !== expected) {
+        violations.push(
+          `apps/docs/content/${claim.doc}:${block.line} claims a ${bound} of ${claimed[bound] ?? "(none)"}, ` +
+            `but ${claim.source} says ${expected}.\n` +
+            `A reader trusting the page is rejected by a limit the docs got wrong.`,
+        );
+      }
+    }
+    expectNoViolations(violations);
+  });
+});
+
+// --- internal links and heading anchors --------------------------------------
+
+/** `content/index.mdx` → `/`, `content/foo/index.mdx` → `/foo`. */
+const routeFor = (doc: string): string => {
+  const withoutExtension = doc.replace(/\.mdx$/, "");
+  const route = withoutExtension.replace(/(^|\/)index$/, "");
+  return route === "" ? "/" : `/${route}`;
+};
+
+/** Approximate the rendered text of a heading before slugging it. */
+const headingText = (raw: string): string =>
+  raw
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/[*_]{1,3}/g, "")
+    .trim();
+
+/**
+ * Slug every heading the way `rehype-slug` does, duplicates included — Nextra
+ * runs the same `github-slugger`, so a `-1` suffix here is a real anchor there.
+ */
+const headingSlugs = (content: string): Set<string> => {
+  const slugger = new GithubSlugger();
+  const slugs = new Set<string>();
+  for (const line of withoutCodeFences(content).split("\n")) {
+    const match = line.match(/^#{1,6}\s+(.*)$/);
+    if (match) slugs.add(slugger.slug(headingText(match[1])));
+  }
+  return slugs;
+};
+
+describe("internal links", () => {
+  const slugsByRoute = new Map<string, Set<string>>();
+  for (const doc of DOCS) {
+    slugsByRoute.set(routeFor(doc), headingSlugs(readDoc(doc)));
+  }
+
+  it("resolves every internal link and heading anchor", () => {
+    const violations: string[] = [];
+    let checked = 0;
+
+    for (const doc of DOCS) {
+      const content = readDoc(doc);
+      const scanned = withoutCodeFences(content).split("\n");
+
+      scanned.forEach((line, index) => {
+        const targets = [
+          ...[...line.matchAll(/\]\((\/[^)\s]*|#[^)\s]+)\)/g)].map((m) => m[1]),
+          ...[...line.matchAll(/href="(\/[^"]*|#[^"]+)"/g)].map((m) => m[1]),
+        ];
+
+        for (const target of targets) {
+          checked += 1;
+          const [rawPath, anchor] = target.split("#");
+          const route =
+            rawPath === ""
+              ? routeFor(doc)
+              : rawPath.length > 1
+                ? rawPath.replace(/\/$/, "")
+                : rawPath;
+          const where = `apps/docs/content/${doc}:${index + 1}`;
+
+          const slugs = slugsByRoute.get(route);
+          if (!slugs) {
+            violations.push(
+              `${where} links to \`${target}\`, but no page under apps/docs/content maps to \`${route}\`.\n` +
+                `Source of truth: the .mdx files on disk.`,
+            );
+            continue;
+          }
+          if (anchor && !slugs.has(anchor)) {
+            violations.push(
+              `${where} links to \`${target}\`, but \`${route}\` has no heading slugging to \`#${anchor}\`.\n` +
+                `Source of truth: the headings in the target .mdx file.`,
+            );
+          }
+        }
+      });
+    }
+
+    expect(
+      checked,
+      "matched no internal links at all — the link extractor stopped working",
+    ).toBeGreaterThan(0);
+    expectNoViolations(violations);
+  });
+});

--- a/apps/docs/content/docs-contract.test.ts
+++ b/apps/docs/content/docs-contract.test.ts
@@ -21,6 +21,11 @@
  *   thousands separators stripped before comparison, but a rewritten sentence
  *   can still move a claim out from under its anchor. When that happens the
  *   failure says so explicitly rather than reporting a wrong number.
+ *
+ * Anything this file reads from outside `apps/docs` must also be declared in
+ * `apps/docs/turbo.json`, or turbo replays a cached pass over stale input. The
+ * list there is the whole of that coupling: add a `readRepoFile` path here, add
+ * it there.
  */
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, posix, relative, sep } from "node:path";
@@ -138,12 +143,29 @@ const markdownTables = (content: string): MarkdownTable[] => {
   return tables;
 };
 
-/** The table whose first header cell matches `label`, e.g. "Event". */
+/**
+ * The one table whose first header cell matches `label`, e.g. "Event".
+ *
+ * Throws when a page grows a second one rather than silently checking the
+ * first: the rows of the table nobody looked at would read as undocumented,
+ * and the failure would point at the wrong thing.
+ */
 const tableByFirstColumn = (
   content: string,
   label: string,
-): MarkdownTable | undefined =>
-  markdownTables(content).find((table) => table.header[0] === label);
+): MarkdownTable | undefined => {
+  const matches = markdownTables(content).filter(
+    (table) => table.header[0] === label,
+  );
+  if (matches.length > 1) {
+    throw new Error(
+      `Found ${matches.length} tables whose first column is "${label}" (lines ` +
+        `${matches.map((table) => table.line).join(", ")}). This check reads one — ` +
+        `merge them, or teach this test which is authoritative.`,
+    );
+  }
+  return matches[0];
+};
 
 const firstCodeSpan = (cell: string): string | undefined =>
   cell.match(/`([^`]+)`/)?.[1];
@@ -161,16 +183,25 @@ const expectNoViolations = (violations: string[]) => {
 
 // --- environment variables ---------------------------------------------------
 
-const ENV_EXAMPLE_FILES = [
-  ".env.example",
-  "apps/backend/.env.example",
-  "apps/frontend/.env.example",
-];
+const BACKEND_REFERENCE_PAGE = "reference/backend-configuration.mdx";
+const FRONTEND_REFERENCE_PAGE = "reference/frontend-configuration.mdx";
 
-const ENV_REFERENCE_PAGES = [
-  "reference/backend-configuration.mdx",
-  "reference/frontend-configuration.mdx",
-];
+const ENV_REFERENCE_PAGES = [BACKEND_REFERENCE_PAGE, FRONTEND_REFERENCE_PAGE];
+
+/**
+ * Which page owes a row for the variables each file ships. The two app files
+ * pair with their own page — a backend variable listed only under "Frontend
+ * configuration" is as good as undocumented to the Operator reading the page
+ * for the service they are configuring. The root Compose file feeds both
+ * containers, so either page discharges it.
+ */
+const ENV_EXAMPLE_FILES: Record<string, string[]> = {
+  ".env.example": ENV_REFERENCE_PAGES,
+  "apps/backend/.env.example": [BACKEND_REFERENCE_PAGE],
+  "apps/frontend/.env.example": [FRONTEND_REFERENCE_PAGE],
+};
+
+const ENV_EXAMPLE_NAMES = Object.keys(ENV_EXAMPLE_FILES);
 
 /**
  * Variables the docs deliberately still name after they stopped existing,
@@ -206,26 +237,61 @@ const parseEnvExample = (content: string): Map<string, number> => {
   return found;
 };
 
+/**
+ * The first column of every `| Variable |` table on a page. Rows, not prose
+ * mentions: the reference pages call themselves "the exhaustive list", and a
+ * variable named only in a warning is one a reader scanning the table never
+ * finds. Reading the column also means no uppercase-word heuristic — `UTC` sits
+ * in a Default cell and is never mistaken for a claim.
+ */
+const variableRows = (content: string): Map<string, number> => {
+  const rows = new Map<string, number>();
+  for (const table of markdownTables(content)) {
+    if (table.header[0] !== "Variable") continue;
+    table.rows.forEach((row, index) => {
+      const name = firstCodeSpan(row[0]);
+      if (name && !rows.has(name)) rows.set(name, table.line + 2 + index);
+    });
+  }
+  return rows;
+};
+
 describe("environment variables", () => {
-  const declared = new Map<string, string>(); // VAR -> "file:line"
-  for (const file of ENV_EXAMPLE_FILES) {
+  type Declaration = { origin: string; pages: string[] };
+  const declared = new Map<string, Declaration>();
+  for (const [file, pages] of Object.entries(ENV_EXAMPLE_FILES)) {
     for (const [name, line] of parseEnvExample(readRepoFile(file))) {
-      if (!declared.has(name)) declared.set(name, `${file}:${line}`);
+      const existing = declared.get(name);
+      if (existing) {
+        existing.pages = [...new Set([...existing.pages, ...pages])];
+      } else {
+        declared.set(name, { origin: `${file}:${line}`, pages: [...pages] });
+      }
     }
   }
 
-  // A bare uppercase word is only read as a variable claim when it really is
-  // one; without this `UTC` in a Default column would look like a phantom row.
-  const looksLikeVariable = (token: string) =>
-    /^[A-Z][A-Z0-9_]*$/.test(token) &&
-    (token.includes("_") || declared.has(token));
+  const rowsByPage = new Map<string, Map<string, number>>();
+  for (const page of ENV_REFERENCE_PAGES) {
+    rowsByPage.set(page, variableRows(readDoc(page)));
+  }
+  const documentedRows = new Map<string, string>(); // VAR -> "page:line"
+  for (const [page, rows] of rowsByPage) {
+    for (const [name, line] of rows) {
+      if (!documentedRows.has(name)) {
+        documentedRows.set(name, `${page}:${line}`);
+      }
+    }
+  }
 
-  const documented = new Map<string, string>(); // VAR -> "page:line"
+  // Prose counts for the allowlists below — a migration note telling a reader
+  // where a removed setting went is exactly a mention without a row.
+  const mentionedAnywhere = new Map<string, string>(); // VAR -> "page:line"
   for (const page of ENV_REFERENCE_PAGES) {
     for (const span of inlineCodeSpans(readDoc(page))) {
       const token = span.text.split("=")[0].trim();
-      if (!looksLikeVariable(token)) continue;
-      if (!documented.has(token)) documented.set(token, `${page}:${span.line}`);
+      if (!mentionedAnywhere.has(token)) {
+        mentionedAnywhere.set(token, `${page}:${span.line}`);
+      }
     }
   }
 
@@ -234,21 +300,29 @@ describe("environment variables", () => {
     // green, which is worse than no test at all.
     expect(
       declared.size,
-      `parsed no assignments out of ${ENV_EXAMPLE_FILES.join(", ")}`,
+      `parsed no assignments out of ${ENV_EXAMPLE_NAMES.join(", ")}`,
     ).toBeGreaterThan(20);
     expect(
-      documented.size,
-      `parsed no variables out of ${ENV_REFERENCE_PAGES.join(", ")}`,
+      documentedRows.size,
+      `parsed no variable rows out of ${ENV_REFERENCE_PAGES.join(", ")}`,
     ).toBeGreaterThan(20);
   });
 
-  it("documents every variable the .env.example files ship", () => {
+  it("gives every variable the .env.example files ship a row on its own page", () => {
     const violations: string[] = [];
-    for (const [name, origin] of declared) {
-      if (documented.has(name)) continue;
+    for (const [name, { origin, pages }] of declared) {
+      if (pages.some((page) => rowsByPage.get(page)?.has(name))) continue;
+
+      const elsewhere = documentedRows.get(name);
+      const owed = pages
+        .map((page) => `apps/docs/content/${page}`)
+        .join(" or ");
       violations.push(
-        `\`${name}\` is set in ${origin} but neither reference page mentions it.\n` +
-          `Add a row to apps/docs/content/${ENV_REFERENCE_PAGES.join(" or apps/docs/content/")}.`,
+        elsewhere
+          ? `\`${name}\` is set in ${origin}, but its only row is apps/docs/content/${elsewhere}.\n` +
+              `Move it to ${owed} — the page for the service that ships it.`
+          : `\`${name}\` is set in ${origin} but no reference table has a row for it.\n` +
+              `Add a row to ${owed}.`,
       );
     }
     expectNoViolations(violations);
@@ -256,16 +330,18 @@ describe("environment variables", () => {
 
   it("names no variable the .env.example files do not ship", () => {
     const violations: string[] = [];
-    for (const [name, origin] of documented) {
-      if (declared.has(name)) continue;
-      if (REMOVED_VARS.has(name)) continue;
-      if (VARS_WITHOUT_ENV_EXAMPLE_ENTRY.has(name)) continue;
-      violations.push(
-        `apps/docs/content/${origin} names \`${name}\`, which no .env.example assigns.\n` +
-          `Source of truth: ${ENV_EXAMPLE_FILES.join(", ")}.\n` +
-          `If the variable was deliberately removed, add it to REMOVED_VARS in this file; ` +
-          `if it is real but no example file ships it, add it to VARS_WITHOUT_ENV_EXAMPLE_ENTRY.`,
-      );
+    for (const [page, rows] of rowsByPage) {
+      for (const [name, line] of rows) {
+        if (declared.has(name)) continue;
+        if (REMOVED_VARS.has(name)) continue;
+        if (VARS_WITHOUT_ENV_EXAMPLE_ENTRY.has(name)) continue;
+        violations.push(
+          `apps/docs/content/${page}:${line} has a row for \`${name}\`, which no .env.example assigns.\n` +
+            `Source of truth: ${ENV_EXAMPLE_NAMES.join(", ")}.\n` +
+            `If the variable was deliberately removed, add it to REMOVED_VARS in this file; ` +
+            `if it is real but no example file ships it, add it to VARS_WITHOUT_ENV_EXAMPLE_ENTRY.`,
+        );
+      }
     }
     expectNoViolations(violations);
   });
@@ -275,13 +351,13 @@ describe("environment variables", () => {
     for (const name of REMOVED_VARS) {
       if (declared.has(name)) {
         violations.push(
-          `\`${name}\` is listed in REMOVED_VARS but ${declared.get(name)} assigns it again.\n` +
+          `\`${name}\` is listed in REMOVED_VARS but ${declared.get(name)?.origin} assigns it again.\n` +
             `Drop it from REMOVED_VARS so the reference page is checked against the env files.`,
         );
       }
     }
     for (const name of [...REMOVED_VARS, ...VARS_WITHOUT_ENV_EXAMPLE_ENTRY]) {
-      if (!documented.has(name)) {
+      if (!mentionedAnywhere.has(name)) {
         violations.push(
           `\`${name}\` is allowlisted in this file but no reference page mentions it any more.\n` +
             `Remove the allowlist entry.`,
@@ -330,8 +406,9 @@ describe("webhook events", () => {
         );
       }
     }
+    const events: readonly string[] = webhookEventSchema.options;
     for (const [event, line] of documented) {
-      if (!webhookEventSchema.options.includes(event as never)) {
+      if (!events.includes(event)) {
         violations.push(
           `apps/docs/content/${page}:${line} lists \`${event}\`, which is not in ${source}.\n` +
             `That event never fires.`,
@@ -351,22 +428,38 @@ describe("webhook events", () => {
  */
 const BUILTIN_SOURCE = "apps/backend/src/plugins/builtin.ts";
 
-/** The literal between `declaration` and the `};` / `];` that closes it. */
-const literalAfter = (content: string, declaration: string): string => {
-  const body = content.slice(content.indexOf(declaration));
-  const end = body.search(/[}\]];/);
-  return body.slice(0, end);
+/**
+ * The literal between `export const <name>` and the `};` / `];` that closes it.
+ *
+ * Anchored on the declaration, not on the first mention of the name: the
+ * registry's own comments cross-reference both constants, and matching a comment
+ * would silently read the neighbouring literal — producing confident failures
+ * that blame the docs for a table that was right.
+ */
+const exportedLiteral = (content: string, name: string): string => {
+  const start = content.search(new RegExp(`export const ${name}\\b`));
+  if (start === -1) {
+    throw new Error(
+      `No \`export const ${name}\` in ${BUILTIN_SOURCE}. It was renamed or moved; ` +
+        `update this test rather than trusting what it parses.`,
+    );
+  }
+  const body = content.slice(start);
+  return body.slice(0, body.search(/[}\]];/));
 };
 
 const parseBuiltinPluginNames = (): string[] => {
-  const literal = literalAfter(readRepoFile(BUILTIN_SOURCE), "BUILTIN_PLUGINS");
+  const literal = exportedLiteral(
+    readRepoFile(BUILTIN_SOURCE),
+    "BUILTIN_PLUGINS",
+  );
   return [...literal.matchAll(/"(@platypus\/[a-z0-9-]+)":/g)].map(
     (match) => match[1],
   );
 };
 
 const parseAlwaysOnPluginNames = (): string[] => {
-  const literal = literalAfter(
+  const literal = exportedLiteral(
     readRepoFile(BUILTIN_SOURCE),
     "ALWAYS_ON_PLUGINS",
   );
@@ -513,6 +606,12 @@ const stringField = (
   schema: { shape: Record<string, unknown> },
   field: string,
 ): { min?: number; max?: number } => {
+  if (schema.shape[field] === undefined) {
+    throw new Error(
+      `No field \`${field}\` on that Zod shape. It was renamed or removed — ` +
+        `re-point the claim, or drop it if the field is gone.`,
+    );
+  }
   const bounds = unwrap(schema.shape[field]);
   const min = bounds.minLength ?? undefined;
   const max = bounds.maxLength ?? undefined;

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,7 +11,9 @@
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "next": "16.2.9",
@@ -22,15 +24,18 @@
   },
   "devDependencies": {
     "@opennextjs/cloudflare": "^1.20.1",
+    "@platypus/schemas": "workspace:*",
     "@tailwindcss/postcss": "^4.3.2",
     "@types/node": "^24.13.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "eslint": "^10.6.0",
     "eslint-config-next": "16.2.9",
+    "github-slugger": "^2.0.0",
     "pagefind": "^1.5.2",
     "tailwindcss": "^4.3.2",
     "typescript": "^6.0.3",
+    "vitest": "^4.1.9",
     "wrangler": "^4.106.0"
   }
 }

--- a/apps/docs/turbo.json
+++ b/apps/docs/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/.env.example",
+        "$TURBO_ROOT$/apps/backend/.env.example",
+        "$TURBO_ROOT$/apps/frontend/.env.example",
+        "$TURBO_ROOT$/apps/backend/src/plugins/builtin.ts"
+      ]
+    }
+  }
+}

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["**/*.test.ts"],
+    exclude: ["node_modules", ".next", ".open-next"],
+  },
+});

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,10 +1,13 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     globals: true,
     environment: "node",
     include: ["**/*.test.ts"],
-    exclude: ["node_modules", ".next", ".open-next"],
+    // Extend the defaults rather than replace them: `include` walks the whole
+    // package, and bare directory names would stop matching as soon as a build
+    // artefact appeared one level down.
+    exclude: [...configDefaults.exclude, "**/.next/**", "**/.open-next/**"],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,9 @@ importers:
       '@opennextjs/cloudflare':
         specifier: ^1.20.1
         version: 1.20.1(next@16.2.9(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(wrangler@4.106.0)
+      '@platypus/schemas':
+        specifier: workspace:*
+        version: link:../../packages/schemas
       '@tailwindcss/postcss':
         specifier: ^4.3.2
         version: 4.3.2
@@ -212,6 +215,9 @@ importers:
       eslint-config-next:
         specifier: 16.2.9
         version: 16.2.9(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       pagefind:
         specifier: ^1.5.2
         version: 1.5.2
@@ -221,6 +227,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@7.3.1(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.16.9)(tsx@4.22.4)(yaml@2.9.0))
       wrangler:
         specifier: ^4.106.0
         version: 4.106.0
@@ -13012,7 +13021,7 @@ snapshots:
       eslint: 10.6.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@10.6.0(jiti@2.7.0)))(eslint@10.6.0(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.6.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.6.0(jiti@2.7.0)))(eslint@10.6.0(jiti@2.7.0)))(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.6.0(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@10.6.0(jiti@2.7.0))
@@ -13045,7 +13054,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.6.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.6.0(jiti@2.7.0)))(eslint@10.6.0(jiti@2.7.0)))(eslint@10.6.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -13059,7 +13068,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.6.0(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.6.0(jiti@2.7.0)))(eslint@10.6.0(jiti@2.7.0)))(eslint@10.6.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
Closes #371.

Nothing in this repo has ever checked whether a documentation claim is true. `apps/docs` had no `test` script, so the package was invisible to `turbo run test` and therefore to the `gate` job — the single required check on `main`.

## Enrolment

`apps/docs` gains `test` and `typecheck` scripts plus a `vitest.config.ts` mirroring `packages/schemas`. No workflow file changed. `pnpm test` now runs 8 turbo tasks instead of 7, and `pnpm typecheck` 6 instead of 5.

## The contract test

`apps/docs/content/docs-contract.test.ts` — 22 assertions over the claims with exactly one authoritative source:

| Assertion | Source of truth |
| --- | --- |
| Env tables, both directions | the three `.env.example` files |
| Webhook events, both directions | `webhookEventSchema.options` |
| Core plugin table, names + tier | `BUILTIN_PLUGINS` / `ALWAYS_ON_PLUGINS` |
| Field limits | the Zod shapes |
| Internal links | `content/**.mdx` on disk |
| Heading anchors | slugified headings (`github-slugger`, same as Nextra) |

Every failure names the doc file, the line, and the source of truth.

## One deviation from the spec, and it's load-bearing

The spec said turbo's `test` task "already has the right inputs". True for the workflow, not for the cache: turbo hashes only a package's own files, and this test reads `.env.example` and `builtin.ts` from outside `apps/docs`. Confirmed empirically — a broken plugin registry produced `cache hit, replaying logs` and a green suite.

`apps/docs/turbo.json` declares those paths via `$TURBO_ROOT$`. After it, the same mutation cache-misses and reds.

## Mutation-tested, not assumed

Every assertion was broken deliberately in both directions and confirmed to fail with an attributable message. Two vacuous-pass bugs surfaced that way and are fixed:

- `stringField` returning empty bounds would have left all 12 limit claims asserting nothing — it now throws at module load.
- `blockContaining` read raw content, so a fenced example could be mistaken for a real limit — it now strips fences.

Also verified: an en-dash → hyphen swap does **not** red the suite, and `pnpm docs-build` still succeeds with the new `@platypus/schemas` devDependency (the pinned `nextra>zod: 4.3.6` override is untouched).

## Beyond the letter of the spec

The spec's table names `BUILTIN_PLUGINS` / `ALWAYS_ON_PLUGINS` as the source, but a "mentioned anywhere in the docs" check pins neither the always-on split nor the row-level list — a plugin named once in an upgrade note would pass while the Operator-facing table stayed a row short. Added a second assertion over the core plugin table in `self-hosting/configuration.mdx` (the page that says "This page owns the list"), checking names and tier in both directions.

## Rule and skill

- Path-keyed docs table in `CLAUDE.md`, inherited by `AGENTS.md` via symlink.
- Three lines mirrored into `CONTRIBUTING.md`, so the rule doesn't bind only agents.
- `.agents/skills/docs-audit/` with `SKILL.md` + `VOICE.md`, `disable-model-invocation: true`, symlinked into `.claude/skills/` so it's actually visible to Claude Code.

## Known limits

Written into the test file's header rather than left implied: it only checks what someone encoded, and cannot see the ~150 bolded UI labels across `building-with-platypus/`. A green suite is not a correct docs site.

Two narrower gaps worth knowing: the field-limit anchors are prose substrings, so a rewritten sentence produces a loud "no longer contains X" failure that needs re-anchoring; and the link checker handles root-relative and same-page links only, so relative links would pass unchecked (the corpus currently has none).

## Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm docs-build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)