### PR TITLE
feat(frontend): show org name in settings sidebar and page title

### DIFF
--- a/apps/frontend/app/[orgId]/settings/layout.tsx
+++ b/apps/frontend/app/[orgId]/settings/layout.tsx
@@ -1,9 +1,52 @@
+import { cache } from "react";
+import { headers } from "next/headers";
+import type { Metadata } from "next";
+import type { Organization } from "@platypus/schemas";
+import { joinUrl } from "@/lib/utils";
 import { OrgSettingsMenu } from "@/components/org-settings-menu";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { Header } from "@/components/header";
 import { HeaderBackButton } from "@/components/header-back-button";
 import { HeaderHomeButton } from "@/components/header-home-button";
 import { ProtectedRoute } from "@/components/protected-route";
+
+// Cached so the metadata and the layout body share one request: both need the
+// organization, and `cache` collapses them into a single backend call.
+const fetchOrganization = cache(async function fetchOrganization(
+  orgId: string,
+): Promise<Organization | null> {
+  const backendUrl =
+    process.env.INTERNAL_BACKEND_URL || process.env.BACKEND_URL || "";
+  const headersList = await headers();
+  // Unlike the workspace shell, a failure here must not break the page: the
+  // organization is only a label and the title, so it degrades to null.
+  try {
+    const response = await fetch(
+      joinUrl(backendUrl, `/organizations/${orgId}`),
+      {
+        headers: {
+          cookie: headersList.get("cookie") || "",
+        },
+      },
+    );
+    return response.ok ? await response.json() : null;
+  } catch {
+    return null;
+  }
+});
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ orgId: string }>;
+}): Promise<Metadata> {
+  const { orgId } = await params;
+  const organization = await fetchOrganization(orgId);
+
+  return {
+    title: organization ? `${organization.name} | Platypus` : "Platypus",
+  };
+}
 
 export default async function OrgSettingsLayout({
   children,
@@ -13,6 +56,7 @@ export default async function OrgSettingsLayout({
   params: Promise<{ orgId: string }>;
 }>) {
   const { orgId } = await params;
+  const organization = await fetchOrganization(orgId);
 
   return (
     <ProtectedRoute requireOrgAccess={true} requiredOrgRole="admin">
@@ -29,7 +73,10 @@ export default async function OrgSettingsLayout({
           <div className="flex-1 flex flex-col items-center overflow-y-auto">
             <div className="flex flex-col md:flex-row w-full md:w-full lg:w-4/5 max-w-5xl py-8 px-4 md:px-0">
               <div className="w-full md:w-48 md:fixed md:top-16 pt-4 mb-8 md:mb-0">
-                <OrgSettingsMenu orgId={orgId} />
+                <OrgSettingsMenu
+                  orgId={orgId}
+                  organizationName={organization?.name}
+                />
               </div>
               <div className="flex-1 p-2 md:ml-48 min-w-0">{children}</div>
             </div>

--- a/apps/frontend/components/org-settings-menu.test.tsx
+++ b/apps/frontend/components/org-settings-menu.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/org1/settings/members",
+}));
+
+import { OrgSettingsMenu } from "./org-settings-menu";
+
+function renderMenu(organizationName?: string) {
+  return render(
+    <SidebarProvider>
+      <OrgSettingsMenu orgId="org1" organizationName={organizationName} />
+    </SidebarProvider>,
+  );
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe("OrgSettingsMenu organization heading", () => {
+  beforeAll(() => {
+    // jsdom has no matchMedia; SidebarProvider subscribes to it via useIsMobile.
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }) as unknown as typeof window.matchMedia;
+  });
+
+  it("shows the organization name resolved by the layout", () => {
+    renderMenu("Acme Corp");
+
+    expect(
+      screen.getByRole("heading", { name: "Acme Corp" }),
+    ).toBeInTheDocument();
+    // Never the org ID in place of the name
+    expect(screen.queryByText("org1")).not.toBeInTheDocument();
+  });
+
+  it("keeps a long name truncated and exposed in full", () => {
+    const name = "A Very Long Organization Name That Overflows";
+    renderMenu(name);
+
+    const heading = screen.getByRole("heading", { name });
+    expect(heading).toHaveClass("truncate");
+    expect(heading).toHaveAttribute("title", name);
+  });
+
+  it("separates the heading from the links with a rule", () => {
+    const { container } = renderMenu("Acme Corp");
+
+    const separator = container.querySelector(
+      '[data-slot="sidebar-separator"]',
+    );
+    expect(separator).toBeInTheDocument();
+
+    // Sits between the heading and the first link
+    const heading = screen.getByRole("heading", { name: "Acme Corp" });
+    const generalLink = screen.getByRole("link", { name: "General" });
+    expect(
+      heading.compareDocumentPosition(separator!) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      separator!.compareDocumentPosition(generalLink) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("omits the heading without surfacing an error when the name is unavailable", () => {
+    const { container } = renderMenu(undefined);
+
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+    // No stray rule with nothing above it
+    expect(
+      container.querySelector('[data-slot="sidebar-separator"]'),
+    ).toBeNull();
+    expect(container.textContent).not.toMatch(/error/i);
+    // The settings pages stay fully navigable
+    expect(screen.getByRole("link", { name: "Members" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Plugins" })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/org-settings-menu.tsx
+++ b/apps/frontend/components/org-settings-menu.tsx
@@ -7,6 +7,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarMenu,
+  SidebarSeparator,
 } from "@/components/ui/sidebar";
 import {
   Blocks,
@@ -24,10 +25,20 @@ import { usePathname } from "next/navigation";
 
 interface OrgSettingsMenuProps {
   orgId: string;
+  /**
+   * Resolved by the settings layout. Undefined when the organization could not
+   * be fetched, in which case the heading is left out rather than blocking the
+   * settings pages behind an error.
+   */
+  organizationName?: string;
 }
 
-export function OrgSettingsMenu({ orgId }: OrgSettingsMenuProps) {
+export function OrgSettingsMenu({
+  orgId,
+  organizationName,
+}: OrgSettingsMenuProps) {
   const pathname = usePathname();
+
   const generalHref = `/${orgId}/settings`;
   const membersHref = `/${orgId}/settings/members`;
   const invitationsHref = `/${orgId}/settings/invitations`;
@@ -41,6 +52,18 @@ export function OrgSettingsMenu({ orgId }: OrgSettingsMenuProps) {
   return (
     <SidebarContent>
       <SidebarGroup>
+        {organizationName && (
+          <>
+            <h2
+              title={organizationName}
+              className="h-8 truncate px-2 text-sm leading-8 font-medium"
+            >
+              {organizationName}
+            </h2>
+            {/* Sets the static heading apart from the links below it */}
+            <SidebarSeparator className="mx-0 my-1" />
+          </>
+        )}
         <SidebarGroupContent>
           <SidebarMenu>
             <SidebarMenuItem>


### PR DESCRIPTION
Closes #403

## Problem

The organization settings area gave no indication of which organization was being edited. The name appeared in exactly one place — the value of the editable **Name** input on the General page. On Members, Invitations, Providers, MCP, Skills, Agents, Blueprints and Plugins, the only identifier on screen was the opaque org ID in the URL, which makes it easy to change settings against the wrong org when you belong to more than one.

## Change

The settings shell resolves the organization server-side and renders its name as a static heading above the section links in the settings sidebar, separated from them by a rule. Because the sidebar is part of the shared shell, every sub-page gets it without opting in.

- `app/[orgId]/settings/layout.tsx` — fetches the organization server-side, forwarding request cookies, mirroring the workspace shell. The fetch is wrapped in `cache` so `generateMetadata` and the layout body share a single backend call. Sets a page title of `<Org name> | Platypus`, falling back to `Platypus`.
- `components/org-settings-menu.tsx` — takes the resolved name as a prop and renders it as an `<h2>` with `truncate` and a `title` attribute, so a long name truncates within the fixed-width column while the full string stays available to assistive tech and on hover. A `SidebarSeparator` sets the heading apart from the links.

Failure is non-blocking: an unreachable or unauthorized fetch degrades to `null`, the heading and its rule are both left out (no stray line above the links), the title falls back, and the settings pages stay fully usable. No error is surfaced in the sidebar.

## Notes

- The header is untouched — it keeps only the back and home buttons.
- The heading is a static label, not a link, switcher, or dropdown.
- Workspace settings is out of scope: the app sidebar switcher already shows the org name above the workspace name there.
- No docs change. Every `.mdx` mentioning organization settings references it as a navigation path (`Organization settings → Plugins`) or lists the screens in `administering/index.mdx`; adding a name heading makes none of those inaccurate.

## Tests

`components/org-settings-menu.test.tsx` covers the resolved name, long-name truncation plus the exposed full name, the separator sitting between the heading and the first link, and the fallback when the name is unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)