### PR TITLE
fix(frontend): gate the search toggle on shared provider capability

### DIFF
--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -57,6 +57,9 @@ search for the messages you send while it is on.
 It is only there when the resolved Provider supports it. It is **absent** when:
 
 - the Provider is **Bedrock**, which has no native search;
+- the Provider is **OpenAI** with **API Mode** set to **Chat Completions** —
+  vendor search runs on the Responses API only, so an OpenAI-compatible server
+  (vLLM, Ollama, LiteLLM) has none;
 - an Org Admin has switched native search off on that Provider;
 - nothing has resolved yet, because no Agent or model is selected.
 

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -32,6 +32,7 @@ import {
   Agent,
   ToolSet,
   Skill,
+  providerHasNativeSearch,
 } from "@platypus/schemas";
 import { type PlatypusUIMessage } from "@platypus/backend/src/types";
 import useSWR from "swr";
@@ -406,11 +407,18 @@ export const Chat = ({
     ? providers.find((p) => p.id === resolvedProviderId)
     : null;
   // Show the search toggle only when the resolved provider supports native
-  // search (not Bedrock) and hasn't disabled it. Hidden when nothing is
-  // resolved yet — we can't search without a model. (#167)
+  // search and hasn't disabled it. Hidden when nothing is resolved yet — we
+  // can't search without a model. (#167)
+  //
+  // The capability test is `providerHasNativeSearch`, shared with the backend's
+  // injection gate, rather than a local `!== "Bedrock"`: the gate is the
+  // authority over what a turn actually serves (see `resolveSearchMode`), so a
+  // second copy of the table here would show a toggle that resolves to no
+  // tools. Bedrock is not the only case — OpenAI's search is Responses-API
+  // only, so a chat-completions endpoint (vLLM, llama.cpp) has none either.
   const canSearch =
     !!resolvedProvider &&
-    resolvedProvider.providerType !== "Bedrock" &&
+    providerHasNativeSearch(resolvedProvider) &&
     resolvedProvider.nativeSearchEnabled !== false;
 
   // The media types the currently-selected model ingests natively (issue #328),


### PR DESCRIPTION
Closes the one gap #393 left open, ahead of PR3.

#393 moved the web-search capability table into `@platypus/schemas` as `providerHasNativeSearch` and made the backend's injection gate consult it. The frontend's own check stayed as `providerType !== "Bedrock"`, so the two now disagree on one case:

| Provider                                                   | Toggle shown (before) | Turn serves search |
| ---------------------------------------------------------- | --------------------- | ------------------ |
| Bedrock                                                    | no                    | no                 |
| **OpenAI on `apiMode: "chat"`** (vLLM, llama.cpp, LiteLLM) | **yes**               | **no**             |
| OpenAI on `apiMode: "responses"`                           | yes                   | yes                |
| Anthropic, Google, OpenRouter                              | yes                   | yes                |

A Workspace Owner on a vLLM Provider sees the **Search** globe, turns it on, and gets nothing. Nothing working is removed here — the toggle previously injected a Responses-API hosted tool that a chat-completions endpoint ignores — but a control that silently does nothing is worse to diagnose than one that fails loudly.

PR3 of #329 reworks `canSearch` as part of a larger change (catalog route, Provider selector, switch relabel, Sources rendering). This lands the one-line half early so the mismatch can't reach a release on its own, since #393 is already on `main` and the release cadence is faster than the rest of the stack.

## Docs

`building-with-platypus/chat.mdx` enumerates the exact conditions that hide the toggle, so it gains the OpenAI/**Chat Completions** case. No new heading, link or limit claim, so `docs-contract.test.ts` is unaffected — ran it, 24 pass.

## Verification

- `apps/frontend` has no `typecheck` script, so CI would not catch a type error here. Ran `tsc --noEmit` against the frontend project manually: clean. Worth adding that script separately.
- Frontend tests 27 pass; docs contract 24 pass.
- Prettier clean on both changed lines. Note `chat.mdx` **already** fails `prettier --check` on `main` (pre-existing wrap drift, no `format` job in CI to catch it). I deliberately did not include the ~40 lines of unrelated reformatting; worth its own `chore(docs)` pass.

## Left for PR3

The other item from the #393 review still stands: `providerHasNativeSearch` takes `Pick<Provider, ...>` while its sibling `defaultPassthroughFileTypes` deliberately takes `{providerType: string; apiMode?: string}` so either side can pass its own shape. It needed no cast here — Chat's `providers` is already typed `Provider[]` — so the case for widening it is weaker than I first thought, and it can ride with PR3 or be dropped.

Refs #329, #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
