### PR TITLE
fix(backend): resolve a sub-agent at the invoking Workspace's scope

### DIFF
--- a/apps/backend/src/routes/agent.test.ts
+++ b/apps/backend/src/routes/agent.test.ts
@@ -421,6 +421,9 @@ describe("Agent Routes", () => {
       });
 
       expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        error: "One or more sub-agents are not available in this workspace",
+      });
       expect(mockDb.update).not.toHaveBeenCalled();
     });
 

--- a/apps/backend/src/routes/agent.test.ts
+++ b/apps/backend/src/routes/agent.test.ts
@@ -18,6 +18,30 @@ describe("Agent Routes", () => {
   const workspaceId = "ws-1";
   const baseUrl = `/organizations/${orgId}/workspaces/${workspaceId}/agents`;
 
+  /**
+   * Stubs the two terminal `where`s of the sub-agent visibility lookup: the
+   * workspace-scoped agents, then the org-scoped ones inner-joined to this
+   * workspace's attachments. `precedingWheres` covers the chainable `where`s the
+   * route makes first — org membership and workspace access on a POST, plus the
+   * agent lookup on a PUT.
+   */
+  const stubSubAgentVisibility = ({
+    precedingWheres,
+    workspaceRows = [],
+    attachedOrgRows = [],
+  }: {
+    precedingWheres: number;
+    workspaceRows?: unknown[];
+    attachedOrgRows?: unknown[];
+  }) => {
+    for (let i = 0; i < precedingWheres; i++) {
+      mockDb.where.mockReturnValueOnce(mockDb);
+    }
+    mockDb.where
+      .mockResolvedValueOnce(workspaceRows)
+      .mockResolvedValueOnce(attachedOrgRows);
+  };
+
   describe("POST /", () => {
     it("should return 401 if not authenticated", async () => {
       mockNoSession();
@@ -80,6 +104,51 @@ describe("Agent Routes", () => {
 
       expect(res.status).toBe(201);
       expect(await res.json()).toEqual(mockAgent);
+      expect(mockDb.insert).toHaveBeenCalled();
+    });
+
+    it("creates an agent that references an attached Shared agent as a sub-agent", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+
+      stubSubAgentVisibility({
+        precedingWheres: 2,
+        attachedOrgRows: [
+          {
+            agent: {
+              id: "shared-sub",
+              organizationId: orgId,
+              workspaceId: null,
+            },
+            attachment: { id: "att-1" },
+          },
+        ],
+      });
+
+      const mockAgent = {
+        id: "agent-1",
+        name: "Parent",
+        workspaceId,
+        subAgentIds: ["shared-sub"],
+      };
+      mockDb.returning.mockResolvedValueOnce([mockAgent]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Parent",
+          description: "A parent agent",
+          providerId: "p1",
+          modelId: "m1",
+          subAgentIds: ["shared-sub"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(201);
       expect(mockDb.insert).toHaveBeenCalled();
     });
 
@@ -282,6 +351,77 @@ describe("Agent Routes", () => {
       expect(mockDb.set).toHaveBeenCalledWith(
         expect.objectContaining({ temperature: null }),
       );
+    });
+
+    it("accepts an attached Shared agent as a sub-agent, so a Promoted sub-Agent keeps its parent savable", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // findVisibleAgent → workspace-scoped agent
+      mockDb.limit.mockResolvedValueOnce([{ id: "agent-1", workspaceId }]);
+
+      stubSubAgentVisibility({
+        precedingWheres: 3,
+        attachedOrgRows: [
+          {
+            agent: {
+              id: "shared-sub",
+              organizationId: orgId,
+              workspaceId: null,
+            },
+            attachment: { id: "att-1" },
+          },
+        ],
+      });
+
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "agent-1", name: "Parent", subAgentIds: ["shared-sub"] },
+      ]);
+
+      const res = await app.request(`${baseUrl}/agent-1`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "Parent",
+          description: "A parent agent",
+          providerId: "p1",
+          modelId: "m1",
+          subAgentIds: ["shared-sub"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+
+    it("rejects a sub-agent that is not visible in this workspace at either scope", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      // findVisibleAgent → workspace-scoped agent
+      mockDb.limit.mockResolvedValueOnce([{ id: "agent-1", workspaceId }]);
+
+      // Neither scope yields the referenced agent.
+      stubSubAgentVisibility({ precedingWheres: 3 });
+
+      const res = await app.request(`${baseUrl}/agent-1`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "Parent",
+          description: "A parent agent",
+          providerId: "p1",
+          modelId: "m1",
+          subAgentIds: ["someone-elses-agent"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(400);
+      expect(mockDb.update).not.toHaveBeenCalled();
     });
 
     it("should lock a shared agent for a workspace owner (non-admin)", async () => {

--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -47,6 +47,7 @@ agent.post(
   sValidator("json", agentCreateSchema),
   async (c) => {
     const data = c.req.valid("json");
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
 
     // Deduplicate arrays
@@ -63,7 +64,7 @@ agent.post(
     // Validate sub-agent assignments
     if (data.subAgentIds && data.subAgentIds.length > 0) {
       const validation = await validateSubAgentAssignment(
-        workspaceId,
+        { orgId, wsId: workspaceId },
         "", // No ID yet for new agent
         data.subAgentIds,
       );
@@ -169,7 +170,7 @@ agent.put(
     // Workspace-scoped update.
     if (data.subAgentIds) {
       const validation = await validateSubAgentAssignment(
-        workspaceId,
+        { orgId, wsId: workspaceId },
         agentId,
         data.subAgentIds,
       );

--- a/apps/backend/src/services/chat-execution.test-fixtures.ts
+++ b/apps/backend/src/services/chat-execution.test-fixtures.ts
@@ -143,10 +143,22 @@ export const createInMemoryChatTurnQueries = (
       return Promise.resolve(m);
     },
 
-    getSubAgentsByIds(ids) {
+    getSubAgentsByIds(ids, orgId, workspaceId) {
       if (ids.length === 0) return Promise.resolve([]);
+      // Same rule as getAgent — a sub-agent resolves in the invoking workspace,
+      // or at org scope where attached (ADR-0007). Enforced here rather than
+      // filtering by id alone, so tests exercise the boundary, not a hole in it.
+      const visible = (fx.agents ?? []).filter(
+        (a) =>
+          a.workspaceId === workspaceId ||
+          (a.organizationId === orgId &&
+            !a.workspaceId &&
+            isAttached("agent", a.id, workspaceId)),
+      );
       return Promise.resolve(
-        (fx.agents ?? []).filter((a) => ids.includes(a.id)),
+        ids
+          .map((id) => visible.find((a) => a.id === id))
+          .filter((a): a is AgentRow => a !== undefined),
       );
     },
 

--- a/apps/backend/src/services/chat-execution.test-fixtures.ts
+++ b/apps/backend/src/services/chat-execution.test-fixtures.ts
@@ -61,6 +61,20 @@ export const createInMemoryChatTurnQueries = (
         a.workspaceId === workspaceId,
     );
 
+  /**
+   * The Agent visibility rule both Agent lookups apply: Workspace-scoped in the
+   * invoking workspace, or org-scoped (Shared) and attached here (ADR-0007).
+   */
+  const isAgentVisible = (
+    a: AgentRow,
+    orgId: string,
+    workspaceId: string,
+  ): boolean =>
+    a.workspaceId === workspaceId ||
+    (a.organizationId === orgId &&
+      !a.workspaceId &&
+      isAttached("agent", a.id, workspaceId));
+
   return {
     getWorkspace(id) {
       return Promise.resolve(fx.workspaces?.find((w) => w.id === id) ?? null);
@@ -75,17 +89,7 @@ export const createInMemoryChatTurnQueries = (
     getAgent(id, orgId, workspaceId) {
       const a = fx.agents?.find((a) => a.id === id) ?? null;
       if (!a) return Promise.resolve(null);
-      // Workspace-scoped Agent in this workspace.
-      if (a.workspaceId === workspaceId) return Promise.resolve(a);
-      // Org-scoped (Shared) Agent resolves only where attached (ADR-0007).
-      if (
-        a.organizationId === orgId &&
-        !a.workspaceId &&
-        isAttached("agent", id, workspaceId)
-      ) {
-        return Promise.resolve(a);
-      }
-      return Promise.resolve(null);
+      return Promise.resolve(isAgentVisible(a, orgId, workspaceId) ? a : null);
     },
 
     getProvider(id, orgId, workspaceId) {
@@ -148,12 +152,8 @@ export const createInMemoryChatTurnQueries = (
       // Same rule as getAgent — a sub-agent resolves in the invoking workspace,
       // or at org scope where attached (ADR-0007). Enforced here rather than
       // filtering by id alone, so tests exercise the boundary, not a hole in it.
-      const visible = (fx.agents ?? []).filter(
-        (a) =>
-          a.workspaceId === workspaceId ||
-          (a.organizationId === orgId &&
-            !a.workspaceId &&
-            isAttached("agent", a.id, workspaceId)),
+      const visible = (fx.agents ?? []).filter((a) =>
+        isAgentVisible(a, orgId, workspaceId),
       );
       return Promise.resolve(
         ids

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -337,6 +337,94 @@ describe("chat-execution", () => {
       ).rejects.toBeInstanceOf(NotFoundError);
     });
 
+    it("resolves a sub-agent at the invoking Workspace's scope, or org-scoped where attached", async () => {
+      const workspaceSubAgent = {
+        ...baseAgent,
+        id: "sub-ws",
+        name: "Research Agent",
+        description: "Looks things up.",
+      };
+      const orgSubAgent = {
+        ...baseAgent,
+        id: "sub-org",
+        name: "Shared Agent",
+        description: "Shared specialist.",
+        organizationId: "org-1",
+        workspaceId: null,
+      };
+      const parent = {
+        ...baseAgent,
+        subAgentIds: ["sub-ws", "sub-org"],
+      };
+
+      const queries = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        agents: [parent, workspaceSubAgent, orgSubAgent],
+        providers: [baseProvider],
+        attachments: [
+          { workspaceId: "ws-1", resourceType: "agent", resourceId: "sub-org" },
+        ],
+      });
+
+      const turn = await prepareChatTurn(
+        { ...baseInput, request: { agentId: parent.id } },
+        queries,
+      );
+
+      expect(turn.stream.tools).toHaveProperty("delegateToResearchAgent");
+      expect(turn.stream.tools).toHaveProperty("delegateToSharedAgent");
+      expect(turn.stream.system).toContain("Research Agent");
+      expect(turn.stream.system).toContain("Shared Agent");
+      expect(turn.stream.system).not.toContain("## Unavailable Sub-Agents");
+    });
+
+    it("does not resolve a sub-agent that is not visible in the invoking Workspace, and reports it by id", async () => {
+      const foreignSubAgent = {
+        ...baseAgent,
+        id: "sub-foreign",
+        name: "Foreign Agent",
+        description: "Belongs to another workspace.",
+        workspaceId: "ws-other",
+      };
+      const detachedSharedSubAgent = {
+        ...baseAgent,
+        id: "sub-detached",
+        name: "Detached Agent",
+        description: "Shared but not attached here.",
+        organizationId: "org-1",
+        workspaceId: null,
+      };
+      const parent = {
+        ...baseAgent,
+        subAgentIds: ["sub-foreign", "sub-detached"],
+      };
+
+      const queries = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        agents: [parent, foreignSubAgent, detachedSharedSubAgent],
+        providers: [baseProvider],
+      });
+
+      const turn = await prepareChatTurn(
+        { ...baseInput, request: { agentId: parent.id } },
+        queries,
+      );
+
+      // No delegate tool, and nothing read off the unresolvable rows reaches the
+      // prompt — the ids the parent's own configuration holds identify them.
+      expect(turn.stream.tools).not.toHaveProperty("delegateToForeignAgent");
+      expect(turn.stream.tools).not.toHaveProperty("delegateToDetachedAgent");
+      expect(turn.stream.system).not.toContain("Foreign Agent");
+      expect(turn.stream.system).not.toContain("Belongs to another workspace.");
+      expect(turn.stream.system).not.toContain("Detached Agent");
+      expect(turn.stream.system).not.toContain("Shared but not attached here.");
+
+      expect(turn.stream.system).toContain("## Unavailable Sub-Agents");
+      expect(turn.stream.system).toContain("`sub-foreign`");
+      expect(turn.stream.system).toContain("`sub-detached`");
+      expect(turn.stream.system).toContain("not available in this workspace");
+    });
+
     it("Direct Provider+Model selection persists the user's own prompt text, not the composed prompt", async () => {
       const queries = createInMemoryChatTurnQueries({
         workspaces: [{ ...baseWorkspace, context: "Ships on Fridays." }],

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -244,7 +244,16 @@ export type ChatTurnQueries = {
     orgId: string,
     workspaceId: string,
   ): Promise<McpRow | null>;
-  getSubAgentsByIds(ids: string[]): Promise<AgentRow[]>;
+  /**
+   * The sub-Agents among `ids` that are visible in the invoking Workspace, in
+   * the order they were assigned. Ids that do not resolve are simply absent —
+   * the caller reports them as unavailable.
+   */
+  getSubAgentsByIds(
+    ids: string[],
+    orgId: string,
+    workspaceId: string,
+  ): Promise<AgentRow[]>;
   getUserContexts(
     userId: string,
     workspaceId: string,
@@ -426,9 +435,48 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
     return row;
   },
 
-  async getSubAgentsByIds(ids) {
+  async getSubAgentsByIds(ids, orgId, workspaceId) {
     if (ids.length === 0) return [];
-    return db.select().from(agentTable).where(inArray(agentTable.id, ids));
+    // A sub-Agent resolves at the parent's Workspace scope, or at Organization
+    // scope where attached (ADR-0007) — the same rule `getAgent` applies. Looked
+    // up by id alone, an Agent from another Workspace resolved here: its name and
+    // description reached this prompt, and its Provider then failed to resolve.
+    const workspaceAgents = await db
+      .select()
+      .from(agentTable)
+      .where(
+        and(
+          eq(agentTable.workspaceId, workspaceId),
+          inArray(agentTable.id, ids),
+        ),
+      );
+
+    // Org-scoped (Shared) sub-Agents, gated by an Attachment for the invoking
+    // workspace via an inner join.
+    const orgAgents = await db
+      .select()
+      .from(agentTable)
+      .innerJoin(
+        attachmentTable,
+        and(
+          eq(attachmentTable.resourceId, agentTable.id),
+          eq(attachmentTable.resourceType, "agent"),
+          eq(attachmentTable.workspaceId, workspaceId),
+        ),
+      )
+      .where(
+        and(eq(agentTable.organizationId, orgId), inArray(agentTable.id, ids)),
+      );
+
+    // Returned in assignment order so the prompt lists sub-agents the way the
+    // Operator configured them, not in whichever order the two queries ran. A
+    // row is at exactly one scope, so the two sets cannot collide on an id.
+    const byId = new Map<string, AgentRow>();
+    for (const row of workspaceAgents) byId.set(row.id, row);
+    for (const row of orgAgents) byId.set(row.agent.id, row.agent);
+    return ids
+      .map((id) => byId.get(id))
+      .filter((row): row is AgentRow => row !== undefined);
   },
 
   async getUserContexts(userId, workspaceId) {
@@ -1136,6 +1184,14 @@ const loadSkills = async (
   return queries.getSkillsByIds(agent.skillIds, orgId, workspaceId);
 };
 
+/**
+ * Reason reported for an assigned sub-agent id that does not resolve in the
+ * invoking Workspace — deleted, or a Shared Agent detached from (or never
+ * attached to) this Workspace. Deliberately says nothing about the row itself.
+ */
+const UNRESOLVED_SUB_AGENT_REASON =
+  "not available in this workspace — it may have been deleted, or it is a shared agent that is not attached here";
+
 const loadSubAgents = async (
   queries: ChatTurnQueries,
   agent: AgentRow | undefined,
@@ -1158,7 +1214,20 @@ const loadSubAgents = async (
     };
   }
 
-  const subAgentRecords = await queries.getSubAgentsByIds(agent.subAgentIds);
+  const assignedIds = [...new Set(agent.subAgentIds)];
+  const subAgentRecords = await queries.getSubAgentsByIds(
+    assignedIds,
+    orgId,
+    workspaceId,
+  );
+
+  // An assigned id that does not resolve in this Workspace is reported by id
+  // alone: it is either gone, or a Shared Agent that is not attached here, and
+  // reading a name off the row is exactly the boundary crossing being avoided.
+  const resolvedIds = new Set(subAgentRecords.map((sa) => sa.id));
+  const unresolved: SubAgentFailure[] = assignedIds
+    .filter((id) => !resolvedIds.has(id))
+    .map((id) => ({ id, reason: UNRESOLVED_SUB_AGENT_REASON }));
 
   const subAgentMcpClients: MCPClient[] = [];
 
@@ -1220,7 +1289,7 @@ const loadSubAgents = async (
 
   return {
     subAgents,
-    unavailableSubAgents: failures,
+    unavailableSubAgents: [...unresolved, ...failures],
     subAgentTools,
     subAgentMcpClients,
   };

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -3,7 +3,7 @@ import {
   type MCPClient,
 } from "@ai-sdk/mcp";
 import { openProvider, type OpenedProvider } from "./provider.ts";
-import { and, eq, or, inArray } from "drizzle-orm";
+import { and, eq, or, inArray, isNull } from "drizzle-orm";
 import { db } from "../index.ts";
 import {
   agent as agentTable,
@@ -452,7 +452,12 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
       );
 
     // Org-scoped (Shared) sub-Agents, gated by an Attachment for the invoking
-    // workspace via an inner join.
+    // workspace via an inner join. Written out rather than via `listScoped`
+    // because that lists a whole resource type; this filters to the ids assigned.
+    // `isNull(workspaceId)` is what makes "org-scoped" mean it here: the two
+    // scope columns are mutually exclusive by convention, not by a DB
+    // constraint, so a row carrying both must not borrow another Workspace's
+    // Attachment to resolve.
     const orgAgents = await db
       .select()
       .from(agentTable)
@@ -465,12 +470,16 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
         ),
       )
       .where(
-        and(eq(agentTable.organizationId, orgId), inArray(agentTable.id, ids)),
+        and(
+          eq(agentTable.organizationId, orgId),
+          isNull(agentTable.workspaceId),
+          inArray(agentTable.id, ids),
+        ),
       );
 
     // Returned in assignment order so the prompt lists sub-agents the way the
-    // Operator configured them, not in whichever order the two queries ran. A
-    // row is at exactly one scope, so the two sets cannot collide on an id.
+    // Operator configured them, not in whichever order the two queries ran. The
+    // two sets cannot collide on an id: each query pins the other scope's column.
     const byId = new Map<string, AgentRow>();
     for (const row of workspaceAgents) byId.set(row.id, row);
     for (const row of orgAgents) byId.set(row.agent.id, row.agent);

--- a/apps/backend/src/services/sub-agent-validation.test.ts
+++ b/apps/backend/src/services/sub-agent-validation.test.ts
@@ -2,13 +2,35 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { mockDb, resetMockDb } from "../test-utils.ts";
 import { validateSubAgentAssignment } from "./sub-agent-validation.ts";
 
+const ctx = { orgId: "org-1", wsId: "workspace-1" };
+
+/**
+ * Stubs the two queries `listScoped` runs: the Workspace-scoped rows, then the
+ * Organization-scoped rows inner-joined to this Workspace's Attachments (keyed
+ * by table name in a join result).
+ */
+const stubVisibleAgents = (
+  workspaceAgentIds: string[],
+  attachedOrgAgentIds: string[] = [],
+) => {
+  mockDb.where.mockResolvedValueOnce(
+    workspaceAgentIds.map((id) => ({ id, workspaceId: "workspace-1" })),
+  );
+  mockDb.where.mockResolvedValueOnce(
+    attachedOrgAgentIds.map((id) => ({
+      agent: { id, organizationId: "org-1", workspaceId: null },
+      attachment: { id: `att-${id}` },
+    })),
+  );
+};
+
 describe("validateSubAgentAssignment", () => {
   beforeEach(() => {
     resetMockDb();
   });
 
   it("returns invalid when agentId is in subAgentIds (self-assignment)", async () => {
-    const result = await validateSubAgentAssignment("workspace-1", "agent-1", [
+    const result = await validateSubAgentAssignment(ctx, "agent-1", [
       "agent-2",
       "agent-1",
     ]);
@@ -18,54 +40,69 @@ describe("validateSubAgentAssignment", () => {
     });
   });
 
-  it("returns invalid when DB returns fewer agents than requested", async () => {
-    mockDb.where.mockResolvedValueOnce([{ id: "agent-2" }]);
-    const result = await validateSubAgentAssignment("workspace-1", "agent-1", [
+  it("returns invalid when a sub-agent is not visible in the workspace", async () => {
+    stubVisibleAgents(["agent-2"]);
+    const result = await validateSubAgentAssignment(ctx, "agent-1", [
       "agent-2",
       "agent-3",
     ]);
     expect(result).toEqual({
       valid: false,
-      error: "One or more sub-agents not found in workspace",
+      error: "One or more sub-agents are not available in this workspace",
     });
   });
 
-  it("returns invalid when DB returns empty array (all agents missing)", async () => {
-    mockDb.where.mockResolvedValueOnce([]);
-    const result = await validateSubAgentAssignment("workspace-1", "agent-1", [
+  it("returns invalid when no sub-agent is visible in the workspace", async () => {
+    stubVisibleAgents([]);
+    const result = await validateSubAgentAssignment(ctx, "agent-1", [
       "agent-2",
       "agent-3",
     ]);
     expect(result).toEqual({
       valid: false,
-      error: "One or more sub-agents not found in workspace",
+      error: "One or more sub-agents are not available in this workspace",
     });
   });
 
-  it("returns valid when all sub-agents found (happy path)", async () => {
-    mockDb.where.mockResolvedValueOnce([{ id: "agent-2" }, { id: "agent-3" }]);
-    const result = await validateSubAgentAssignment("workspace-1", "agent-1", [
+  it("returns valid when all sub-agents are workspace-scoped here (happy path)", async () => {
+    stubVisibleAgents(["agent-2", "agent-3"]);
+    const result = await validateSubAgentAssignment(ctx, "agent-1", [
       "agent-2",
       "agent-3",
     ]);
     expect(result).toEqual({ valid: true });
   });
 
-  it("returns valid for single sub-agent", async () => {
-    mockDb.where.mockResolvedValueOnce([{ id: "agent-2" }]);
-    const result = await validateSubAgentAssignment("workspace-1", "agent-1", [
+  it("returns valid for a single sub-agent", async () => {
+    stubVisibleAgents(["agent-2"]);
+    const result = await validateSubAgentAssignment(ctx, "agent-1", [
       "agent-2",
     ]);
     expect(result).toEqual({ valid: true });
   });
 
-  it("returns valid for empty subAgentIds array", async () => {
-    mockDb.where.mockResolvedValueOnce([]);
-    const result = await validateSubAgentAssignment(
-      "workspace-1",
-      "agent-1",
-      [],
-    );
+  it("accepts an org-scoped (Shared) sub-agent attached to this workspace", async () => {
+    stubVisibleAgents([], ["shared-agent"]);
+    const result = await validateSubAgentAssignment(ctx, "agent-1", [
+      "shared-agent",
+    ]);
     expect(result).toEqual({ valid: true });
+  });
+
+  it("rejects an org-scoped sub-agent that is not attached to this workspace", async () => {
+    stubVisibleAgents([], []);
+    const result = await validateSubAgentAssignment(ctx, "agent-1", [
+      "shared-agent",
+    ]);
+    expect(result).toEqual({
+      valid: false,
+      error: "One or more sub-agents are not available in this workspace",
+    });
+  });
+
+  it("returns valid for empty subAgentIds array without querying", async () => {
+    const result = await validateSubAgentAssignment(ctx, "agent-1", []);
+    expect(result).toEqual({ valid: true });
+    expect(mockDb.select).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/services/sub-agent-validation.ts
+++ b/apps/backend/src/services/sub-agent-validation.ts
@@ -1,9 +1,21 @@
 import { db } from "../index.ts";
-import { agent as agentTable } from "../db/schema.ts";
-import { and, eq, inArray } from "drizzle-orm";
+import { listScoped, type ScopeContext } from "./scoped-resource.ts";
 
+/**
+ * Save-time guard on an Agent's `subAgentIds`, applied wherever a Workspace
+ * surface writes them (the Agent routes and the agent-management tools).
+ *
+ * A sub-Agent must be **visible in this Workspace** — Workspace-scoped here, or
+ * an Organization-scoped (Shared) Agent attached here (ADR-0007) — which is the
+ * same rule the Chat turn applies when it loads them. Validating at Workspace
+ * scope alone rejected an attached Shared Agent, so promoting a sub-Agent left
+ * its parent unsavable from the Workspace surface.
+ *
+ * Promotion is a separate, stricter rule: a Shared Agent may reference only
+ * other Shared resources (`findNonSharedReferences`).
+ */
 export const validateSubAgentAssignment = async (
-  workspaceId: string,
+  ctx: ScopeContext,
   agentId: string,
   subAgentIds: string[],
 ): Promise<{ valid: boolean; error?: string }> => {
@@ -15,22 +27,16 @@ export const validateSubAgentAssignment = async (
     };
   }
 
-  // 2. Fetch all proposed sub-agents
-  const subAgents = await db
-    .select()
-    .from(agentTable)
-    .where(
-      and(
-        eq(agentTable.workspaceId, workspaceId),
-        inArray(agentTable.id, subAgentIds),
-      ),
-    );
+  if (subAgentIds.length === 0) return { valid: true };
 
-  // 3. Verify all sub-agents exist in workspace
-  if (subAgents.length !== subAgentIds.length) {
+  // 2. Every proposed sub-agent must be visible in this workspace at either scope
+  const visible = await listScoped(db, "agent", ctx);
+  const visibleIds = new Set(visible.map(({ row }) => row.id));
+
+  if (subAgentIds.some((id) => !visibleIds.has(id))) {
     return {
       valid: false,
-      error: "One or more sub-agents not found in workspace",
+      error: "One or more sub-agents are not available in this workspace",
     };
   }
 

--- a/apps/backend/src/system-prompt.test.ts
+++ b/apps/backend/src/system-prompt.test.ts
@@ -324,6 +324,7 @@ describe("renderSystemPrompt — sub-agents", () => {
     ctx.subAgents = [{ name: "Obsidian Agent", description: "Notes." }];
     ctx.unavailableSubAgents = [
       {
+        id: "sub-1",
         name: "Dashboard Agent",
         reason: "Provider 'p1' not found for sub-agent",
       },
@@ -343,12 +344,28 @@ describe("renderSystemPrompt — sub-agents", () => {
   it("emits the unavailable block even when no sub-agent loaded at all", () => {
     const ctx = baseCtx();
     ctx.subAgents = [];
-    ctx.unavailableSubAgents = [{ name: "Kanban Agent" }];
+    ctx.unavailableSubAgents = [{ id: "sub-1", name: "Kanban Agent" }];
     const out = renderSystemPrompt(ctx);
 
     expect(out).not.toContain("## Available Sub-Agents");
     expect(out).toContain("## Unavailable Sub-Agents");
     expect(out).toContain("- **Kanban Agent**: failed to load");
+  });
+
+  it("names an unavailable sub-agent by id when it has no name to report", () => {
+    const ctx = baseCtx();
+    ctx.subAgents = [];
+    ctx.unavailableSubAgents = [
+      { id: "sub-1", reason: "not available in this workspace" },
+    ];
+    const out = renderSystemPrompt(ctx);
+
+    expect(out).toContain("## Unavailable Sub-Agents");
+    expect(out).toContain(
+      "- Sub-agent `sub-1`: not available in this workspace — no delegation tool exists this turn.",
+    );
+    // No name means no tool slug to name; `delegateToUndefined` must never appear.
+    expect(out).not.toContain("delegateTo");
   });
 });
 

--- a/apps/backend/src/system-prompt.ts
+++ b/apps/backend/src/system-prompt.ts
@@ -26,12 +26,18 @@ export type SystemPromptContext = {
   skills: Array<Pick<Skill, "name" | "description">>;
   subAgents: Array<{ name: string; description?: string | null }>;
   /**
-   * Sub-agents assigned to this Agent that failed to initialize for this turn
-   * and therefore have no delegation tool. Named in the prompt as explicitly
-   * unavailable: staying silent leaves the model to discover the gap by taking
-   * an AI_NoSuchToolError, and leaves the user with no idea why.
+   * Sub-agents assigned to this Agent that have no delegation tool this turn.
+   * Named in the prompt as explicitly unavailable: staying silent leaves the
+   * model to discover the gap by taking an AI_NoSuchToolError, and leaves the
+   * user with no idea why.
+   *
+   * `name` is present only where the sub-agent's row resolved and the failure
+   * came after (its Provider, its model). An assignment that did not resolve in
+   * this Workspace has no name to report — deliberately: reading one off the row
+   * is the Workspace boundary crossing being closed — so it is identified by the
+   * `id` the Agent's own configuration holds.
    */
-  unavailableSubAgents?: Array<{ name: string; reason?: string }>;
+  unavailableSubAgents?: Array<{ id: string; name?: string; reason?: string }>;
   /**
    * Names of workspace-default env vars that will be merged into every
    * sandbox shell.exec call. Keys only — values never enter the system prompt
@@ -157,9 +163,12 @@ Each task description MUST be entirely self-contained — sub-agents cannot see 
   }
 
   if (unavailable.length) {
-    const lines = unavailable.map(
-      (sa) =>
-        `- **${sa.name}**: ${sa.reason || "failed to load"} — no \`${subAgentToolName(sa)}\` tool exists this turn.`,
+    const lines = unavailable.map((sa) =>
+      // A nameless entry never resolved, so there is no tool slug to quote —
+      // deriving one from `undefined` would invent `delegateToUndefined`.
+      sa.name
+        ? `- **${sa.name}**: ${sa.reason || "failed to load"} — no \`${subAgentToolName({ name: sa.name })}\` tool exists this turn.`
+        : `- Sub-agent \`${sa.id}\`: ${sa.reason || "failed to load"} — no delegation tool exists this turn.`,
     );
     sections.push(`## Unavailable Sub-Agents
 

--- a/apps/backend/src/tools/agent-management.ts
+++ b/apps/backend/src/tools/agent-management.ts
@@ -72,7 +72,7 @@ export function createAgentManagementTools(
       if (data.subAgentIds && data.subAgentIds.length > 0) {
         const newId = nanoid();
         const validation = await validateSubAgentAssignment(
-          workspaceId,
+          { orgId, wsId: workspaceId },
           newId,
           data.subAgentIds,
         );
@@ -170,7 +170,7 @@ export function createAgentManagementTools(
 
       if (data.subAgentIds) {
         const validation = await validateSubAgentAssignment(
-          workspaceId,
+          { orgId, wsId: workspaceId },
           agentId,
           data.subAgentIds,
         );

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -312,8 +312,12 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
  * Returned — not just logged — because the caller has to keep the system
  * prompt in step with the toolset: describing a delegation tool that was never
  * registered makes the model call it and take an `AI_NoSuchToolError`.
+ *
+ * `name` is optional because the caller also reports assignments whose row never
+ * resolved in the invoking Workspace; those have only the assigned `id`, which is
+ * the one identifier available without crossing the boundary that dropped them.
  */
-export type SubAgentFailure = { id: string; name: string; reason: string };
+export type SubAgentFailure = { id: string; name?: string; reason: string };
 
 /**
  * Creates sub-agent tools for all sub-agents assigned to a parent agent.

--- a/apps/docs/content/building-with-platypus/agents.mdx
+++ b/apps/docs/content/building-with-platypus/agents.mdx
@@ -174,7 +174,7 @@ it:
 - The sub-agent is **not available in this Workspace** — it was deleted, or it
   is a Shared Agent that was detached from this Workspace or never attached to
   it. A Shared Agent is only ever visible where it is attached, so a parent
-  attached to a second Workspace loses a sub-agent that lives only in the first.
+  attached to a second Workspace loses a sub-agent attached only to the first.
 - Its **Provider** no longer resolves in this Workspace — a Shared Provider that
   was detached, say.
 - Its pinned **model** is gone from the Provider's model list.

--- a/apps/docs/content/building-with-platypus/agents.mdx
+++ b/apps/docs/content/building-with-platypus/agents.mdx
@@ -168,20 +168,28 @@ Everything else is absent:
 ### When a sub-agent can't run
 
 Selecting a sub-agent in the form is not a guarantee it will be there at run
-time. Each one is built fresh on every turn, and that build fails if its
-Provider no longer resolves in this Workspace — a Shared Provider that was
-detached, say — or if its pinned model is gone from the Provider's model list.
+time. Each one is resolved and built fresh on every turn, and three things stop
+it:
 
-A sub-agent that fails to build gets **no delegate tool for that turn**. The
-parent Agent is told which ones are unavailable and why, so ask it and it will
-tell you. The switch stays flipped in the form either way: the assignment is
-still saved, it just can't be honoured right now. Fix the sub-agent's Provider
-or model and the tool comes back on the next turn.
+- The sub-agent is **not available in this Workspace** — it was deleted, or it
+  is a Shared Agent that was detached from this Workspace or never attached to
+  it. A Shared Agent is only ever visible where it is attached, so a parent
+  attached to a second Workspace loses a sub-agent that lives only in the first.
+- Its **Provider** no longer resolves in this Workspace — a Shared Provider that
+  was detached, say.
+- Its pinned **model** is gone from the Provider's model list.
+
+Any of these means **no delegate tool for that turn**. The parent Agent is told
+which ones are unavailable and why, so ask it and it will tell you. The switch
+stays flipped in the form either way: the assignment is still saved, it just
+can't be honoured right now. Re-attach the Agent, or fix its Provider or model,
+and the tool comes back on the next turn.
 
 <Callout type="warning">
   "The Agent says it can't reach its sub-agent, but I can see the switch is on"
   is the trap. The **Sub-Agents** card shows what you assigned, not what loaded.
-  Open the sub-agent itself and check its Provider and model still resolve.
+  Check the sub-agent is still attached to this Workspace, then open it and check
+  its Provider and model still resolve.
 </Callout>
 
 If the sub-agent builds but its run then fails part-way, the delegate tool


### PR DESCRIPTION
Closes #415

`getSubAgentsByIds` looked sub-agents up by id alone — the one resource lookup in the Chat-turn query object taking neither `orgId` nor `workspaceId`. An Agent belonging to another Workspace resolved, its name and description reached the parent's system prompt, and its Provider then failed to resolve against the parent's Workspace, so the delegate tool was never built. Save-time validation had the mirror-image defect: it accepted only Agents whose `workspaceId` matched, so once a sub-Agent was Promoted its parent could no longer be saved from the Workspace surface at all.

## Run time

A sub-agent now resolves the way the single-Agent lookup does: Workspace-scoped in the invoking Workspace, or Organization-scoped where attached (ADR-0007). The org-scoped branch also requires a null `workspaceId` — the two scope columns are mutually exclusive by convention, not by a database constraint, so a row carrying both must not borrow another Workspace's Attachment to resolve. Rows come back in assignment order, so the prompt lists sub-agents the way the Operator configured them.

An assigned id that does not resolve is reported to the parent as unavailable **by id**, alongside the build failures #413 already surfaced. It carries no name, deliberately: reading one off the row is the boundary crossing being closed. `SubAgentFailure.name` is therefore optional, and a nameless entry renders as `- Sub-agent \`<id>\`: … — no delegation tool exists this turn.` rather than deriving a `delegateToUndefined` slug.

## Save time

`validateSubAgentAssignment` takes the Workspace's scope context and accepts any Agent visible there at either scope, so a reference to an attached Shared Agent succeeds and anything invisible is still rejected. Promotion is untouched — a Shared Agent may still reference only Organization-scoped sub-Agents.

## Tests

The in-memory `ChatTurnQueries` double enforces the same visibility rule, so the new tests exercise the boundary rather than a hole in it. Covered: a workspace-scoped sub-agent stays callable; an attached org-scoped one becomes callable; an unattached Shared one and a foreign-Workspace one resolve to nothing, with neither name nor description reaching the prompt; each unresolved id is named in the unavailable block; and both Agent routes accept an attached Shared sub-agent while still rejecting one that is not visible.

## Docs

The Agents page's "When a sub-agent can't run" section now lists three reasons, leading with a detached or never-attached Shared sub-Agent, and notes that a parent attached to a second Workspace loses a sub-agent attached only to the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)