### PR TITLE
chore(docs): correct the Web-search backend Extension point page

### DIFF
--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -17,11 +17,12 @@ deploy time; it exports a manifest whose `contributes` block fills one or more
 
 ## Which one do you want
 
-| You want to…                                                              | Reach for              | Because                                                                            |
-| ------------------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------- |
-| Let an Agent call your internal service, or a third-party API             | **MCP server**         | No code in Platypus, no restart, configured per Workspace by whoever needs it       |
-| Ship tools that are part of the product for everyone on the deployment    | **[Tool set](/extending/tool-sets)** contribution | One install, one switch on the Agent form, available to every Workspace |
-| Run an Agent's shell and filesystem tools somewhere new — Modal, E2B, a VM | **[Sandbox backend](/extending/sandbox-backends)** contribution | Core owns the five tools; you supply the environment they run in |
+| You want to…                                                               | Reach for                                                       | Because                                                                       |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Let an Agent call your internal service, or a third-party API              | **MCP server**                                                  | No code in Platypus, no restart, configured per Workspace by whoever needs it |
+| Ship tools that are part of the product for everyone on the deployment     | **[Tool set](/extending/tool-sets)** contribution               | One install, one switch on the Agent form, available to every Workspace       |
+| Run an Agent's shell and filesystem tools somewhere new — Modal, E2B, a VM | **[Sandbox backend](/extending/sandbox-backends)** contribution | Core owns the five tools; you supply the environment they run in              |
+| Serve the Chat **Search** toggle from your own search service              | **[Web-search backend](#web-search-backends)** contribution     | Core owns the two tools and the toggle; you supply the calls to your upstream |
 
 If you are integrating an external service for your own use, you almost always
 want an MCP server. Reach for a Plugin when the capability should ship _with_
@@ -31,8 +32,8 @@ the deployment rather than be configured in it.
   Both Sandbox backends and Tool sets already ship as core plugins —
   `@platypus/tools-basic`, `@platypus/tools-platform`, `@platypus/web-fetch`,
   `@platypus/docker` and `@platypus/ssh`. Yours loads through the same manifest
-  path. The inventory an Operator controls is in
-  [Configuration → Plugins](/self-hosting/configuration#plugins).
+  path. The inventory an Operator controls is in [Configuration →
+  Plugins](/self-hosting/configuration#plugins).
 </Callout>
 
 ## Start here
@@ -57,16 +58,37 @@ what the caps are, what happens at boot. For the exact shape of an interface,
 read it from the package you have installed. A signature pasted onto a docs page
 drifts silently; the one in your `node_modules` cannot.
 
-## A third Extension point, not yet reachable
+## Web-search backends
 
-`contributes.webBackends` exists in the SDK and a Web-search backend
-contribution is validated and registered at boot. Nothing selects one yet — no
-Provider field points at a web backend, and a Chat turn never calls its
-executors.
+A **Web-search backend** fills the **Search** toggle in Chat for Providers whose
+model has no web search of its own — a self-hosted OpenAI-compatible endpoint
+such as vLLM, llama.cpp or LiteLLM. Contribute one under
+`contributes.webBackends`.
+
+You supply two executors: a mandatory `web_search` and an optional `read_url`.
+Core owns everything around them — the tool names and input schemas the model
+sees, the descriptions, a cap of **10** search results, page slicing for reads,
+the per-call timeout (**30 seconds** by default, and a contribution cannot
+declare more than **120**), and a guard that resolves every URL the model
+supplies and refuses loopback, link-local and non-`http(s)` addresses. Your job
+is the call to your upstream and nothing else. Return the full content; core
+truncates.
+
+The tools are ephemeral. They exist for a turn the toggle was on for, and no
+other.
+
+Selection is not on the Provider form yet. In this release the only way to point
+a Provider at your backend is the Provider API's `webBackend` field, set to the
+id your manifest contributes.
 
 <Callout type="warning">
-  Contribute a Web-search backend today and it loads without complaint, appears
-  in **Organization settings → Plugins**, and is never called. If your tools
-  aren't firing, that is why. Wait for a release that wires a Provider to it
-  before building against this point.
+  Two Provider settings decide whether your backend is reached, and both
+  currently work against the endpoints this Extension point exists for. The Chat
+  **Search** toggle is offered only on Providers that have native web search, so
+  on a vLLM or LiteLLM Provider it stays hidden and no Chat message reaches your
+  backend; a Trigger with **Web Search** on is the path that does. Turning
+  **Native web search** off disables your backend along with the built-in tool,
+  so leave it on. To exercise a backend from Chat today, attach it to a Provider
+  that does have native search — a configured backend takes precedence over the
+  built-in tool.
 </Callout>


### PR DESCRIPTION
The **Extending** page ships a section titled *"A third Extension point, not yet reachable"*, telling plugin authors that "no Provider field points at a web backend, and a Chat turn never calls its executors", and to "wait for a release that wires a Provider to it before building against this point".

#393 made all three claims false and touched no docs. Caught while reviewing #389 (the pending 2.3.0 release) for release safety.

## The claims vs. the code

| The page says | On `main` |
| --- | --- |
| "no Provider field points at a web backend" | A Provider stores `webBackend`; both `providerCreateSchema` and `providerUpdateSchema` accept it, and the route writes it |
| "a Chat turn never calls its executors" | `resolveSearchMode` returns the configured backend *ahead of* native search, and the turn calls it |
| "loads without complaint … and is never called" | It is called on every searching turn of any Provider whose `webBackend` is set |

The net effect is a docs page telling an author their tools cannot fire while core is in fact firing them — so they never test the path that actually runs.

## What the section says now

- **The point is live**, and the tools are ephemeral to the turn the toggle was on for.
- **What core owns vs. what you supply**, with the numbers: 10 search results, a 30s default per-call timeout against a 120s ceiling, core-owned page slicing, and the egress guard on model-supplied URLs.
- **Selection is API-only in this release.** There is no Provider form field yet, so the Provider API's `webBackend` is the only way in — stated plainly rather than implied.
- **The trap, named** per `VOICE.md`: the Chat **Search** toggle is offered only on Providers that have native web search, so on exactly the vLLM/LiteLLM endpoints this point exists for it stays hidden and no Chat message reaches the backend; a Trigger with **Web Search** on is the path that does. Turning **Native web search** off disables the plugin backend along with the built-in tool. And the way through: attach the backend to a Provider that *does* have native search, since a configured backend takes precedence.

Also adds the fourth row to the **Which one do you want** table, pointing at the in-page anchor, so the point is discoverable from the top of the page.

## Out of scope

Two related gaps stay with their planned PRs, both from the #329 plan:

- The **Native web search** field description on the Provider form still reads "Use this provider's built-in `web_search` tool", now incomplete since that switch also gates plugin backends — PR3's relabel.
- The 200-char `webBackend` bound is still undocumented — PR4. Worth noting the deferral's stated justification (that nothing can set the field) does not hold: the API accepts it today.

## Verification

- `docs-contract.test.ts` 24/24 — the new in-page anchor and table link resolve
- Docs build clean, 46 static pages
- Prettier clean

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)