### PR TITLE
fix(backend): record why a generation stopped and name invalid tool input

### DIFF
--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -86,6 +86,8 @@ vi.mock("../logger.ts", () => ({
 }));
 
 import { AgentRunner } from "./agent-runner.ts";
+import { TRUNCATED_BY_TOKEN_LIMIT } from "./stream-error.ts";
+import { logger } from "../logger.ts";
 import { runRegistry, TimeoutError } from "./run-registry.ts";
 import type { ResolvedRunPlan, RunInput, RunSink } from "./types.ts";
 import type { WorkspaceScope } from "../scope.ts";
@@ -175,6 +177,165 @@ const fakeGenerateResult = {
   steps: [],
   totalUsage: { inputTokens: 10, outputTokens: 5 },
 };
+
+// Issue #406: a step that ended at the output ceiling, or that the provider
+// rejected as a malformed tool use, used to log identically to a clean one.
+// The unified reason alone is not enough — it is exactly what collapses
+// Bedrock's `malformed_tool_use` into `other`, so the raw value must survive.
+describe("finish reason instrumentation", () => {
+  let runner: AgentRunner;
+  beforeEach(() => {
+    runner = new AgentRunner();
+    vi.clearAllMocks();
+  });
+
+  const stepLogs = () =>
+    vi
+      .mocked(logger.info)
+      .mock.calls.filter((call) => call[1] === "Step finished")
+      .map((call) => call[0] as Record<string, unknown>);
+
+  it("logs both the unified and the raw finish reason for every step", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    mockGenerateText.mockImplementationOnce(
+      (args: { onStepFinish: (s: unknown) => void }) => {
+        args.onStepFinish({
+          toolCalls: [{ toolName: "listBoards" }],
+          usage: { inputTokens: 10, outputTokens: 5 },
+          finishReason: "tool-calls",
+          rawFinishReason: "tool_use",
+        });
+        return fakeGenerateResult;
+      },
+    );
+
+    await runner.generate({
+      scope,
+      input: baseInput,
+      sink: new RecordingSink(),
+    });
+
+    expect(stepLogs()[0]).toMatchObject({
+      finishReason: "tool-calls",
+      rawFinishReason: "tool_use",
+    });
+  });
+
+  // The whole point of keeping the raw value: an unrecognised provider reason
+  // collapses to `other` in the unified union and is otherwise unrecoverable.
+  it("logs an unrecognised raw finish reason verbatim rather than swallowing it", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    mockGenerateText.mockImplementationOnce(
+      (args: { onStepFinish: (s: unknown) => void }) => {
+        args.onStepFinish({
+          toolCalls: [],
+          usage: { inputTokens: 1, outputTokens: 1 },
+          finishReason: "other",
+          rawFinishReason: "malformed_tool_use",
+        });
+        return fakeGenerateResult;
+      },
+    );
+
+    await runner.generate({
+      scope,
+      input: baseInput,
+      sink: new RecordingSink(),
+    });
+
+    expect(stepLogs()[0]).toMatchObject({
+      finishReason: "other",
+      rawFinishReason: "malformed_tool_use",
+    });
+  });
+
+  it("warns when a step stops at the output token limit", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    mockGenerateText.mockImplementationOnce(
+      (args: { onStepFinish: (s: unknown) => void }) => {
+        args.onStepFinish({
+          toolCalls: [],
+          usage: { inputTokens: 1, outputTokens: 1 },
+          finishReason: "length",
+          rawFinishReason: "max_tokens",
+        });
+        return fakeGenerateResult;
+      },
+    );
+
+    await runner.generate({
+      scope,
+      input: baseInput,
+      sink: new RecordingSink(),
+    });
+
+    const warned = vi
+      .mocked(logger.warn)
+      .mock.calls.some((call) => /truncated/i.test(String(call[1])));
+    expect(warned).toBe(true);
+  });
+
+  it("tells the caller when an unattended run was cut off at the token limit", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    mockGenerateText.mockResolvedValueOnce({
+      ...fakeGenerateResult,
+      text: "half an ans",
+      finishReason: "length",
+      rawFinishReason: "max_tokens",
+    });
+
+    const result = await runner.generate({
+      scope,
+      input: baseInput,
+      sink: new RecordingSink(),
+    });
+
+    // The model that receives this text can adapt; previously it could not
+    // tell a truncated answer from a complete one.
+    expect(result.text).toContain("half an ans");
+    expect(result.text).toContain(TRUNCATED_BY_TOKEN_LIMIT);
+  });
+
+  it("leaves a cleanly finished unattended run's text untouched", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    mockGenerateText.mockResolvedValueOnce({
+      ...fakeGenerateResult,
+      finishReason: "stop",
+      rawFinishReason: "end_turn",
+    });
+
+    const result = await runner.generate({
+      scope,
+      input: baseInput,
+      sink: new RecordingSink(),
+    });
+
+    expect(result.text).toBe("ok");
+  });
+
+  it("records the finish reasons on the unattended completion log", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    mockGenerateText.mockResolvedValueOnce({
+      ...fakeGenerateResult,
+      finishReason: "stop",
+      rawFinishReason: "end_turn",
+    });
+
+    await runner.generate({
+      scope,
+      input: baseInput,
+      sink: new RecordingSink(),
+    });
+
+    const completed = vi
+      .mocked(logger.info)
+      .mock.calls.find((call) => call[1] === "Run generate completed");
+    expect(completed?.[0]).toMatchObject({
+      finishReason: "stop",
+      rawFinishReason: "end_turn",
+    });
+  });
+});
 
 describe("AgentRunner.generate", () => {
   let runner: AgentRunner;

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -1,6 +1,4 @@
 import {
-  APICallError,
-  LoadAPIKeyError,
   convertToModelMessages,
   createIdGenerator,
   createUIMessageStreamResponse,
@@ -9,6 +7,7 @@ import {
   stepCountIs,
   streamText,
 } from "ai";
+import { formatStreamError, TRUNCATED_BY_TOKEN_LIMIT } from "./stream-error.ts";
 import {
   prepareChatTurn,
   validateTurnAttachments,
@@ -318,6 +317,13 @@ export class AgentRunner {
     const onStep = (step: {
       toolCalls?: Array<{ toolName: string }>;
       usage?: { inputTokens?: number; outputTokens?: number };
+      // Both, deliberately. The unified union collapses any reason the
+      // provider adapter doesn't recognise into `other` — which is how
+      // Bedrock's `malformed_tool_use` becomes indistinguishable from a
+      // dozen other endings. The raw value is the only record of what the
+      // provider actually said (issue #406).
+      finishReason?: string;
+      rawFinishReason?: string;
     }): void => {
       handle.bumpStep();
       accumulateStepStats(state.stats, step);
@@ -326,10 +332,22 @@ export class AgentRunner {
           runId: input.runId,
           step: state.stats.steps,
           toolCalls: step.toolCalls?.map((tc) => tc.toolName) ?? [],
+          finishReason: step.finishReason,
+          rawFinishReason: step.rawFinishReason,
           stats: state.stats,
         },
         "Step finished",
       );
+      if (step.finishReason === "length") {
+        logger.warn(
+          {
+            runId: input.runId,
+            step: state.stats.steps,
+            rawFinishReason: step.rawFinishReason,
+          },
+          "Step truncated at the output token limit",
+        );
+      }
       // Sink decides write cadence (FlushScheduler in ChatSink).
       void sink
         .onProgress({
@@ -512,18 +530,30 @@ export class AgentRunner {
         return { text: result.text, stats };
       }
 
+      // Nobody is watching an unattended run, so this log is the only record
+      // of how it ended. Carry both reasons for the same reason `onStep` does.
       logger.info(
         {
           runId: input.runId,
           duration: Date.now() - startTime,
           responseLength: result.text.length,
+          finishReason: result.finishReason,
+          rawFinishReason: result.rawFinishReason,
           stats,
         },
         "Run generate completed",
       );
 
       await finalize("succeeded");
-      return { text: result.text, stats };
+      // A truncated answer is worse than a failed one when it's indistinguishable
+      // from a complete one: the caller stores it, and whatever reads it later
+      // has no way to know the tail is missing. Say so in the text itself, which
+      // is the only channel an unattended caller has.
+      const text =
+        result.finishReason === "length"
+          ? `${result.text}\n\n${TRUNCATED_BY_TOKEN_LIMIT}`
+          : result.text;
+      return { text, stats };
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       logger.error(
@@ -546,33 +576,6 @@ export class AgentRunner {
     }
   }
 }
-
-/**
- * Converts AI SDK errors into user-facing strings for the UI message stream.
- * Behaviour-preserving copy of the previous inline `onError` handler.
- */
-const formatStreamError = (error: unknown): string => {
-  logger.error({ error }, "Chat stream error");
-  if (LoadAPIKeyError.isInstance(error)) {
-    return "AI provider API key is missing or not configured.";
-  }
-  if (APICallError.isInstance(error)) {
-    if (error.statusCode === 401 || error.statusCode === 403) {
-      return "AI provider authentication failed. Your API key may be invalid or expired.";
-    }
-    if (error.statusCode === 429) {
-      return "AI provider rate limit exceeded. Please try again later.";
-    }
-    if (error.statusCode != null && error.statusCode >= 500) {
-      return "AI provider is currently unavailable. Please try again later.";
-    }
-    return `AI provider error: ${error.message}`;
-  }
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return "An unexpected error occurred.";
-};
 
 /** Singleton runner — services and routes share one instance. */
 export const agentRunner = new AgentRunner();

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -7,7 +7,11 @@ import {
   stepCountIs,
   streamText,
 } from "ai";
-import { formatStreamError, TRUNCATED_BY_TOKEN_LIMIT } from "./stream-error.ts";
+import {
+  formatStreamError,
+  isTruncatedByTokenLimit,
+  TRUNCATED_BY_TOKEN_LIMIT,
+} from "./stream-error.ts";
 import {
   prepareChatTurn,
   validateTurnAttachments,
@@ -338,7 +342,7 @@ export class AgentRunner {
         },
         "Step finished",
       );
-      if (step.finishReason === "length") {
+      if (isTruncatedByTokenLimit(step.finishReason)) {
         logger.warn(
           {
             runId: input.runId,
@@ -522,6 +526,10 @@ export class AgentRunner {
             toolName: trip.toolName,
             count: trip.count,
             duration: Date.now() - startTime,
+            // Carried here too: this path returns before the completion log
+            // below, so without it a no-progress run records neither reason.
+            finishReason: result.finishReason,
+            rawFinishReason: result.rawFinishReason,
             stats,
           },
           "Run aborted: no progress",
@@ -549,10 +557,9 @@ export class AgentRunner {
       // from a complete one: the caller stores it, and whatever reads it later
       // has no way to know the tail is missing. Say so in the text itself, which
       // is the only channel an unattended caller has.
-      const text =
-        result.finishReason === "length"
-          ? `${result.text}\n\n${TRUNCATED_BY_TOKEN_LIMIT}`
-          : result.text;
+      const text = isTruncatedByTokenLimit(result.finishReason)
+        ? `${result.text}\n\n${TRUNCATED_BY_TOKEN_LIMIT}`
+        : result.text;
       return { text, stats };
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));

--- a/apps/backend/src/runs/stream-error.test.ts
+++ b/apps/backend/src/runs/stream-error.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  APICallError,
+  InvalidToolInputError,
+  LoadAPIKeyError,
+  NoSuchToolError,
+  TypeValidationError,
+} from "ai";
+import { z } from "zod";
+import { formatStreamError, TRUNCATED_BY_TOKEN_LIMIT } from "./stream-error.ts";
+
+vi.mock("../logger.ts", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+/**
+ * The real error the SDK raises when a tool call's arguments fail their input
+ * schema: an `InvalidToolInputError` wrapping a `TypeValidationError` wrapping
+ * the `ZodError`. Built from a real Zod failure so the shape can't drift from
+ * what the SDK actually produces.
+ */
+const invalidToolInput = (opts: {
+  toolName: string;
+  schema: z.ZodType;
+  value: unknown;
+}) => {
+  const parsed = opts.schema.safeParse(opts.value);
+  const cause = new TypeValidationError({
+    value: opts.value,
+    cause: parsed.error,
+  });
+  return new InvalidToolInputError({
+    toolName: opts.toolName,
+    toolInput: JSON.stringify(opts.value),
+    cause,
+  });
+};
+
+describe("formatStreamError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("existing branches are preserved", () => {
+    it("names a missing API key", () => {
+      expect(
+        formatStreamError(new LoadAPIKeyError({ message: "no key" })),
+      ).toBe("AI provider API key is missing or not configured.");
+    });
+
+    it.each([
+      [401, "AI provider authentication failed"],
+      [403, "AI provider authentication failed"],
+      [429, "rate limit exceeded"],
+      [500, "currently unavailable"],
+      [503, "currently unavailable"],
+    ])("maps HTTP %i to a specific message", (statusCode, expected) => {
+      const error = new APICallError({
+        message: "boom",
+        url: "https://example.test",
+        requestBodyValues: {},
+        statusCode,
+      });
+      expect(formatStreamError(error)).toContain(expected);
+    });
+
+    it("falls back to the message of an unrecognised Error", () => {
+      expect(formatStreamError(new Error("something specific"))).toBe(
+        "something specific",
+      );
+    });
+  });
+
+  describe("invalid tool input", () => {
+    const schema = z.object({ body: z.string().min(1).max(2000) });
+
+    it("names the tool and the failing field rather than returning the raw message", () => {
+      const error = invalidToolInput({
+        toolName: "updateNotification",
+        schema,
+        value: { body: "x".repeat(2900) },
+      });
+
+      const formatted = formatStreamError(error);
+
+      expect(formatted).toContain("updateNotification");
+      expect(formatted).toContain("body");
+      expect(formatted).toMatch(/2000/);
+      // The whole point: this must REPLACE the SDK's message, which embeds the
+      // entire rejected value plus the serialized ZodError.
+      expect(formatted).not.toBe(error.message);
+      expect(formatted).not.toContain("x".repeat(50));
+    });
+
+    it("stays short even when the rejected value is enormous", () => {
+      const error = invalidToolInput({
+        toolName: "updateNotification",
+        schema,
+        value: { body: "y".repeat(40000) },
+      });
+
+      expect(formatStreamError(error).length).toBeLessThan(500);
+    });
+
+    it("reports every failing field when more than one is invalid", () => {
+      const multi = z.object({
+        title: z.string().max(5),
+        body: z.string().min(10),
+      });
+      const error = invalidToolInput({
+        toolName: "createNotification",
+        schema: multi,
+        value: { title: "far too long", body: "short" },
+      });
+
+      const formatted = formatStreamError(error);
+      expect(formatted).toContain("title");
+      expect(formatted).toContain("body");
+    });
+
+    it("still names the tool when the cause carries no Zod issues", () => {
+      const error = new InvalidToolInputError({
+        toolName: "mysteryTool",
+        toolInput: "{}",
+        cause: new Error("unparseable"),
+      });
+
+      const formatted = formatStreamError(error);
+      expect(formatted).toContain("mysteryTool");
+      expect(formatted).toContain("unparseable");
+    });
+  });
+
+  describe("unknown tool", () => {
+    it("names the tool the model tried to call", () => {
+      const error = new NoSuchToolError({
+        toolName: "delegateToDashboardAgent",
+        availableTools: ["delegateToObsidianAgent"],
+      });
+
+      const formatted = formatStreamError(error);
+      expect(formatted).toContain("delegateToDashboardAgent");
+      expect(formatted).not.toBe("An unexpected error occurred.");
+    });
+  });
+
+  describe("generic fallback", () => {
+    it.each([
+      ["a string throw", "just a string"],
+      ["a plain object throw", { nope: true }],
+      ["a null throw", null],
+    ])("records what actually arrived for %s", (_label, thrown) => {
+      const formatted = formatStreamError(thrown);
+      expect(formatted).toContain("An unexpected error occurred");
+      // Must carry enough to identify the value that arrived — the reported
+      // failure hit this branch and the type was never captured.
+      expect(formatted.length).toBeGreaterThan(
+        "An unexpected error occurred.".length,
+      );
+    });
+  });
+});
+
+describe("TRUNCATED_BY_TOKEN_LIMIT", () => {
+  it("states the cause in terms an agent can act on", () => {
+    expect(TRUNCATED_BY_TOKEN_LIMIT).toMatch(/truncated/i);
+    expect(TRUNCATED_BY_TOKEN_LIMIT).toMatch(/token limit/i);
+  });
+});

--- a/apps/backend/src/runs/stream-error.test.ts
+++ b/apps/backend/src/runs/stream-error.test.ts
@@ -131,6 +131,56 @@ describe("formatStreamError", () => {
     });
   });
 
+  // The streaming path never hands the formatter an Error for this case. An
+  // invalid tool call is converted to a `tool-error` stream part whose `error`
+  // is `getErrorMessage(cause)` — i.e. `error.toString()`, a plain string — so
+  // `isInstance` is false and the real production failure lands here. Both
+  // production log lines from the reported incident are represented below.
+  describe("invalid tool input arriving as a stringified error", () => {
+    const stringified = (toolName: string, issues: unknown) =>
+      `AI_InvalidToolInputError: Invalid input for tool ${toolName}: ` +
+      `AI_TypeValidationError: Type validation failed: Value: ${JSON.stringify({ body: "z".repeat(2900) })}.\n` +
+      `Error message: ${JSON.stringify(issues, null, 2)}`;
+
+    it("names the tool and the failing field instead of the generic fallback", () => {
+      const formatted = formatStreamError(
+        stringified("updateNotification", [
+          {
+            origin: "string",
+            code: "too_big",
+            maximum: 2000,
+            path: ["body"],
+            message: "Too big: expected string to have <=2000 characters",
+          },
+        ]),
+      );
+
+      expect(formatted).toContain("updateNotification");
+      expect(formatted).toContain("body");
+      expect(formatted).toContain("2000");
+      expect(formatted).not.toContain("An unexpected error occurred");
+      // The rejected value must not be echoed back.
+      expect(formatted).not.toContain("z".repeat(50));
+      expect(formatted.length).toBeLessThan(500);
+    });
+
+    it("still names the tool when the issue JSON cannot be parsed", () => {
+      const formatted = formatStreamError(
+        "AI_InvalidToolInputError: Invalid input for tool upsertSkill: something went wrong",
+      );
+
+      expect(formatted).toContain("upsertSkill");
+      expect(formatted).not.toContain("An unexpected error occurred");
+    });
+
+    it("passes an unrecognised string through rather than discarding it", () => {
+      // Previously ANY string hit the generic fallback and its content was lost.
+      expect(formatStreamError("upstream connection reset")).toContain(
+        "upstream connection reset",
+      );
+    });
+  });
+
   describe("unknown tool", () => {
     it("names the tool the model tried to call", () => {
       const error = new NoSuchToolError({
@@ -145,10 +195,12 @@ describe("formatStreamError", () => {
   });
 
   describe("generic fallback", () => {
+    // Strings are handled above — they carry their own message and are
+    // returned rather than replaced. The fallback is for values that don't.
     it.each([
-      ["a string throw", "just a string"],
       ["a plain object throw", { nope: true }],
       ["a null throw", null],
+      ["an undefined throw", undefined],
     ])("records what actually arrived for %s", (_label, thrown) => {
       const formatted = formatStreamError(thrown);
       expect(formatted).toContain("An unexpected error occurred");

--- a/apps/backend/src/runs/stream-error.ts
+++ b/apps/backend/src/runs/stream-error.ts
@@ -1,0 +1,164 @@
+import {
+  APICallError,
+  InvalidToolInputError,
+  LoadAPIKeyError,
+  NoSuchToolError,
+} from "ai";
+import { logger } from "../logger.ts";
+
+/**
+ * What the user and the model are told when a generation stopped because it
+ * ran out of output budget rather than because it was finished.
+ *
+ * A constant so the streaming and unattended paths cannot word this
+ * differently, and so a test can assert on it without restating the prose.
+ */
+export const TRUNCATED_BY_TOKEN_LIMIT =
+  "The response was truncated because it reached the maximum output token limit. Retry with a shorter response, or split the work across several steps.";
+
+/** How much of a single validation issue is worth repeating back. */
+const MAX_ISSUE_LENGTH = 160;
+/** Beyond a handful of issues the list stops being diagnostic. */
+const MAX_ISSUES = 5;
+
+/** A Zod issue, structurally — avoids importing zod into the run pipeline. */
+type ZodLikeIssue = { path?: unknown[]; message?: string };
+
+const truncate = (text: string, max: number): string =>
+  text.length > max ? `${text.slice(0, max - 1)}…` : text;
+
+/**
+ * Walk an error's `cause` chain looking for Zod's `issues` array.
+ *
+ * The SDK nests these two deep — `InvalidToolInputError` → `TypeValidationError`
+ * → `ZodError` — and the depth is an implementation detail we shouldn't encode,
+ * so this searches rather than reaching through a fixed path.
+ */
+const findIssues = (error: unknown, depth = 0): ZodLikeIssue[] | undefined => {
+  if (depth > 5 || error == null || typeof error !== "object") return undefined;
+  const issues = (error as { issues?: unknown }).issues;
+  if (Array.isArray(issues) && issues.length > 0)
+    return issues as ZodLikeIssue[];
+  return findIssues((error as { cause?: unknown }).cause, depth + 1);
+};
+
+/** `["body"]` → `body`, `["items", 2, "id"]` → `items[2].id`, `[]` → `(root)`. */
+const formatPath = (path: unknown[] | undefined): string => {
+  if (!path || path.length === 0) return "(root)";
+  return path.reduce<string>((acc, segment) => {
+    if (typeof segment === "number") return `${acc}[${segment}]`;
+    return acc ? `${acc}.${String(segment)}` : String(segment);
+  }, "");
+};
+
+/**
+ * Describe why a tool's arguments were rejected, in one line per failing field.
+ *
+ * Deliberately does NOT include the rejected value. The SDK's own message
+ * embeds the entire value plus the serialized `ZodError`, which is how a
+ * single over-long field became several thousand characters of unreadable
+ * output for the user and the model alike (issue #406).
+ */
+const describeValidationFailure = (error: InvalidToolInputError): string => {
+  const issues = findIssues(error.cause);
+  if (!issues) {
+    // No structured issues to unpack — fall back to the cause's own text,
+    // capped, which is still better than the full SDK message.
+    const cause = error.cause;
+    const message =
+      cause instanceof Error ? cause.message : stringify(cause ?? "unknown");
+    return truncate(message.replace(/\s+/g, " ").trim(), MAX_ISSUE_LENGTH);
+  }
+
+  const shown = issues
+    .slice(0, MAX_ISSUES)
+    .map(
+      (issue) =>
+        `${formatPath(issue.path)}: ${truncate(
+          (issue.message ?? "invalid").replace(/\s+/g, " ").trim(),
+          MAX_ISSUE_LENGTH,
+        )}`,
+    );
+  const omitted = issues.length - shown.length;
+  return shown.join("; ") + (omitted > 0 ? ` (+${omitted} more)` : "");
+};
+
+/**
+ * Converts AI SDK errors into user-facing strings for the UI message stream.
+ *
+ * The text produced here reaches both the user and, on a failed step, the
+ * model — so it has to be short enough to read and specific enough to act on.
+ */
+export const formatStreamError = (error: unknown): string => {
+  logger.error({ error }, "Chat stream error");
+
+  if (LoadAPIKeyError.isInstance(error)) {
+    return "AI provider API key is missing or not configured.";
+  }
+  if (APICallError.isInstance(error)) {
+    if (error.statusCode === 401 || error.statusCode === 403) {
+      return "AI provider authentication failed. Your API key may be invalid or expired.";
+    }
+    if (error.statusCode === 429) {
+      return "AI provider rate limit exceeded. Please try again later.";
+    }
+    if (error.statusCode != null && error.statusCode >= 500) {
+      return "AI provider is currently unavailable. Please try again later.";
+    }
+    return `AI provider error: ${error.message}`;
+  }
+  // Checked before the generic `Error` branch: both of these ARE Errors, so
+  // without this they fall through to `error.message` — which for an invalid
+  // tool input is the unreadable wall of validator output.
+  if (InvalidToolInputError.isInstance(error)) {
+    return `Invalid input for tool "${error.toolName}": ${describeValidationFailure(error)}`;
+  }
+  if (NoSuchToolError.isInstance(error)) {
+    const available = error.availableTools?.length
+      ? ` Available tools: ${error.availableTools.join(", ")}.`
+      : "";
+    return `The tool "${error.toolName}" does not exist and cannot be called.${available}`;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  // The reported failure landed here and the runtime type was never captured,
+  // which is why nobody could tell what had actually been thrown.
+  return `An unexpected error occurred (received ${describeNonError(error)}).`;
+};
+
+/**
+ * Render an unknown value as text without ever producing "[object Object]",
+ * which is the failure mode this whole branch exists to avoid.
+ */
+const stringify = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    typeof value === "symbol"
+  ) {
+    return value.toString();
+  }
+  if (typeof value === "function")
+    return `function ${value.name || "anonymous"}`;
+  try {
+    return (
+      JSON.stringify(value) ?? String(value === null ? "null" : "undefined")
+    );
+  } catch {
+    return "[unserializable]";
+  }
+};
+
+/** Identify a non-`Error` throw well enough to recognise it in a bug report. */
+const describeNonError = (value: unknown): string => {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "object") {
+    const name = value.constructor?.name ?? "object";
+    return truncate(`${name} ${stringify(value)}`, MAX_ISSUE_LENGTH);
+  }
+  return truncate(`${typeof value} ${stringify(value)}`, MAX_ISSUE_LENGTH);
+};

--- a/apps/backend/src/runs/stream-error.ts
+++ b/apps/backend/src/runs/stream-error.ts
@@ -7,21 +7,28 @@ import {
 import { logger } from "../logger.ts";
 
 /**
- * What the user and the model are told when a generation stopped because it
- * ran out of output budget rather than because it was finished.
+ * What an unattended caller is told when a generation stopped because it ran
+ * out of output budget rather than because it was finished.
  *
- * A constant so the streaming and unattended paths cannot word this
- * differently, and so a test can assert on it without restating the prose.
+ * A constant so the wording is asserted in tests without restating the prose.
+ * Currently appended only by the unattended (`generate`) path — the streaming
+ * path reports truncation to the operator via `logger.warn` and has no seam for
+ * injecting text into an already-flushed stream.
  */
 export const TRUNCATED_BY_TOKEN_LIMIT =
   "The response was truncated because it reached the maximum output token limit. Retry with a shorter response, or split the work across several steps.";
+
+/** The unified finish reason the SDK reports for an output-budget cutoff. */
+export const isTruncatedByTokenLimit = (
+  finishReason: string | undefined,
+): boolean => finishReason === "length";
 
 /** How much of a single validation issue is worth repeating back. */
 const MAX_ISSUE_LENGTH = 160;
 /** Beyond a handful of issues the list stops being diagnostic. */
 const MAX_ISSUES = 5;
 
-/** A Zod issue, structurally — avoids importing zod into the run pipeline. */
+/** A Zod issue, structurally — avoids coupling to a specific zod version. */
 type ZodLikeIssue = { path?: unknown[]; message?: string };
 
 const truncate = (text: string, max: number): string =>
@@ -59,17 +66,7 @@ const formatPath = (path: unknown[] | undefined): string => {
  * single over-long field became several thousand characters of unreadable
  * output for the user and the model alike (issue #406).
  */
-const describeValidationFailure = (error: InvalidToolInputError): string => {
-  const issues = findIssues(error.cause);
-  if (!issues) {
-    // No structured issues to unpack — fall back to the cause's own text,
-    // capped, which is still better than the full SDK message.
-    const cause = error.cause;
-    const message =
-      cause instanceof Error ? cause.message : stringify(cause ?? "unknown");
-    return truncate(message.replace(/\s+/g, " ").trim(), MAX_ISSUE_LENGTH);
-  }
-
+const formatIssues = (issues: ZodLikeIssue[]): string => {
   const shown = issues
     .slice(0, MAX_ISSUES)
     .map(
@@ -81,6 +78,63 @@ const describeValidationFailure = (error: InvalidToolInputError): string => {
     );
   const omitted = issues.length - shown.length;
   return shown.join("; ") + (omitted > 0 ? ` (+${omitted} more)` : "");
+};
+
+const describeValidationFailure = (error: InvalidToolInputError): string => {
+  const issues = findIssues(error.cause);
+  if (issues) return formatIssues(issues);
+  // No structured issues to unpack — fall back to the cause's own text,
+  // capped, which is still better than the full SDK message.
+  const cause = error.cause;
+  const message =
+    cause instanceof Error ? cause.message : stringify(cause ?? "unknown");
+  return truncate(message.replace(/\s+/g, " ").trim(), MAX_ISSUE_LENGTH);
+};
+
+/**
+ * The same failure, arriving as a string instead of an `Error`.
+ *
+ * The streaming path never hands us the instance: an invalid tool call becomes
+ * a `tool-error` stream part whose `error` is `getErrorMessage(cause)` — which
+ * is `error.toString()` — and that string is what reaches `onError`. So the
+ * `isInstance` branches below cannot fire for the case this issue is about, and
+ * without this the real production failure lands in the generic fallback.
+ *
+ * Matching on the SDK's message format is unavoidably coupled to that format.
+ * It degrades safely: an unrecognised shape falls through to returning the
+ * string unchanged, which is still better than discarding it.
+ */
+const TOOL_INPUT_MESSAGE =
+  /^(?:AI_)?InvalidToolInputError: Invalid input for tool (\S+?):\s*([\s\S]*)$/;
+/** The SDK appends the serialized ZodError after this marker. */
+const ISSUES_MARKER = "Error message:";
+
+const describeStringifiedToolInputError = (
+  text: string,
+): string | undefined => {
+  const match = TOOL_INPUT_MESSAGE.exec(text);
+  if (!match) return undefined;
+  const [, toolName, detail] = match;
+
+  const markerAt = detail.lastIndexOf(ISSUES_MARKER);
+  if (markerAt !== -1) {
+    try {
+      const parsed: unknown = JSON.parse(
+        detail.slice(markerAt + ISSUES_MARKER.length).trim(),
+      );
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        return `Invalid input for tool "${toolName}": ${formatIssues(parsed as ZodLikeIssue[])}`;
+      }
+    } catch {
+      // Fall through to the capped detail below.
+    }
+  }
+  // Strip the echoed value, which is the bulk of the SDK's message.
+  const withoutValue = detail.split(/Value:/)[0] || detail;
+  return `Invalid input for tool "${toolName}": ${truncate(
+    withoutValue.replace(/\s+/g, " ").trim(),
+    MAX_ISSUE_LENGTH,
+  )}`;
 };
 
 /**
@@ -114,10 +168,24 @@ export const formatStreamError = (error: unknown): string => {
     return `Invalid input for tool "${error.toolName}": ${describeValidationFailure(error)}`;
   }
   if (NoSuchToolError.isInstance(error)) {
-    const available = error.availableTools?.length
-      ? ` Available tools: ${error.availableTools.join(", ")}.`
-      : "";
-    return `The tool "${error.toolName}" does not exist and cannot be called.${available}`;
+    return `The tool "${error.toolName}" does not exist and cannot be called.`;
+  }
+  // The streaming path stringifies tool-call failures before they reach here,
+  // so the same two cases have to be recognised again in text form.
+  if (typeof error === "string") {
+    const asToolInput = describeStringifiedToolInputError(error);
+    if (asToolInput) return asToolInput;
+    const noSuchTool = /^(?:AI_)?NoSuchToolError:\s*([\s\S]*)$/.exec(error);
+    if (noSuchTool) {
+      return truncate(
+        noSuchTool[1].replace(/\s+/g, " ").trim(),
+        MAX_ISSUE_LENGTH,
+      );
+    }
+    // Any other string is returned as-is: it used to be discarded entirely in
+    // favour of the generic fallback, which is how the reported failure lost
+    // the one sentence that named its cause.
+    return error;
   }
   if (error instanceof Error) {
     return error.message;


### PR DESCRIPTION
Closes #406. Two of its acceptance criteria are split out to #420 and #421 — see the bottom.

A generation that ran out of output budget, or that the provider rejected as a malformed tool use, logged identically to a clean one. Nothing read the finish reason, so the single fact that separates them was discarded on every turn.

## Finish-reason instrumentation

Every finished step now logs the unified `finishReason` **and** the provider's `rawFinishReason`, on both the streaming and unattended paths. Both, because the unified union collapses anything a provider adapter doesn't recognise into `other` — which is exactly what turns Bedrock's `malformed_tool_use` into an ending nobody can identify. That collapse is the difference between hypothesis 1 and hypothesis 2 in the issue's follow-up comment.

A step finishing at the output limit also warns explicitly, and an unattended run cut off that way says so in the text it returns, so the caller can adapt instead of bisecting payload sizes. The no-progress early return carries both reasons too — it returns before the completion log, so those runs would otherwise record neither.

## Invalid tool input, in both the forms it actually arrives in

`formatStreamError` moves to its own module and gains branches for `InvalidToolInputError` and `NoSuchToolError`. Both are `Error`s, so both previously fell through to `error.message` — and for an invalid tool input that message embeds the entire rejected value plus the serialized `ZodError`. The new branch names the tool and lists one line per failing field, and never echoes the value back.

**That alone would not have fixed the reported failure.** An invalid tool call doesn't reach `onError` as an `Error`: the SDK converts it to a `tool-error` stream part whose `error` is `getErrorMessage(cause)` — that is, `error.toString()` — so a plain string arrives and `isInstance` is false. Both forms appear in the production logs on the issue; only one is an `Error`. The string form is now recognised too, reusing the same issue formatter.

Matching the SDK's message format is unavoidably coupled to that format. It degrades safely: an unrecognised shape returns the string unchanged, which still beats replacing it with the generic fallback. And any unrecognised string is now returned rather than discarded — it carried its own message all along, which is how the reported failure lost the one sentence naming its cause.

The generic fallback now records what actually arrived, per the brief's note that *"the value that reached the formatter was not an `Error` instance at all — worth capturing the runtime type of what arrives there."*

## Not included

**No repair function.** Out of scope per the brief: *"a repair function written now would be guessing at what the malformed input looks like, and the instrumentation in this issue is what determines whether there is anything repairable."* Nothing here touches the output ceiling, provider warnings, ADR-0010's error seam, or the docs tree.

## Acceptance criteria not met here — split out, not dropped

Two, each now its own issue rather than left implicit:

- **AC3, the streaming half** — #420. The brief wants the truncation message reaching the model as well as the operator. The streaming path warns to the log, but there is no seam for injecting text into an already-flushed stream, and `ChatMessageMetadata` has no frontend consumer, so flagging it there would be plumbing nothing reads. The remaining work is mostly a product decision about how a truncated reply should present.
- **AC7** — #421. Nothing logs the raw accumulated tool-call argument string, so signature A (truncated partial JSON) and signature B (`{}`) still aren't distinguishable. That issue identifies the seam: `onChunk` fires for every part including `tool-error`, whose `input` is a raw string when the JSON was unparseable and a parsed object when it wasn't — which is precisely the discriminator.

## Verification

Twenty-two new tests across the two axes: the error/instance branches, the stringified forms including one built from the exact shape in the production log, the generic fallback, both finish reasons logged per step, an unrecognised raw reason surviving verbatim, the truncation warning, and the unattended text notice.

`pnpm lint`, `pnpm typecheck` and `pnpm test` pass — 1421 backend, 63 frontend, 24 docs-contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
