### PR TITLE
fix(backend): stop one rejected prompt from filling the log

### DIFF
--- a/apps/backend/src/log-serializers.test.ts
+++ b/apps/backend/src/log-serializers.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect } from "vitest";
+import { generateText } from "ai";
+import { Writable } from "node:stream";
+import pino from "pino";
+import { z } from "zod";
+import { errorSerializers, serializeLoggedError } from "./log-serializers.ts";
+
+const sizeOf = (value: unknown) => JSON.stringify(value)?.length ?? 0;
+
+/**
+ * The production failure, rebuilt through the SDK rather than hand-assembled.
+ *
+ * A tool result carrying Drizzle `Date` values fails `standardizePrompt()`, so
+ * the whole `InvalidPromptError` → `TypeValidationError` → `ZodError` chain is
+ * the SDK's own. Validation happens before the model is resolved, so this makes
+ * no network call.
+ */
+const invalidPromptError = async () => {
+  const at = new Date("2026-01-01T00:00:00.000Z");
+  const card = (n: number) => ({
+    id: `card-${n}`,
+    title: `Card ${n}`,
+    createdAt: at,
+    updatedAt: at,
+  });
+  const column = (n: number) => ({
+    id: `col-${n}`,
+    name: `Column ${n}`,
+    createdAt: at,
+    updatedAt: at,
+    cards: [card(n * 3), card(n * 3 + 1), card(n * 3 + 2)],
+  });
+  const board = {
+    id: "board-1",
+    createdAt: at,
+    updatedAt: at,
+    columns: [column(0), column(1), column(2)],
+  };
+
+  try {
+    await generateText({
+      model: "openai/gpt-4o" as never,
+      messages: [
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call_1",
+              toolName: "list_boards",
+              output: { type: "json", value: board as never },
+            },
+          ],
+        },
+      ],
+    });
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the prompt to be rejected");
+};
+
+/**
+ * A real pino instance writing in-process, so the registration is exercised
+ * through pino's own serializer dispatch rather than by calling the function
+ * directly. Registering a serializer under a key that is not pino's `errorKey`
+ * is the part most likely to break silently.
+ */
+const logLine = (payload: Record<string, unknown>): string => {
+  let written = "";
+  const sink = new Writable({
+    write(chunk, _encoding, done) {
+      written += String(chunk);
+      done();
+    },
+  });
+  pino({ serializers: errorSerializers }, sink).error(payload, "boom");
+  return written;
+};
+
+describe("errorSerializers", () => {
+  it("registers the same treatment for both keys pino might see", () => {
+    expect(errorSerializers.error).toBe(serializeLoggedError);
+    expect(errorSerializers.err).toBe(serializeLoggedError);
+  });
+
+  it("caps the reported failure identically under either key", async () => {
+    const error = await invalidPromptError();
+
+    const underError = logLine({ error });
+    const underErr = logLine({ err: error });
+
+    expect(underError.length).toBeLessThan(4096);
+    expect(underErr.length).toBeLessThan(4096);
+    for (const line of [underError, underErr]) {
+      expect(line).toContain(
+        "The messages do not match the ModelMessage[] schema",
+      );
+      expect(line).toMatch(/content\[0\]\.output\.value\.columns\[\d+\]/);
+      expect(line).not.toContain("invalid_union");
+    }
+    // Same entry either way. Compared as the parsed payload rather than the
+    // raw line, which also carries pino's own per-call timestamp.
+    const parse = (line: string) => JSON.parse(line) as Record<string, unknown>;
+    expect(parse(underError).error).toEqual(parse(underErr).err);
+  });
+
+  it("leaves a logged value that is not an error alone", () => {
+    expect(logLine({ error: "upstream connection reset" })).toContain(
+      "upstream connection reset",
+    );
+  });
+});
+
+describe("serializeLoggedError", () => {
+  describe("the reported failure", () => {
+    it("collapses a 320 KB nested ZodError into a readable entry", async () => {
+      const error = await invalidPromptError();
+
+      // The unserialized error is the problem this change exists to fix.
+      expect(sizeOf(error)).toBeGreaterThan(100_000);
+      expect(sizeOf(serializeLoggedError(error))).toBeLessThan(4096);
+    });
+
+    it("keeps the one sentence that names the failure", async () => {
+      const serialized = serializeLoggedError(await invalidPromptError());
+
+      // Non-enumerable on `Error`, so today it is absent from the log entirely.
+      expect(JSON.stringify(serialized)).toContain(
+        "The messages do not match the ModelMessage[] schema",
+      );
+    });
+
+    it("keeps the absolute path of an offending field, indices included", async () => {
+      const serialized = JSON.stringify(
+        serializeLoggedError(await invalidPromptError()),
+      );
+
+      expect(serialized).toMatch(/content\[0\]\.output\.value\.columns\[\d+\]/);
+      expect(serialized).toContain("createdAt");
+    });
+
+    it("does not complain about the message role it actually matched", async () => {
+      // A tool message also fits the shape of an assistant message carrying a
+      // tool result, so both union branches reach the offending field. Leading
+      // with `expected "assistant"` sends the reader after the wrong thing.
+      const serialized = JSON.stringify(
+        serializeLoggedError(await invalidPromptError()),
+      );
+
+      expect(serialized).not.toContain('expected \\"assistant\\"');
+    });
+
+    it("drops the union search space", async () => {
+      const serialized = JSON.stringify(
+        serializeLoggedError(await invalidPromptError()),
+      );
+
+      expect(serialized).not.toContain("invalid_union");
+    });
+
+    it("says so when it had to leave issues out", async () => {
+      const serialized = JSON.stringify(
+        serializeLoggedError(await invalidPromptError()),
+      );
+
+      expect(serialized).toMatch(/\+\d+ more/);
+    });
+
+    it("does not echo the rejected payload back", async () => {
+      const serialized = JSON.stringify(
+        serializeLoggedError(await invalidPromptError()),
+      );
+
+      // `TypeValidationError` carries the entire offending value as an
+      // enumerable property, which serializes today.
+      expect(serialized).not.toContain("Card 7");
+      expect(serialized).toMatch(/omitted/i);
+    });
+  });
+
+  describe("ordinary errors keep what they carry today", () => {
+    it("keeps message, stack and the cause chain", () => {
+      const error = new Error("outer boom", { cause: new Error("inner boom") });
+      const serialized = serializeLoggedError(error) as Record<string, unknown>;
+
+      expect(serialized.type).toBe("Error");
+      expect(serialized.message).toBe("outer boom");
+      expect(serialized.stack).toContain("log-serializers.test");
+      expect((serialized.cause as Record<string, unknown>).message).toBe(
+        "inner boom",
+      );
+    });
+
+    it("keeps the diagnostic properties of a provider error", () => {
+      const error = Object.assign(new Error("rate limited"), {
+        statusCode: 429,
+        url: "https://api.example.test/v1/messages",
+        isRetryable: true,
+      });
+
+      const serialized = serializeLoggedError(error) as Record<string, unknown>;
+
+      expect(serialized.statusCode).toBe(429);
+      expect(serialized.url).toBe("https://api.example.test/v1/messages");
+      expect(serialized.isRetryable).toBe(true);
+    });
+
+    it("keeps a small structured property intact", () => {
+      const error = Object.assign(new Error("boom"), {
+        context: { workspaceId: "ws_1" },
+      });
+
+      const serialized = serializeLoggedError(error) as Record<string, unknown>;
+
+      expect(serialized.context).toEqual({ workspaceId: "ws_1" });
+    });
+
+    it("replaces an oversized property with a marked placeholder", () => {
+      const error = Object.assign(new Error("boom"), {
+        payload: { blob: "q".repeat(20_000) },
+      });
+
+      const serialized = serializeLoggedError(error) as Record<string, unknown>;
+
+      expect(String(serialized.payload)).toMatch(/omitted/i);
+      expect(String(serialized.payload)).not.toContain("qqqqqqqqqq");
+    });
+
+    it("marks a message it had to shorten", () => {
+      const serialized = serializeLoggedError(
+        new Error("b".repeat(5000)),
+      ) as Record<string, unknown>;
+
+      expect(String(serialized.message)).toContain("…");
+      expect(String(serialized.message).length).toBeLessThan(1000);
+    });
+  });
+
+  describe("values that are not errors", () => {
+    it.each([
+      ["a string", "upstream connection reset"],
+      ["a number", 42],
+      ["null", null],
+      ["undefined", undefined],
+      ["a boolean", false],
+    ])("passes %s through unchanged", (_label, value) => {
+      expect(serializeLoggedError(value)).toBe(value);
+    });
+
+    it("serializes a plain object throw without inventing an Error shape", () => {
+      const serialized = serializeLoggedError({ nope: true }) as Record<
+        string,
+        unknown
+      >;
+
+      expect(serialized.nope).toBe(true);
+    });
+  });
+
+  describe("hostile shapes", () => {
+    it("does not hang on a cyclic cause chain", () => {
+      const a = new Error("a");
+      const b = new Error("b", { cause: a });
+      (a as { cause?: unknown }).cause = b;
+
+      expect(() => serializeLoggedError(a)).not.toThrow();
+      expect(sizeOf(serializeLoggedError(a))).toBeLessThan(4096);
+    });
+
+    it("does not hang on a self-referential property", () => {
+      const error = new Error("boom") as Error & { self?: unknown };
+      error.self = error;
+
+      expect(() => serializeLoggedError(error)).not.toThrow();
+    });
+
+    it("handles a cause that is not an error", () => {
+      const serialized = serializeLoggedError(
+        new Error("boom", { cause: "a plain string cause" }),
+      ) as Record<string, unknown>;
+
+      expect(JSON.stringify(serialized)).toContain("a plain string cause");
+    });
+
+    it("keeps the message when the issue tree summarises to nothing", () => {
+      // Suppressing the message because issues are *present* would lose the
+      // only readable line when the tree yields no reportable leaf.
+      const error = Object.assign(new Error("the failure still has a name"), {
+        issues: [] as unknown[],
+      });
+
+      const serialized = serializeLoggedError(error) as Record<string, unknown>;
+
+      expect(serialized.message).toBe("the failure still has a name");
+    });
+
+    it("says so rather than ending a long cause chain in silence", () => {
+      let error = new Error("root cause");
+      for (let link = 0; link < 8; link++) {
+        error = new Error(`wrapper ${link}`, { cause: error });
+      }
+
+      const serialized = JSON.stringify(serializeLoggedError(error));
+
+      expect(serialized).toMatch(/omitted: cause chain deeper than \d+ links/);
+    });
+
+    it("summarises a bare ZodError logged on its own", () => {
+      const parsed = z.object({ body: z.string() }).safeParse({ body: 1 });
+      const serialized = serializeLoggedError(
+        (parsed as { error: unknown }).error,
+      ) as Record<string, unknown>;
+
+      expect(serialized.type).toBe("ZodError");
+      expect(String(serialized.issues)).toContain("body");
+    });
+  });
+});

--- a/apps/backend/src/log-serializers.ts
+++ b/apps/backend/src/log-serializers.ts
@@ -1,0 +1,165 @@
+import {
+  findIssues,
+  flattenIssues,
+  formatIssues,
+  truncate,
+  type ZodLikeIssue,
+} from "./zod-issues.ts";
+
+/**
+ * How errors are written to the log.
+ *
+ * Pino's default treatment of an error is either too little or too much. Under
+ * a key that is not the configured `errorKey`, `message` and `stack` are
+ * non-enumerable and vanish, leaving `{name, cause}`. Under `err`, the standard
+ * serializer walks the whole `cause` chain with a stack per link. Neither caps
+ * anything, so one rejected prompt containing Drizzle `Date` values wrote 320 KB
+ * — or 1.28 MB under `err` — for a single failed generation (issue #414).
+ *
+ * This serializer keeps the identifying parts of every link in the chain and
+ * puts a ceiling on each of them.
+ */
+
+/** Enough to identify a failure; past this a message is a payload, not prose. */
+const MAX_MESSAGE_LENGTH = 512;
+/** Roughly a dozen frames — where it surfaced, not the whole call graph. */
+const MAX_STACK_LENGTH = 1024;
+/** A property bigger than this is being carried, not described. */
+const MAX_PROPERTY_LENGTH = 512;
+/** Wrapped errors nest a few deep; past this something is looping. */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * Rendered in place of anything the caps removed, so a cut is never silent.
+ *
+ * Counts characters rather than bytes: it comes from a JSON string's `length`,
+ * and an operator comparing the number against a cap should see the same unit
+ * the cap is expressed in.
+ */
+const omitted = (characters: number) => `[omitted: ${characters} characters]`;
+
+/** Fields this serializer renders itself; anything else is an extra. */
+const HANDLED = new Set(["name", "message", "stack", "cause", "issues"]);
+
+/**
+ * The tail an SDK validation error appends: the rejected value, then the
+ * serialized `ZodError`. Both are reproduced better elsewhere in the entry —
+ * the value as a size, the issues as leaf paths — and together they are the
+ * bulk of the bytes. Only stripped from links that actually wrap a Zod failure,
+ * so an ordinary message that happens to contain "Value:" keeps its tail.
+ */
+const VALIDATOR_DETAIL = /\s*(?:Value:|Error message:)[\s\S]*$/;
+
+const safeStringify = (value: unknown): string | undefined => {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+};
+
+/** Keep a property if it describes the failure; replace it if it carries one. */
+const serializeProperty = (value: unknown): unknown => {
+  if (value === null || typeof value !== "object") {
+    return typeof value === "string"
+      ? truncate(value, MAX_PROPERTY_LENGTH)
+      : value;
+  }
+  const encoded = safeStringify(value);
+  if (encoded === undefined) return "[unserializable]";
+  return encoded.length > MAX_PROPERTY_LENGTH ? omitted(encoded.length) : value;
+};
+
+const serializeLink = (
+  value: object,
+  depth: number,
+  seen: Set<object>,
+): unknown => {
+  if (seen.has(value)) return "[circular]";
+  seen.add(value);
+
+  const source = value as Record<string, unknown>;
+  const entry: Record<string, unknown> = {
+    type: value.constructor?.name ?? "object",
+  };
+
+  // Both read by property access, not enumeration: zod defines `issues`
+  // non-enumerably, which is why it never reached the log before. `wrapsZod`
+  // covers the whole chain, `ownIssues` only this link.
+  const ownIssues = Array.isArray(source.issues)
+    ? (source.issues as ZodLikeIssue[])
+    : undefined;
+  const wrapsZod = findIssues(value, 0) !== undefined;
+
+  // Computed before the message so the message can be kept when this comes back
+  // empty. Suppressing the message on the mere *presence* of issues would let a
+  // tree that summarises to nothing take the only readable line with it.
+  const summary =
+    ownIssues && ownIssues.length > 0
+      ? formatIssues(flattenIssues(ownIssues))
+      : "";
+
+  if (typeof source.message === "string") {
+    const message = wrapsZod
+      ? source.message.replace(VALIDATOR_DETAIL, "").trim()
+      : source.message;
+    // A ZodError's own message *is* the union search tree, so a summary
+    // replaces it rather than sitting alongside it.
+    if (message && !summary) {
+      entry.message = truncate(message, MAX_MESSAGE_LENGTH);
+    }
+  }
+
+  // Only the outermost stack: the inner links are named by type and message,
+  // and a stack per link is what makes the standard serializer so large.
+  if (depth === 0 && typeof source.stack === "string") {
+    entry.stack = truncate(source.stack, MAX_STACK_LENGTH);
+  }
+
+  for (const key of Object.keys(source)) {
+    if (HANDLED.has(key)) continue;
+    entry[key] = serializeProperty(source[key]);
+  }
+
+  if (summary) entry.issues = summary;
+
+  const cause = source.cause;
+  if (cause != null) {
+    entry.cause =
+      depth >= MAX_CAUSE_DEPTH
+        ? `[omitted: cause chain deeper than ${MAX_CAUSE_DEPTH} links]`
+        : typeof cause === "object"
+          ? serializeLink(cause, depth + 1, seen)
+          : serializeProperty(cause);
+  }
+
+  return entry;
+};
+
+/**
+ * Pino serializer for logged errors, registered for both the `error` and `err`
+ * keys so an entry reads the same whichever the call site used.
+ *
+ * Non-objects pass through untouched — a thrown string is already its own
+ * description.
+ */
+export const serializeLoggedError = (value: unknown): unknown => {
+  if (value === null || typeof value !== "object") return value;
+  return serializeLink(value, 0, new Set());
+};
+
+/**
+ * The serializer registration the logger installs.
+ *
+ * Both keys are in use across the backend and an error is as likely to arrive
+ * under either, so an entry has to read the same whichever the call site chose.
+ * Registering `err` deliberately displaces pino's standard error serializer,
+ * whose uncapped `cause` walk is the larger half of what this replaces.
+ *
+ * Exported as a map rather than wired inline so the pairing can be asserted
+ * without constructing a logger and its transport.
+ */
+export const errorSerializers = {
+  error: serializeLoggedError,
+  err: serializeLoggedError,
+};

--- a/apps/backend/src/logger.ts
+++ b/apps/backend/src/logger.ts
@@ -1,4 +1,5 @@
 import pino from "pino";
+import { errorSerializers } from "./log-serializers.ts";
 
 const isProduction = process.env.NODE_ENV === "production";
 
@@ -21,6 +22,7 @@ const transport = pino.transport({
 export const logger = pino(
   {
     level: process.env.LOG_LEVEL || "info",
+    serializers: errorSerializers,
   },
   transport,
 );

--- a/apps/backend/src/runs/stream-error.ts
+++ b/apps/backend/src/runs/stream-error.ts
@@ -5,6 +5,13 @@ import {
   NoSuchToolError,
 } from "ai";
 import { logger } from "../logger.ts";
+import {
+  formatIssues,
+  findIssues,
+  MAX_ISSUE_LENGTH,
+  truncate,
+  type ZodLikeIssue,
+} from "../zod-issues.ts";
 
 /**
  * What an unattended caller is told when a generation stopped because it ran
@@ -22,63 +29,6 @@ export const TRUNCATED_BY_TOKEN_LIMIT =
 export const isTruncatedByTokenLimit = (
   finishReason: string | undefined,
 ): boolean => finishReason === "length";
-
-/** How much of a single validation issue is worth repeating back. */
-const MAX_ISSUE_LENGTH = 160;
-/** Beyond a handful of issues the list stops being diagnostic. */
-const MAX_ISSUES = 5;
-
-/** A Zod issue, structurally — avoids coupling to a specific zod version. */
-type ZodLikeIssue = { path?: unknown[]; message?: string };
-
-const truncate = (text: string, max: number): string =>
-  text.length > max ? `${text.slice(0, max - 1)}…` : text;
-
-/**
- * Walk an error's `cause` chain looking for Zod's `issues` array.
- *
- * The SDK nests these two deep — `InvalidToolInputError` → `TypeValidationError`
- * → `ZodError` — and the depth is an implementation detail we shouldn't encode,
- * so this searches rather than reaching through a fixed path.
- */
-const findIssues = (error: unknown, depth = 0): ZodLikeIssue[] | undefined => {
-  if (depth > 5 || error == null || typeof error !== "object") return undefined;
-  const issues = (error as { issues?: unknown }).issues;
-  if (Array.isArray(issues) && issues.length > 0)
-    return issues as ZodLikeIssue[];
-  return findIssues((error as { cause?: unknown }).cause, depth + 1);
-};
-
-/** `["body"]` → `body`, `["items", 2, "id"]` → `items[2].id`, `[]` → `(root)`. */
-const formatPath = (path: unknown[] | undefined): string => {
-  if (!path || path.length === 0) return "(root)";
-  return path.reduce<string>((acc, segment) => {
-    if (typeof segment === "number") return `${acc}[${segment}]`;
-    return acc ? `${acc}.${String(segment)}` : String(segment);
-  }, "");
-};
-
-/**
- * Describe why a tool's arguments were rejected, in one line per failing field.
- *
- * Deliberately does NOT include the rejected value. The SDK's own message
- * embeds the entire value plus the serialized `ZodError`, which is how a
- * single over-long field became several thousand characters of unreadable
- * output for the user and the model alike (issue #406).
- */
-const formatIssues = (issues: ZodLikeIssue[]): string => {
-  const shown = issues
-    .slice(0, MAX_ISSUES)
-    .map(
-      (issue) =>
-        `${formatPath(issue.path)}: ${truncate(
-          (issue.message ?? "invalid").replace(/\s+/g, " ").trim(),
-          MAX_ISSUE_LENGTH,
-        )}`,
-    );
-  const omitted = issues.length - shown.length;
-  return shown.join("; ") + (omitted > 0 ? ` (+${omitted} more)` : "");
-};
 
 const describeValidationFailure = (error: InvalidToolInputError): string => {
   const issues = findIssues(error.cause);

--- a/apps/backend/src/zod-issues.test.ts
+++ b/apps/backend/src/zod-issues.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import {
+  findIssues,
+  flattenIssues,
+  formatIssues,
+  formatPath,
+} from "./zod-issues.ts";
+
+/** Run a real parse so the issue shapes can't drift from what zod produces. */
+const issuesFor = (schema: z.ZodType, value: unknown) => {
+  const result = schema.safeParse(value);
+  if (result.success) throw new Error("expected the parse to fail");
+  return result.error.issues;
+};
+
+describe("formatPath", () => {
+  it.each([
+    [[], "(root)"],
+    [["body"], "body"],
+    [["items", 2, "id"], "items[2].id"],
+    [[0, "content", 0, "output"], "[0].content[0].output"],
+  ])("renders %j as %s", (path, expected) => {
+    expect(formatPath(path)).toBe(expected);
+  });
+});
+
+describe("flattenIssues", () => {
+  it("leaves a non-union issue alone", () => {
+    const issues = issuesFor(z.object({ body: z.string() }), { body: 1 });
+    const flat = flattenIssues(issues);
+
+    expect(flat).toHaveLength(1);
+    expect(formatPath(flat[0].path)).toBe("body");
+  });
+
+  it("descends a union and reports the absolute path of the offending field", () => {
+    // The union sits at `[0]`; the offending field is `meta.at` inside the
+    // matching branch. Only the concatenation of the two is actionable.
+    const schema = z.array(
+      z.union([
+        z.string(),
+        z.object({ id: z.string(), meta: z.object({ at: z.string() }) }),
+      ]),
+    );
+    const flat = flattenIssues(
+      issuesFor(schema, [{ id: "a", meta: { at: new Date() } }]),
+    );
+
+    expect(flat.map((issue) => formatPath(issue.path))).toContain(
+      "[0].meta.at",
+    );
+  });
+
+  it("keeps the branch that got furthest and discards the rest of the search space", () => {
+    // A discriminated-ish union: the `b` branch fails immediately on `kind`,
+    // the `a` branch gets all the way down to `nested.value`. Reporting both
+    // is what buries the signal.
+    const schema = z.union([
+      z.object({
+        kind: z.literal("a"),
+        nested: z.object({ value: z.string() }),
+      }),
+      z.object({ kind: z.literal("b"), other: z.string() }),
+    ]);
+    const flat = flattenIssues(
+      issuesFor(schema, { kind: "a", nested: { value: 1 } }),
+    );
+
+    expect(flat).toHaveLength(1);
+    expect(formatPath(flat[0].path)).toBe("nested.value");
+    expect(JSON.stringify(flat)).not.toContain("kind");
+  });
+
+  it("merges equally-shallow alternatives into one issue naming every accepted type", () => {
+    // A `Date` against a JSON-value union fails all branches at the same path.
+    // Reporting only the first ("expected null") implies null was the sole
+    // option; reporting all six verbatim is six near-identical lines.
+    const schema = z.object({
+      at: z.union([z.null(), z.string(), z.number(), z.boolean()]),
+    });
+    const flat = flattenIssues(issuesFor(schema, { at: new Date() }));
+
+    expect(flat).toHaveLength(1);
+    expect(formatPath(flat[0].path)).toBe("at");
+    expect(flat[0].message).toContain("null");
+    expect(flat[0].message).toContain("string");
+    expect(flat[0].message).toContain("number");
+    expect(flat[0].message).toContain("boolean");
+    expect(flat[0].message).toContain("Date");
+  });
+
+  it("prefers the branch that objected least when two reach the same depth", () => {
+    // Both branches descend to `nested.at` and fail there, but the second also
+    // rejects the discriminator. The first is the shape the value was trying
+    // to be, so complaining about `kind` is noise.
+    const schema = z.union([
+      z.object({
+        kind: z.literal("tool"),
+        nested: z.object({ at: z.string() }),
+      }),
+      z.object({
+        kind: z.literal("assistant"),
+        nested: z.object({ at: z.string() }),
+      }),
+    ]);
+    const flat = flattenIssues(
+      issuesFor(schema, { kind: "tool", nested: { at: new Date() } }),
+    );
+
+    expect(flat).toHaveLength(1);
+    expect(formatPath(flat[0].path)).toBe("nested.at");
+    expect(JSON.stringify(flat)).not.toContain("assistant");
+  });
+
+  it("never emits the union search space itself", () => {
+    const schema = z.array(
+      z.union([
+        z.object({ kind: z.literal("a"), at: z.union([z.null(), z.string()]) }),
+        z.object({ kind: z.literal("b") }),
+      ]),
+    );
+    const flat = flattenIssues(
+      issuesFor(schema, [{ kind: "a", at: new Date() }]),
+    );
+
+    expect(JSON.stringify(flat)).not.toContain("invalid_union");
+  });
+
+  it("reports each offending field once per occurrence", () => {
+    const schema = z.object({
+      rows: z.array(z.object({ at: z.union([z.null(), z.string()]) })),
+    });
+    const flat = flattenIssues(
+      issuesFor(schema, {
+        rows: [{ at: new Date() }, { at: new Date() }, { at: new Date() }],
+      }),
+    );
+
+    expect(flat.map((issue) => formatPath(issue.path))).toEqual([
+      "rows[0].at",
+      "rows[1].at",
+      "rows[2].at",
+    ]);
+  });
+
+  it("keeps the union's own message when no branch reported anything", () => {
+    // Losing the last record that a field failed is the bug being fixed, so
+    // an unhelpful tree has to degrade to the union's own line, not to
+    // nothing.
+    const flat = flattenIssues([
+      {
+        code: "invalid_union",
+        path: ["a"],
+        errors: [[], []],
+        message: "Invalid input",
+      },
+    ]);
+
+    expect(flat).toHaveLength(1);
+    expect(formatPath(flat[0].path)).toBe("a");
+    expect(flat[0].message).toBe("Invalid input");
+  });
+
+  it("marks the point where it stopped descending a self-referential tree", () => {
+    const issue: Record<string, unknown> = {
+      code: "invalid_union",
+      path: ["a"],
+      message: "Invalid input",
+    };
+    issue.errors = [[issue]];
+
+    const flat = flattenIssues([issue]);
+
+    expect(flat.length).toBeGreaterThan(0);
+    expect(flat.at(-1)?.message).toContain("not expanded");
+  });
+});
+
+describe("formatIssues", () => {
+  it("marks the issues it dropped rather than trimming silently", () => {
+    const many = Array.from({ length: 9 }, (_, index) => ({
+      path: ["rows", index, "at"],
+      message: "Invalid input",
+    }));
+
+    const formatted = formatIssues(many);
+
+    expect(formatted).toContain("rows[0].at");
+    expect(formatted).toContain("(+4 more)");
+  });
+
+  it("marks a message it had to shorten", () => {
+    const formatted = formatIssues([
+      { path: ["body"], message: "x".repeat(400) },
+    ]);
+
+    expect(formatted).toContain("…");
+    expect(formatted.length).toBeLessThan(400);
+  });
+});
+
+describe("findIssues", () => {
+  it("finds issues nested behind a cause chain", () => {
+    const zodError = new Error("inner") as Error & { issues: unknown[] };
+    zodError.issues = [{ path: ["body"], message: "nope" }];
+    const wrapped = new Error("outer", {
+      cause: new Error("mid", { cause: zodError }),
+    });
+
+    expect(findIssues(wrapped)).toHaveLength(1);
+  });
+
+  it("returns undefined when nothing in the chain carries issues", () => {
+    expect(
+      findIssues(new Error("outer", { cause: new Error("inner") })),
+    ).toBeUndefined();
+  });
+
+  it("reads issues even though zod makes them non-enumerable", () => {
+    // The bug this whole change exists for: `Object.keys(zodError)` omits
+    // `issues`, so anything enumeration-based finds nothing.
+    const parsed = z.object({ body: z.string() }).safeParse({ body: 1 });
+    const error = (parsed as { error: unknown }).error;
+
+    expect(Object.keys(error as object)).not.toContain("issues");
+    expect(findIssues(error)).toHaveLength(1);
+  });
+});

--- a/apps/backend/src/zod-issues.ts
+++ b/apps/backend/src/zod-issues.ts
@@ -1,0 +1,210 @@
+/**
+ * Reducing a Zod validation failure to the few lines that identify it.
+ *
+ * Shared by two surfaces with the same problem and different audiences: the
+ * user-facing stream error text, and the serializer that writes errors to the
+ * log. Kept free of any logger dependency so the logger can import it.
+ */
+
+/** How much of a single validation issue is worth repeating back. */
+export const MAX_ISSUE_LENGTH = 160;
+/** Beyond a handful of issues the list stops being diagnostic. */
+export const MAX_ISSUES = 5;
+/** A union nested past this is a pathological schema, not a diagnosable one. */
+const MAX_UNION_DEPTH = 12;
+/** How far down a `cause` chain a Zod failure is worth looking for. */
+const MAX_CAUSE_SEARCH_DEPTH = 5;
+
+/** A Zod issue, structurally — avoids coupling to a specific zod version. */
+export type ZodLikeIssue = {
+  path?: unknown[];
+  message?: string;
+  code?: string;
+  /** Present on `invalid_union`: one issue list per rejected branch. */
+  errors?: ZodLikeIssue[][];
+  /** Present on `invalid_type`: the type that branch was hoping for. */
+  expected?: unknown;
+};
+
+/** A union issue, whose `errors` holds one issue list per rejected branch. */
+type UnionIssue = ZodLikeIssue & { errors: ZodLikeIssue[][] };
+
+/** An issue reduced to an absolute path and a single line of prose. */
+export type FlatIssue = { path: unknown[]; message: string };
+
+export const truncate = (text: string, max: number): string =>
+  text.length > max ? `${text.slice(0, max - 1)}…` : text;
+
+/**
+ * Walk an error's `cause` chain looking for Zod's `issues` array.
+ *
+ * The SDK nests these two deep — `InvalidToolInputError` → `TypeValidationError`
+ * → `ZodError` — and the depth is an implementation detail we shouldn't encode,
+ * so this searches rather than reaching through a fixed path.
+ *
+ * Reads `issues` by property access on purpose: zod defines it non-enumerably,
+ * so anything driven by `Object.keys` finds nothing.
+ */
+export const findIssues = (
+  error: unknown,
+  depth = 0,
+): ZodLikeIssue[] | undefined => {
+  if (
+    depth > MAX_CAUSE_SEARCH_DEPTH ||
+    error == null ||
+    typeof error !== "object"
+  )
+    return undefined;
+  const issues = (error as { issues?: unknown }).issues;
+  if (Array.isArray(issues) && issues.length > 0)
+    return issues as ZodLikeIssue[];
+  return findIssues((error as { cause?: unknown }).cause, depth + 1);
+};
+
+/** `["body"]` → `body`, `["items", 2, "id"]` → `items[2].id`, `[]` → `(root)`. */
+export const formatPath = (path: unknown[] | undefined): string => {
+  if (!path || path.length === 0) return "(root)";
+  return path.reduce<string>((acc, segment) => {
+    if (typeof segment === "number") return `${acc}[${segment}]`;
+    return acc ? `${acc}.${String(segment)}` : String(segment);
+  }, "");
+};
+
+const isUnionIssue = (issue: ZodLikeIssue): issue is UnionIssue =>
+  issue.code === "invalid_union" && Array.isArray(issue.errors);
+
+const deepestPath = (issues: FlatIssue[]): number =>
+  issues.reduce((max, issue) => Math.max(max, issue.path.length), 0);
+
+/** The type a branch was hoping for, when the branch failed on type alone. */
+const expectedType = (issue: ZodLikeIssue): string | undefined =>
+  issue.code === "invalid_type" ? issue.expected?.toString() : undefined;
+
+/**
+ * Collapse branches that all failed the same way at the same place.
+ *
+ * A `Date` checked against a JSON value union fails all six branches at one
+ * path. Keeping the first alone reads as "expected null", which implies null
+ * was the only option; keeping all six is the same sentence six times. Naming
+ * every accepted type in one line is both shorter and true.
+ */
+const mergeAlternatives = (
+  branches: AnnotatedLeaf[][],
+): AnnotatedLeaf[] | undefined => {
+  if (branches.some((branch) => branch.length !== 1)) return undefined;
+  const leaves = branches.map((branch) => branch[0]);
+
+  const path = formatPath(leaves[0].path);
+  if (leaves.some((leaf) => formatPath(leaf.path) !== path)) return undefined;
+
+  const expected = leaves.map((leaf) => leaf.expected);
+  if (expected.some((type) => type === undefined)) return undefined;
+
+  // Every branch rejected the same value, so any branch's message names it.
+  const received = /received (.+)$/.exec(leaves[0].message)?.[1];
+  const alternatives = [...new Set(expected)].join(" | ");
+  return [
+    {
+      path: leaves[0].path,
+      message: received
+        ? `Invalid input: expected ${alternatives}, received ${received}`
+        : `Invalid input: expected ${alternatives}`,
+    },
+  ];
+};
+
+/**
+ * Pick the branch that got furthest into the value.
+ *
+ * A union reports why *every* branch failed, which is the validator's search
+ * space rather than the user's mistake. The branch that reached deepest is the
+ * one the value was actually trying to be — for a tool message, the branch that
+ * matched `role: "tool"` and then choked on a `Date` twelve levels down, not
+ * the five that stopped at `role`.
+ */
+const selectBranch = (branches: AnnotatedLeaf[][]): AnnotatedLeaf[] => {
+  const candidates = branches.filter((branch) => branch.length > 0);
+  if (candidates.length === 0) return [];
+
+  const deepest = deepestPath(candidates.flat());
+  const furthest = candidates.filter(
+    (branch) => deepestPath(branch) === deepest,
+  );
+  if (furthest.length === 1) return furthest[0];
+
+  const merged = mergeAlternatives(furthest);
+  if (merged) return merged;
+
+  // Two branches reached the same depth, so depth alone can't separate them —
+  // a tool message also satisfies the shape of an assistant message carrying a
+  // tool result, and both descend to the same offending field. The branch that
+  // objected least is the closer match: it agreed on everything the other one
+  // additionally complained about, such as the discriminating `role`.
+  const fewest = Math.min(...furthest.map((branch) => branch.length));
+  return furthest.find((branch) => branch.length === fewest) ?? furthest[0];
+};
+
+/** A leaf carrying the `expected` type through branch selection. */
+type AnnotatedLeaf = FlatIssue & { expected?: string };
+
+/** Appended where a union was too deeply nested to be worth descending. */
+const NOT_EXPANDED = "(nested unions not expanded)";
+
+/** One issue's prose, collapsed to a single line. */
+const issueText = (issue: ZodLikeIssue): string =>
+  (issue.message ?? "invalid").replace(/\s+/g, " ").trim();
+
+const flatten = (
+  issues: ZodLikeIssue[],
+  base: unknown[],
+  depth: number,
+): AnnotatedLeaf[] =>
+  issues.flatMap((issue) => {
+    const path = [...base, ...(issue.path ?? [])];
+    const message = issueText(issue);
+
+    if (!isUnionIssue(issue)) {
+      return [{ path, message, expected: expectedType(issue) }];
+    }
+    if (depth >= MAX_UNION_DEPTH) {
+      return [{ path, message: `${message} ${NOT_EXPANDED}` }];
+    }
+
+    const selected = selectBranch(
+      issue.errors.map((branch) => flatten(branch, path, depth + 1)),
+    );
+    // A union whose branches reported nothing still knows that this field
+    // failed. Returning the empty selection would drop that last record, and
+    // losing the one line that names the failure is the bug being fixed, not a
+    // corner worth cutting.
+    return selected.length > 0 ? selected : [{ path, message }];
+  });
+
+/**
+ * Reduce a Zod issue tree to concrete failures with absolute paths.
+ *
+ * The path of a union's branch issue is relative to the union node, so the only
+ * actionable path — `content[0].output.value.columns[2].createdAt` — exists
+ * nowhere in the tree until the descent concatenates it.
+ */
+export const flattenIssues = (issues: ZodLikeIssue[]): FlatIssue[] =>
+  flatten(issues, [], 0).map(({ path, message }) => ({ path, message }));
+
+/**
+ * Render issues as one capped line per failing field.
+ *
+ * Deliberately does NOT include the rejected value. The SDK's own message
+ * embeds the entire value plus the serialized `ZodError`, which is how a
+ * single over-long field became several thousand characters of unreadable
+ * output for the user and the model alike (issue #406).
+ */
+export const formatIssues = (issues: ZodLikeIssue[]): string => {
+  const shown = issues
+    .slice(0, MAX_ISSUES)
+    .map(
+      (issue) =>
+        `${formatPath(issue.path)}: ${truncate(issueText(issue), MAX_ISSUE_LENGTH)}`,
+    );
+  const omitted = issues.length - shown.length;
+  return shown.join("; ") + (omitted > 0 ? ` (+${omitted} more)` : "");
+};


### PR DESCRIPTION
## Summary

A tool result carrying Drizzle `Date` values fails the SDK's prompt validation, and the resulting `InvalidPromptError` wraps a `ZodError` whose `invalid_union` tree nests one level per union member per field per array element. Logged, that was **320 KB on a single line** for one failed generation.

The same failure now logs at **1.4 KB**, naming the offending field:

```
[0].content[0].output.value.columns[0].cards[0].createdAt:
  Invalid input: expected null | string | number | boolean | record | array, received Date  (+21 more)
```

## What was actually wrong

Two problems, and each one ruled out an obvious-looking fix.

**The bloat was a string, not an object tree.** Zod defines `ZodError.issues` non-enumerably — `Object.keys(zodError)` returns `['name', 'message']` — so nothing enumeration-based ever saw it. What serialized was `ZodError.message`, a single pre-rendered JSON dump of the whole union search space. A serializer that walks the object graph looking for `issues` arrays would have found nothing.

**The one actionable sentence was absent, not buried.** `message` and `stack` are non-enumerable on `Error`, and `error` is not pino's configured `errorKey`, so the serialized object was only `{name, cause}`. `Invalid prompt: The messages do not match the ModelMessage[] schema.` never reached the log at all. This was an information-loss bug wearing a bloat bug's clothes.

Switching the call sites to the `err` key would have made it worse, not better: pino's standard serializer walks the same `cause` chain and adds a stack per link, giving **1.28 MB**.

## Approach

Errors are serialized by one registration covering both the `error` and `err` keys, so an entry reads the same whichever key a call site used — roughly 25 sites use `error`, three use `err`, and any of them can hit this.

Each link in the chain keeps its type, message and properties under a cap. A Zod failure anywhere in the chain is reduced to leaf issues carrying the **absolute path** of the offending field, which exists nowhere in the tree until the union descent concatenates it — the top-level issue is a bare `{code: "invalid_union", path: [0]}`.

Two heuristics keep the summary honest rather than merely short:

- **Deepest branch wins.** A union reports why _every_ branch failed, which is the validator's search space, not the mistake. The branch that reached furthest into the value is the one the value was trying to be.
- **Fewest objections breaks a tie.** A tool message also satisfies the shape of an assistant message carrying a tool result, so both branches descend to the same field. Without this the entry led with `expected "assistant"` and sent the reader after the wrong thing.

Equally-shallow alternatives merge into one line naming every accepted type, so a `Date` against a JSON-value union reads `expected null | string | number | boolean | record | array` instead of implying `null` was the only option.

Every cap says when it trimmed something — issue count, message length, property size, cause depth, and union nesting.

The issue-formatting helpers move out of the stream-error module so the logger can share them without an import cycle. What `formatStreamError` returns to the user and the model is unchanged.

## Verification

Measured end to end through the real logger config, using the SDK's own validation path:

|                                      | Before             | After                      |
| ------------------------------------ | ------------------ | -------------------------- |
| `NODE_ENV=production`, `error` key   | 320,676 bytes      | ~1.5 KB                    |
| `NODE_ENV=development` (pino-pretty) | 111 lines / 323 KB | ~1.5 KB                    |
| `err` key                            | 1,281,815 bytes    | ~1.5 KB, identical payload |

`pnpm typecheck` and `pnpm lint` clean; full suite green (1466 backend, 63 frontend).

The four new guards were mutation-tested — dropping the `err` registration, suppressing the message on the presence rather than the summary of issues, cutting the cause chain silently, and returning nothing from an empty union selection each fail a test.

## Notes for review

- **No new environment variable.** The caps are module constants; no configuration docs change, and the diff intersects no row of the docs table in `CLAUDE.md`.
- **The union collapsing deliberately does not reach the user-facing text.** `formatStreamError` still renders raw issues, per the brief's byte-for-byte constraint. The better paths would help there too — worth a follow-up if wanted.
- **`Date` values reaching tool results at all** is the underlying bug this one made hard to diagnose. Not addressed here; it needs its own issue.

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
