### PR TITLE
fix(backend): align upsertSkill description bound with shared schema

### DIFF
--- a/apps/backend/src/tools/skill-management.test.ts
+++ b/apps/backend/src/tools/skill-management.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { z } from "zod";
 import { mockDb, resetMockDb } from "../test-utils.ts";
 
 import { createSkillManagementTools } from "./skill-management.ts";
@@ -7,6 +8,8 @@ const ctx = { toolCallId: "test", messages: [], context: {} };
 const workspaceId = "ws-1";
 const orgId = "org-1";
 const frontendUrl = "http://localhost:3000";
+const validBody =
+  "This is the skill body content that should be long enough to pass validation";
 
 describe("createSkillManagementTools", () => {
   let tools: ReturnType<typeof createSkillManagementTools>;
@@ -68,11 +71,34 @@ describe("createSkillManagementTools", () => {
           {
             name: "my-skill",
             description: "A skill for testing purposes",
-            body: "This is the skill body content that should be long enough to pass validation",
+            body: validBody,
           },
           ctx,
         ),
       ).toMatchObject({ name: "my-skill" });
+    });
+
+    describe("description length", () => {
+      const parse = (description: string) =>
+        (tools.upsertSkill.inputSchema as z.ZodType).safeParse({
+          name: "my-skill",
+          description,
+          body: validBody,
+        });
+
+      it.each([24, 129, 500, 1024])(
+        "accepts a description of %i characters",
+        (length) => {
+          expect(parse("a".repeat(length)).success).toBe(true);
+        },
+      );
+
+      it.each([23, 1025])(
+        "rejects a description of %i characters",
+        (length) => {
+          expect(parse("a".repeat(length)).success).toBe(false);
+        },
+      );
     });
   });
 

--- a/apps/backend/src/tools/skill-management.ts
+++ b/apps/backend/src/tools/skill-management.ts
@@ -1,11 +1,14 @@
 import { tool, type Tool } from "ai";
 import { z } from "zod";
 import { and, eq, sql } from "drizzle-orm";
+import { skillBaseSchema } from "@platypus/schemas";
 import { db } from "../index.ts";
 import { skill as skillTable, agent as agentTable } from "../db/schema.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
 
-const skillNameRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+// Field constraints come from the shared schema so the agent-facing tool can
+// never drift from the bounds the HTTP routes and the web form enforce.
+const skillFields = skillBaseSchema.shape;
 
 export function createSkillManagementTools(
   workspaceId: string,
@@ -66,13 +69,13 @@ export function createSkillManagementTools(
     description:
       "Create a new skill or update an existing skill by name. If a skill with the given name already exists in this workspace, it will be updated.",
     inputSchema: z.object({
-      name: z
-        .string()
-        .min(5)
-        .max(64)
-        .regex(skillNameRegex, "Skill name must be kebab-case"),
-      description: z.string().min(24).max(128),
-      body: z.string().min(48).max(50000),
+      name: skillFields.name.describe(
+        "Kebab-case name of the skill, unique within the workspace",
+      ),
+      description: skillFields.description.describe(
+        "Short summary of what the skill does and when to use it",
+      ),
+      body: skillFields.body.describe("The Markdown content of the skill"),
     }),
     execute: async ({ name, description, body }) => {
       const { nanoid } = await import("nanoid");

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -285,7 +285,7 @@ const skillNameRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 // exclusive), mirroring the dual-scope shape of `provider`/`mcp`. Org-scoped
 // Skills are Shared resources managed by Org Admins (ADR-0007). The XOR is
 // enforced on `skillSchema` below; the create routes inject the scope.
-const skillBaseSchema = z.object({
+export const skillBaseSchema = z.object({
   id: z.string(),
   organizationId: z.string().optional(),
   workspaceId: z.string().optional(),


### PR DESCRIPTION
Closes #405

## Problem

A Skill's `description` had two different maximum lengths depending on the write path. The agent-facing `upsertSkill` tool declared its own inline bounds (`max(128)`), while `skillBaseSchema` in `@platypus/schemas` — which backs the HTTP routes and, through them, the web form — allows 1024.

A 129–1024 character description was therefore accepted through the API and the UI but rejected for an agent, so an agent could not read a human-created Skill and write it back unchanged.

## Change

- `upsertSkill`'s `name`, `description`, and `body` constraints are derived from `skillBaseSchema.shape` instead of restating literal numbers, so the two cannot drift again. `skillBaseSchema` is now exported for this.
- Added the `.describe()` parameter docs the tool-authoring guide asks for — the old inline schema had none.
- The kebab-case name regex was duplicated in the tool module; it now comes from the shared schema.

`min` stays at 24, and the `name` / `body` bounds are byte-identical to what the tool declared before — no behaviour change there.

## Tests

Boundary cases over the tool's `inputSchema`: accepts 24 / 129 / 500 / 1024, rejects 23 / 1025. The 129, 500, and 1024 cases were red before the fix.

Also dumped the model-facing JSON Schema to confirm the bound survives the AI SDK's zod conversion, not just `safeParse`: `{"type":"string","minLength":24,"maxLength":1024}`.

`pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm format` all pass.

## Docs

No docs change needed. `building-with-platypus/skills.mdx` already publishes 24–1024 and the contract test pins that claim to `skillSchema.description`. The tool's stale 128 was invisible to that gate, which is how it drifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)