### PR TITLE
feat(frontend): reveal MCP secrets with an eye toggle

### DIFF
--- a/apps/frontend/components/mcp-form.test.tsx
+++ b/apps/frontend/components/mcp-form.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { MCP } from "@platypus/schemas";
+
+// --- Module mocks ------------------------------------------------------------
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "u1" } }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+// The MCP the edit form loads. Set per test before rendering.
+let loadedMcp: MCP | undefined;
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: () => ({
+    data: loadedMcp,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+}));
+
+import { McpForm } from "./mcp-form";
+
+// --- Tests -------------------------------------------------------------------
+
+describe("McpForm secret reveal", () => {
+  afterEach(() => {
+    loadedMcp = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it("toggles the bearer token between masked and revealed", () => {
+    loadedMcp = {
+      id: "m1",
+      name: "Docs",
+      url: "http://mcp.test",
+      authType: "Bearer",
+      bearerToken: "secret-token",
+    } as unknown as MCP;
+    render(<McpForm orgId="org1" mcpId="m1" />);
+
+    const input = screen.getByLabelText("Bearer Token");
+    expect(input).toHaveAttribute("type", "password");
+
+    fireEvent.click(screen.getByRole("button", { name: "Show bearer token" }));
+    expect(input).toHaveAttribute("type", "text");
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide bearer token" }));
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("toggles the OAuth client secret between masked and revealed", () => {
+    loadedMcp = {
+      id: "m1",
+      name: "Docs",
+      url: "http://mcp.test",
+      authType: "OAuth",
+      oauthClientId: "client-id",
+    } as unknown as MCP;
+    render(<McpForm orgId="org1" mcpId="m1" />);
+
+    const input = screen.getByLabelText("Client Secret");
+    expect(input).toHaveAttribute("type", "password");
+
+    fireEvent.click(screen.getByRole("button", { name: "Show client secret" }));
+    expect(input).toHaveAttribute("type", "text");
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide client secret" }));
+    expect(input).toHaveAttribute("type", "password");
+  });
+});

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -9,6 +9,12 @@ import {
   FieldError,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import {
@@ -41,6 +47,8 @@ import {
   Check,
   X,
   ExternalLink,
+  Eye,
+  EyeOff,
   ShieldCheck,
   ShieldOff,
   Plus,
@@ -102,6 +110,8 @@ const McpForm = ({
   const [validationErrors, setValidationErrors] = useState<
     Record<string, string>
   >({});
+  const [showBearerToken, setShowBearerToken] = useState(false);
+  const [showOauthClientSecret, setShowOauthClientSecret] = useState(false);
   const [isTesting, setIsTesting] = useState(false);
   const [testResult, setTestResult] = useState<{
     success: boolean;
@@ -568,15 +578,32 @@ const McpForm = ({
                 data-invalid={!!validationErrors.bearerToken}
               >
                 <FieldLabel htmlFor="bearerToken">Bearer Token</FieldLabel>
-                <Input
-                  id="bearerToken"
-                  type="password"
-                  placeholder="Bearer token"
-                  value={formData.bearerToken}
-                  onChange={handleChange}
-                  disabled={isSubmitting}
-                  aria-invalid={!!validationErrors.bearerToken}
-                />
+                <InputGroup>
+                  <InputGroupInput
+                    id="bearerToken"
+                    type={showBearerToken ? "text" : "password"}
+                    placeholder="Bearer token"
+                    value={formData.bearerToken}
+                    onChange={handleChange}
+                    disabled={isSubmitting}
+                    aria-invalid={!!validationErrors.bearerToken}
+                  />
+                  <InputGroupAddon align="inline-end">
+                    <InputGroupButton
+                      type="button"
+                      size="icon-xs"
+                      onClick={() => setShowBearerToken(!showBearerToken)}
+                      disabled={isSubmitting}
+                      aria-label={
+                        showBearerToken
+                          ? "Hide bearer token"
+                          : "Show bearer token"
+                      }
+                    >
+                      {showBearerToken ? <EyeOff /> : <Eye />}
+                    </InputGroupButton>
+                  </InputGroupAddon>
+                </InputGroup>
                 {validationErrors.bearerToken && (
                   <FieldError>{validationErrors.bearerToken}</FieldError>
                 )}
@@ -606,19 +633,38 @@ const McpForm = ({
                 <FieldLabel htmlFor="oauthClientSecret">
                   Client Secret
                 </FieldLabel>
-                <Input
-                  id="oauthClientSecret"
-                  type="password"
-                  placeholder={
-                    mcpId && mcp?.oauthClientId
-                      ? "Leave blank to keep current"
-                      : "OAuth Client Secret"
-                  }
-                  value={formData.oauthClientSecret}
-                  onChange={handleChange}
-                  disabled={isSubmitting}
-                  aria-invalid={!!validationErrors.oauthClientSecret}
-                />
+                <InputGroup>
+                  <InputGroupInput
+                    id="oauthClientSecret"
+                    type={showOauthClientSecret ? "text" : "password"}
+                    placeholder={
+                      mcpId && mcp?.oauthClientId
+                        ? "Leave blank to keep current"
+                        : "OAuth Client Secret"
+                    }
+                    value={formData.oauthClientSecret}
+                    onChange={handleChange}
+                    disabled={isSubmitting}
+                    aria-invalid={!!validationErrors.oauthClientSecret}
+                  />
+                  <InputGroupAddon align="inline-end">
+                    <InputGroupButton
+                      type="button"
+                      size="icon-xs"
+                      onClick={() =>
+                        setShowOauthClientSecret(!showOauthClientSecret)
+                      }
+                      disabled={isSubmitting}
+                      aria-label={
+                        showOauthClientSecret
+                          ? "Hide client secret"
+                          : "Show client secret"
+                      }
+                    >
+                      {showOauthClientSecret ? <EyeOff /> : <Eye />}
+                    </InputGroupButton>
+                  </InputGroupAddon>
+                </InputGroup>
                 {validationErrors.oauthClientSecret && (
                   <FieldError>{validationErrors.oauthClientSecret}</FieldError>
                 )}


### PR DESCRIPTION
## What

The **Bearer Token** and OAuth **Client Secret** fields on the MCP form were masked with no way to check what had been typed. Both now have a show/hide eye toggle, matching the **API Key** field on the Provider form.

## How

- `mcp-form.tsx` — swapped both fields from a plain `Input` to `InputGroup`/`InputGroupInput` with an `InputGroupAddon` eye button (`Eye`/`EyeOff`), each backed by its own `useState`. The buttons are disabled while submitting, same as the inputs, and the Client Secret's dynamic placeholder ("Leave blank to keep current" in edit mode) is unchanged.
- `mcp-form.test.tsx` — new file with a test per field asserting the input flips between `type="password"` and `type="text"`. Uses the same mock scaffolding as `provider-form.test.tsx`.

## Docs

No docs change. `building-with-platypus/mcp.mdx` documents both fields but never described the masking, and the equivalent Provider API Key toggle is likewise undocumented — nothing goes stale here.

## Testing

`pnpm --filter frontend typecheck`, `lint`, prettier, and the full frontend suite (45 tests, 9 files) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)