### PR TITLE
fix(backend): attribute plugin factory throws and harden the tool-set registry

### DIFF
--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -540,7 +540,7 @@ describe("loadPlugins — sandbox backends", () => {
         credentialsSchema: z.object({}),
         create: () => ({}),
       },
-      /non-empty "backend" id/s,
+      /@platypus\/bad.*non-empty "backend" id/s,
     ],
     [
       "a missing name",
@@ -550,7 +550,7 @@ describe("loadPlugins — sandbox backends", () => {
         credentialsSchema: z.object({}),
         create: () => ({}),
       },
-      /must declare a non-empty "name"/s,
+      /@platypus\/bad.*must declare a non-empty "name"/s,
     ],
     [
       "a missing create",
@@ -560,7 +560,7 @@ describe("loadPlugins — sandbox backends", () => {
         configSchema: z.object({}),
         credentialsSchema: z.object({}),
       },
-      /must provide a "create" function/s,
+      /@platypus\/bad.*must provide a "create" function/s,
     ],
     [
       "a missing configSchema",
@@ -570,7 +570,7 @@ describe("loadPlugins — sandbox backends", () => {
         credentialsSchema: z.object({}),
         create: () => ({}),
       },
-      /must provide a Zod "configSchema"/s,
+      /@platypus\/bad.*must provide a Zod "configSchema"/s,
     ],
     [
       "a missing credentialsSchema",
@@ -580,7 +580,25 @@ describe("loadPlugins — sandbox backends", () => {
         configSchema: z.object({}),
         create: () => ({}),
       },
-      /must provide a Zod "credentialsSchema"/s,
+      /@platypus\/bad.*must provide a Zod "credentialsSchema"/s,
+    ],
+    // A factory-form configSchema is third-party code narrowing a config block
+    // it owns, so it can throw before it ever returns a schema — the shape check
+    // downstream only sees a non-schema *return*. Without attribution here, a
+    // plugin assuming an Operator supplied `config.region` aborts boot with a
+    // bare `Cannot read properties of undefined` naming nothing.
+    [
+      "a throwing configSchema factory",
+      {
+        backend: "b",
+        name: "x",
+        configSchema: () => {
+          throw new Error("region is required");
+        },
+        credentialsSchema: z.object({}),
+        create: () => ({}),
+      },
+      /@platypus\/bad.*configSchema factory threw.*region is required/s,
     ],
   ])(
     "aborts (fail-loud, plugin-named) on %s",

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -471,10 +471,27 @@ export async function loadPlugins(
       // route, teardown, tool resolver) always receive a concrete schema — they
       // never see plugin config. A plain schema passes through untouched
       // (append-only: plugin-config-agnostic backends are unaffected).
-      const resolvedConfigSchema =
-        typeof contribution.configSchema === "function"
-          ? contribution.configSchema(pluginCtx.config)
-          : contribution.configSchema;
+      //
+      // The factory is third-party code reading a config block it narrows
+      // itself, so it can throw — a plugin that assumes an Operator supplied
+      // `config.region` raises a bare `Cannot read properties of undefined`
+      // naming nothing. Attributed here for the same reason the shape checks
+      // above exist: the schema check below only catches a factory that
+      // *returns* a non-schema, not one that throws on the way there.
+      let resolvedConfigSchema: SandboxBackendRegistration["configSchema"];
+      try {
+        resolvedConfigSchema =
+          typeof contribution.configSchema === "function"
+            ? contribution.configSchema(pluginCtx.config)
+            : contribution.configSchema;
+      } catch (cause) {
+        throw new Error(
+          `Plugin "${manifest.name}": sandbox backend "${effectiveBackend}" configSchema factory threw (${
+            cause instanceof Error ? cause.message : String(cause)
+          }).`,
+          { cause },
+        );
+      }
 
       // Checked after the factory form is resolved away, and duck-typed on
       // `safeParse` rather than `instanceof z.ZodType`, because that is exactly

--- a/apps/backend/src/tools/index.test.ts
+++ b/apps/backend/src/tools/index.test.ts
@@ -80,6 +80,20 @@ describe("Tool Set Registry", () => {
         "Tool set with id 'nonexistent' has not been registered.",
       );
     });
+
+    it("throws for Object.prototype members rather than resolving them", () => {
+      // `toolSetId` reaches this lookup from `agent.toolSetIds`, which is
+      // request-body data. A plain-object registry answered `"toString" in
+      // TOOL_SETS_REGISTRY` with true and handed back
+      // `Object.prototype.toString` — a function with no `tools`, so the chat
+      // turn resolved no tools *without* throwing, and the caller's MCP fallback
+      // never ran. Unregistered must mean unregistered whatever the id is called.
+      for (const id of ["toString", "constructor", "__proto__", "valueOf"]) {
+        expect(() => getToolSet(id)).toThrow(
+          `Tool set with id '${id}' has not been registered.`,
+        );
+      }
+    });
   });
 
   describe("registerToolSet", () => {

--- a/apps/backend/src/tools/index.ts
+++ b/apps/backend/src/tools/index.ts
@@ -23,9 +23,17 @@ type ToolSet = {
       ) => Record<string, Tool> | Promise<Record<string, Tool>>);
 };
 
-const TOOL_SETS_REGISTRY: {
+// `Object.create(null)`, not `{}`, for the same reason as the Sandbox and
+// Web-search backend registries: `toolSetId` reaches `getToolSet` from
+// `agent.toolSetIds`, which is request-body data. With a plain object,
+// `"toString" in TOOL_SETS_REGISTRY` is true, so the lookup handed back
+// `Object.prototype.toString` — a function with no `tools`, which resolved to no
+// tools *without* throwing, so the caller's MCP fallback never ran. A null
+// prototype has nothing to inherit, so an unregistered id throws whatever it is
+// called.
+const TOOL_SETS_REGISTRY = Object.create(null) as {
   [toolSetId: string]: ToolSet;
-} = {};
+};
 
 export const registerToolSet = (
   toolSetId: string,

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -136,6 +136,15 @@ startup with a plugin-named error. Runtime Chat-turn resolution stays graceful (
 Workspace pointing at a since-removed Tool set degrades to no tools, as before) —
 strict at boot, forgiving at runtime.
 
+Each Contribution is shape-checked at boot too, so an incomplete one is refused
+up front rather than failing later in a Chat turn or on an Operator's settings
+form. A Sandbox backend must supply `backend`, `name`, both schemas, and
+`create`; a Web-search backend must supply `backend`, `name`, and
+`createExecutors`. TypeScript already requires all of these — the boot check is
+what catches a plugin shipped as plain JavaScript, and what turns a missing field
+into an error naming your plugin. A `configSchema` factory that throws while
+reading its plugin config is reported the same way.
+
 ### Deploy-time plugin config & credentials
 
 A plugin can declare **plugin-level** `configSchema` / `credentialsSchema` on its


### PR DESCRIPTION
Follow-up to the review on #388, which closed the sandbox registry's `Object.prototype` flaw and added boot-time shape checks to the `sandboxBackends` loop. Three gaps that review turned up, none of which belonged in that PR.

## A throwing `configSchema` factory was unattributed

A factory-form `configSchema` is third-party code narrowing a config block it owns, so it can throw before it ever returns a schema — #388's duck-type check only sees a non-schema *return*. A plugin assuming an Operator supplied `config.region`:

```
Cannot read properties of undefined (reading 'toUpperCase')
```

No plugin named — the exact failure mode the surrounding checks exist to eliminate, one line above them. The resolve is now wrapped and reported like every other malformed shape in the loop.

## `TOOL_SETS_REGISTRY` was the last plain-object registry

`toolSetId` reaches `getToolSet` from `agent.toolSetIds`, which is request-body data. `"toString" in TOOL_SETS_REGISTRY` was true, so the lookup handed back `Object.prototype.toString` — a function with no `tools`. That resolved to no tools *without* throwing, so `chat-execution.ts`'s catch never fired and the MCP fallback never ran: a silently tool-less turn rather than an error.

Impact was negligible in practice (MCP ids are nanoids, so no real id collides), but it was the remaining instance of the class #388 set out to close. The Sandbox and Web-search registries already use `Object.create(null)`; all three now match, including the `as` cast form — `Object.create` returns `any`, which trips `no-unsafe-assignment` otherwise.

## Five test regexes didn't pin the plugin name

#388's description said each of its six table cases asserts the plugin name is in the message; only the `null`-entry case did. Attribution could have been dropped from the other five and the suite would have stayed green. They now pin it.

## Docs

`extending/index.mdx` gains the per-Contribution boot checks alongside the existing fail-loud paragraph, per the CLAUDE.md docs table — #388 added plugin-author-visible boot rejections with no docs change, and a plugin author reading the Sandbox-backend section got no signal that omitting a field is now a boot failure rather than a latent one.

Only the new paragraph is in the diff. `.mdx` is outside the repo's `format` script (`{ts,tsx,md}`), so main was never mdx-formatted and running Prettier over the file reflows two unrelated Callouts — that churn is deliberately excluded.

## Tests

- `loader.test.ts` — a seventh table case for the throwing factory; the five loosened regexes tightened
- `tools/index.test.ts` — `toString`, `constructor`, `__proto__` and `valueOf` all throw "has not been registered"

Both new tests were confirmed red against the source before the fix. Full monorepo gate green: 1329 backend tests, `pnpm lint`, `pnpm typecheck`, `pnpm test`, docs-contract 22/22, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)