### PR TITLE
feat(frontend): label and declutter the Provider model rows

### DIFF
--- a/apps/docs/content/getting-started/index.mdx
+++ b/apps/docs/content/getting-started/index.mdx
@@ -153,8 +153,8 @@ Fill in the form:
 - **Name** — a label for this connection.
 - **API Key** — your credential from that vendor.
 - **Models** — a repeatable list, not a text box. Click **Add model** for each
-  one, type its id into the **Model ID** field (e.g. `gpt-4o`,
-  `claude-sonnet-4-6`), and leave the per-model file-type checkboxes alone for
+  one and type its id into the **Model ID** field (e.g. `gpt-4o`,
+  `claude-sonnet-4-6`). Leave **Alias** empty and **Advanced** collapsed for
   now.
 
 Click **Save**.

--- a/apps/docs/content/self-hosting/providers-and-auth.mdx
+++ b/apps/docs/content/self-hosting/providers-and-auth.mdx
@@ -76,6 +76,10 @@ not guessed**: each entry in `modelIds` is a per-model object.
 | `passthroughFileTypes`  | The media types this model ingests **natively**. Comma-separated in the UI; wildcards like `image/*` allowed. Empty inherits the provider-type default below. |
 | `maxExtractedTextChars` | Cap on the text a single extracted document may add to a turn. Empty uses the default (50,000 characters).                                                    |
 
+In the form, the last two sit behind **Advanced** on each model row — collapsed
+unless that model already has one of them set. Every field carries an **i** you
+can hover or focus for the same explanation.
+
 On every chat turn, each attached file takes exactly one of these routes:
 
 | Route                  | When                                                      | What the model receives                                                           |

--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { Provider } from "@platypus/schemas";
+
+// --- Module mocks ------------------------------------------------------------
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "u1" } }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+// The provider the edit form loads. Set per test before rendering.
+let loadedProvider: Provider | undefined;
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: () => ({
+    data: loadedProvider,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+}));
+
+import { ProviderForm } from "./provider-form";
+
+// --- Helpers -----------------------------------------------------------------
+
+function renderEditForm(modelIds: Provider["modelIds"]) {
+  loadedProvider = {
+    id: "p1",
+    name: "OpenAI",
+    providerType: "OpenAI",
+    apiKey: "sk-test",
+    apiMode: "responses",
+    modelIds,
+    taskModelId: "gpt-4o",
+    memoryExtractionModelId: "gpt-4o",
+  } as unknown as Provider;
+  return render(<ProviderForm orgId="org1" providerId="p1" />);
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe("ProviderForm model rows", () => {
+  afterEach(() => {
+    loadedProvider = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it("labels the Model ID input rather than relying on its placeholder", () => {
+    renderEditForm([{ id: "gpt-4o", passthroughFileTypes: [] }]);
+
+    expect(screen.getByLabelText("Model ID")).toHaveValue("gpt-4o");
+  });
+
+  it("gives every model field an info control carrying its help text", () => {
+    renderEditForm([{ id: "gpt-4o", passthroughFileTypes: ["image/*"] }]);
+
+    for (const label of [
+      "Model ID",
+      "Alias",
+      "Native file types",
+      "Max extracted text characters",
+    ]) {
+      expect(
+        screen.getByRole("button", { name: `About ${label}` }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("hides the file-handling fields until the row is expanded", () => {
+    renderEditForm([{ id: "gpt-4o", passthroughFileTypes: [] }]);
+
+    expect(screen.queryByLabelText("Native file types")).toBeNull();
+    expect(screen.queryByLabelText("Max extracted text characters")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Advanced" }));
+
+    expect(screen.getByLabelText("Native file types")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Max extracted text characters"),
+    ).toBeInTheDocument();
+  });
+
+  it("opens a row already carrying file-handling config, so nothing set is hidden", () => {
+    renderEditForm([
+      {
+        id: "gpt-4o",
+        passthroughFileTypes: ["image/*", "application/pdf"],
+        maxExtractedTextChars: 1000,
+      },
+    ]);
+
+    expect(screen.getByLabelText("Native file types")).toHaveValue(
+      "image/*, application/pdf",
+    );
+    expect(screen.getByLabelText("Max extracted text characters")).toHaveValue(
+      1000,
+    );
+  });
+
+  it("expands only the row that has config, leaving its neighbours collapsed", () => {
+    renderEditForm([
+      { id: "gpt-4o", passthroughFileTypes: [] },
+      { id: "gpt-4o-mini", passthroughFileTypes: ["image/*"] },
+    ]);
+
+    // One expanded row means one visible pair of file-handling inputs.
+    expect(screen.getAllByLabelText("Native file types")).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "Advanced" })).toHaveLength(2);
+  });
+});

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -25,13 +25,20 @@ import {
 } from "@/components/ui/collapsible";
 import {
   Building,
+  ChevronRight,
   ChevronsUpDown,
   Eye,
   EyeOff,
+  Info,
   OctagonX,
   Plus,
   Trash2,
 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   Select,
   SelectContent,
@@ -51,7 +58,7 @@ import {
   type Provider,
 } from "@platypus/schemas";
 import useSWR from "swr";
-import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import { cn, fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
 import {
   getModelConfigs,
   defaultPassthroughFileTypes,
@@ -60,6 +67,215 @@ import {
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
+
+/**
+ * Per-field help for a model row. The four fields each need a paragraph of
+ * explanation, which as one block under the list was a wall nobody read and
+ * left the reader matching sentences to fields by hand.
+ */
+const InfoHint = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  // A short delay, so sweeping the pointer across a row of fields doesn't fire
+  // a tooltip at every icon on the way past.
+  <Tooltip delayDuration={400}>
+    <TooltipTrigger
+      // Focusable, so the help is reachable by keyboard and not hover-only.
+      type="button"
+      aria-label={`About ${label}`}
+      className="text-muted-foreground hover:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 rounded-full outline-none focus-visible:ring-[3px]"
+    >
+      <Info className="size-3.5" />
+    </TooltipTrigger>
+    <TooltipContent className="max-w-xs">{children}</TooltipContent>
+  </Tooltip>
+);
+
+const ModelField = ({
+  htmlFor,
+  label,
+  hint,
+  children,
+}: {
+  htmlFor: string;
+  label: string;
+  hint: React.ReactNode;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-1">
+    <div className="flex items-center gap-1.5">
+      <FieldLabel htmlFor={htmlFor} className="text-xs text-muted-foreground">
+        {label}
+      </FieldLabel>
+      <InfoHint label={label}>{hint}</InfoHint>
+    </div>
+    {children}
+  </div>
+);
+
+/**
+ * One entry in the Models list. The file-handling settings are collapsed by
+ * default — most models take the provider-type defaults, and two extra inputs
+ * per row turned a ten-model provider into a wall. A row that has either value
+ * set opens expanded, so nothing configured is hidden from the reader.
+ */
+const ModelRow = ({
+  model,
+  index,
+  disabled,
+  fileTypesPlaceholder,
+  onChange,
+  onRemove,
+}: {
+  model: ModelConfigView;
+  index: number;
+  disabled: boolean;
+  fileTypesPlaceholder: string;
+  onChange: (patch: Partial<ModelConfigView>) => void;
+  onRemove: () => void;
+}) => {
+  const [showAdvanced, setShowAdvanced] = useState(
+    model.passthroughFileTypes.length > 0 ||
+      model.maxExtractedTextChars !== undefined,
+  );
+
+  // Passthrough types are edited as a comma-separated string of media types.
+  const parsePassthroughTypes = (value: string): string[] =>
+    value
+      .split(",")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+
+  // An empty (or nonsense) cap means "use the shared default" rather than 0 —
+  // sending 0 would truncate every extracted document to nothing (issue #342).
+  const parseExtractedTextCap = (value: string): number | undefined => {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  };
+
+  return (
+    <div className="flex items-start gap-2 rounded-md border p-3">
+      <div className="flex flex-1 flex-col gap-3">
+        <ModelField
+          htmlFor={`model-id-${index}`}
+          label="Model ID"
+          hint="The model id sent to the vendor, exactly as the vendor names it."
+        >
+          <Input
+            id={`model-id-${index}`}
+            placeholder="e.g. gpt-4o"
+            value={model.id}
+            onChange={(e) => onChange({ id: e.target.value })}
+            disabled={disabled}
+          />
+        </ModelField>
+
+        <ModelField
+          htmlFor={`alias-${index}`}
+          label="Alias"
+          hint="Optional stable name Agents and Chats can select instead of the model ID. Pointing the alias at a newer model upgrades all of them at once."
+        >
+          <Input
+            id={`alias-${index}`}
+            placeholder="e.g. flagship"
+            value={model.alias ?? ""}
+            onChange={(e) =>
+              // An empty field means "no alias". Anything else goes to the
+              // schema as typed, so a whitespace-only name is rejected rather
+              // than silently dropped.
+              onChange({
+                alias: e.target.value === "" ? undefined : e.target.value,
+              })
+            }
+            disabled={disabled}
+          />
+        </ModelField>
+
+        <Collapsible open={showAdvanced} onOpenChange={setShowAdvanced}>
+          <CollapsibleTrigger
+            // Not a ghost Button: the trigger sits flush with the left edge of
+            // the inputs above it, so it takes no horizontal padding and no
+            // hover fill. `h-9` matches an Input, keeping the hit box the size
+            // of the fields it sits among rather than the size of its text.
+            className="flex h-9 w-fit items-center gap-1 rounded-sm text-xs text-muted-foreground outline-none hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          >
+            <ChevronRight
+              className={cn(
+                "size-3.5 transition-transform",
+                showAdvanced && "rotate-90",
+              )}
+            />
+            Advanced
+          </CollapsibleTrigger>
+          <CollapsibleContent className="flex flex-col gap-3 pt-3">
+            <ModelField
+              htmlFor={`passthrough-${index}`}
+              label="Native file types"
+              hint={
+                <>
+                  Media types this model ingests <strong>natively</strong>,
+                  comma-separated (wildcards like <code>image/*</code> allowed).
+                  Other types are converted to text where possible, so this is a
+                  capability setting, <strong>not a security filter</strong>.
+                  Leave empty to use the provider-type default.
+                </>
+              }
+            >
+              <Input
+                id={`passthrough-${index}`}
+                placeholder={fileTypesPlaceholder}
+                value={model.passthroughFileTypes.join(", ")}
+                onChange={(e) =>
+                  onChange({
+                    passthroughFileTypes: parsePassthroughTypes(e.target.value),
+                  })
+                }
+                disabled={disabled}
+              />
+            </ModelField>
+
+            <ModelField
+              htmlFor={`extracted-chars-${index}`}
+              label="Max extracted text characters"
+              hint="How much extracted document text a single file may add to a turn. Protects a small context window. Leave empty for the default."
+            >
+              <Input
+                id={`extracted-chars-${index}`}
+                type="number"
+                min={1}
+                placeholder={String(DEFAULT_MAX_EXTRACTED_TEXT_CHARS)}
+                value={model.maxExtractedTextChars ?? ""}
+                onChange={(e) =>
+                  onChange({
+                    maxExtractedTextChars: parseExtractedTextCap(
+                      e.target.value,
+                    ),
+                  })
+                }
+                disabled={disabled}
+              />
+            </ModelField>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="shrink-0"
+        aria-label={`Remove model ${index + 1}`}
+        onClick={onRemove}
+        disabled={disabled}
+      >
+        <Trash2 />
+      </Button>
+    </div>
+  );
+};
 
 type ProviderFormData = Omit<
   Provider,
@@ -291,20 +507,6 @@ const ProviderForm = ({
       ...prev,
       modelIds: prev.modelIds.filter((_, i) => i !== index),
     }));
-  };
-
-  // Passthrough types are edited as a comma-separated string of media types.
-  const parsePassthroughTypes = (value: string): string[] =>
-    value
-      .split(",")
-      .map((t) => t.trim())
-      .filter((t) => t.length > 0);
-
-  // An empty (or nonsense) cap means "use the shared default" rather than 0 —
-  // sending 0 would truncate every extracted document to nothing (issue #342).
-  const parseExtractedTextCap = (value: string): number | undefined => {
-    const parsed = Number.parseInt(value, 10);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
   };
 
   // Placeholder for the native-file-types input: the provider-type default an
@@ -628,102 +830,15 @@ const ProviderForm = ({
                 </p>
               )}
               {formData.modelIds.map((model, index) => (
-                <div
+                <ModelRow
                   key={index}
-                  className="flex items-start gap-2 rounded-md border p-3"
-                >
-                  <div className="flex flex-1 flex-col gap-2">
-                    <Input
-                      aria-label={`Model ID ${index + 1}`}
-                      placeholder="Model ID (e.g. gpt-4o)"
-                      value={model.id}
-                      onChange={(e) =>
-                        updateModel(index, { id: e.target.value })
-                      }
-                      disabled={isSubmitting || isReadOnly}
-                    />
-                    <div className="flex flex-col gap-1">
-                      <FieldLabel
-                        htmlFor={`alias-${index}`}
-                        className="text-xs text-muted-foreground"
-                      >
-                        Alias
-                      </FieldLabel>
-                      <Input
-                        id={`alias-${index}`}
-                        placeholder="e.g. flagship"
-                        value={model.alias ?? ""}
-                        onChange={(e) =>
-                          // An empty field means "no alias". Anything else goes
-                          // to the schema as typed, so a whitespace-only name is
-                          // rejected rather than silently dropped.
-                          updateModel(index, {
-                            alias:
-                              e.target.value === ""
-                                ? undefined
-                                : e.target.value,
-                          })
-                        }
-                        disabled={isSubmitting || isReadOnly}
-                      />
-                    </div>
-                    <div className="flex flex-col gap-1">
-                      <FieldLabel
-                        htmlFor={`passthrough-${index}`}
-                        className="text-xs text-muted-foreground"
-                      >
-                        Native file types
-                      </FieldLabel>
-                      <Input
-                        id={`passthrough-${index}`}
-                        placeholder={defaultFileTypesPlaceholder}
-                        value={model.passthroughFileTypes.join(", ")}
-                        onChange={(e) =>
-                          updateModel(index, {
-                            passthroughFileTypes: parsePassthroughTypes(
-                              e.target.value,
-                            ),
-                          })
-                        }
-                        disabled={isSubmitting || isReadOnly}
-                      />
-                    </div>
-                    <div className="flex flex-col gap-1">
-                      <FieldLabel
-                        htmlFor={`extracted-chars-${index}`}
-                        className="text-xs text-muted-foreground"
-                      >
-                        Max extracted text characters
-                      </FieldLabel>
-                      <Input
-                        id={`extracted-chars-${index}`}
-                        type="number"
-                        min={1}
-                        placeholder={String(DEFAULT_MAX_EXTRACTED_TEXT_CHARS)}
-                        value={model.maxExtractedTextChars ?? ""}
-                        onChange={(e) =>
-                          updateModel(index, {
-                            maxExtractedTextChars: parseExtractedTextCap(
-                              e.target.value,
-                            ),
-                          })
-                        }
-                        disabled={isSubmitting || isReadOnly}
-                      />
-                    </div>
-                  </div>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="shrink-0"
-                    aria-label={`Remove model ${index + 1}`}
-                    onClick={() => removeModel(index)}
-                    disabled={isSubmitting || isReadOnly}
-                  >
-                    <Trash2 />
-                  </Button>
-                </div>
+                  model={model}
+                  index={index}
+                  disabled={isSubmitting || isReadOnly}
+                  fileTypesPlaceholder={defaultFileTypesPlaceholder}
+                  onChange={(patch) => updateModel(index, patch)}
+                  onRemove={() => removeModel(index)}
+                />
               ))}
             </div>
             {!isReadOnly && (
@@ -739,17 +854,8 @@ const ProviderForm = ({
               </Button>
             )}
             <FieldDescription>
-              Models this provider exposes. For each model, list the file media
-              types it can ingest <strong>natively</strong> (comma-separated,
-              wildcards like <code>image/*</code> allowed). Files of other types
-              are converted to text where possible — text and code files are
-              inlined, PDF and DOCX are extracted — so this is a capability
-              setting, <strong>not a security filter</strong>. Leave the types
-              empty to use the provider-type default. The character cap limits
-              how much extracted document text a single file may add, protecting
-              a small context window. An optional alias gives a model a stable
-              name Agents and Chats can select instead of the model ID, so
-              pointing the alias at a newer model upgrades all of them at once.
+              The models this provider exposes. Agents and Chats choose from
+              this list.
             </FieldDescription>
             {validationErrors.modelIds && (
               <FieldError>{validationErrors.modelIds}</FieldError>


### PR DESCRIPTION
The Models list on the Provider form grew a fourth field with Model aliases
(#397), and all four were explained by a single paragraph under **Add model**.
It left the reader matching sentences to fields by hand, and the **Model ID**
input had no visible label at all — only a placeholder.

## What changed

**Model ID is labelled.** A `FieldLabel` like the one Alias already had. The
placeholder drops to `e.g. gpt-4o` and the `aria-label` goes, since the label
now supplies the accessible name.

**Help sits with its field.** Each of the four fields carries an `i` beside its
label, opening a tooltip with that field's own explanation. The paragraph under
**Add model** shrinks to one line. The delay is 400ms, so sweeping the pointer
across a row doesn't fire a tooltip at every icon on the way past. The trigger
is a real `<button>`, so the help opens on keyboard focus too — not hover-only.

**File settings collapse.** **Native file types** and **Max extracted text
characters** move behind an **Advanced** disclosure per row. Two extra inputs
per model turned a ten-model provider into a wall, and most models take the
provider-type defaults.

A row that already has either value set **renders expanded**, so nothing an
operator configured is hidden behind a collapsed section. The disclosure also
stays clickable in the read-only Shared Provider view (a Workspace looking at an
org-scoped Provider) — the inputs stay disabled, but the values are readable.

The row markup moves into a `ModelRow` component, which is where the per-row
disclosure state lives. That takes ~90 lines out of the form body.

## Not in scope

The other issues in this form — per-row validation errors collapsing onto the
whole Models field, the Submit button stranding on an error key with no clear
path, and the free-text pointer fields — are untouched. Separate work.

## Tests

`apps/frontend/components/provider-form.test.tsx` is new: 5 tests over the
label, the info controls, and the collapse/expand defaults. This component had
no tests before.

## Docs

- `getting-started` told the reader to leave "the per-model file-type
  checkboxes" alone — they were never checkboxes, and they're now collapsed.
- `self-hosting/providers-and-auth` gains two sentences saying where the two
  file-handling fields live in the form.

## Verification

Driven against a running instance: both rows collapsed on load, tooltip absent
150ms after hover and present at 650ms, expanding one row leaves its neighbour
collapsed, the **Advanced** trigger measures 36px tall and flush-left with the
inputs (matching an `Input`) with no hover fill, and the read-only view reveals
disabled fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)