### PR TITLE
fix: mark a streamed reply that stopped at the model's output limit

### DIFF
--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -52,6 +52,11 @@ const {
       onStepFinish: undefined as ((step: unknown) => void) | undefined,
       onFinish: undefined as
         ((ctx: { messages: unknown[] }) => Promise<void> | void) | undefined,
+      // `toUIMessageStream`'s metadata extractor. The SDK calls it per stream
+      // part; the tests call it by hand with the part they care about.
+      messageMetadata: undefined as
+        | ((opts: { part: { type: string; finishReason?: string } }) => unknown)
+        | undefined,
       responseSentinel: { __isResponse: true },
     },
   };
@@ -633,35 +638,45 @@ describe("AgentRunner.cancel", () => {
   });
 });
 
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+const resetStreamHarness = (): void => {
+  streamHarness.queue = null;
+  streamHarness.onStepFinish = undefined;
+  streamHarness.onFinish = undefined;
+  streamHarness.messageMetadata = undefined;
+};
+
+// Make streamText return a fake result whose UI-stream callbacks the test can
+// drive by hand: `onStepFinish` (per step), `onFinish` (completion), and
+// `messageMetadata` (per stream part).
+const primeStreamText = () => {
+  mockStreamText.mockImplementation(
+    (opts: { onStepFinish?: (step: unknown) => void }) => {
+      streamHarness.onStepFinish = opts.onStepFinish;
+      return {
+        toUIMessageStream: (uiOpts: {
+          onFinish: (ctx: { messages: unknown[] }) => Promise<void> | void;
+          messageMetadata: (opts: {
+            part: { type: string; finishReason?: string };
+          }) => unknown;
+        }) => {
+          streamHarness.onFinish = uiOpts.onFinish;
+          streamHarness.messageMetadata = uiOpts.messageMetadata;
+          return { tee: () => [{}, {}] };
+        },
+      };
+    },
+  );
+};
+
 describe("AgentRunner.stream — success & interruption", () => {
   let runner: AgentRunner;
   beforeEach(() => {
     runner = new AgentRunner();
     vi.clearAllMocks();
-    streamHarness.queue = null;
-    streamHarness.onStepFinish = undefined;
-    streamHarness.onFinish = undefined;
+    resetStreamHarness();
   });
-
-  const tick = () => new Promise((r) => setTimeout(r, 0));
-
-  // Make streamText return a fake result whose UI-stream callbacks the test
-  // can drive by hand: `onStepFinish` (per step) and `onFinish` (completion).
-  const primeStreamText = () => {
-    mockStreamText.mockImplementation(
-      (opts: { onStepFinish: (step: unknown) => void }) => {
-        streamHarness.onStepFinish = opts.onStepFinish;
-        return {
-          toUIMessageStream: (uiOpts: {
-            onFinish: (ctx: { messages: unknown[] }) => Promise<void> | void;
-          }) => {
-            streamHarness.onFinish = uiOpts.onFinish;
-            return { tee: () => [{}, {}] };
-          },
-        };
-      },
-    );
-  };
 
   it("runs the full lifecycle on success and persists the final messages", async () => {
     const dispose = vi.fn().mockResolvedValue(undefined);
@@ -825,6 +840,116 @@ describe("AgentRunner.stream — success & interruption", () => {
     // The snapshot accumulated before the timeout is what gets persisted.
     expect(finish.messages).toEqual([partial]);
     expect(runRegistry.has("s-timeout")).toBe(false);
+  });
+});
+
+// Issue #420: the operator sees a truncated stream in the log, the reader saw
+// nothing. The metadata callback is the only seam for saying so on a stream
+// that has already been flushed to the client.
+describe("AgentRunner.stream — truncation metadata", () => {
+  let runner: AgentRunner;
+  beforeEach(() => {
+    runner = new AgentRunner();
+    vi.clearAllMocks();
+    resetStreamHarness();
+  });
+
+  const startStream = async (turn: ReturnType<typeof fakeTurn>) => {
+    mockPrepareChatTurn.mockResolvedValueOnce(turn);
+    const queue = new streamHarness.AsyncQueue();
+    streamHarness.queue = queue;
+    primeStreamText();
+
+    await runner.stream({
+      scope,
+      input: { ...baseInput, runId: `s-meta-${Math.random()}` },
+      sink: new RecordingSink(),
+      options: { origin: "http://test" },
+    });
+
+    return {
+      metadataFor: (part: { type: string; finishReason?: string }) =>
+        streamHarness.messageMetadata!({ part }),
+      end: async () => {
+        await streamHarness.onFinish!({ messages: [] });
+        queue.end();
+        await tick();
+      },
+    };
+  };
+
+  it("attributes the message to the resolved agent at the start of the stream", async () => {
+    const stream = await startStream(fakeTurn());
+
+    expect(stream.metadataFor({ type: "start" })).toEqual({
+      agentId: "agent-1",
+    });
+
+    await stream.end();
+  });
+
+  // A direct provider/model chat resolves no agent, so its start carries no
+  // metadata at all — which is exactly the case that had no way to be flagged
+  // while `agentId` was a required field.
+  it("still flags a truncated direct provider/model stream that has no attribution", async () => {
+    const turn = fakeTurn();
+    turn.resolved = {
+      ...turn.resolved,
+      agentId: undefined as unknown as string,
+    };
+    const stream = await startStream(turn);
+
+    expect(stream.metadataFor({ type: "start" })).toBeUndefined();
+    expect(
+      stream.metadataFor({ type: "finish", finishReason: "length" }),
+    ).toEqual({ truncatedByTokenLimit: true });
+
+    await stream.end();
+  });
+
+  it("flags the message as truncated when the terminal finish hit the output limit", async () => {
+    const stream = await startStream(fakeTurn());
+
+    expect(
+      stream.metadataFor({ type: "finish", finishReason: "length" }),
+    ).toEqual({ truncatedByTokenLimit: true });
+
+    await stream.end();
+  });
+
+  // Each event contributes only the key it owns, so the merge that produces
+  // the final metadata does not depend on how the SDK treats an `undefined`
+  // value — the `agentId` emitted at `start` is simply never overwritten.
+  it("does not restate the agent attribution on the truncation chunk", async () => {
+    const stream = await startStream(fakeTurn());
+
+    expect(
+      stream.metadataFor({ type: "finish", finishReason: "length" }),
+    ).not.toHaveProperty("agentId");
+
+    await stream.end();
+  });
+
+  it("leaves a cleanly finished stream with no truncation key", async () => {
+    const stream = await startStream(fakeTurn());
+
+    expect(
+      stream.metadataFor({ type: "finish", finishReason: "stop" }),
+    ).toBeUndefined();
+
+    await stream.end();
+  });
+
+  // A step inside a tool loop can end at the ceiling and the run still recover
+  // and finish normally. Marking those flags runs that were never truncated.
+  it("ignores a step that ended at the limit mid tool-loop", async () => {
+    const stream = await startStream(fakeTurn());
+
+    expect(
+      stream.metadataFor({ type: "finish-step", finishReason: "length" }),
+    ).toBeUndefined();
+
+    await stream.end();
   });
 });
 

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -428,10 +428,28 @@ export class AgentRunner {
     const uiStream = result.toUIMessageStream<PlatypusUIMessage>({
       originalMessages: input.messages,
       generateMessageId: createIdGenerator({ prefix: "msg", size: 16 }),
-      messageMetadata: () =>
-        state.turn?.resolved.agentId
-          ? { agentId: state.turn.resolved.agentId }
-          : undefined,
+      // The only seam for saying anything about a stream that has already been
+      // flushed to the client. The SDK calls this per stream part and merges
+      // what it returns into the message, so each event contributes only the
+      // key it owns and the finish chunk leaves the `agentId` from `start`
+      // standing. Returning the whole object every time would work too, but
+      // only because the SDK happens to skip `undefined` values while merging.
+      messageMetadata: ({ part }) => {
+        if (part.type === "start") {
+          const agentId = state.turn?.resolved.agentId;
+          return agentId ? { agentId } : undefined;
+        }
+        // The terminal finish only. A step inside a tool loop can end at the
+        // ceiling and the run still recover and complete normally; flagging
+        // those marks answers that were never cut short.
+        if (
+          part.type === "finish" &&
+          isTruncatedByTokenLimit(part.finishReason)
+        ) {
+          return { truncatedByTokenLimit: true };
+        }
+        return undefined;
+      },
       onError: (error) => formatStreamError(error),
       onFinish: async ({ messages: finalMessages }) => {
         state.messages = finalMessages;

--- a/apps/backend/src/runs/stream-error.ts
+++ b/apps/backend/src/runs/stream-error.ts
@@ -18,9 +18,10 @@ import {
  * out of output budget rather than because it was finished.
  *
  * A constant so the wording is asserted in tests without restating the prose.
- * Currently appended only by the unattended (`generate`) path — the streaming
- * path reports truncation to the operator via `logger.warn` and has no seam for
- * injecting text into an already-flushed stream.
+ * Appended only by the unattended (`generate`) path, whose one channel back to
+ * the caller is the returned text. A streamed turn says the same thing to the
+ * person reading it through the message metadata instead, in its own wording —
+ * this notice is addressed to a model consuming the output, not to a reader.
  */
 export const TRUNCATED_BY_TOKEN_LIMIT =
   "The response was truncated because it reached the maximum output token limit. Retry with a shorter response, or split the work across several steps.";

--- a/apps/backend/src/types.ts
+++ b/apps/backend/src/types.ts
@@ -4,13 +4,22 @@ import { createLoadSkillTool } from "./tools/skill.ts";
 /**
  * Metadata the run pipeline attaches to a streamed assistant message.
  *
- * Omitted entirely for runs that resolved no agent (a direct provider/model
- * chat), which is why `UIMessage["metadata"]` stays optional rather than the
- * fields inside it.
+ * Every field is optional and each is emitted on its own stream chunk: the
+ * client merges metadata chunks into the message rather than replacing it, so
+ * a run that resolves no agent but ends truncated still carries the truncation
+ * flag, and a truncated agent run keeps its attribution.
+ *
+ * A key that does not apply is absent rather than `false`, so a message's
+ * metadata says only what is true of it.
  */
 export type ChatMessageMetadata = {
   /** Agent the run resolved; the chat UI renders its name and avatar. */
-  agentId: string;
+  agentId?: string;
+  /**
+   * The turn's terminal finish hit the model's output token ceiling, so the
+   * answer stops mid-thought. The chat marks the message as cut short.
+   */
+  truncatedByTokenLimit?: true;
 };
 
 /**

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -85,6 +85,23 @@ specific pages instead wants the **Web Fetch** Tool set — see
 A microphone button next to it transcribes speech into the input box. The text
 lands in the box rather than sending, so you can edit before pressing **Enter**.
 
+## When a reply stops early
+
+Every model has a ceiling on how much it can write in one reply. Reach it and
+the answer stops wherever it got to — mid-sentence, mid-list, mid-word. A muted
+line appears under the message reading **Response cut short at the model's
+output limit.**
+
+Everything above the marker is a real answer; there is no more of it. The marker
+is stored with the message, so it is still there when you reload the Chat.
+
+<Callout type="warning">
+  **Nothing resumes a cut-short reply.** **Regenerate** re-runs the whole turn
+  from the beginning against the same ceiling; it does not carry on from where
+  the reply stopped. Ask for the remainder in a follow-up message, or ask for
+  the work in smaller pieces to begin with.
+</Callout>
+
 ## Fixing a conversation instead of restarting it
 
 Hover a message for its actions:

--- a/apps/frontend/components/chat-message.test.tsx
+++ b/apps/frontend/components/chat-message.test.tsx
@@ -11,7 +11,7 @@ vi.mock("streamdown", () => ({
   ),
 }));
 
-import { ChatMessage } from "./chat-message";
+import { ChatMessage, CUT_SHORT_NOTICE } from "./chat-message";
 
 const makeAgent = (overrides: Partial<Agent>): Agent =>
   ({
@@ -74,5 +74,35 @@ describe("ChatMessage agent attribution", () => {
     // The fallback is our own `bg-muted` circle wrapping an icon — asserted
     // via markup we own rather than a lucide-generated class name.
     expect(container.querySelector("div.bg-muted > svg")).not.toBeNull();
+  });
+});
+
+// Issue #420: a reply that stopped at the model's output ceiling used to just
+// stop mid-sentence, with the only record of it in the operator's log.
+describe("ChatMessage truncation marker", () => {
+  it("marks a message the run flagged as cut short at the output limit", () => {
+    renderMessage(assistantMessage({ truncatedByTokenLimit: true }));
+
+    expect(screen.getByText(CUT_SHORT_NOTICE)).toBeInTheDocument();
+  });
+
+  it.each([
+    ["a message that finished cleanly", { agentId: "agent-1" }],
+    ["a message with no metadata at all", undefined],
+  ] as const)("renders no marker for %s", (_, metadata) => {
+    renderMessage(assistantMessage(metadata));
+
+    expect(screen.queryByText(CUT_SHORT_NOTICE)).toBeNull();
+  });
+
+  // The two keys arrive on separate metadata chunks that merge into one
+  // message, so a truncated agent turn is the one case where both are set.
+  it("keeps the agent avatar on a truncated agent turn", () => {
+    renderMessage(
+      assistantMessage({ agentId: "agent-1", truncatedByTokenLimit: true }),
+    );
+
+    expect(screen.getByAltText("Research Agent")).toBeInTheDocument();
+    expect(screen.getByText(CUT_SHORT_NOTICE)).toBeInTheDocument();
   });
 });

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -43,11 +43,20 @@ import {
   CopyIcon,
   TrashIcon,
   RefreshCwIcon,
+  TriangleAlertIcon,
   XIcon,
 } from "lucide-react";
 import { Textarea } from "./ui/textarea";
 import { LoadSkillTool } from "./load-skill-tool";
 import { SubAgentTool } from "./sub-agent-tool";
+
+/**
+ * What the person reading a reply is told when it stopped at the model's
+ * output ceiling rather than because the model was finished. A constant so
+ * tests assert the wording without restating the prose.
+ */
+export const CUT_SHORT_NOTICE =
+  "Response cut short at the model's output limit.";
 
 interface ChatMessageProps {
   /** The message object to render */
@@ -275,6 +284,13 @@ export const ChatMessage = memo(function ChatMessage({
           return null;
         }
       })}
+      {message.role === "assistant" &&
+        message.metadata?.truncatedByTokenLimit && (
+          <div className="flex items-center gap-1.5 pl-8 text-xs text-muted-foreground">
+            <TriangleAlertIcon className="size-3.5 shrink-0" />
+            <span>{CUT_SHORT_NOTICE}</span>
+          </div>
+        )}
       {!(isLastMessage && status === "streaming") &&
         (isEditing ? (
           <MessageActions className="justify-end">


### PR DESCRIPTION
Closes #420

## The problem

A streaming Chat turn ending with a unified finish reason of `length` stopped mid-sentence with nothing said to the reader. The operator saw it in the log (#419), and an unattended caller got `TRUNCATED_BY_TOKEN_LIMIT` appended to the returned text — but the person watching the stream got no signal at all.

## The change

`toUIMessageStream`'s `messageMetadata` callback runs on the terminal `finish` part, which carries the finish reason. That is the one channel that reaches a stream already flushed to the client, so the flag rides it.

- **`ChatMessageMetadata`** gains `truncatedByTokenLimit?: true`. `agentId` becomes optional: a direct provider/model Chat resolves no agent and previously yielded no metadata at all, so there was no way to flag a truncated direct chat. The avatar consumer already tolerated an absent `agentId`.
- **The metadata callback** now reads the stream part — `agentId` at `start`, the truncation flag at `finish`. Each event contributes only the key it owns, so the client-side merge leaves the attribution standing and a truncated Agent turn keeps its avatar.
- **It keys off the terminal `finish`, not `finish-step`.** A step inside a tool loop can end at the ceiling in a run that then completes normally; flagging those would mark answers that were never cut short. The per-step warn log is unchanged.
- **The chat renders** a muted line with a warning icon after the message, from an exported constant so tests assert the wording without restating the prose.

## Persistence

Verified rather than built — **no schema migration and no new column**. The `finish` chunk's metadata merges into the message before the stream's end callback fires, so `ChatSink` writes the flag into the existing `messages` `jsonb`, and the chat client re-seeds it from that row on load. This is the same path the Agent avatar has survived a reload on since #181.

## Tests

Backend covers the metadata callback at `start`, at a truncated `finish`, at a clean `finish`, on a mid-loop `finish-step`, and for a direct provider/model stream with no attribution. Frontend covers the marker rendering, not rendering, and the Agent avatar surviving a truncated turn.

`pnpm lint`, `pnpm typecheck` and `pnpm test` pass.

## Docs

A **When a reply stops early** section on the Chat page, shipped in this PR: what the marker says, that it survives a reload, and a warning that **Regenerate** re-runs the whole turn rather than carrying on from where the reply stopped.

## Not in scope

A configurable output ceiling (#404 was closed as superseded and the reasoning holds), any retry or "continue the response" affordance, changes to the unattended notice, and surfacing any finish reason other than `length`.

## Note for review

The brief asked for the marker "after the last text part". It renders after the whole message instead: if a turn is cut off mid tool-call, the marker belongs at the end rather than above the tool block. In the common case — text last — the two are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)