### PR TITLE
fix(frontend): restore the missing space in the sharing dialog description

### DIFF
--- a/apps/frontend/components/manage-sharing.tsx
+++ b/apps/frontend/components/manage-sharing.tsx
@@ -181,8 +181,10 @@ export const ManageAttachmentsDialog = ({
         <DialogHeader>
           <DialogTitle>Share “{resourceName}”</DialogTitle>
           <DialogDescription>
+            {/* Keep the apostrophe literal, not `&apos;` — see
+                jsx-entity-whitespace.test.ts. */}
             Choose which workspaces this {LABEL[resourceType]} appears in. It
-            runs against each workspace&apos;s own resources.
+            runs against each workspace’s own resources.
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/frontend/jsx-entity-whitespace.test.ts
+++ b/apps/frontend/jsx-entity-whitespace.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+/**
+ * Next compiles JSX with SWC, and SWC drops the leading space of a multi-line
+ * JSX text run that contains an HTML entity:
+ *
+ *   this {label} appears in. It
+ *   runs against each workspace&apos;s own resources.
+ *
+ * compiles to `"this ", label, "appears in. …"` — the UI renders
+ * "skillappears in" while the source reads correctly (issue #387). Babel keeps
+ * the space, so the vitest render tests cannot see it; this compiles the real
+ * files with the real transform instead.
+ *
+ * Each candidate file is compiled twice: as-is, and with its entities swapped
+ * for a plain letter (the shape SWC handles correctly). Any difference in the
+ * leading/trailing whitespace of an emitted string is the bug. Write the
+ * character literally (’, ", &, —) to avoid it.
+ *
+ * This loads Next's own SWC binding, so a Next upgrade that moves or fixes it
+ * fails here loudly rather than quietly letting the bug back in.
+ */
+
+const require = createRequire(import.meta.url);
+const swc = require("next/dist/build/swc");
+
+const APP_ROOT = path.dirname(fileURLToPath(import.meta.url));
+// Any named or numeric entity, so a future &rsquo; or &hellip; is covered too.
+const ENTITY = /&(?:[a-zA-Z][a-zA-Z0-9]{1,10}|#\d+|#x[0-9a-fA-F]+);/g;
+
+const tsxFiles = (dir: string): string[] => {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".next") continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) found.push(...tsxFiles(full));
+    else if (full.endsWith(".tsx")) found.push(full);
+  }
+  return found;
+};
+
+/** String literals in emitted JS, in source order. */
+const literals = (code: string): string[] => {
+  const found: string[] = [];
+  const re = /"((?:[^"\\\n]|\\.)*)"|'((?:[^'\\\n]|\\.)*)'/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(code))) found.push(match[1] ?? match[2]);
+  return found;
+};
+
+// Deliberately excludes \xa0 so an intentional &nbsp; at an edge is not a diff.
+const edgeSignature = (s: string) =>
+  `${/^[ \t\n\r]*/.exec(s)![0].length}|${/[ \t\n\r]*$/.exec(s)![0].length}`;
+
+const compile = async (source: string, filename: string) =>
+  (
+    await swc.transform(source, {
+      filename,
+      jsc: { parser: { syntax: "typescript", tsx: true } },
+    })
+  ).code as string;
+
+describe("HTML entities in JSX text", () => {
+  it("does not lose spaces around the entity's text run", async () => {
+    await swc.loadBindings();
+
+    const mangled: string[] = [];
+
+    for (const file of tsxFiles(APP_ROOT)) {
+      const source = readFileSync(file, "utf8");
+      ENTITY.lastIndex = 0;
+      if (!ENTITY.test(source)) continue;
+
+      const relative = path.relative(APP_ROOT, file);
+      const emitted = literals(await compile(source, file));
+      const control = literals(
+        await compile(source.replace(ENTITY, "X"), file),
+      );
+
+      if (emitted.length !== control.length) {
+        mangled.push(
+          `${relative}: emitted ${emitted.length} strings, control ${control.length}`,
+        );
+        continue;
+      }
+      for (let i = 0; i < emitted.length; i++) {
+        if (edgeSignature(emitted[i]) !== edgeSignature(control[i])) {
+          mangled.push(
+            `${relative}: ${JSON.stringify(emitted[i])} (expected the edge whitespace of ${JSON.stringify(control[i])})`,
+          );
+        }
+      }
+    }
+
+    expect(mangled).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #387

## The bug

The sharing dialog read "Choose which workspaces this skill**appears** in". The source already had the space, so the cause was downstream — Next's SWC drops the **leading space of a multi-line JSX text run that contains an HTML entity**, and this description ended its second line with `&apos;`.

From a Turbopack-built chunk on `main`:

```
Choose which workspaces this ",h[t],"appears in. It runs against eac…
```

Bisecting with Next's own SWC binding: single-line + entity is fine, multi-line without an entity is fine, multi-line **with** an entity loses the space.

## The fix

Write the apostrophe as a literal `’` (matching the curly quotes already in the dialog title), which removes the trigger. Verified in the recompiled dev chunk:

```js
"Choose which workspaces this ", LABEL[resourceType],
" appears in. It runs against each workspace’s own resources."
```

## The test

Babel — which the vitest transform uses — never loses the space, so a render test cannot see this class of bug. `jsx-entity-whitespace.test.ts` instead compiles every `.tsx` containing an entity with Next's own SWC twice (as-is, and with entities swapped for a plain letter) and fails if any emitted string's edge whitespace differs. It covers 19 files in ~70ms, reports exactly one finding before this fix and none after, and that sweep confirmed **no other site in the app is affected**.

Two trade-offs worth knowing:

- It loads `next/dist/build/swc`, a Next internal. Next is pinned exactly (`16.2.9`), and an upgrade that moves or fixes that path fails the test loudly rather than quietly letting the bug back in.
- No screenshot: the dialog needs auth plus an org-scoped shared resource. For a compiler whitespace defect the compiled chunk is the authoritative artifact, and both are quoted above.

No docs change is owed — the intended wording is unchanged and no page under `apps/docs/content` quotes the sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)