### PR TITLE
fix(backend): advertise Model aliases from listModelProviders

### DIFF
--- a/apps/backend/src/services/model-capability.test.ts
+++ b/apps/backend/src/services/model-capability.test.ts
@@ -3,7 +3,7 @@ import type { ConcreteModelId, Provider } from "@platypus/schemas";
 import {
   defaultPassthroughFileTypes,
   resolveProviderModels,
-  providerModelIds,
+  providerModelReferences,
   passthroughFileTypesForModel,
   maxExtractedTextCharsForModel,
   dedupeModelConfigs,
@@ -111,15 +111,37 @@ describe("resolveProviderModels", () => {
   });
 });
 
-describe("providerModelIds", () => {
-  const p = provider({
-    modelIds: [
-      { id: "a", passthroughFileTypes: [] },
-      { id: "b", passthroughFileTypes: [] },
-    ],
-  });
+describe("providerModelReferences", () => {
   it("lists ids in order", () => {
-    expect(providerModelIds(p)).toEqual(["a", "b"]);
+    const p = provider({
+      modelIds: [
+        { id: "a", passthroughFileTypes: [] },
+        { id: "b", passthroughFileTypes: [] },
+      ],
+    });
+    expect(providerModelReferences(p)).toEqual(["a", "b"]);
+  });
+
+  it("lists the alias reference for an aliased model", () => {
+    // What the Agent picker submits: the concrete id of an aliased model is
+    // deliberately not offered, so a repoint reaches every reference (#386).
+    const p = provider({
+      modelIds: [
+        { id: "gpt-4", passthroughFileTypes: [], alias: "flagship" },
+        { id: "gpt-4o-mini", passthroughFileTypes: [] },
+      ],
+    });
+    expect(providerModelReferences(p)).toEqual([
+      "alias:flagship",
+      "gpt-4o-mini",
+    ]);
+  });
+
+  it("lists ids for a legacy string[], which cannot carry aliases", () => {
+    const p = provider({
+      modelIds: ["a", "b"] as unknown as Provider["modelIds"],
+    });
+    expect(providerModelReferences(p)).toEqual(["a", "b"]);
   });
 });
 

--- a/apps/backend/src/services/model-capability.ts
+++ b/apps/backend/src/services/model-capability.ts
@@ -1,5 +1,6 @@
 import {
   defaultPassthroughFileTypes,
+  modelReferenceFor,
   resolveExtractedTextCap,
   resolveModelReference,
   type ConcreteModelId,
@@ -57,9 +58,19 @@ export const resolveProviderModels = (provider: Provider): ModelConfig[] => {
   });
 };
 
-/** The plain model-id list, preserving order — for existing `string[]` consumers. */
-export const providerModelIds = (provider: Provider): string[] =>
-  resolveProviderModels(provider).map((model) => model.id);
+/**
+ * The list of model REFERENCES a caller should store, preserving order — the
+ * alias reference for an aliased entry, the concrete id otherwise.
+ *
+ * The backend mirror of the frontend's `getModelOptions`: what an alias-aware
+ * picker submits. Deliberately not a plain id list, so a tool advertising a
+ * Provider's models to an Agent cannot hand back a concrete id the UI would
+ * never have offered and thereby opt that Agent out of future repoints
+ * (ADR-0017). Anything that needs the concrete id must go through
+ * `resolveModelId`, which is the only mint of `ConcreteModelId`.
+ */
+export const providerModelReferences = (provider: Provider): string[] =>
+  resolveProviderModels(provider).map(modelReferenceFor);
 
 /**
  * Dedupe a provider payload's models by id (first entry wins, so an operator's

--- a/apps/backend/src/tools/agent-discovery.test.ts
+++ b/apps/backend/src/tools/agent-discovery.test.ts
@@ -55,6 +55,34 @@ describe("createAgentDiscoveryTools", () => {
         { id: "p1", name: "Provider 1", modelIds: ["model-a", "model-b"] },
       ]);
     });
+
+    it("advertises an aliased model by its alias reference, not its id", async () => {
+      // The tool is the agentic counterpart of the Agent model picker, so it
+      // offers what the picker submits — otherwise an agent it creates pins the
+      // concrete id and misses the next repoint (#386, ADR-0017).
+      mockDb.where.mockResolvedValue([
+        {
+          id: "p1",
+          name: "Provider 1",
+          modelIds: [
+            {
+              id: "gpt-4",
+              passthroughFileTypes: ["image/*"],
+              alias: "flagship",
+            },
+            { id: "gpt-4o-mini", passthroughFileTypes: [] },
+          ],
+        },
+      ]);
+
+      expect(await tools.listModelProviders.execute!({}, ctx)).toEqual([
+        {
+          id: "p1",
+          name: "Provider 1",
+          modelIds: ["alias:flagship", "gpt-4o-mini"],
+        },
+      ]);
+    });
   });
 
   describe("listAgents", () => {

--- a/apps/backend/src/tools/agent-discovery.ts
+++ b/apps/backend/src/tools/agent-discovery.ts
@@ -9,7 +9,7 @@ import {
 } from "../db/schema.ts";
 import { getToolSets } from "../tools/index.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
-import { providerModelIds } from "../services/model-capability.ts";
+import { providerModelReferences } from "../services/model-capability.ts";
 import type { Provider } from "@platypus/schemas";
 
 /**
@@ -71,7 +71,7 @@ export function createAgentDiscoveryTools(
 
   const listModelProviders = tool({
     description:
-      "List all configured providers and their available model IDs. Use the returned provider IDs and model IDs when creating or updating agents.",
+      "List all configured providers and their available model IDs. Use the returned provider IDs and model IDs when creating or updating agents, and pass a model ID back exactly as returned. An entry of the form 'alias:<name>' is a Model alias the provider gave one of its models: submit it unchanged rather than the vendor model id it currently points at, so the agent follows the alias when an admin repoints it.",
     inputSchema: z.object({}),
     execute: async () => {
       const providers = await db
@@ -87,14 +87,17 @@ export function createAgentDiscoveryTools(
             eq(providerTable.organizationId, orgId),
           ),
         );
-      // Advertise plain model-id strings regardless of whether the row stores
-      // the new per-model objects or a legacy `string[]` (issue #328). Reuse the
-      // canonical resolver so this can't drift from the capability logic. Only
-      // `modelIds` is read for id extraction; the partial row is cast to satisfy
-      // its signature.
+      // Advertise the reference an alias-aware picker would submit — the alias
+      // for an aliased model, the concrete id otherwise — regardless of whether
+      // the row stores the new per-model objects or a legacy `string[]` (issues
+      // #328, #386). This tool is the agentic counterpart of the Agent model
+      // picker, so it must offer the same choices: handing back the concrete id
+      // of an aliased model would silently opt every agent created this way out
+      // of the next repoint (ADR-0017). Only `modelIds` is read, so the partial
+      // row is cast to satisfy the resolver's signature.
       return providers.map((p) => ({
         ...p,
-        modelIds: providerModelIds(p as unknown as Provider),
+        modelIds: providerModelReferences(p as unknown as Provider),
       }));
     },
   });

--- a/apps/backend/src/tools/agent-management.ts
+++ b/apps/backend/src/tools/agent-management.ts
@@ -14,6 +14,12 @@ import { buildResourceUrl } from "../utils/resource-url.ts";
 const INSTRUCTIONS_DESCRIPTION =
   "The agent's own instructions — how it should behave. Platypus composes the full system prompt around this, adding workspace and user context, memories, Skills, sub-agents and the provider's security guardrails, so do not restate those here.";
 
+// Also shared, for the same reason. An 'alias:<name>' value is a Model alias
+// (ADR-0017) and must be stored as-is: rewriting it to the vendor model id it
+// points at pins the agent to today's model and opts it out of future repoints.
+const MODEL_ID_DESCRIPTION =
+  "Model ID to use, exactly as listModelProviders returned it — including an 'alias:<name>' value, which must not be replaced with the vendor model id it points at.";
+
 export function createAgentManagementTools(
   workspaceId: string,
   orgId: string,
@@ -26,7 +32,7 @@ export function createAgentManagementTools(
       name: z.string().min(3).max(30).describe("Agent display name"),
       description: z.string().min(1).max(128).describe("Short description"),
       providerId: z.string().describe("Provider ID to use"),
-      modelId: z.string().describe("Model ID to use"),
+      modelId: z.string().describe(MODEL_ID_DESCRIPTION),
       instructions: z.string().optional().describe(INSTRUCTIONS_DESCRIPTION),
       maxSteps: z.number().optional().describe("Max agentic steps"),
       temperature: z.number().optional().describe("Sampling temperature"),
@@ -127,7 +133,7 @@ export function createAgentManagementTools(
         .optional()
         .describe("Short description"),
       providerId: z.string().optional().describe("Provider ID to use"),
-      modelId: z.string().optional().describe("Model ID to use"),
+      modelId: z.string().optional().describe(MODEL_ID_DESCRIPTION),
       instructions: z.string().optional().describe(INSTRUCTIONS_DESCRIPTION),
       maxSteps: z.number().optional().describe("Max agentic steps"),
       temperature: z.number().optional().describe("Sampling temperature"),

--- a/apps/docs/content/concepts/providers.mdx
+++ b/apps/docs/content/concepts/providers.mdx
@@ -81,6 +81,9 @@ model id, so you can no longer pin an Agent to that exact id. An Agent that
 already stored the id keeps running unchanged and now shows the alias; saving it
 switches it to the alias.
 
+An Agent that builds other Agents sees the same list you do, so the Agents it
+creates use the alias and move with your repoints too.
+
 **Renaming an alias is not a rename.** An alias is only its name, so changing it
 removes the old name and creates a new one. Platypus handles this for you:
 clearing or renaming an alias points every Agent and Chat that used it back at


### PR DESCRIPTION
## Problem

`listModelProviders` flattened each Provider's `modelIds` to concrete ids, so an aliased model was advertised as `gpt-4` rather than `alias:flagship`. An Agent using `createAgent` / `updateAgent` therefore stored the concrete id — a value the Agent model picker no longer offers — and the Agents it built silently missed the next alias repoint. `getAgent` / `listAgents`, which return the stored reference, could also surface an `alias:` value that appeared nowhere in the Provider listing.

## Change

- `providerModelIds` → `providerModelReferences` in `model-capability.ts`, mapping resolved entries through the shared `modelReferenceFor`. It is the backend mirror of the frontend's `getModelOptions`, so the tool and the picker cannot drift. The old helper had a single caller and is replaced rather than kept, since a plain-id list is the wrong default here; concrete ids still come only from `resolveModelId`, so the `ConcreteModelId` mint is unchanged.
- `listModelProviders` returns references in `modelIds` (`["alias:flagship", "gpt-4o-mini"]`) and its description explains that a value must be passed back as returned, and what an `alias:<name>` entry means.
- `createAgent` / `updateAgent` share one `modelId` description saying not to rewrite an alias reference to the vendor id.
- Docs: one sentence in the Model aliases section of `concepts/providers.mdx` — an Agent that builds Agents sees the same list, so what it creates moves with a repoint.

Legacy `string[]` Providers are unaffected, since they cannot carry aliases. Both shapes are covered by tests.

Refs #386, ADR-0017.

## Verification

- `pnpm --filter backend test` — 1381 passed
- `pnpm --filter docs test` — docs contract, 24 passed
- `pnpm typecheck`, `pnpm format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)