### PR TITLE
fix(backend): resolve every scoped resource through one visibility authority

### DIFF
--- a/apps/backend/src/routes/agent.test.ts
+++ b/apps/backend/src/routes/agent.test.ts
@@ -493,7 +493,7 @@ describe("Agent Routes", () => {
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
       // Avatar lookup (agent has no avatar) — also confirms workspace row exists
-      mockDb.limit.mockResolvedValueOnce([{ avatarKey: null }]);
+      mockDb.limit.mockResolvedValueOnce([{ avatarKey: null, workspaceId }]);
 
       const res = await app.request(`${baseUrl}/agent-1`, {
         method: "DELETE",

--- a/apps/backend/src/routes/kanban.test.ts
+++ b/apps/backend/src/routes/kanban.test.ts
@@ -660,6 +660,77 @@ describe("Kanban Routes", () => {
         expect(body.assignees).toEqual([{ type: "user", id: "admin-user" }]);
       });
 
+      it("should allow a shared agent attached to this workspace to be assigned", async () => {
+        // The assignee picker offers every Agent visible in the Workspace, which
+        // includes attached Shared Agents — and one can run here, so it can own
+        // a card (ADR-0007).
+        mockSession();
+        mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { ownerId: "user-1", organizationId: "org-1" },
+        ]); // requireWorkspaceAccess
+        mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
+        mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
+        // No user assignees, so the visibility lookup's two queries come first:
+        // workspace-scoped agents, then org-scoped ones joined to an attachment.
+        mockDb.where.mockResolvedValueOnce([]);
+        mockDb.where.mockResolvedValueOnce([
+          {
+            agent: {
+              id: "shared-agent",
+              organizationId: "org-1",
+              workspaceId: null,
+            },
+            attachment: { id: "att-1" },
+          },
+        ]);
+        mockDb.where.mockReturnValueOnce(mockDb); // update subquery chain
+        mockDb.where.mockReturnValueOnce(mockDb); // update main where chain
+
+        const mockCard = {
+          id: "card-1",
+          title: "Test",
+          assignees: [{ type: "agent", id: "shared-agent" }],
+        };
+        mockDb.returning.mockResolvedValueOnce([mockCard]);
+
+        const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
+          method: "PUT",
+          body: JSON.stringify({
+            assignees: [{ type: "agent", id: "shared-agent" }],
+          }),
+          headers: { "Content-Type": "application/json" },
+        });
+
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body.assignees).toEqual([{ type: "agent", id: "shared-agent" }]);
+      });
+
+      it("should return 400 for an agent that is not visible in this workspace", async () => {
+        mockSession();
+        mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { ownerId: "user-1", organizationId: "org-1" },
+        ]); // requireWorkspaceAccess
+        mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
+        mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
+        mockDb.where.mockResolvedValueOnce([]); // no workspace-scoped match
+        mockDb.where.mockResolvedValueOnce([]); // no attached org-scoped match
+
+        const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
+          method: "PUT",
+          body: JSON.stringify({
+            assignees: [{ type: "agent", id: "someone-elses-agent" }],
+          }),
+          headers: { "Content-Type": "application/json" },
+        });
+
+        expect(res.status).toBe(400);
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body.error).toBe("Invalid agent assignee");
+      });
+
       it("should allow org member to be assigned", async () => {
         mockSession();
         mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess

--- a/apps/backend/src/routes/kanban.test.ts
+++ b/apps/backend/src/routes/kanban.test.ts
@@ -729,6 +729,9 @@ describe("Kanban Routes", () => {
         expect(res.status).toBe(400);
         const body = (await res.json()) as Record<string, unknown>;
         expect(body.error).toBe("Invalid agent assignee");
+        // Both scopes were consulted: the second query is the Attachment join
+        // that a workspace-only lookup never makes.
+        expect(mockDb.innerJoin).toHaveBeenCalledTimes(1);
       });
 
       it("should allow org member to be assigned", async () => {

--- a/apps/backend/src/routes/kanban.ts
+++ b/apps/backend/src/routes/kanban.ts
@@ -36,10 +36,13 @@ import {
 } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { calculateCardPosition } from "../utils/kanban-positioning.ts";
+import { listScopedByIds } from "../services/scoped-resource.ts";
 
 /**
- * Validates that all assignees reference valid org members (users) or
- * workspace agents. Returns an error message string if invalid, or null if OK.
+ * Validates that all assignees reference valid org members (users) or Agents
+ * visible in this Workspace — its own, plus the Shared Agents attached to it
+ * (ADR-0007), which is the set the assignee picker offers and the set that can
+ * actually run here. Returns an error message string if invalid, or null if OK.
  */
 async function validateAssignees(
   assignees: { type: string; id: string }[],
@@ -67,17 +70,10 @@ async function validateAssignees(
           .from(user)
           .where(and(eq(user.role, "admin"), inArray(user.id, userIds)))
       : Promise.resolve([]),
-    agentIds.length > 0
-      ? db
-          .select({ id: agentTable.id })
-          .from(agentTable)
-          .where(
-            and(
-              eq(agentTable.workspaceId, workspaceId),
-              inArray(agentTable.id, agentIds),
-            ),
-          )
-      : Promise.resolve([]),
+    listScopedByIds(db, "agent", agentIds, {
+      orgId,
+      wsId: workspaceId,
+    }),
   ]);
 
   // Combine org members and super admins (who may not have an org membership record)

--- a/apps/backend/src/routes/mcp.test.ts
+++ b/apps/backend/src/routes/mcp.test.ts
@@ -48,6 +48,38 @@ describe("MCP Routes", () => {
       expect(await res.json()).toEqual(mockMcp);
     });
 
+    it("takes the scope from the route, ignoring any scope in the body", async () => {
+      // A workspace-surface create is always Workspace-scoped. Spreading the body
+      // let a caller name another Workspace, or set organizationId and mint a
+      // Shared MCP here — which only an Org Admin may do (ADR-0006/0007).
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "mcp-1", name: "New MCP" },
+      ]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          name: "New MCP",
+          url: "http://mcp.com",
+          authType: "None",
+          workspaceId: "ws-somewhere-else",
+          organizationId: orgId,
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockDb.values).toHaveBeenCalledWith(
+        expect.objectContaining({ workspaceId, organizationId: null }),
+      );
+    });
+
     // ADR-0006: MCP config is admin-only unless the workspace's
     // mcpSelfManagement flag delegates it to the owner.
     const createBody = {

--- a/apps/backend/src/routes/mcp.ts
+++ b/apps/backend/src/routes/mcp.ts
@@ -82,6 +82,12 @@ mcp.post(
       .values({
         id: nanoid(),
         ...data,
+        // The scope comes from the route, never the body — as it does for Agents
+        // and Skills. Spreading the body let a caller name another Workspace, or
+        // set `organizationId` and mint a Shared MCP from the Workspace surface,
+        // which only an Org Admin may do (ADR-0006, ADR-0007).
+        workspaceId: c.req.param("workspaceId")!,
+        organizationId: null,
       })
       .returning();
     return c.json(sanitizeMcpResponse(record[0]), 201);

--- a/apps/backend/src/routes/org-agent.ts
+++ b/apps/backend/src/routes/org-agent.ts
@@ -8,6 +8,7 @@ import { dedupeArray } from "../utils.ts";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { findNonSharedReferences } from "../services/agent-scope-validation.ts";
+import { SUB_AGENT_SELF_ASSIGNMENT_ERROR } from "../services/sub-agent-validation.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
 import { requireSharedDeletable } from "../services/scoped-resource.ts";
 import { storeAvatar, deleteAvatar } from "../services/avatar.ts";
@@ -79,10 +80,7 @@ orgAgent.put(
     if (data.subAgentIds) data.subAgentIds = dedupeArray(data.subAgentIds);
 
     if (data.subAgentIds?.includes(agentId)) {
-      return c.json(
-        { error: "An agent cannot assign itself as a sub-agent" },
-        400,
-      );
+      return c.json({ error: SUB_AGENT_SELF_ASSIGNMENT_ERROR }, 400);
     }
 
     // A Shared Agent may reference only other Shared resources (ADR-0007).

--- a/apps/backend/src/routes/provider.test.ts
+++ b/apps/backend/src/routes/provider.test.ts
@@ -42,6 +42,39 @@ describe("Provider Routes", () => {
       expect(await res.json()).toEqual(mockProvider);
     });
 
+    it("takes the scope from the route, ignoring any scope in the body", async () => {
+      // A workspace-surface create is always Workspace-scoped. Spreading the body
+      // let a caller name another Workspace, or set organizationId and mint a
+      // Shared Provider here — which only an Org Admin may do (ADR-0006/0007).
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+
+      mockDb.returning.mockResolvedValueOnce([{ id: "p1", name: "OpenAI" }]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          name: "OpenAI",
+          providerType: "OpenAI",
+          apiKey: "sk-123",
+          modelIds: ["gpt-4"],
+          taskModelId: "gpt-4",
+          memoryExtractionModelId: "gpt-4",
+          workspaceId: "ws-somewhere-else",
+          organizationId: orgId,
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockDb.values).toHaveBeenCalledWith(
+        expect.objectContaining({ workspaceId, organizationId: null }),
+      );
+    });
+
     it("should return 409 if provider name already exists in workspace", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess

--- a/apps/backend/src/routes/provider.ts
+++ b/apps/backend/src/routes/provider.ts
@@ -50,6 +50,12 @@ provider.post(
       .values({
         id: nanoid(),
         ...data,
+        // The scope comes from the route, never the body — as it does for Agents
+        // and Skills. Spreading the body let a caller name another Workspace, or
+        // set `organizationId` and mint a Shared Provider from the Workspace
+        // surface, which only an Org Admin may do (ADR-0006, ADR-0007).
+        workspaceId: c.req.param("workspaceId")!,
+        organizationId: null,
       })
       .returning();
     return c.json(record[0], 201);

--- a/apps/backend/src/services/agent-scope-validation.test.ts
+++ b/apps/backend/src/services/agent-scope-validation.test.ts
@@ -77,6 +77,33 @@ describe("findNonSharedReferences (no-cascade rule)", () => {
     expect(blockers).toEqual([]);
   });
 
+  it("flags a reference that carries a workspace as well as the org", async () => {
+    // The scope columns are mutually exclusive on write, not by a database
+    // constraint. A row holding both is workspace-private in every other query,
+    // so counting it as Shared here would promote an Agent that borrows it.
+    mockDb.where
+      .mockResolvedValueOnce([
+        { id: "p1", name: "P", organizationId: orgId, workspaceId: null },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "a1",
+          name: "Dual-scope Agent",
+          organizationId: orgId,
+          workspaceId: "ws-1",
+        },
+      ]);
+
+    const blockers = await findNonSharedReferences(orgId, {
+      providerId: "p1",
+      subAgentIds: ["a1"],
+    });
+
+    expect(blockers).toEqual([
+      { type: "subAgent", id: "a1", name: "Dual-scope Agent" },
+    ]);
+  });
+
   it("flags a missing reference using its id as the name fallback", async () => {
     mockDb.where
       .mockResolvedValueOnce([{ id: "p1", name: "P", organizationId: orgId }])

--- a/apps/backend/src/services/agent-scope-validation.ts
+++ b/apps/backend/src/services/agent-scope-validation.ts
@@ -27,6 +27,20 @@ type AgentReferences = {
 };
 
 /**
+ * Whether a referenced row is genuinely a Shared resource of this Organization:
+ * org-scoped **and** at no Workspace. The two scope columns are mutually
+ * exclusive by a Zod refinement on write, not by a database constraint, so a row
+ * carrying both must not count as Shared — that would let a Shared Agent
+ * reference a Workspace-private row, which is the one thing this rule forbids.
+ * A missing row is not Shared either, so a dangling id is always a blocker.
+ */
+const isShared = (
+  row:
+    { organizationId: string | null; workspaceId: string | null } | undefined,
+  orgId: string,
+): boolean => !!row && row.organizationId === orgId && !row.workspaceId;
+
+/**
  * The defining rule of a Shared resource: it may reference only other Shared
  * (Organization-scoped) resources (ADR-0007). Returns every reference of the
  * given Agent that is NOT org-scoped and therefore blocks Promotion — an empty
@@ -55,11 +69,12 @@ export const findNonSharedReferences = async (
       id: providerTable.id,
       name: providerTable.name,
       organizationId: providerTable.organizationId,
+      workspaceId: providerTable.workspaceId,
     })
     .from(providerTable)
     .where(eq(providerTable.id, refs.providerId));
   const prov = providerRows[0];
-  if (!prov || prov.organizationId !== orgId) {
+  if (!isShared(prov, orgId)) {
     blockers.push({
       type: "provider",
       id: refs.providerId,
@@ -75,13 +90,14 @@ export const findNonSharedReferences = async (
         id: skillTable.id,
         name: skillTable.name,
         organizationId: skillTable.organizationId,
+        workspaceId: skillTable.workspaceId,
       })
       .from(skillTable)
       .where(inArray(skillTable.id, skillIds));
     const byId = new Map(rows.map((r) => [r.id, r]));
     for (const id of skillIds) {
       const row = byId.get(id);
-      if (!row || row.organizationId !== orgId) {
+      if (!isShared(row, orgId)) {
         blockers.push({ type: "skill", id, name: row?.name ?? id });
       }
     }
@@ -95,13 +111,14 @@ export const findNonSharedReferences = async (
         id: agentTable.id,
         name: agentTable.name,
         organizationId: agentTable.organizationId,
+        workspaceId: agentTable.workspaceId,
       })
       .from(agentTable)
       .where(inArray(agentTable.id, subAgentIds));
     const byId = new Map(rows.map((r) => [r.id, r]));
     for (const id of subAgentIds) {
       const row = byId.get(id);
-      if (!row || row.organizationId !== orgId) {
+      if (!isShared(row, orgId)) {
         blockers.push({ type: "subAgent", id, name: row?.name ?? id });
       }
     }
@@ -119,13 +136,14 @@ export const findNonSharedReferences = async (
         id: mcpTable.id,
         name: mcpTable.name,
         organizationId: mcpTable.organizationId,
+        workspaceId: mcpTable.workspaceId,
       })
       .from(mcpTable)
       .where(inArray(mcpTable.id, mcpIds));
     const byId = new Map(rows.map((r) => [r.id, r]));
     for (const id of mcpIds) {
       const row = byId.get(id);
-      if (!row || row.organizationId !== orgId) {
+      if (!isShared(row, orgId)) {
         blockers.push({ type: "mcp", id, name: row?.name ?? id });
       }
     }

--- a/apps/backend/src/services/agent-scope-validation.ts
+++ b/apps/backend/src/services/agent-scope-validation.ts
@@ -7,6 +7,7 @@ import {
 } from "../db/schema.ts";
 import { eq, inArray } from "drizzle-orm";
 import { getToolSets } from "../tools/index.ts";
+import { isSharedRow } from "./scoped-resource.ts";
 
 /**
  * A reference that blocks Promotion because it is not itself Organization-scoped
@@ -25,20 +26,6 @@ type AgentReferences = {
   subAgentIds?: string[] | null;
   toolSetIds?: string[] | null;
 };
-
-/**
- * Whether a referenced row is genuinely a Shared resource of this Organization:
- * org-scoped **and** at no Workspace. The two scope columns are mutually
- * exclusive by a Zod refinement on write, not by a database constraint, so a row
- * carrying both must not count as Shared — that would let a Shared Agent
- * reference a Workspace-private row, which is the one thing this rule forbids.
- * A missing row is not Shared either, so a dangling id is always a blocker.
- */
-const isShared = (
-  row:
-    { organizationId: string | null; workspaceId: string | null } | undefined,
-  orgId: string,
-): boolean => !!row && row.organizationId === orgId && !row.workspaceId;
 
 /**
  * The defining rule of a Shared resource: it may reference only other Shared
@@ -74,7 +61,7 @@ export const findNonSharedReferences = async (
     .from(providerTable)
     .where(eq(providerTable.id, refs.providerId));
   const prov = providerRows[0];
-  if (!isShared(prov, orgId)) {
+  if (!isSharedRow(prov, orgId)) {
     blockers.push({
       type: "provider",
       id: refs.providerId,
@@ -97,7 +84,7 @@ export const findNonSharedReferences = async (
     const byId = new Map(rows.map((r) => [r.id, r]));
     for (const id of skillIds) {
       const row = byId.get(id);
-      if (!isShared(row, orgId)) {
+      if (!isSharedRow(row, orgId)) {
         blockers.push({ type: "skill", id, name: row?.name ?? id });
       }
     }
@@ -118,7 +105,7 @@ export const findNonSharedReferences = async (
     const byId = new Map(rows.map((r) => [r.id, r]));
     for (const id of subAgentIds) {
       const row = byId.get(id);
-      if (!isShared(row, orgId)) {
+      if (!isSharedRow(row, orgId)) {
         blockers.push({ type: "subAgent", id, name: row?.name ?? id });
       }
     }
@@ -143,7 +130,7 @@ export const findNonSharedReferences = async (
     const byId = new Map(rows.map((r) => [r.id, r]));
     for (const id of mcpIds) {
       const row = byId.get(id);
-      if (!isShared(row, orgId)) {
+      if (!isSharedRow(row, orgId)) {
         blockers.push({ type: "mcp", id, name: row?.name ?? id });
       }
     }

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -3,18 +3,15 @@ import {
   type MCPClient,
 } from "@ai-sdk/mcp";
 import { openProvider, type OpenedProvider } from "./provider.ts";
-import { and, eq, or, inArray } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "../index.ts";
 import {
   agent as agentTable,
   context as contextTable,
   mcp as mcpTable,
   organization as organizationTable,
-  provider as providerTable,
   sandbox as sandboxTable,
-  skill as skillTable,
   workspace as workspaceTable,
-  attachment as attachmentTable,
 } from "../db/schema.ts";
 import { getToolSet } from "../tools/index.ts";
 import { createLoadSkillTool } from "../tools/skill.ts";
@@ -56,7 +53,7 @@ import {
   normalizeFileParts,
 } from "./file-gate.ts";
 import type { PlatypusUIMessage } from "../types.ts";
-import { listScopedByIds } from "./scoped-resource.ts";
+import { listScopedByIds, resolveScoped } from "./scoped-resource.ts";
 
 /**
  * Default agentic step ceiling for an agent that has no explicit `maxSteps`.
@@ -271,28 +268,14 @@ export type ChatTurnQueries = {
 };
 
 /**
- * Whether an org-scoped Shared resource is attached to the given workspace
- * (ADR-0007). Org-scoped resources resolve at Chat-turn time only where attached.
+ * Every resource a Chat turn resolves goes through the Scoped-resource read
+ * module: Workspace-scoped rows, plus the Organization-scoped (Shared) rows
+ * attached to the invoking Workspace (ADR-0007). Each lookup below used to carry
+ * its own copy of that rule, and the copies drifted — the sub-Agent one had no
+ * scope filter at all, and each treated "has an organizationId, has no
+ * workspaceId" as the definition of Shared, which lets a row carrying both
+ * columns resolve in a Workspace that neither owns nor attached it.
  */
-const isAttached = async (
-  resourceType: "mcp" | "provider" | "skill" | "agent",
-  resourceId: string,
-  workspaceId: string,
-): Promise<boolean> => {
-  const rows = await db
-    .select()
-    .from(attachmentTable)
-    .where(
-      and(
-        eq(attachmentTable.workspaceId, workspaceId),
-        eq(attachmentTable.resourceType, resourceType),
-        eq(attachmentTable.resourceId, resourceId),
-      ),
-    )
-    .limit(1);
-  return rows.length > 0;
-};
-
 export const drizzleChatTurnQueries: ChatTurnQueries = {
   async getWorkspace(id) {
     const rows = await db
@@ -313,127 +296,49 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
   },
 
   async getAgent(id, orgId, workspaceId) {
-    // Resolve an Agent at either scope: the invoking workspace, or the
-    // organization (a Shared Agent — ADR-0007).
-    const rows = await db
-      .select()
-      .from(agentTable)
-      .where(
-        and(
-          eq(agentTable.id, id),
-          or(
-            eq(agentTable.workspaceId, workspaceId),
-            eq(agentTable.organizationId, orgId),
-          ),
-        ),
-      )
-      .limit(1);
-    const row = rows[0];
-    if (!row) return null;
     // A Shared Agent runs only in a Workspace it is attached to (ADR-0007); its
     // Sandbox/MCP tools still rebind to that invoking Workspace via loadTools.
-    if (
-      row.organizationId &&
-      !row.workspaceId &&
-      !(await isAttached("agent", id, workspaceId))
-    ) {
-      return null;
-    }
-    return row;
+    const found = await resolveScoped(db, "agent", id, {
+      orgId,
+      wsId: workspaceId,
+    });
+    return found?.row ?? null;
   },
 
   async getProvider(id, orgId, workspaceId) {
-    const rows = await db
-      .select()
-      .from(providerTable)
-      .where(
-        and(
-          eq(providerTable.id, id),
-          or(
-            eq(providerTable.workspaceId, workspaceId),
-            eq(providerTable.organizationId, orgId),
-          ),
-        ),
-      )
-      .limit(1);
-    const row = rows[0];
-    if (!row) return null;
-    // An org-scoped (Shared) Provider resolves only where attached (ADR-0007).
-    if (
-      row.organizationId &&
-      !row.workspaceId &&
-      !(await isAttached("provider", id, workspaceId))
-    ) {
-      return null;
-    }
-    return row as Provider;
+    const found = await resolveScoped(db, "provider", id, {
+      orgId,
+      wsId: workspaceId,
+    });
+    return (found?.row as Provider | undefined) ?? null;
   },
 
   async getSkillsByIds(ids, orgId, workspaceId) {
-    if (ids.length === 0) return [];
-    // Workspace-scoped Skills referenced by the Agent.
-    const workspaceSkills = await db
-      .select({ name: skillTable.name, description: skillTable.description })
-      .from(skillTable)
-      .where(
-        and(
-          eq(skillTable.workspaceId, workspaceId),
-          inArray(skillTable.id, ids),
-        ),
-      );
-
-    // Org-scoped (Shared) Skills resolve only where attached (ADR-0007) — gate
-    // by an inner join on the Attachment table for the invoking workspace.
-    const orgSkills = await db
-      .select({ name: skillTable.name, description: skillTable.description })
-      .from(skillTable)
-      .innerJoin(
-        attachmentTable,
-        and(
-          eq(attachmentTable.resourceId, skillTable.id),
-          eq(attachmentTable.resourceType, "skill"),
-          eq(attachmentTable.workspaceId, workspaceId),
-        ),
-      )
-      .where(
-        and(eq(skillTable.organizationId, orgId), inArray(skillTable.id, ids)),
-      );
+    const visible = await listScopedByIds(db, "skill", ids, {
+      orgId,
+      wsId: workspaceId,
+    });
 
     // A workspace-scoped Skill wins a name collision with an attached org-scoped
     // one, matching loadSkill's workspace-first resolution — so the advertised
     // list and the tool agree on which body the model loads, with no duplicate
     // entry in the system prompt.
-    const seen = new Set(workspaceSkills.map((s) => s.name));
-    return [...workspaceSkills, ...orgSkills.filter((s) => !seen.has(s.name))];
+    const workspaceSkills = visible.filter((s) => s.scope === "workspace");
+    const seen = new Set(workspaceSkills.map(({ row }) => row.name));
+    return [
+      ...workspaceSkills,
+      ...visible.filter(
+        (s) => s.scope === "organization" && !seen.has(s.row.name),
+      ),
+    ].map(({ row }) => ({ name: row.name, description: row.description }));
   },
 
   async getMcp(id, orgId, workspaceId) {
-    // Resolve an MCP referenced by an Agent's tool sets at either scope: the
-    // invoking workspace, or the organization (a Shared MCP — ADR-0007).
-    const rows = await db
-      .select()
-      .from(mcpTable)
-      .where(
-        and(
-          eq(mcpTable.id, id),
-          or(
-            eq(mcpTable.workspaceId, workspaceId),
-            eq(mcpTable.organizationId, orgId),
-          ),
-        ),
-      )
-      .limit(1);
-    const row = rows[0];
-    if (!row) return null;
-    // An org-scoped (Shared) MCP resolves only where attached (ADR-0007).
-    if (
-      row.organizationId &&
-      !row.workspaceId &&
-      !(await isAttached("mcp", id, workspaceId))
-    ) {
-      return null;
-    }
-    return row;
+    const found = await resolveScoped(db, "mcp", id, {
+      orgId,
+      wsId: workspaceId,
+    });
+    return found?.row ?? null;
   },
 
   async getSubAgentsByIds(ids, orgId, workspaceId) {

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -3,7 +3,7 @@ import {
   type MCPClient,
 } from "@ai-sdk/mcp";
 import { openProvider, type OpenedProvider } from "./provider.ts";
-import { and, eq, or, inArray, isNull } from "drizzle-orm";
+import { and, eq, or, inArray } from "drizzle-orm";
 import { db } from "../index.ts";
 import {
   agent as agentTable,
@@ -56,6 +56,7 @@ import {
   normalizeFileParts,
 } from "./file-gate.ts";
 import type { PlatypusUIMessage } from "../types.ts";
+import { listScopedByIds } from "./scoped-resource.ts";
 
 /**
  * Default agentic step ceiling for an agent that has no explicit `maxSteps`.
@@ -436,53 +437,19 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
   },
 
   async getSubAgentsByIds(ids, orgId, workspaceId) {
-    if (ids.length === 0) return [];
     // A sub-Agent resolves at the parent's Workspace scope, or at Organization
-    // scope where attached (ADR-0007) — the same rule `getAgent` applies. Looked
-    // up by id alone, an Agent from another Workspace resolved here: its name and
-    // description reached this prompt, and its Provider then failed to resolve.
-    const workspaceAgents = await db
-      .select()
-      .from(agentTable)
-      .where(
-        and(
-          eq(agentTable.workspaceId, workspaceId),
-          inArray(agentTable.id, ids),
-        ),
-      );
-
-    // Org-scoped (Shared) sub-Agents, gated by an Attachment for the invoking
-    // workspace via an inner join. Written out rather than via `listScoped`
-    // because that lists a whole resource type; this filters to the ids assigned.
-    // `isNull(workspaceId)` is what makes "org-scoped" mean it here: the two
-    // scope columns are mutually exclusive by convention, not by a DB
-    // constraint, so a row carrying both must not borrow another Workspace's
-    // Attachment to resolve.
-    const orgAgents = await db
-      .select()
-      .from(agentTable)
-      .innerJoin(
-        attachmentTable,
-        and(
-          eq(attachmentTable.resourceId, agentTable.id),
-          eq(attachmentTable.resourceType, "agent"),
-          eq(attachmentTable.workspaceId, workspaceId),
-        ),
-      )
-      .where(
-        and(
-          eq(agentTable.organizationId, orgId),
-          isNull(agentTable.workspaceId),
-          inArray(agentTable.id, ids),
-        ),
-      );
+    // scope where attached (ADR-0007) — the same rule `getAgent` applies, and the
+    // same authority the save-time check uses. Looked up by id alone, an Agent
+    // from another Workspace resolved here: its name and description reached this
+    // prompt, and its Provider then failed to resolve.
+    const visible = await listScopedByIds(db, "agent", ids, {
+      orgId,
+      wsId: workspaceId,
+    });
 
     // Returned in assignment order so the prompt lists sub-agents the way the
-    // Operator configured them, not in whichever order the two queries ran. The
-    // two sets cannot collide on an id: each query pins the other scope's column.
-    const byId = new Map<string, AgentRow>();
-    for (const row of workspaceAgents) byId.set(row.id, row);
-    for (const row of orgAgents) byId.set(row.agent.id, row.agent);
+    // Operator configured them, not in whichever order the scope queries ran.
+    const byId = new Map(visible.map(({ row }) => [row.id, row]));
     return ids
       .map((id) => byId.get(id))
       .filter((row): row is AgentRow => row !== undefined);

--- a/apps/backend/src/services/scoped-resource.test.ts
+++ b/apps/backend/src/services/scoped-resource.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+// test-utils installs the drizzle-orm mock, so it must be imported before the
+// operators this file asserts on — `inArray` is a spy only through that mock.
 import { mockDb, resetMockDb, asDb } from "../test-utils.ts";
+import { inArray } from "drizzle-orm";
 import {
   resolveScoped,
   listScoped,
@@ -108,16 +111,24 @@ describe("ScopedResource read module", () => {
         .mockResolvedValueOnce([wsRow])
         .mockResolvedValueOnce([{ agent: orgRow }]);
 
-      const results = await listScopedByIds(
-        asDb(mockDb),
-        "agent",
-        ["ws-a", "org-a", "invisible"],
-        ctx,
-      );
+      const ids = ["ws-a", "org-a", "invisible"];
+      const results = await listScopedByIds(asDb(mockDb), "agent", ids, ctx);
       expect(results).toEqual([
         { row: wsRow, scope: "workspace" },
         { row: orgRow, scope: "organization" },
       ]);
+      // Both scope branches are narrowed to the ids asked for — without this the
+      // call would read every row of the type and filter in memory.
+      expect(inArray).toHaveBeenCalledTimes(2);
+      expect(inArray).toHaveBeenNthCalledWith(1, expect.anything(), ids);
+      expect(inArray).toHaveBeenNthCalledWith(2, expect.anything(), ids);
+    });
+
+    it("applies no id filter when listing the whole type", async () => {
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      await listScoped(asDb(mockDb), "agent", ctx);
+      expect(inArray).not.toHaveBeenCalled();
     });
 
     it("returns an empty list without querying when given no ids", async () => {

--- a/apps/backend/src/services/scoped-resource.test.ts
+++ b/apps/backend/src/services/scoped-resource.test.ts
@@ -3,6 +3,7 @@ import { mockDb, resetMockDb, asDb } from "../test-utils.ts";
 import {
   resolveScoped,
   listScoped,
+  listScopedByIds,
   requireScoped,
   requireWorkspaceMutable,
   requireSharedDeletable,
@@ -64,6 +65,18 @@ describe("ScopedResource read module", () => {
       const found = await resolveScoped(asDb(mockDb), "agent", "a1", ctx);
       expect(found).toBeNull();
     });
+
+    it("returns null for a row that carries this org and another workspace", async () => {
+      // The scope columns are mutually exclusive on write, not by a database
+      // constraint. Such a row belongs to ws-other, so matching it on
+      // organizationId alone would make it visible in ws-1.
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "a1", organizationId: "org-1", workspaceId: "ws-other" },
+      ]);
+
+      const found = await resolveScoped(asDb(mockDb), "agent", "a1", ctx);
+      expect(found).toBeNull();
+    });
   });
 
   describe("listScoped", () => {
@@ -80,6 +93,37 @@ describe("ScopedResource read module", () => {
         { row: wsRow, scope: "workspace" },
         { row: orgRow, scope: "organization" },
       ]);
+    });
+  });
+
+  describe("listScopedByIds", () => {
+    it("unions workspace rows with attached org rows for the given ids", async () => {
+      const wsRow = { id: "ws-a", workspaceId: "ws-1" };
+      const orgRow = {
+        id: "org-a",
+        organizationId: "org-1",
+        workspaceId: null,
+      };
+      mockDb.where
+        .mockResolvedValueOnce([wsRow])
+        .mockResolvedValueOnce([{ agent: orgRow }]);
+
+      const results = await listScopedByIds(
+        asDb(mockDb),
+        "agent",
+        ["ws-a", "org-a", "invisible"],
+        ctx,
+      );
+      expect(results).toEqual([
+        { row: wsRow, scope: "workspace" },
+        { row: orgRow, scope: "organization" },
+      ]);
+    });
+
+    it("returns an empty list without querying when given no ids", async () => {
+      const results = await listScopedByIds(asDb(mockDb), "agent", [], ctx);
+      expect(results).toEqual([]);
+      expect(mockDb.select).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/services/scoped-resource.ts
+++ b/apps/backend/src/services/scoped-resource.ts
@@ -78,6 +78,23 @@ export type ScopeContext = { orgId: string; wsId: string };
 type Database = typeof db;
 
 /**
+ * Whether a row is a **Shared resource** of this Organization: org-scoped, and at
+ * no Workspace. The two scope columns are mutually exclusive by a Zod refinement
+ * on write, not by a database constraint, so "has this organizationId" is not on
+ * its own enough — a row holding both belongs to its Workspace and must not reach
+ * another one on the strength of the org column. Absent rows are not Shared, so a
+ * dangling id fails this too.
+ *
+ * Exported because the Promotion guard (`findNonSharedReferences`) asks the same
+ * question of rows it fetched itself.
+ */
+export const isSharedRow = (
+  row:
+    { organizationId: string | null; workspaceId: string | null } | undefined,
+  orgId: string,
+): boolean => !!row && row.organizationId === orgId && !row.workspaceId;
+
+/**
  * Resolves a single resource visible inside this Workspace, or `null` when it
  * is not visible here. A Workspace-scoped row matches directly; an
  * Organization-scoped (Shared) row is visible only where an Attachment for this
@@ -107,17 +124,13 @@ export const resolveScoped = async <T extends ScopedResourceType>(
   const row = rows[0] as RowOf[T] | undefined;
   if (!row) return null;
 
-  // Classified by which scope the row actually carries, not by elimination. The
-  // two columns are mutually exclusive on write but nothing in the database
-  // enforces it, and a row holding both would otherwise fall through to
-  // "workspace" — making another Workspace's row visible here on the strength of
-  // its organizationId alone.
+  // Classified by which scope the row actually carries, not by elimination: a row
+  // holding both columns would otherwise fall through to "workspace" and be
+  // visible here on the strength of its organizationId alone.
   if (row.workspaceId === ctx.wsId) {
     return { row, scope: "workspace" };
   }
-  if (!(row.organizationId === ctx.orgId && !row.workspaceId)) {
-    return null;
-  }
+  if (!isSharedRow(row, ctx.orgId)) return null;
 
   // A Shared resource is visible here only through an Attachment (ADR-0007).
   const [attached] = await database
@@ -136,11 +149,12 @@ export const resolveScoped = async <T extends ScopedResourceType>(
 };
 
 /**
- * The two queries behind `listScoped` and `listScopedByIds`: the Workspace's own
- * rows, then the Organization-scoped rows an Attachment exposes here. `ids`
- * narrows both to a known set of references; omitted, it lists the type.
+ * Lists the resources of this type visible in the Workspace: its Workspace-scoped
+ * rows plus the Organization-scoped (Shared) rows attached to it. `ids` narrows
+ * both to a known set of references — pass it through `listScopedByIds`, which
+ * handles the empty case. Never throws.
  */
-const listVisible = async <T extends ScopedResourceType>(
+export const listScoped = async <T extends ScopedResourceType>(
   database: Database,
   type: T,
   ctx: ScopeContext,
@@ -200,23 +214,12 @@ const listVisible = async <T extends ScopedResourceType>(
 };
 
 /**
- * Lists every resource of this type visible in the Workspace: its
- * Workspace-scoped rows plus the Organization-scoped (Shared) rows attached to
- * it. Never throws.
- */
-export const listScoped = <T extends ScopedResourceType>(
-  database: Database,
-  type: T,
-  ctx: ScopeContext,
-): Promise<{ row: RowOf[T]; scope: Scope }[]> =>
-  listVisible(database, type, ctx);
-
-/**
  * The subset of `ids` visible in this Workspace, each with its scope — the
  * single authority for "which of these references may this Workspace use?".
  * Ids that resolve to nothing are simply absent, so a caller can compare against
  * what it asked for (a save-time rejection) or carry on without them (a
- * run-time drop). Never throws; no query runs for an empty `ids`.
+ * run-time drop). Never throws; no query runs for an empty `ids`, which would
+ * otherwise reach the database as `IN ()`.
  */
 export const listScopedByIds = <T extends ScopedResourceType>(
   database: Database,
@@ -224,9 +227,7 @@ export const listScopedByIds = <T extends ScopedResourceType>(
   ids: string[],
   ctx: ScopeContext,
 ): Promise<{ row: RowOf[T]; scope: Scope }[]> =>
-  ids.length === 0
-    ? Promise.resolve([])
-    : listVisible(database, type, ctx, ids);
+  ids.length === 0 ? Promise.resolve([]) : listScoped(database, type, ctx, ids);
 
 /**
  * Like `resolveScoped` but throws `NotFoundError` when the resource is not

--- a/apps/backend/src/services/scoped-resource.ts
+++ b/apps/backend/src/services/scoped-resource.ts
@@ -1,4 +1,4 @@
-import { and, eq, or } from "drizzle-orm";
+import { and, eq, or, inArray, isNull } from "drizzle-orm";
 import {
   agent as agentTable,
   skill as skillTable,
@@ -107,9 +107,16 @@ export const resolveScoped = async <T extends ScopedResourceType>(
   const row = rows[0] as RowOf[T] | undefined;
   if (!row) return null;
 
-  const isOrgScoped = !!row.organizationId && !row.workspaceId;
-  if (!isOrgScoped) {
+  // Classified by which scope the row actually carries, not by elimination. The
+  // two columns are mutually exclusive on write but nothing in the database
+  // enforces it, and a row holding both would otherwise fall through to
+  // "workspace" — making another Workspace's row visible here on the strength of
+  // its organizationId alone.
+  if (row.workspaceId === ctx.wsId) {
     return { row, scope: "workspace" };
+  }
+  if (!(row.organizationId === ctx.orgId && !row.workspaceId)) {
+    return null;
   }
 
   // A Shared resource is visible here only through an Attachment (ADR-0007).
@@ -129,24 +136,33 @@ export const resolveScoped = async <T extends ScopedResourceType>(
 };
 
 /**
- * Lists every resource of this type visible in the Workspace: its
- * Workspace-scoped rows plus the Organization-scoped (Shared) rows attached to
- * it. Never throws.
+ * The two queries behind `listScoped` and `listScopedByIds`: the Workspace's own
+ * rows, then the Organization-scoped rows an Attachment exposes here. `ids`
+ * narrows both to a known set of references; omitted, it lists the type.
  */
-export const listScoped = async <T extends ScopedResourceType>(
+const listVisible = async <T extends ScopedResourceType>(
   database: Database,
   type: T,
   ctx: ScopeContext,
+  ids?: string[],
 ): Promise<{ row: RowOf[T]; scope: Scope }[]> => {
   const { table } = REGISTRY[type];
 
   const workspaceRows = await database
     .select()
     .from(table)
-    .where(eq(table.workspaceId, ctx.wsId));
+    .where(
+      and(
+        eq(table.workspaceId, ctx.wsId),
+        ids ? inArray(table.id, ids) : undefined,
+      ),
+    );
 
   // Shared rows appear in a Workspace only where attached (ADR-0007) — gate by
-  // an inner join on the Attachment table.
+  // an inner join on the Attachment table. `isNull(workspaceId)` is what makes
+  // the row org-scoped: the scope columns are mutually exclusive on write, not by
+  // a database constraint, so a row carrying both must not reach another
+  // Workspace through that Workspace's Attachment.
   const attachedRows = await database
     .select()
     .from(table)
@@ -158,7 +174,13 @@ export const listScoped = async <T extends ScopedResourceType>(
         eq(attachmentTable.workspaceId, ctx.wsId),
       ),
     )
-    .where(eq(table.organizationId, ctx.orgId));
+    .where(
+      and(
+        eq(table.organizationId, ctx.orgId),
+        isNull(table.workspaceId),
+        ids ? inArray(table.id, ids) : undefined,
+      ),
+    );
 
   // The inner-join rows are keyed by the table's name, which matches the
   // resource type for every dual-scope table (`agent`, `skill`, `mcp`,
@@ -176,6 +198,35 @@ export const listScoped = async <T extends ScopedResourceType>(
     ...orgRows.map((row) => ({ row, scope: "organization" as const })),
   ];
 };
+
+/**
+ * Lists every resource of this type visible in the Workspace: its
+ * Workspace-scoped rows plus the Organization-scoped (Shared) rows attached to
+ * it. Never throws.
+ */
+export const listScoped = <T extends ScopedResourceType>(
+  database: Database,
+  type: T,
+  ctx: ScopeContext,
+): Promise<{ row: RowOf[T]; scope: Scope }[]> =>
+  listVisible(database, type, ctx);
+
+/**
+ * The subset of `ids` visible in this Workspace, each with its scope — the
+ * single authority for "which of these references may this Workspace use?".
+ * Ids that resolve to nothing are simply absent, so a caller can compare against
+ * what it asked for (a save-time rejection) or carry on without them (a
+ * run-time drop). Never throws; no query runs for an empty `ids`.
+ */
+export const listScopedByIds = <T extends ScopedResourceType>(
+  database: Database,
+  type: T,
+  ids: string[],
+  ctx: ScopeContext,
+): Promise<{ row: RowOf[T]; scope: Scope }[]> =>
+  ids.length === 0
+    ? Promise.resolve([])
+    : listVisible(database, type, ctx, ids);
 
 /**
  * Like `resolveScoped` but throws `NotFoundError` when the resource is not

--- a/apps/backend/src/services/sub-agent-validation.ts
+++ b/apps/backend/src/services/sub-agent-validation.ts
@@ -2,6 +2,15 @@ import { db } from "../index.ts";
 import { listScopedByIds, type ScopeContext } from "./scoped-resource.ts";
 
 /**
+ * Rejection message for an Agent listed among its own sub-agents. Shared with
+ * the Organization surface, which applies this same rule while resolving
+ * sub-Agents differently (a Shared Agent's sub-Agents must themselves be
+ * Shared), so the two surfaces cannot drift on the wording an Operator sees.
+ */
+export const SUB_AGENT_SELF_ASSIGNMENT_ERROR =
+  "An agent cannot assign itself as a sub-agent";
+
+/**
  * Save-time guard on an Agent's `subAgentIds`, applied wherever a Workspace
  * surface writes them (the Agent routes and the agent-management tools).
  *
@@ -14,15 +23,6 @@ import { listScopedByIds, type ScopeContext } from "./scoped-resource.ts";
  * Promotion is a separate, stricter rule: a Shared Agent may reference only
  * other Shared resources (`findNonSharedReferences`).
  */
-/**
- * Rejection message for an Agent listed among its own sub-agents. Shared with
- * the Organization surface, which applies the same rule under a different
- * visibility rule (a Shared Agent's sub-Agents must themselves be Shared), so
- * the two surfaces cannot drift on the wording an Operator sees.
- */
-export const SUB_AGENT_SELF_ASSIGNMENT_ERROR =
-  "An agent cannot assign itself as a sub-agent";
-
 export const validateSubAgentAssignment = async (
   ctx: ScopeContext,
   agentId: string,

--- a/apps/backend/src/services/sub-agent-validation.ts
+++ b/apps/backend/src/services/sub-agent-validation.ts
@@ -1,5 +1,5 @@
 import { db } from "../index.ts";
-import { listScoped, type ScopeContext } from "./scoped-resource.ts";
+import { listScopedByIds, type ScopeContext } from "./scoped-resource.ts";
 
 /**
  * Save-time guard on an Agent's `subAgentIds`, applied wherever a Workspace
@@ -14,6 +14,15 @@ import { listScoped, type ScopeContext } from "./scoped-resource.ts";
  * Promotion is a separate, stricter rule: a Shared Agent may reference only
  * other Shared resources (`findNonSharedReferences`).
  */
+/**
+ * Rejection message for an Agent listed among its own sub-agents. Shared with
+ * the Organization surface, which applies the same rule under a different
+ * visibility rule (a Shared Agent's sub-Agents must themselves be Shared), so
+ * the two surfaces cannot drift on the wording an Operator sees.
+ */
+export const SUB_AGENT_SELF_ASSIGNMENT_ERROR =
+  "An agent cannot assign itself as a sub-agent";
+
 export const validateSubAgentAssignment = async (
   ctx: ScopeContext,
   agentId: string,
@@ -21,16 +30,13 @@ export const validateSubAgentAssignment = async (
 ): Promise<{ valid: boolean; error?: string }> => {
   // 1. Check self-assignment
   if (subAgentIds.includes(agentId)) {
-    return {
-      valid: false,
-      error: "An agent cannot assign itself as a sub-agent",
-    };
+    return { valid: false, error: SUB_AGENT_SELF_ASSIGNMENT_ERROR };
   }
 
-  if (subAgentIds.length === 0) return { valid: true };
-
-  // 2. Every proposed sub-agent must be visible in this workspace at either scope
-  const visible = await listScoped(db, "agent", ctx);
+  // 2. Every proposed sub-agent must be visible in this workspace at either
+  // scope — resolved through the same authority the Chat turn uses, so a save
+  // cannot accept a reference the run would then drop.
+  const visible = await listScopedByIds(db, "agent", subAgentIds, ctx);
   const visibleIds = new Set(visible.map(({ row }) => row.id));
 
   if (subAgentIds.some((id) => !visibleIds.has(id))) {

--- a/apps/backend/src/tools/agent-discovery.test.ts
+++ b/apps/backend/src/tools/agent-discovery.test.ts
@@ -72,6 +72,9 @@ describe("createAgentDiscoveryTools", () => {
       expect(await tools.listModelProviders.execute!({}, ctx)).toEqual([
         { id: "p1", name: "Provider 1", modelIds: ["model-a"] },
       ]);
+      // The org-scoped half is gated by a join on the Attachment table. Without
+      // it the whole organization's providers would be listed, attached or not.
+      expect(mockDb.innerJoin).toHaveBeenCalledTimes(1);
     });
 
     it("flattens per-model object modelIds to plain id strings", async () => {

--- a/apps/backend/src/tools/agent-discovery.test.ts
+++ b/apps/backend/src/tools/agent-discovery.test.ts
@@ -8,6 +8,26 @@ const workspaceId = "ws-1";
 const orgId = "org-1";
 const frontendUrl = "http://localhost:3000";
 
+/**
+ * Stubs the two queries every scoped lookup runs: the workspace-scoped rows,
+ * then the org-scoped (Shared) rows inner-joined to this workspace's
+ * Attachments. A join result is keyed by table name, which is why the second
+ * argument wraps each row.
+ */
+const stubScopedList = (
+  resourceType: "agent" | "mcp" | "provider",
+  workspaceRows: Record<string, unknown>[],
+  attachedOrgRows: Record<string, unknown>[],
+) => {
+  mockDb.where.mockResolvedValueOnce(workspaceRows);
+  mockDb.where.mockResolvedValueOnce(
+    attachedOrgRows.map((row) => ({
+      [resourceType]: row,
+      attachment: { id: `att-${String(row.id)}` },
+    })),
+  );
+};
+
 describe("createAgentDiscoveryTools", () => {
   let tools: ReturnType<typeof createAgentDiscoveryTools>;
 
@@ -27,29 +47,48 @@ describe("createAgentDiscoveryTools", () => {
   });
 
   describe("listModelProviders", () => {
-    it("returns providers for workspace and org", async () => {
-      const providers = [
-        { id: "p1", name: "Provider 1", modelIds: ["model-a", "model-b"] },
-        { id: "p2", name: "Provider 2", modelIds: ["model-c"] },
-      ];
-      mockDb.where.mockResolvedValue(providers);
-
-      expect(await tools.listModelProviders.execute!({}, ctx)).toEqual(
-        providers,
+    it("returns workspace providers and attached shared providers", async () => {
+      stubScopedList(
+        "provider",
+        [{ id: "p1", name: "Provider 1", modelIds: ["model-a", "model-b"] }],
+        [{ id: "p-org", name: "Shared Provider", modelIds: ["model-c"] }],
       );
+
+      expect(await tools.listModelProviders.execute!({}, ctx)).toEqual([
+        { id: "p1", name: "Provider 1", modelIds: ["model-a", "model-b"] },
+        { id: "p-org", name: "Shared Provider", modelIds: ["model-c"] },
+      ]);
+    });
+
+    it("omits a shared provider that is not attached to this workspace", async () => {
+      // An unattached Shared Provider cannot resolve at Chat-turn time, so
+      // offering it would only produce an Agent that cannot run.
+      stubScopedList(
+        "provider",
+        [{ id: "p1", name: "Provider 1", modelIds: ["model-a"] }],
+        [],
+      );
+
+      expect(await tools.listModelProviders.execute!({}, ctx)).toEqual([
+        { id: "p1", name: "Provider 1", modelIds: ["model-a"] },
+      ]);
     });
 
     it("flattens per-model object modelIds to plain id strings", async () => {
-      mockDb.where.mockResolvedValue([
-        {
-          id: "p1",
-          name: "Provider 1",
-          modelIds: [
-            { id: "model-a", passthroughFileTypes: ["image/*"] },
-            { id: "model-b", passthroughFileTypes: [] },
-          ],
-        },
-      ]);
+      stubScopedList(
+        "provider",
+        [
+          {
+            id: "p1",
+            name: "Provider 1",
+            modelIds: [
+              { id: "model-a", passthroughFileTypes: ["image/*"] },
+              { id: "model-b", passthroughFileTypes: [] },
+            ],
+          },
+        ],
+        [],
+      );
 
       expect(await tools.listModelProviders.execute!({}, ctx)).toEqual([
         { id: "p1", name: "Provider 1", modelIds: ["model-a", "model-b"] },
@@ -60,20 +99,24 @@ describe("createAgentDiscoveryTools", () => {
       // The tool is the agentic counterpart of the Agent model picker, so it
       // offers what the picker submits — otherwise an agent it creates pins the
       // concrete id and misses the next repoint (#386, ADR-0017).
-      mockDb.where.mockResolvedValue([
-        {
-          id: "p1",
-          name: "Provider 1",
-          modelIds: [
-            {
-              id: "gpt-4",
-              passthroughFileTypes: ["image/*"],
-              alias: "flagship",
-            },
-            { id: "gpt-4o-mini", passthroughFileTypes: [] },
-          ],
-        },
-      ]);
+      stubScopedList(
+        "provider",
+        [
+          {
+            id: "p1",
+            name: "Provider 1",
+            modelIds: [
+              {
+                id: "gpt-4",
+                passthroughFileTypes: ["image/*"],
+                alias: "flagship",
+              },
+              { id: "gpt-4o-mini", passthroughFileTypes: [] },
+            ],
+          },
+        ],
+        [],
+      );
 
       expect(await tools.listModelProviders.execute!({}, ctx)).toEqual([
         {
@@ -85,12 +128,73 @@ describe("createAgentDiscoveryTools", () => {
     });
   });
 
-  describe("listAgents", () => {
-    it("returns agents in workspace", async () => {
-      const agents = [{ id: "a1", name: "Agent 1" }];
-      mockDb.where.mockResolvedValue(agents);
+  describe("listToolSets", () => {
+    it("includes attached shared MCPs alongside the registered tool sets", async () => {
+      stubScopedList(
+        "mcp",
+        [{ id: "mcp-ws", name: "Workspace MCP" }],
+        [{ id: "mcp-org", name: "Shared MCP" }],
+      );
 
-      expect(await tools.listAgents.execute!({}, ctx)).toEqual(agents);
+      const result = (await tools.listToolSets.execute!({}, ctx)) as Array<{
+        id: string;
+        name: string;
+        category: string;
+      }>;
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          { id: "mcp-ws", name: "Workspace MCP", category: "MCP" },
+          { id: "mcp-org", name: "Shared MCP", category: "MCP" },
+        ]),
+      );
+      // The statically registered sets are still listed.
+      expect(result.some((entry) => entry.category !== "MCP")).toBe(true);
+    });
+  });
+
+  describe("listAgents", () => {
+    it("returns workspace agents and attached shared agents, each tagged with its scope", async () => {
+      stubScopedList(
+        "agent",
+        [
+          {
+            id: "a1",
+            name: "Agent 1",
+            description: "Local",
+            modelId: "m1",
+            providerId: "p1",
+          },
+        ],
+        [
+          {
+            id: "a-org",
+            name: "Shared Agent",
+            description: "Shared",
+            modelId: "m1",
+            providerId: "p-org",
+          },
+        ],
+      );
+
+      expect(await tools.listAgents.execute!({}, ctx)).toEqual([
+        {
+          id: "a1",
+          name: "Agent 1",
+          description: "Local",
+          modelId: "m1",
+          providerId: "p1",
+          scope: "workspace",
+        },
+        {
+          id: "a-org",
+          name: "Shared Agent",
+          description: "Shared",
+          modelId: "m1",
+          providerId: "p-org",
+          scope: "organization",
+        },
+      ]);
     });
   });
 
@@ -106,23 +210,46 @@ describe("createAgentDiscoveryTools", () => {
       ).toEqual({ error: "Agent not found" });
     });
 
-    it("returns agent details when found", async () => {
-      const agent = {
-        id: "a1",
-        name: "Agent 1",
-        workspaceId,
-        modelId: "m1",
-        providerId: "p1",
-      };
-      mockDb.limit.mockResolvedValue([agent]);
+    it("returns error for a shared agent that is not attached to this workspace", async () => {
+      // The row exists at org scope; the attachment lookup finds nothing.
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "a-org", name: "Shared Agent", organizationId: orgId },
+      ]);
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      expect(
+        await tools.getAgent.execute!(
+          { agentId: "a-org", label: "Shared Agent" },
+          ctx,
+        ),
+      ).toEqual({ error: "Agent not found" });
+    });
+
+    it("returns agent details when found, tagged with its scope", async () => {
+      mockDb.limit.mockResolvedValue([
+        {
+          id: "a1",
+          name: "Agent 1",
+          workspaceId,
+          modelId: "m1",
+          providerId: "p1",
+          avatarKey: "agents/a1.png",
+        },
+      ]);
 
       const result = (await tools.getAgent.execute!(
         { agentId: "a1", label: "Agent 1" },
         ctx,
-      )) as { id: string; name: string; url?: string };
+      )) as { id: string; name: string; scope: string; url?: string };
 
-      expect(result).toMatchObject({ id: "a1", name: "Agent 1" });
+      expect(result).toMatchObject({
+        id: "a1",
+        name: "Agent 1",
+        scope: "workspace",
+      });
       expect(result.url).toContain("agents/a1");
+      // The avatar key is not a field the model has any use for.
+      expect(result).not.toHaveProperty("avatarKey");
     });
   });
 });

--- a/apps/backend/src/tools/agent-discovery.ts
+++ b/apps/backend/src/tools/agent-discovery.ts
@@ -114,9 +114,10 @@ export function createAgentDiscoveryTools(
         return { error: "Agent not found" };
       }
 
-      // Projected field by field rather than spread, so the avatar key stays out
-      // of the tool result (it is not a field the model has any use for).
-      const { row, scope } = found;
+      // Everything but the avatar key, which is a storage detail the model has no
+      // use for. Dropped by name rather than listing the twenty fields that stay,
+      // so a column added to `agent` later is included, not silently missed.
+      const { avatarKey: _avatarKey, ...rest } = found.row;
       const url = buildResourceUrl(
         frontendUrl,
         orgId,
@@ -124,31 +125,7 @@ export function createAgentDiscoveryTools(
         `agents/${agentId}`,
       );
 
-      return {
-        id: row.id,
-        organizationId: row.organizationId,
-        workspaceId: row.workspaceId,
-        scope,
-        name: row.name,
-        description: row.description,
-        providerId: row.providerId,
-        modelId: row.modelId,
-        instructions: row.instructions,
-        maxSteps: row.maxSteps,
-        temperature: row.temperature,
-        topP: row.topP,
-        topK: row.topK,
-        seed: row.seed,
-        presencePenalty: row.presencePenalty,
-        frequencyPenalty: row.frequencyPenalty,
-        toolSetIds: row.toolSetIds,
-        skillIds: row.skillIds,
-        subAgentIds: row.subAgentIds,
-        inputPlaceholder: row.inputPlaceholder,
-        createdAt: row.createdAt,
-        updatedAt: row.updatedAt,
-        ...(url && { url }),
-      };
+      return { ...rest, scope: found.scope, ...(url && { url }) };
     },
   });
 

--- a/apps/backend/src/tools/agent-discovery.ts
+++ b/apps/backend/src/tools/agent-discovery.ts
@@ -1,37 +1,44 @@
 import { tool, type Tool } from "ai";
 import { z } from "zod";
-import { and, eq, or } from "drizzle-orm";
 import { db } from "../index.ts";
-import {
-  agent as agentTable,
-  mcp as mcpTable,
-  provider as providerTable,
-} from "../db/schema.ts";
 import { getToolSets } from "../tools/index.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
 import { providerModelReferences } from "../services/model-capability.ts";
+import {
+  listScoped,
+  resolveScoped,
+  type ScopeContext,
+} from "../services/scoped-resource.ts";
 import type { Provider } from "@platypus/schemas";
+
+/**
+ * Every lookup in this module resolves at the invoking Workspace's scope:
+ * Workspace-scoped rows, plus the Organization-scoped (Shared) rows attached to
+ * it (ADR-0007). That is the same set the Workspace's own list routes return, so
+ * an Operator working through an Agent sees exactly what they would see in the
+ * UI — no Shared resource it could name but not use, and none it could use but
+ * not name.
+ */
 
 /**
  * Standalone factory for the listAgents tool so it can be shared across
  * multiple tool sets (e.g. agent-discovery AND kanban).
  */
-export function createListAgentsTool(workspaceId: string): Tool {
+export function createListAgentsTool(ctx: ScopeContext): Tool {
   return tool({
-    description: "List all agents in the current workspace.",
+    description:
+      "List the agents available in the current workspace, including shared agents attached to it.",
     inputSchema: z.object({}),
     execute: async () => {
-      const agents = await db
-        .select({
-          id: agentTable.id,
-          name: agentTable.name,
-          description: agentTable.description,
-          modelId: agentTable.modelId,
-          providerId: agentTable.providerId,
-        })
-        .from(agentTable)
-        .where(eq(agentTable.workspaceId, workspaceId));
-      return agents;
+      const scoped = await listScoped(db, "agent", ctx);
+      return scoped.map(({ row, scope }) => ({
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        modelId: row.modelId,
+        providerId: row.providerId,
+        scope,
+      }));
     },
   });
 }
@@ -41,6 +48,8 @@ export function createAgentDiscoveryTools(
   orgId: string,
   frontendUrl: string | undefined,
 ): Record<string, Tool> {
+  const ctx: ScopeContext = { orgId, wsId: workspaceId };
+
   const listToolSets = tool({
     description:
       "List all available tool sets and MCP servers. Use the returned IDs when assigning toolSetIds to agents.",
@@ -55,13 +64,10 @@ export function createAgentDiscoveryTools(
         }),
       );
 
-      const mcps = await db
-        .select()
-        .from(mcpTable)
-        .where(eq(mcpTable.workspaceId, workspaceId));
-      const mcpList = mcps.map((mcp) => ({
-        id: mcp.id,
-        name: mcp.name,
+      const mcps = await listScoped(db, "mcp", ctx);
+      const mcpList = mcps.map(({ row }) => ({
+        id: row.id,
+        name: row.name,
         category: "MCP",
       }));
 
@@ -74,35 +80,27 @@ export function createAgentDiscoveryTools(
       "List all configured providers and their available model IDs. Use the returned provider IDs and model IDs when creating or updating agents, and pass a model ID back exactly as returned. An entry of the form 'alias:<name>' is a Model alias the provider gave one of its models: submit it unchanged rather than the vendor model id it currently points at, so the agent follows the alias when an admin repoints it.",
     inputSchema: z.object({}),
     execute: async () => {
-      const providers = await db
-        .select({
-          id: providerTable.id,
-          name: providerTable.name,
-          modelIds: providerTable.modelIds,
-        })
-        .from(providerTable)
-        .where(
-          or(
-            eq(providerTable.workspaceId, workspaceId),
-            eq(providerTable.organizationId, orgId),
-          ),
-        );
+      // Only providers usable here: a Shared Provider that is not attached to
+      // this workspace would be assignable but unresolvable at Chat-turn time,
+      // leaving an Agent that cannot run.
+      const providers = await listScoped(db, "provider", ctx);
       // Advertise the reference an alias-aware picker would submit — the alias
       // for an aliased model, the concrete id otherwise — regardless of whether
       // the row stores the new per-model objects or a legacy `string[]` (issues
       // #328, #386). This tool is the agentic counterpart of the Agent model
       // picker, so it must offer the same choices: handing back the concrete id
       // of an aliased model would silently opt every agent created this way out
-      // of the next repoint (ADR-0017). Only `modelIds` is read, so the partial
-      // row is cast to satisfy the resolver's signature.
-      return providers.map((p) => ({
-        ...p,
-        modelIds: providerModelReferences(p as unknown as Provider),
+      // of the next repoint (ADR-0017). Only `modelIds` is read, so the row is
+      // cast to satisfy the resolver's signature.
+      return providers.map(({ row }) => ({
+        id: row.id,
+        name: row.name,
+        modelIds: providerModelReferences(row as unknown as Provider),
       }));
     },
   });
 
-  const listAgents = createListAgentsTool(workspaceId);
+  const listAgents = createListAgentsTool(ctx);
 
   const getAgent = tool({
     description: "Get full agent details by ID (excludes avatar).",
@@ -111,42 +109,14 @@ export function createAgentDiscoveryTools(
       label: z.string().describe("The agent name (for display purposes)"),
     }),
     execute: async ({ agentId }) => {
-      const result = await db
-        .select({
-          id: agentTable.id,
-          workspaceId: agentTable.workspaceId,
-          name: agentTable.name,
-          description: agentTable.description,
-          providerId: agentTable.providerId,
-          modelId: agentTable.modelId,
-          instructions: agentTable.instructions,
-          maxSteps: agentTable.maxSteps,
-          temperature: agentTable.temperature,
-          topP: agentTable.topP,
-          topK: agentTable.topK,
-          seed: agentTable.seed,
-          presencePenalty: agentTable.presencePenalty,
-          frequencyPenalty: agentTable.frequencyPenalty,
-          toolSetIds: agentTable.toolSetIds,
-          skillIds: agentTable.skillIds,
-          subAgentIds: agentTable.subAgentIds,
-          inputPlaceholder: agentTable.inputPlaceholder,
-          createdAt: agentTable.createdAt,
-          updatedAt: agentTable.updatedAt,
-        })
-        .from(agentTable)
-        .where(
-          and(
-            eq(agentTable.id, agentId),
-            eq(agentTable.workspaceId, workspaceId),
-          ),
-        )
-        .limit(1);
-
-      if (result.length === 0) {
+      const found = await resolveScoped(db, "agent", agentId, ctx);
+      if (!found) {
         return { error: "Agent not found" };
       }
 
+      // Projected field by field rather than spread, so the avatar key stays out
+      // of the tool result (it is not a field the model has any use for).
+      const { row, scope } = found;
       const url = buildResourceUrl(
         frontendUrl,
         orgId,
@@ -154,7 +124,31 @@ export function createAgentDiscoveryTools(
         `agents/${agentId}`,
       );
 
-      return { ...result[0], ...(url && { url }) };
+      return {
+        id: row.id,
+        organizationId: row.organizationId,
+        workspaceId: row.workspaceId,
+        scope,
+        name: row.name,
+        description: row.description,
+        providerId: row.providerId,
+        modelId: row.modelId,
+        instructions: row.instructions,
+        maxSteps: row.maxSteps,
+        temperature: row.temperature,
+        topP: row.topP,
+        topK: row.topK,
+        seed: row.seed,
+        presencePenalty: row.presencePenalty,
+        frequencyPenalty: row.frequencyPenalty,
+        toolSetIds: row.toolSetIds,
+        skillIds: row.skillIds,
+        subAgentIds: row.subAgentIds,
+        inputPlaceholder: row.inputPlaceholder,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        ...(url && { url }),
+      };
     },
   });
 

--- a/apps/backend/src/tools/kanban.ts
+++ b/apps/backend/src/tools/kanban.ts
@@ -99,7 +99,7 @@ export function createKanbanTools(
     return result[0]?.boardId;
   }
 
-  const listAgents = createListAgentsTool(workspaceId);
+  const listAgents = createListAgentsTool({ orgId, wsId: workspaceId });
 
   const listBoards = tool({
     description: "List all kanban boards in the current workspace.",


### PR DESCRIPTION
Follow-up to #423, which fixed the sub-agent lookup but left the same rule reimplemented in several other places — and they disagreed with each other.

## One authority for "may this Workspace use this?"

`listScopedByIds` is the ids-filtered form of `listScoped`: the Workspace's own rows, plus the Organization-scoped (Shared) rows attached to it (ADR-0007). The Chat turn's Agent, Provider, Skill, MCP and sub-Agent lookups, the save-time sub-agent check, and Kanban assignee validation all resolve through it now. Three near-identical copies of the rule and one local attachment helper are gone.

## Bugs this closes

**A workspace-surface create could choose its own scope.** The Provider and MCP create routes spread the request body straight into the insert, and their create schemas accept `organizationId`/`workspaceId` while dropping the XOR refinement that `providerSchema`/`mcpSchema` carry. A caller with workspace access could name a *different* Workspace, or set `organizationId` and mint a **Shared** Provider or MCP from the Workspace surface — something only an Org Admin may do (ADR-0006, ADR-0007). Both routes now take the scope from the route, as the Agent and Skill routes already did.

**A Kanban card could not be assigned to a Shared Agent.** The assignee picker offers every Agent visible in the Workspace, which includes attached Shared Agents, but validation accepted only workspace-scoped ones — so assigning an Agent that can run here failed with `Invalid agent assignee`.

**The Agent Discovery tool set resolved at the wrong scope in both directions.** `listAgents`, `getAgent` and the MCP list were workspace-only, so an Operator working through an Agent could not see a Shared resource attached to their Workspace — while `listModelProviders` offered every Shared Provider in the Organization, attached or not, which yields an Agent that cannot run. All four now resolve at the Workspace's scope and tag each row with it.

## Hardening

The scope columns are mutually exclusive by a Zod refinement on write, not by a database constraint. `resolveScoped` now classifies a row by the scope it actually carries rather than by elimination, the org-scoped queries require a null workspace, and the Promotion guard counts a reference as Shared only if it is org-scoped *and* at no Workspace — so a row holding both columns can no longer reach a Workspace that neither owns nor attached it. With the create routes fixed, that is belt and braces rather than the only line of defence.

## Notes

- No user-facing docs change: the Boards page already says an **Assignee** "can be a Workspace member _or an Agent_", and the Agent Discovery row already says "in the Workspace" — this makes the code match the prose in both cases.
- Full suite green (backend 1486, frontend 63, schemas 100, docs contract 24), `typecheck` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)