### PR TITLE
fix(frontend): show a rejected model row its own error

### DIFF
--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -48,7 +48,12 @@ import {
   type Skill,
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import {
+  clearFieldError,
+  fetcher,
+  parseValidationErrors,
+  joinUrl,
+} from "@/lib/utils";
 import { findModelOption, getModelOptions } from "@/lib/model-config";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
@@ -215,14 +220,9 @@ const AgentForm = ({
   // Drop the stored server validation error for the given field(s) so a
   // corrected field stops rendering its error and re-enables the Save button.
   const clearValidationErrors = useCallback((...ids: string[]) => {
-    setValidationErrors((prev) => {
-      if (!ids.some((id) => id in prev)) return prev;
-      const newErrors = { ...prev };
-      for (const id of ids) {
-        delete newErrors[id];
-      }
-      return newErrors;
-    });
+    setValidationErrors((prev) =>
+      ids.reduce((errors, id) => clearFieldError(errors, id), prev),
+    );
   }, []);
 
   const handleChange = (

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -26,7 +26,12 @@ import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type MCP } from "@platypus/schemas";
 import useSWR from "swr";
-import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import {
+  clearFieldError,
+  fetcher,
+  parseValidationErrors,
+  joinUrl,
+} from "@/lib/utils";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -143,14 +148,9 @@ const McpForm = ({
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { id, value } = e.target;
 
-    // Clear validation error for this field
-    if (validationErrors[id]) {
-      setValidationErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[id];
-        return newErrors;
-      });
-    }
+    // Clear the error for this field, including any reported against a path
+    // inside it.
+    setValidationErrors((prev) => clearFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,
@@ -162,14 +162,9 @@ const McpForm = ({
   };
 
   const handleSelectChange = (id: string, value: string) => {
-    // Clear validation error for this field
-    if (validationErrors[id]) {
-      setValidationErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[id];
-        return newErrors;
-      });
-    }
+    // Clear the error for this field, including any reported against a path
+    // inside it.
+    setValidationErrors((prev) => clearFieldError(prev, id));
 
     // Clear bearerToken error when authType changes
     if (id === "authType" && validationErrors.bearerToken) {

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -23,7 +23,12 @@ import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type Organization } from "@platypus/schemas";
-import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import {
+  clearFieldError,
+  fetcher,
+  parseValidationErrors,
+  joinUrl,
+} from "@/lib/utils";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { Trash2 } from "lucide-react";
@@ -74,14 +79,9 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
   ) => {
     const { id, value } = e.target;
 
-    // Clear validation error for this field
-    if (validationErrors[id]) {
-      setValidationErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[id];
-        return newErrors;
-      });
-    }
+    // Clear the error for this field, including any reported against a path
+    // inside it.
+    setValidationErrors((prev) => clearFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,

--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { Provider } from "@platypus/schemas";
 
 // --- Module mocks ------------------------------------------------------------
@@ -50,6 +50,18 @@ function renderEditForm(modelIds: Provider["modelIds"]) {
   } as unknown as Provider;
   return render(<ProviderForm orgId="org1" providerId="p1" />);
 }
+
+/** A server rejection carrying standardschema issues, as the API returns them. */
+function mockRejectedSave(issues: Array<{ path: unknown[]; message: string }>) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status: 400,
+    json: async () => ({ error: issues }),
+  } as unknown as Response);
+}
+
+const save = () =>
+  fireEvent.click(screen.getByRole("button", { name: "Update" }));
 
 // --- Tests -------------------------------------------------------------------
 
@@ -120,5 +132,147 @@ describe("ProviderForm model rows", () => {
     // One expanded row means one visible pair of file-handling inputs.
     expect(screen.getAllByLabelText("Native file types")).toHaveLength(1);
     expect(screen.getAllByRole("button", { name: "Advanced" })).toHaveLength(2);
+  });
+});
+
+describe("ProviderForm validation errors on model rows", () => {
+  afterEach(() => {
+    loadedProvider = undefined;
+    vi.restoreAllMocks();
+  });
+
+  const threeModels = () => [
+    { id: "a", passthroughFileTypes: [] },
+    { id: "b", alias: "dup", passthroughFileTypes: [] },
+    { id: "c", alias: "DUP", passthroughFileTypes: [] },
+  ];
+
+  // Keyed on the first path segment, both messages landed on the Models field
+  // and the second overwrote the first: one message, one fix per round-trip,
+  // and no indication of which row was wrong.
+  it("shows every rejected row its own message, against the field that failed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockRejectedSave([
+        { path: ["modelIds", 1, "alias"], message: "Alias 'dup' duplicates" },
+        { path: ["modelIds", 2, "alias"], message: "Alias 'DUP' duplicates" },
+      ]),
+    );
+
+    renderEditForm(threeModels());
+    save();
+
+    await waitFor(() =>
+      expect(screen.getByText("Alias 'dup' duplicates")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Alias 'DUP' duplicates")).toBeInTheDocument();
+
+    // The message lands on the row that failed, not on its neighbours.
+    const aliases = screen.getAllByLabelText("Alias");
+    expect(aliases[0]).not.toHaveAttribute("aria-invalid", "true");
+    expect(aliases[1]).toHaveAttribute("aria-invalid", "true");
+    expect(aliases[2]).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("does not repeat a row's message against the Models field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockRejectedSave([
+        { path: ["modelIds", 1, "alias"], message: "Alias 'dup' duplicates" },
+      ]),
+    );
+
+    renderEditForm(threeModels());
+    save();
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Alias 'dup' duplicates")).toHaveLength(1),
+    );
+  });
+
+  it("still shows an error reported against the list itself", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockRejectedSave([
+        { path: ["modelIds"], message: "At least one model is required" },
+      ]),
+    );
+
+    renderEditForm([]);
+    save();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("At least one model is required"),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  // The button used to be disabled while any error was outstanding, and errors
+  // were only retracted by field-specific handlers. An error key with no
+  // matching handler disabled Save with no way back but a reload.
+  it("leaves Save usable after a rejection, so the retry is one click", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockRejectedSave([
+        { path: ["modelIds", 1, "alias"], message: "Alias 'dup' duplicates" },
+      ]),
+    );
+
+    renderEditForm(threeModels());
+    save();
+
+    await waitFor(() =>
+      expect(screen.getByText("Alias 'dup' duplicates")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: "Update" })).toBeEnabled();
+  });
+
+  it("retracts the row errors once the list is edited", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockRejectedSave([
+        { path: ["modelIds", 1, "alias"], message: "Alias 'dup' duplicates" },
+        { path: ["modelIds", 2, "alias"], message: "Alias 'DUP' duplicates" },
+      ]),
+    );
+
+    renderEditForm(threeModels());
+    save();
+
+    await waitFor(() =>
+      expect(screen.getByText("Alias 'dup' duplicates")).toBeInTheDocument(),
+    );
+
+    fireEvent.change(screen.getAllByLabelText("Alias")[1], {
+      target: { value: "unique" },
+    });
+
+    expect(screen.queryByText("Alias 'dup' duplicates")).toBeNull();
+    expect(screen.queryByText("Alias 'DUP' duplicates")).toBeNull();
+  });
+
+  it("opens a collapsed row when the server rejects a field inside it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockRejectedSave([
+        {
+          path: ["modelIds", 0, "maxExtractedTextChars"],
+          message: "Too small",
+        },
+      ]),
+    );
+
+    renderEditForm([{ id: "a", passthroughFileTypes: [] }]);
+    expect(screen.queryByLabelText("Max extracted text characters")).toBeNull();
+
+    save();
+
+    await waitFor(() =>
+      expect(
+        screen.getByLabelText("Max extracted text characters"),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Too small")).toBeInTheDocument();
   });
 });

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -58,7 +58,13 @@ import {
   type Provider,
 } from "@platypus/schemas";
 import useSWR from "swr";
-import { cn, fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import {
+  clearFieldError,
+  cn,
+  fetcher,
+  parseValidationErrors,
+  joinUrl,
+} from "@/lib/utils";
 import {
   getModelConfigs,
   defaultPassthroughFileTypes,
@@ -99,14 +105,16 @@ const ModelField = ({
   htmlFor,
   label,
   hint,
+  error,
   children,
 }: {
   htmlFor: string;
   label: string;
   hint: React.ReactNode;
+  error?: string;
   children: React.ReactNode;
 }) => (
-  <div className="flex flex-col gap-1">
+  <div className="flex flex-col gap-1" data-invalid={!!error}>
     <div className="flex items-center gap-1.5">
       <FieldLabel htmlFor={htmlFor} className="text-xs text-muted-foreground">
         {label}
@@ -114,8 +122,12 @@ const ModelField = ({
       <InfoHint label={label}>{hint}</InfoHint>
     </div>
     {children}
+    {error && <FieldError>{error}</FieldError>}
   </div>
 );
+
+/** Errors reported against one model row, split by the field each belongs to. */
+type ModelRowErrors = { row?: string; fields: Record<string, string> };
 
 /**
  * One entry in the Models list. The file-handling settings are collapsed by
@@ -128,6 +140,7 @@ const ModelRow = ({
   index,
   disabled,
   fileTypesPlaceholder,
+  errors,
   onChange,
   onRemove,
 }: {
@@ -135,6 +148,7 @@ const ModelRow = ({
   index: number;
   disabled: boolean;
   fileTypesPlaceholder: string;
+  errors: ModelRowErrors;
   onChange: (patch: Partial<ModelConfigView>) => void;
   onRemove: () => void;
 }) => {
@@ -142,6 +156,13 @@ const ModelRow = ({
     model.passthroughFileTypes.length > 0 ||
       model.maxExtractedTextChars !== undefined,
   );
+
+  // A rejected row is no use collapsed: the reader has to see the field the
+  // server is complaining about.
+  const hasAdvancedError =
+    !!errors.fields.passthroughFileTypes ||
+    !!errors.fields.maxExtractedTextChars;
+  const advancedOpen = showAdvanced || hasAdvancedError;
 
   // Passthrough types are edited as a comma-separated string of media types.
   const parsePassthroughTypes = (value: string): string[] =>
@@ -160,10 +181,13 @@ const ModelRow = ({
   return (
     <div className="flex items-start gap-2 rounded-md border p-3">
       <div className="flex flex-1 flex-col gap-3">
+        {errors.row && <FieldError>{errors.row}</FieldError>}
+
         <ModelField
           htmlFor={`model-id-${index}`}
           label="Model ID"
           hint="The model id sent to the vendor, exactly as the vendor names it."
+          error={errors.fields.id}
         >
           <Input
             id={`model-id-${index}`}
@@ -171,6 +195,7 @@ const ModelRow = ({
             value={model.id}
             onChange={(e) => onChange({ id: e.target.value })}
             disabled={disabled}
+            aria-invalid={!!errors.fields.id}
           />
         </ModelField>
 
@@ -178,11 +203,13 @@ const ModelRow = ({
           htmlFor={`alias-${index}`}
           label="Alias"
           hint="Optional stable name Agents and Chats can select instead of the model ID. Pointing the alias at a newer model upgrades all of them at once."
+          error={errors.fields.alias}
         >
           <Input
             id={`alias-${index}`}
             placeholder="e.g. flagship"
             value={model.alias ?? ""}
+            aria-invalid={!!errors.fields.alias}
             onChange={(e) =>
               // An empty field means "no alias". Anything else goes to the
               // schema as typed, so a whitespace-only name is rejected rather
@@ -195,7 +222,7 @@ const ModelRow = ({
           />
         </ModelField>
 
-        <Collapsible open={showAdvanced} onOpenChange={setShowAdvanced}>
+        <Collapsible open={advancedOpen} onOpenChange={setShowAdvanced}>
           <CollapsibleTrigger
             // Not a ghost Button: the trigger sits flush with the left edge of
             // the inputs above it, so it takes no horizontal padding and no
@@ -206,7 +233,7 @@ const ModelRow = ({
             <ChevronRight
               className={cn(
                 "size-3.5 transition-transform",
-                showAdvanced && "rotate-90",
+                advancedOpen && "rotate-90",
               )}
             />
             Advanced
@@ -224,6 +251,7 @@ const ModelRow = ({
                   Leave empty to use the provider-type default.
                 </>
               }
+              error={errors.fields.passthroughFileTypes}
             >
               <Input
                 id={`passthrough-${index}`}
@@ -242,6 +270,7 @@ const ModelRow = ({
               htmlFor={`extracted-chars-${index}`}
               label="Max extracted text characters"
               hint="How much extracted document text a single file may add to a turn. Protects a small context window. Leave empty for the default."
+              error={errors.fields.maxExtractedTextChars}
             >
               <Input
                 id={`extracted-chars-${index}`}
@@ -405,13 +434,7 @@ const ProviderForm = ({
     const { id, value } = e.target;
 
     // Clear validation error for this field
-    if (validationErrors[id]) {
-      setValidationErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[id];
-        return newErrors;
-      });
-    }
+    setValidationErrors((prev) => clearFieldError(prev, id));
     setError(null);
 
     if (id === "headers") {
@@ -448,13 +471,7 @@ const ProviderForm = ({
 
   const handleSelectChange = (id: string, value: string) => {
     // Clear validation error for this field
-    if (validationErrors[id]) {
-      setValidationErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[id];
-        return newErrors;
-      });
-    }
+    setValidationErrors((prev) => clearFieldError(prev, id));
     setError(null);
 
     setFormData((prevData) => {
@@ -465,19 +482,36 @@ const ProviderForm = ({
 
   // --- Per-model config editing (issue #328) ---
 
-  // The submit button is disabled while ANY validation error is outstanding, so
-  // every edit to the model list has to retract the list's error — otherwise
-  // fixing the mistake leaves the form unsubmittable and the only ways out are
-  // unrelated. Reachable since Model aliases (#386) gave `modelIds` rules a
-  // user can plausibly break, like naming two models the same thing.
+  // Retracts the list's error and every row error under it, so a stale message
+  // doesn't sit under a row the user has already corrected.
   const clearModelIdsError = () => {
-    if (!validationErrors.modelIds) return;
-    setValidationErrors((prev) => {
-      const next = { ...prev };
-      delete next.modelIds;
-      return next;
-    });
+    setValidationErrors((prev) => clearFieldError(prev, "modelIds"));
   };
+
+  /**
+   * Split the outstanding errors for one row out of the flat map. A row rule
+   * reports as `modelIds.<index>.<field>`; `modelIds.<index>` is the row as a
+   * whole.
+   */
+  const errorsForRow = (index: number): ModelRowErrors => {
+    const prefix = `modelIds.${index}`;
+    const result: ModelRowErrors = { fields: {} };
+    for (const [key, message] of Object.entries(validationErrors)) {
+      if (key === prefix) result.row = message;
+      else if (key.startsWith(`${prefix}.`))
+        result.fields[key.slice(prefix.length + 1)] = message;
+    }
+    return result;
+  };
+
+  // `parseValidationErrors` mirrors every row error onto `modelIds` as well, so
+  // a form that only knows flat names still shows something. This one knows
+  // better: when a row is showing the message, the list's own slot stays empty
+  // rather than repeating it.
+  const hasRowError = Object.keys(validationErrors).some((key) =>
+    key.startsWith("modelIds."),
+  );
+  const modelIdsError = hasRowError ? undefined : validationErrors.modelIds;
 
   const updateModel = (index: number, patch: Partial<ModelConfigView>) => {
     clearModelIdsError();
@@ -821,7 +855,10 @@ const ProviderForm = ({
             )}
           </Field>
 
-          <Field data-invalid={!!validationErrors.modelIds}>
+          {/* Invalid only for an error against the list itself: `data-invalid`
+              reddens every descendant, which on a row error would paint the
+              innocent rows the same colour as the guilty one. */}
+          <Field data-invalid={!!modelIdsError}>
             <FieldLabel htmlFor="modelIds">Models</FieldLabel>
             <div className="flex flex-col gap-3">
               {formData.modelIds.length === 0 && (
@@ -836,6 +873,7 @@ const ProviderForm = ({
                   index={index}
                   disabled={isSubmitting || isReadOnly}
                   fileTypesPlaceholder={defaultFileTypesPlaceholder}
+                  errors={errorsForRow(index)}
                   onChange={(patch) => updateModel(index, patch)}
                   onRemove={() => removeModel(index)}
                 />
@@ -857,9 +895,7 @@ const ProviderForm = ({
               The models this provider exposes. Agents and Chats choose from
               this list.
             </FieldDescription>
-            {validationErrors.modelIds && (
-              <FieldError>{validationErrors.modelIds}</FieldError>
-            )}
+            {modelIdsError && <FieldError>{modelIdsError}</FieldError>}
           </Field>
 
           <Field data-invalid={!!validationErrors.taskModelId}>
@@ -1145,13 +1181,14 @@ const ProviderForm = ({
         <div className="flex gap-2">
           <Button
             className="cursor-pointer"
+            // Deliberately NOT gated on `validationErrors`. Those come back
+            // from the server, and every key needs a matching path that
+            // retracts it; one that has none disables Save forever, with no
+            // way out but reloading. Re-submitting simply re-validates. The
+            // JSON errors below are different — they are computed here as the
+            // user types and always clear themselves.
             onClick={handleSubmit}
-            disabled={
-              isSubmitting ||
-              !!headersError ||
-              !!extraBodyError ||
-              Object.keys(validationErrors).length > 0
-            }
+            disabled={isSubmitting || !!headersError || !!extraBodyError}
           >
             {providerId ? "Update" : "Save"}
           </Button>

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -20,7 +20,12 @@ import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 import { type Skill, type Agent } from "@platypus/schemas";
 import useSWR from "swr";
-import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import {
+  clearFieldError,
+  fetcher,
+  parseValidationErrors,
+  joinUrl,
+} from "@/lib/utils";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { AgentAvatar } from "@/components/agent-avatar";
@@ -114,14 +119,9 @@ const SkillForm = ({
   ) => {
     const { id, value } = e.target;
 
-    // Clear validation error for this field
-    if (validationErrors[id]) {
-      setValidationErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[id];
-        return newErrors;
-      });
-    }
+    // Clear the error for this field, including any reported against a path
+    // inside it.
+    setValidationErrors((prev) => clearFieldError(prev, id));
 
     const nextValue = id === "name" ? value.toLowerCase() : value;
 

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -36,7 +36,12 @@ import {
   type KanbanBoardState,
 } from "@platypus/schemas";
 import useSWR from "swr";
-import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import {
+  clearFieldError,
+  fetcher,
+  parseValidationErrors,
+  joinUrl,
+} from "@/lib/utils";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { Cron } from "croner";
@@ -470,13 +475,9 @@ const TriggerForm = ({
   ) => {
     const { id, value } = e.target;
 
-    if (validationErrors[id]) {
-      setValidationErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[id];
-        return newErrors;
-      });
-    }
+    // Clear the error for this field, including any reported against a path
+    // inside it.
+    setValidationErrors((prev) => clearFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -31,7 +31,12 @@ import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type Workspace, type Provider } from "@platypus/schemas";
-import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import {
+  clearFieldError,
+  fetcher,
+  parseValidationErrors,
+  joinUrl,
+} from "@/lib/utils";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { Trash2 } from "lucide-react";
@@ -155,14 +160,9 @@ const WorkspaceForm = ({
   ) => {
     const { id, value } = e.target;
 
-    // Clear validation error for this field
-    if (validationErrors[id]) {
-      setValidationErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors[id];
-        return newErrors;
-      });
-    }
+    // Clear the error for this field, including any reported against a path
+    // inside it.
+    setValidationErrors((prev) => clearFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,

--- a/apps/frontend/lib/utils.test.ts
+++ b/apps/frontend/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { joinUrl, parseValidationErrors } from "./utils";
+import { clearFieldError, joinUrl, parseValidationErrors } from "./utils";
 
 describe("joinUrl", () => {
   it("should join base URL and path", () => {
@@ -44,5 +44,90 @@ describe("parseValidationErrors", () => {
     expect(parseValidationErrors(null)).toEqual({});
     expect(parseValidationErrors({})).toEqual({});
     expect(parseValidationErrors({ error: "string" })).toEqual({});
+  });
+
+  // A rule over a list reports the row it failed on. Keyed on the first path
+  // segment alone, every row's message landed on the same key and all but one
+  // was lost — two bad rows meant one message and one fix per round-trip.
+  it("keys an error inside a list on its full path", () => {
+    const result = parseValidationErrors({
+      error: [
+        { path: ["modelIds", 1, "alias"], message: "Alias 'dup' duplicates" },
+        { path: ["modelIds", 2, "alias"], message: "Alias 'DUP' duplicates" },
+      ],
+    });
+
+    expect(result["modelIds.1.alias"]).toBe("Alias 'dup' duplicates");
+    expect(result["modelIds.2.alias"]).toBe("Alias 'DUP' duplicates");
+  });
+
+  // Not every form knows about paths. Each issue also reports under its
+  // top-level field so a form that only reads flat names still shows something
+  // rather than failing silently.
+  it("also reports a nested error under its top-level field", () => {
+    const result = parseValidationErrors({
+      error: [{ path: ["modelIds", 1, "alias"], message: "Alias duplicates" }],
+    });
+
+    expect(result.modelIds).toBe("Alias duplicates");
+  });
+
+  // An error against the list itself is the better message for the list's own
+  // slot, whichever order the two arrive in.
+  it("prefers an error on the field itself over one derived from a row", () => {
+    const rowFirst = parseValidationErrors({
+      error: [
+        { path: ["modelIds", 0, "alias"], message: "Row message" },
+        { path: ["modelIds"], message: "Field message" },
+      ],
+    });
+
+    expect(rowFirst.modelIds).toBe("Field message");
+    expect(rowFirst["modelIds.0.alias"]).toBe("Row message");
+  });
+
+  it("keeps the first message when one field has several", () => {
+    const result = parseValidationErrors({
+      error: [
+        { path: ["name"], message: "Too short" },
+        { path: ["name"], message: "Also invalid" },
+      ],
+    });
+
+    expect(result.name).toBe("Too short");
+  });
+});
+
+describe("clearFieldError", () => {
+  it("drops the field's own error", () => {
+    expect(
+      clearFieldError({ name: "Required", apiKey: "Bad" }, "name"),
+    ).toEqual({ apiKey: "Bad" });
+  });
+
+  // The edit that fixes a row is an edit to the field the row lives in, so the
+  // rows' errors have to go with it. A form gating Submit on the error map
+  // stays stuck forever otherwise.
+  it("drops errors nested under the field", () => {
+    const errors = {
+      "modelIds.1.alias": "Duplicate",
+      "modelIds.2.alias": "Duplicate",
+      modelIds: "Duplicate",
+      name: "Required",
+    };
+
+    expect(clearFieldError(errors, "modelIds")).toEqual({ name: "Required" });
+  });
+
+  it("leaves a field whose name merely prefixes the edited one", () => {
+    const errors = { modelIdsExtra: "Bad" };
+
+    expect(clearFieldError(errors, "modelIds")).toEqual(errors);
+  });
+
+  it("returns the same object when nothing matches, so state does not churn", () => {
+    const errors = { name: "Required" };
+
+    expect(clearFieldError(errors, "apiKey")).toBe(errors);
   });
 });

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -47,32 +47,75 @@ export function getInitials(name: string): string {
     .slice(0, 2);
 }
 
+/**
+ * Map a validation failure onto the fields that can show it.
+ *
+ * Each issue is keyed on its **full path**, dot-joined: a rule over a list
+ * reports the row it failed on (`modelIds.2.alias`), so two bad rows produce
+ * two messages the form can render in two places. Keyed on the first segment
+ * alone, they overwrote each other — one message, one fix per round-trip.
+ *
+ * Every issue is *also* reported under its top-level field, because most forms
+ * only know flat names. An error on the field itself wins that slot over one
+ * derived from a row.
+ */
 export function parseValidationErrors(
   errorData: unknown,
 ): Record<string, string> {
   const errors: Record<string, string> = {};
 
   if (
-    errorData &&
-    typeof errorData === "object" &&
-    "error" in errorData &&
-    Array.isArray(errorData.error)
+    !errorData ||
+    typeof errorData !== "object" ||
+    !("error" in errorData) ||
+    !Array.isArray(errorData.error)
   ) {
-    for (const issue of errorData.error) {
-      if (
-        issue &&
-        typeof issue === "object" &&
-        "path" in issue &&
-        Array.isArray(issue.path) &&
-        issue.path.length > 0 &&
-        "message" in issue &&
-        typeof issue.message === "string"
-      ) {
-        const fieldName = String(issue.path[0]);
-        errors[fieldName] = issue.message;
-      }
+    return errors;
+  }
+
+  const issues: Array<{ path: string[]; message: string }> = [];
+  for (const issue of errorData.error) {
+    if (
+      issue &&
+      typeof issue === "object" &&
+      "path" in issue &&
+      Array.isArray(issue.path) &&
+      issue.path.length > 0 &&
+      "message" in issue &&
+      typeof issue.message === "string"
+    ) {
+      issues.push({ path: issue.path.map(String), message: issue.message });
     }
   }
 
+  // Exact paths first, so the top-level pass below can't take a slot an issue
+  // on the field itself is entitled to.
+  for (const { path, message } of issues) {
+    const key = path.join(".");
+    if (!(key in errors)) errors[key] = message;
+  }
+  for (const { path, message } of issues) {
+    if (!(path[0] in errors)) errors[path[0]] = message;
+  }
+
   return errors;
+}
+
+/**
+ * Retract the error shown against a field, including any keyed at a path
+ * *under* it — the edit that fixes a row is an edit to the field the row lives
+ * in. Returns the original object when nothing matched, so a no-op leaves
+ * state untouched.
+ */
+export function clearFieldError(
+  errors: Record<string, string>,
+  fieldName: string,
+): Record<string, string> {
+  const prefix = `${fieldName}.`;
+  const remaining = Object.entries(errors).filter(
+    ([key]) => key !== fieldName && !key.startsWith(prefix),
+  );
+
+  if (remaining.length === Object.keys(errors).length) return errors;
+  return Object.fromEntries(remaining);
 }


### PR DESCRIPTION
Problems 1 and 2 from the Provider form handoff, fixed together — they're
entangled, and fixing the first alone makes the second worse.

## A row's error had nowhere to go

`parseValidationErrors` keyed every issue on `path[0]`. The alias namespace rule
reports `["modelIds", 2, "alias"]`, so:

```
modelIds: [{id: "a"}, {id: "b", alias: "dup"}, {id: "c", alias: "DUP"}]
→ error: [{path: ["modelIds",1,"alias"], ...}, {path: ["modelIds",2,"alias"], ...}]
→ { modelIds: "Alias \"DUP\" duplicates another model's alias or id" }
```

Both messages collapsed onto one key, the second overwrote the first, and the
survivor rendered under the entire **Models** field. Two bad rows meant one
message, one fix, and another round-trip — with no indication of which row was
wrong.

Issues are now keyed on the full dot-joined path. The Provider form routes
`modelIds.2.alias` to row 2's **Alias** input, renders the message beneath it,
and marks that input `aria-invalid`.

Three things fall out of that:

- **The other eleven forms are unaffected.** Every issue is *also* mirrored onto
  its top-level field, so a form that only knows flat names still shows what it
  always did. An issue on the field itself wins that slot over one derived from
  a row.
- **A rejected row opens itself** if the offending field is inside the collapsed
  **Advanced** section. An error you can't see is an error you can't fix.
- **The Models field no longer reddens as a whole** on a row error. `data-invalid`
  cascades to every descendant, which painted the innocent rows the same colour
  as the guilty one — the exact thing this change exists to stop.

## Save could strand permanently

The button was disabled while any validation error was outstanding, and errors
were retracted only by field-specific handlers. Any key without a matching
handler disabled Save forever, with no way out but a reload. #397 hit this; the
one case was patched, the pattern wasn't.

Two changes:

- `clearFieldError` replaces the inline `delete errors[id]` in all eight forms
  that clear by field id. It drops the field's key *and* anything keyed beneath
  it, so correcting a row retracts the row's message. Without this, the new key
  shape would have stranded every form that received a nested error.
- The Provider form no longer gates Save on `validationErrors` at all.
  Re-submitting re-validates; there is nothing to strand. The JSON parse errors
  beside it still gate, since those are computed here as the user types and
  always clear themselves.

I left the other six forms' Save gating alone. `agent-form.test.tsx` pins that
behaviour deliberately, and changing it is a decision for its own PR.

## Tests

`utils.test.ts` covers the new key shape, the top-level mirror, the
field-beats-row precedence, and `clearFieldError` (including that it leaves
`modelIdsExtra` alone and returns the same object when nothing matched).
`provider-form.test.tsx` covers per-row rendering, no duplicate message on the
list, list-level errors still showing, Save staying enabled, retraction on edit,
and a collapsed row opening.

57 frontend tests pass, plus typecheck and lint.

## Verification

Driven against a running instance with two real duplicate aliases: the message
lands under the offending row's Alias field with only that input marked invalid,
Save stays enabled, correcting the row clears the message, and the retry saves
and navigates away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)