### PR TITLE
feat(backend): attribute OpenRouter requests to the Platypus app

### DIFF
--- a/apps/backend/src/services/provider.test.ts
+++ b/apps/backend/src/services/provider.test.ts
@@ -156,6 +156,126 @@ describe("openProvider", () => {
     expect(mockCreateOpenRouter.creator).toHaveBeenCalled();
   });
 
+  describe("OpenRouter app attribution", () => {
+    const openRouter = (headers?: Record<string, string>) => {
+      openProvider({
+        ...baseProvider,
+        providerType: "OpenRouter" as const,
+        headers,
+      }).languageModel(concrete("openai/gpt-4"));
+      // The shared mock creator is typed as taking no args, so reach for the
+      // recorded config through `unknown`.
+      const [config] = mockCreateOpenRouter.creator.mock
+        .calls[0] as unknown as [{ headers: Record<string, string> }];
+      return config;
+    };
+
+    it("sends the Platypus attribution headers by default", () => {
+      expect(openRouter().headers).toEqual({
+        "HTTP-Referer": "https://github.com/willdady/platypus",
+        "X-OpenRouter-Title": "Platypus",
+        "X-OpenRouter-Categories": "personal-agent,general-chat",
+      });
+    });
+
+    it("lets a provider header override a default", () => {
+      expect(openRouter({ "X-OpenRouter-Title": "Acme Corp" }).headers).toEqual(
+        {
+          "HTTP-Referer": "https://github.com/willdady/platypus",
+          "X-OpenRouter-Title": "Acme Corp",
+          "X-OpenRouter-Categories": "personal-agent,general-chat",
+        },
+      );
+    });
+
+    it("matches overrides case-insensitively, leaving one entry per header", () => {
+      // HTTP header names are case-insensitive, so a differently-cased key must
+      // replace the default rather than sit alongside it as a duplicate.
+      const headers = openRouter({
+        "http-referer": "https://acme.example",
+      }).headers;
+      expect(headers).toEqual({
+        "http-referer": "https://acme.example",
+        "X-OpenRouter-Title": "Platypus",
+        "X-OpenRouter-Categories": "personal-agent,general-chat",
+      });
+      expect(
+        Object.keys(headers).filter((k) => k.toLowerCase() === "http-referer"),
+      ).toHaveLength(1);
+    });
+
+    it("sends unrelated provider headers alongside the defaults", () => {
+      expect(openRouter({ "X-Acme-Trace": "abc123" }).headers).toEqual({
+        "HTTP-Referer": "https://github.com/willdady/platypus",
+        "X-OpenRouter-Title": "Platypus",
+        "X-OpenRouter-Categories": "personal-agent,general-chat",
+        "X-Acme-Trace": "abc123",
+      });
+    });
+
+    it("treats an empty HTTP-Referer as opting out of attribution entirely", () => {
+      // Title and categories are inert without a referer, so all three go.
+      expect(
+        openRouter({
+          "HTTP-Referer": "",
+          "X-OpenRouter-Title": "Ignored",
+          "X-Acme-Trace": "abc123",
+        }).headers,
+      ).toEqual({ "X-Acme-Trace": "abc123" });
+    });
+
+    it("opts out on a differently-cased empty referer", () => {
+      expect(openRouter({ "http-referer": "" }).headers).toEqual({});
+    });
+
+    it("treats a whitespace-only referer as blank", () => {
+      // A blank referer is unattributable, so it opts out rather than shipping.
+      expect(openRouter({ "HTTP-Referer": "   " }).headers).toEqual({});
+    });
+
+    it("opts out when any casing of the referer is blank", () => {
+      // An operator can write both casings. Resolving to a single key would let
+      // the non-empty one hide the blank and silently keep attribution on.
+      expect(
+        openRouter({
+          "http-referer": "",
+          "HTTP-Referer": "https://acme.example",
+        }).headers,
+      ).toEqual({});
+    });
+
+    it("passes a non-string header value through without crashing", () => {
+      // `headers` is cast, not parsed, on read from jsonb, so a malformed row
+      // must not take down every model call for the Provider.
+      const headers = { "HTTP-Referer": null } as unknown as Record<
+        string,
+        string
+      >;
+      // Not an opt-out — only a blank string is — so the other defaults stand.
+      expect(openRouter(headers).headers).toEqual({
+        "HTTP-Referer": null,
+        "X-OpenRouter-Title": "Platypus",
+        "X-OpenRouter-Categories": "personal-agent,general-chat",
+      });
+    });
+  });
+
+  it.each([
+    ["OpenAI", () => mockCreateOpenAI.creator],
+    ["Bedrock", () => mockCreateAmazonBedrock.creator],
+    ["Google", () => mockCreateGoogleGenerativeAI.creator],
+    ["Anthropic", () => mockCreateAnthropic.creator],
+  ])("does not add attribution headers for %s", (providerType, creator) => {
+    openProvider({
+      ...baseProvider,
+      providerType: providerType as Provider["providerType"],
+      apiMode: "responses",
+    }).languageModel(concrete("some-model"));
+    expect(creator()).toHaveBeenCalledWith(
+      expect.objectContaining({ headers: undefined }),
+    );
+  });
+
   it("dispatches Bedrock to the Amazon Bedrock SDK", () => {
     openProvider({
       ...baseProvider,

--- a/apps/backend/src/services/provider.ts
+++ b/apps/backend/src/services/provider.ts
@@ -19,6 +19,70 @@ export interface OpenedProvider {
   searchTools?(): Record<string, Tool>;
 }
 
+/**
+ * OpenRouter attributes usage to an app via request headers, which is what puts
+ * Platypus on its public app pages and rankings. `HTTP-Referer` is the primary
+ * identifier — without it OpenRouter creates no app page and does not track the
+ * request; title and categories do nothing on their own.
+ *
+ * These are defaults, not policy: a Provider's own `headers` win, so an operator
+ * can re-attribute usage to their own deployment or opt out per Provider. There
+ * is deliberately no environment variable for this — every other per-Provider
+ * knob lives on the Provider row, and env vars here are deploy-time infra.
+ */
+const OPENROUTER_ATTRIBUTION_HEADERS: Record<string, string> = {
+  "HTTP-Referer": "https://github.com/willdady/platypus",
+  "X-OpenRouter-Title": "Platypus",
+  "X-OpenRouter-Categories": "personal-agent,general-chat",
+};
+
+/**
+ * Merge the attribution defaults beneath a Provider's own headers. Collisions
+ * are matched case-insensitively because HTTP header names are — otherwise an
+ * operator's `http-referer` would sit alongside our `HTTP-Referer` and send two.
+ *
+ * An empty (or whitespace-only) referer is an explicit opt-out: all three
+ * attribution headers are dropped, rather than sending a blank referer OpenRouter
+ * cannot attribute. The Provider's unrelated headers are untouched either way.
+ */
+const withOpenRouterAttribution = (
+  headers: Record<string, string> | undefined,
+): Record<string, string> => {
+  const own = headers ?? {};
+
+  // Nothing stops an operator writing the same header under two casings, so
+  // group every key under its lowercase name rather than resolving to one.
+  // Resolving would let a later `HTTP-Referer` hide an earlier blank
+  // `http-referer` and silently defeat the opt-out.
+  const ownKeysByName = new Map<string, string[]>();
+  for (const key of Object.keys(own)) {
+    const name = key.toLowerCase();
+    ownKeysByName.set(name, [...(ownKeysByName.get(name) ?? []), key]);
+  }
+
+  // `headers` is stored as jsonb and cast, not parsed, on read — a value can be
+  // a non-string at runtime despite the type. Only a real blank string opts out;
+  // anything else is passed through as before rather than crashing the call.
+  const isBlank = (key: string) =>
+    typeof own[key] === "string" && own[key].trim() === "";
+
+  if ((ownKeysByName.get("http-referer") ?? []).some(isBlank)) {
+    const withoutAttribution = { ...own };
+    for (const name of Object.keys(OPENROUTER_ATTRIBUTION_HEADERS)) {
+      for (const key of ownKeysByName.get(name.toLowerCase()) ?? []) {
+        delete withoutAttribution[key];
+      }
+    }
+    return withoutAttribution;
+  }
+
+  const defaults: Record<string, string> = {};
+  for (const [name, value] of Object.entries(OPENROUTER_ATTRIBUTION_HEADERS)) {
+    if (!ownKeysByName.has(name.toLowerCase())) defaults[name] = value;
+  }
+  return { ...defaults, ...own };
+};
+
 export const openProvider = (provider: Provider): OpenedProvider => {
   switch (provider.providerType) {
     case "OpenAI": {
@@ -74,7 +138,7 @@ export const openProvider = (provider: Provider): OpenedProvider => {
       const sdk = createOpenRouter({
         baseURL: provider.baseUrl ?? undefined,
         apiKey: provider.apiKey ?? undefined,
-        headers: provider.headers ?? undefined,
+        headers: withOpenRouterAttribution(provider.headers),
         extraBody: provider.extraBody ?? undefined,
       });
       return {

--- a/apps/docs/content/self-hosting/providers-and-auth.mdx
+++ b/apps/docs/content/self-hosting/providers-and-auth.mdx
@@ -46,6 +46,7 @@ translating gateway in front of it.
 | `providerType`       | The vendor (`OpenAI`, `OpenRouter`, `Bedrock`, `Google`, `Anthropic`).                                                                                          |
 | `apiKey`             | The vendor credential.                                                                                                                                          |
 | `baseUrl`            | Optional override for OpenAI-compatible / self-hosted endpoints.                                                                                                |
+| `headers`            | Optional extra HTTP headers, as a JSON object, sent with every request to this Provider. On OpenRouter these also override the [app attribution](#openrouter-app-attribution) headers. |
 | `region`             | Required for Bedrock (AWS region).                                                                                                                              |
 | `modelIds`           | The models this Provider exposes for selection (at least one). Each entry carries its own config: file capability — see [File handling](#file-handling-what-each-model-accepts) — and an optional [Model alias](/concepts/providers#model-aliases). |
 | `taskModelId`        | The model used for one-shot internal tasks (e.g. generating a chat title), not chat turns. Must be a real model id — a Model alias is rejected.                  |
@@ -61,6 +62,48 @@ embeddings), so background memory features have a model to call. Like
   which uses `taskModelId`) is part of the domain vocabulary — see
   [Concepts](/concepts).
 </Callout>
+
+### OpenRouter app attribution
+
+OpenRouter credits each request to an app, and that credit is what puts an app on
+its public model pages and rankings. Platypus claims that credit for the project
+by default: every request from an **OpenRouter** Provider carries
+
+| Header                     | Value                                   |
+| -------------------------- | --------------------------------------- |
+| `HTTP-Referer`             | `https://github.com/willdady/platypus`  |
+| `X-OpenRouter-Title`       | `Platypus`                              |
+| `X-OpenRouter-Categories`  | `personal-agent,general-chat`           |
+
+So out of the box, your usage counts toward the Platypus project's public
+ranking. Nothing else changes: requests go to the same endpoint, on your own API
+key and your own OpenRouter account, at the same cost.
+
+To claim it for your own deployment instead, set the headers you want in the
+Provider's **Headers** field. A header you set there replaces the default of the
+same name, matched case-insensitively, so `http-referer` replaces `HTTP-Referer`
+rather than sending a second one:
+
+```json
+{
+  "HTTP-Referer": "https://acme.example",
+  "X-OpenRouter-Title": "Acme Assistant"
+}
+```
+
+`HTTP-Referer` is the one that matters — it's what OpenRouter identifies an app
+by. A title on its own creates no app page and tracks nothing.
+
+<Callout type="warning">
+  Leaving **Headers** empty does not opt out — that's what gives you the Platypus
+  defaults. To send no attribution at all, set `HTTP-Referer` to an empty string.
+  That drops all three headers — including a title or categories you set
+  yourself, since OpenRouter cannot attribute those without a referer. Your
+  other custom headers are still sent.
+</Callout>
+
+Attribution is per Provider, not per deployment, so two OpenRouter Providers in
+the same Organization can attribute differently.
 
 ### File handling: what each model accepts
 


### PR DESCRIPTION
Closes #426

## What

OpenRouter credits each request to an app via `HTTP-Referer`, and that credit is what puts an app on its public model pages and rankings. Platypus sent nothing, so usage went untracked unless an operator hand-typed the headers into a Provider's **Headers** field.

OpenRouter Providers now send three attribution headers by default:

| Header | Value |
| --- | --- |
| `HTTP-Referer` | `https://github.com/willdady/platypus` |
| `X-OpenRouter-Title` | `Platypus` |
| `X-OpenRouter-Categories` | `personal-agent,general-chat` |

These are defaults, not policy. A Provider's own `headers` win, matched **case-insensitively** so a hand-written `http-referer` replaces the default rather than shipping a second referer. A blank referer in any casing is an explicit opt-out and drops all three, while leaving unrelated custom headers alone.

Header names and both category slugs were verified against OpenRouter's app-attribution docs.

## Deliberately no environment variables

The issue proposed `OPENROUTER_HTTP_REFERER` / `OPENROUTER_APP_TITLE` / `OPENROUTER_APP_CATEGORIES`. Rejected during triage: every other per-Provider knob (API key, base URL, headers, extra body, region) lives on the Provider row, which is scoped to an Organization or Workspace, while backend env vars here are deploy-time infrastructure. The existing **Headers** field already provides override and opt-out — at finer granularity than env vars would. No schema change, no form change, no new config surface.

## Notes for review

- **Default-on attribution is a policy call.** Self-hosters' OpenRouter usage counts toward the Platypus project's public ranking unless they opt out. Nothing else changes — same endpoint, their own key and account, same cost. Worth a conscious sign-off; it also sits against ADR-0006's default-deny posture for reach-bearing config, though attribution headers add no destination and no credential.
- **Blank-referer opt-out checks every casing.** Resolving a header name to one key would let a later `HTTP-Referer` hide an earlier blank `http-referer` and silently keep attribution on.
- **`headers` is jsonb, cast rather than parsed on read**, so a value can be a non-string at runtime despite the type. A malformed row passes through as before instead of throwing on every model call.
- **Two non-blank casings of the same header both still ship.** That is the operator's own data passing through as it did before this change; silently dropping one seemed worse.

## Docs

Documents the Provider **Headers** field, which was previously undocumented — headers were covered for MCPs and Webhooks but not Providers — plus the attribution defaults and how to re-attribute or opt out.

## Testing

- `pnpm test` — 1513 backend tests pass, 8/8 tasks
- `pnpm typecheck` and `pnpm lint` clean
- Docs contract 24/24
- New coverage: defaults, override, case-insensitive collision, passthrough of unrelated headers, opt-out (both casings, whitespace-only), non-string values, and that no other Provider type gained defaults

**Not verified:** that requests appear under the Platypus app in the OpenRouter dashboard. That needs a real account and actual spend — a manual post-merge check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
