### PR TITLE
fix(backend): record what the model emitted for a rejected tool call

### DIFF
--- a/apps/backend/src/log-serializers.ts
+++ b/apps/backend/src/log-serializers.ts
@@ -36,7 +36,8 @@ const MAX_CAUSE_DEPTH = 5;
  * and an operator comparing the number against a cap should see the same unit
  * the cap is expressed in.
  */
-const omitted = (characters: number) => `[omitted: ${characters} characters]`;
+export const omitted = (characters: number) =>
+  `[omitted: ${characters} characters]`;
 
 /** Fields this serializer renders itself; anything else is an extra. */
 const HANDLED = new Set(["name", "message", "stack", "cause", "issues"]);

--- a/apps/backend/src/log-serializers.ts
+++ b/apps/backend/src/log-serializers.ts
@@ -51,7 +51,9 @@ const HANDLED = new Set(["name", "message", "stack", "cause", "issues"]);
  */
 const VALIDATOR_DETAIL = /\s*(?:Value:|Error message:)[\s\S]*$/;
 
-const safeStringify = (value: unknown): string | undefined => {
+/** JSON, or nothing — a value that can't be rendered must not take the log
+ *  call down with it. */
+export const safeStringify = (value: unknown): string | undefined => {
   try {
     return JSON.stringify(value);
   } catch {

--- a/apps/backend/src/rejected-tool-input.test.ts
+++ b/apps/backend/src/rejected-tool-input.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import {
+  describeToolInput,
+  MAX_TOOL_INPUT_PREFIX,
+  rejectedToolInputs,
+} from "./rejected-tool-input.ts";
+
+describe("describeToolInput", () => {
+  it("identifies a payload the SDK could not parse as JSON", () => {
+    // Signature A from issue #406: generation stopped mid-string, so the SDK
+    // left the raw text in place instead of a parsed value.
+    const raw = '{"path":"notes/todo.md","body":"the first half of a very lon';
+
+    expect(
+      describeToolInput({
+        type: "tool-error",
+        toolCallId: "call_1",
+        toolName: "writeFile",
+        input: raw,
+      }),
+    ).toEqual({
+      toolCallId: "call_1",
+      toolName: "writeFile",
+      inputType: "string",
+      inputKind: "unparseable",
+      inputLength: raw.length,
+      inputPrefix: raw,
+    });
+  });
+
+  it("tells an empty argument string apart from a literal empty object", () => {
+    // The SDK validates an empty argument string as `{}`, so both land in the
+    // production logs as `Value: {}` — the ambiguity this record exists to end.
+    const emitted = describeToolInput({ input: "" });
+    const literal = describeToolInput({ input: {} });
+
+    expect(emitted).toMatchObject({
+      inputType: "string",
+      inputKind: "empty",
+      inputLength: 0,
+    });
+    expect(literal).toMatchObject({
+      inputType: "object",
+      inputKind: "parsed",
+      inputLength: 2,
+      inputPrefix: "{}",
+    });
+  });
+
+  it("identifies a payload that parsed but failed the schema", () => {
+    expect(
+      describeToolInput({ input: { title: "a", body: 12 } }),
+    ).toMatchObject({
+      inputType: "object",
+      inputKind: "parsed",
+      inputPrefix: '{"title":"a","body":12}',
+    });
+  });
+
+  it("classifies a parsed non-object JSON value by the type it saw", () => {
+    // `123` is valid JSON, so the SDK hands back a number the schema rejects.
+    expect(describeToolInput({ input: 123 })).toMatchObject({
+      inputType: "number",
+      inputKind: "parsed",
+      inputPrefix: "123",
+    });
+    expect(describeToolInput({ input: null })).toMatchObject({
+      inputType: "null",
+      inputKind: "parsed",
+    });
+    expect(describeToolInput({ input: [1, 2] })).toMatchObject({
+      inputType: "array",
+      inputKind: "parsed",
+    });
+  });
+
+  it("records an absent input rather than inventing one", () => {
+    expect(describeToolInput({ input: undefined })).toMatchObject({
+      inputType: "undefined",
+      inputKind: "absent",
+    });
+  });
+
+  it("caps the prefix and says how much it cut", () => {
+    const raw = "x".repeat(MAX_TOOL_INPUT_PREFIX + 40);
+    const record = describeToolInput({ input: raw });
+
+    expect(record.inputLength).toBe(MAX_TOOL_INPUT_PREFIX + 40);
+    expect(record.inputPrefix?.length).toBe(MAX_TOOL_INPUT_PREFIX);
+    // A silently shortened diagnostic is worse than none. 41, not 40: the
+    // ellipsis the cap leaves behind occupies one of the kept characters.
+    expect(record.omitted).toBe("[omitted: 41 characters]");
+  });
+
+  it("leaves a payload that fits uncut and unmarked", () => {
+    const record = describeToolInput({ input: "x".repeat(20) });
+
+    expect(record.inputPrefix).toBe("x".repeat(20));
+    expect(record.omitted).toBeUndefined();
+  });
+
+  it("records an unserializable input instead of throwing", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(describeToolInput({ input: circular })).toMatchObject({
+      inputType: "object",
+      inputKind: "unserializable",
+      inputPrefix: "[unserializable]",
+    });
+    expect(describeToolInput({ input: { big: 1n } })).toMatchObject({
+      inputKind: "unserializable",
+    });
+  });
+});
+
+describe("rejectedToolInputs", () => {
+  it("describes every failed tool call in a finished step", () => {
+    const records = rejectedToolInputs([
+      { type: "text", text: "here goes" },
+      { type: "tool-call", toolCallId: "call_1", toolName: "writeFile" },
+      {
+        type: "tool-error",
+        toolCallId: "call_1",
+        toolName: "writeFile",
+        input: '{"body":"cut',
+        error: "AI_InvalidToolInputError: Invalid input for tool writeFile",
+      },
+      {
+        type: "tool-error",
+        toolCallId: "call_2",
+        toolName: "updateNotification",
+        input: { message: "far too long" },
+        error: "AI_InvalidToolInputError",
+      },
+    ]);
+
+    expect(records.map((r) => [r.toolName, r.inputKind])).toEqual([
+      ["writeFile", "unparseable"],
+      ["updateNotification", "parsed"],
+    ]);
+  });
+
+  it("says nothing about a step whose tool calls all succeeded", () => {
+    expect(
+      rejectedToolInputs([
+        { type: "text", text: "done" },
+        { type: "tool-call", toolCallId: "call_1", toolName: "listBoards" },
+        {
+          type: "tool-result",
+          toolCallId: "call_1",
+          toolName: "listBoards",
+          input: { workspaceId: "ws-1" },
+          output: { boards: [] },
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("ignores content it cannot read rather than throwing inside a log call", () => {
+    expect(rejectedToolInputs(undefined)).toEqual([]);
+    expect(rejectedToolInputs("not an array")).toEqual([]);
+    expect(rejectedToolInputs([null, 42, { type: "tool-error" }])).toEqual([
+      { inputType: "undefined", inputKind: "absent" },
+    ]);
+  });
+});

--- a/apps/backend/src/rejected-tool-input.ts
+++ b/apps/backend/src/rejected-tool-input.ts
@@ -19,7 +19,7 @@
  * arguments are model and user data that may carry secrets (issue #414).
  */
 
-import { omitted } from "./log-serializers.ts";
+import { omitted, safeStringify } from "./log-serializers.ts";
 import { truncate } from "./zod-issues.ts";
 
 /**
@@ -59,7 +59,13 @@ export type ToolInputRecord = {
   /** The runtime type as seen, including `null` and `array`. */
   inputType: string;
   inputKind: ToolInputKind;
-  /** Characters, so the number and the cap share a unit. */
+  /**
+   * Characters, so the number and the cap share a unit.
+   *
+   * On a `parsed` value this measures the re-serialized JSON, not the text the
+   * model emitted — the SDK keeps no copy of that once it has parsed it. Only
+   * an `unparseable` length can be held against a suspected output ceiling.
+   */
   inputLength?: number;
   inputPrefix?: string;
   /** Present only when the prefix was cut; a cut is never silent. */
@@ -73,16 +79,22 @@ const runtimeType = (value: unknown): string => {
   return typeof value;
 };
 
-const asText = (value: unknown): string | undefined => {
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return undefined;
-  }
-};
-
 const asString = (value: unknown): string | undefined =>
   typeof value === "string" ? value : undefined;
+
+/** The length, a capped prefix, and what the cap removed. */
+const payload = (text: string): Partial<ToolInputRecord> => {
+  const prefix = truncate(text, MAX_TOOL_INPUT_PREFIX);
+  if (prefix === text) return { inputLength: text.length, inputPrefix: prefix };
+  return {
+    inputLength: text.length,
+    inputPrefix: prefix,
+    // Counted off the prefix rather than the cap so the two can't drift apart.
+    // `truncate` ends on an ellipsis, which stands in for one character more
+    // than the tail it replaced.
+    omitted: omitted(text.length - (prefix.length - 1)),
+  };
+};
 
 /**
  * Describe one failed tool call's arguments.
@@ -104,35 +116,24 @@ export const describeToolInput = (part: ToolErrorLike): ToolInputRecord => {
   if (part.input === undefined) return record;
 
   if (typeof part.input === "string") {
-    record.inputKind = part.input.length === 0 ? "empty" : "unparseable";
-    return withPayload(record, part.input);
+    return {
+      ...record,
+      inputKind: part.input.length === 0 ? "empty" : "unparseable",
+      ...payload(part.input),
+    };
   }
 
   // Anything else came back from `JSON.parse`, including a bare number or null:
   // valid JSON the schema went on to reject.
-  const text = asText(part.input);
+  const text = safeStringify(part.input);
   if (text === undefined) {
-    record.inputKind = "unserializable";
-    record.inputPrefix = "[unserializable]";
-    return record;
+    return {
+      ...record,
+      inputKind: "unserializable",
+      inputPrefix: "[unserializable]",
+    };
   }
-  record.inputKind = "parsed";
-  return withPayload(record, text);
-};
-
-/** Attach the length and a capped prefix, marking the cut when there is one. */
-const withPayload = (
-  record: ToolInputRecord,
-  text: string,
-): ToolInputRecord => {
-  record.inputLength = text.length;
-  record.inputPrefix = truncate(text, MAX_TOOL_INPUT_PREFIX);
-  if (text.length > MAX_TOOL_INPUT_PREFIX) {
-    // `truncate` keeps `max - 1` characters and ends on an ellipsis, so the
-    // ellipsis stands in for one character more than the tail it replaced.
-    record.omitted = omitted(text.length - (MAX_TOOL_INPUT_PREFIX - 1));
-  }
-  return record;
+  return { ...record, inputKind: "parsed", ...payload(text) };
 };
 
 /**

--- a/apps/backend/src/rejected-tool-input.ts
+++ b/apps/backend/src/rejected-tool-input.ts
@@ -1,0 +1,158 @@
+/**
+ * What the model actually emitted for a tool call that failed.
+ *
+ * Two different failures reach production with the same symptom (issue #406):
+ * arguments cut off mid-JSON, and an `AI_InvalidToolInputError` whose value is
+ * an empty object. Neither is distinguishable from the outside, because the SDK
+ * validates an *empty* argument string against the schema as `{}` — so
+ * `Value: {}` in a log means either "the model emitted `{}`" or "the model
+ * emitted nothing at all".
+ *
+ * The SDK itself carries the discriminator. When a tool call fails to parse it
+ * builds `input = parsedInput.success ? parsedInput.value : toolCall.input`, so
+ * unparseable JSON leaves the raw string in place while a parsed-but-rejected
+ * value arrives as the parsed object. Reading the runtime type of `input`
+ * classifies the failure without having to read the payload itself.
+ *
+ * Everything here is capped before it reaches the logger: this is a plain field
+ * rather than an error, so the error serializer never sees it, and tool
+ * arguments are model and user data that may carry secrets (issue #414).
+ */
+
+import { omitted } from "./log-serializers.ts";
+import { truncate } from "./zod-issues.ts";
+
+/**
+ * How much of the rejected payload is worth keeping.
+ *
+ * Enough to see whether a JSON string stops mid-value, and no more: past this
+ * the record is carrying the arguments rather than describing them. Matches the
+ * property cap the log serializer already applies.
+ */
+export const MAX_TOOL_INPUT_PREFIX = 512;
+
+/** The `tool-error` part, structurally — both stream parts and step content. */
+export type ToolErrorLike = {
+  type?: unknown;
+  toolCallId?: unknown;
+  toolName?: unknown;
+  input?: unknown;
+};
+
+/**
+ * How the payload arrived, stated outright so nobody has to infer it from the
+ * prefix:
+ *
+ * - `unparseable` — a non-empty raw string the SDK could not parse as JSON,
+ *   which is the truncated-mid-generation signature
+ * - `empty` — the model emitted no arguments at all
+ * - `parsed` — valid JSON the tool's schema (or its execution) then rejected
+ * - `unserializable` — a parsed value that cannot be rendered as text
+ * - `absent` — no input on the part at all (a provider-executed result)
+ */
+export type ToolInputKind =
+  "unparseable" | "empty" | "parsed" | "unserializable" | "absent";
+
+export type ToolInputRecord = {
+  toolCallId?: string;
+  toolName?: string;
+  /** The runtime type as seen, including `null` and `array`. */
+  inputType: string;
+  inputKind: ToolInputKind;
+  /** Characters, so the number and the cap share a unit. */
+  inputLength?: number;
+  inputPrefix?: string;
+  /** Present only when the prefix was cut; a cut is never silent. */
+  omitted?: string;
+};
+
+/** `typeof`, minus the two answers it gets uselessly wrong. */
+const runtimeType = (value: unknown): string => {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+};
+
+const asText = (value: unknown): string | undefined => {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+};
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+/**
+ * Describe one failed tool call's arguments.
+ *
+ * Never throws: an input it doesn't recognise still produces a record naming
+ * the runtime type it saw, because this is coupled to SDK internals and logging
+ * nothing is the one outcome that leaves the original question unanswered.
+ */
+export const describeToolInput = (part: ToolErrorLike): ToolInputRecord => {
+  const record: ToolInputRecord = {
+    inputType: runtimeType(part.input),
+    inputKind: "absent",
+  };
+  const toolCallId = asString(part.toolCallId);
+  const toolName = asString(part.toolName);
+  if (toolCallId !== undefined) record.toolCallId = toolCallId;
+  if (toolName !== undefined) record.toolName = toolName;
+
+  if (part.input === undefined) return record;
+
+  if (typeof part.input === "string") {
+    record.inputKind = part.input.length === 0 ? "empty" : "unparseable";
+    return withPayload(record, part.input);
+  }
+
+  // Anything else came back from `JSON.parse`, including a bare number or null:
+  // valid JSON the schema went on to reject.
+  const text = asText(part.input);
+  if (text === undefined) {
+    record.inputKind = "unserializable";
+    record.inputPrefix = "[unserializable]";
+    return record;
+  }
+  record.inputKind = "parsed";
+  return withPayload(record, text);
+};
+
+/** Attach the length and a capped prefix, marking the cut when there is one. */
+const withPayload = (
+  record: ToolInputRecord,
+  text: string,
+): ToolInputRecord => {
+  record.inputLength = text.length;
+  record.inputPrefix = truncate(text, MAX_TOOL_INPUT_PREFIX);
+  if (text.length > MAX_TOOL_INPUT_PREFIX) {
+    // `truncate` keeps `max - 1` characters and ends on an ellipsis, so the
+    // ellipsis stands in for one character more than the tail it replaced.
+    record.omitted = omitted(text.length - (MAX_TOOL_INPUT_PREFIX - 1));
+  }
+  return record;
+};
+
+/**
+ * Pick the failed tool calls out of a finished step's content.
+ *
+ * Every `tool-error` part is described, not just the ones whose error text
+ * matches an invalid-input message. Gating on the error's shape would couple a
+ * *decision* to the SDK's message format, and the failure mode of that coupling
+ * drifting is silence — which is exactly the state this record exists to end.
+ * A `tool-error` is never the success path, so nothing here can fire for a tool
+ * call that worked.
+ */
+export const rejectedToolInputs = (content: unknown): ToolInputRecord[] => {
+  if (!Array.isArray(content)) return [];
+  return content
+    .filter(
+      (part): part is ToolErrorLike =>
+        typeof part === "object" &&
+        part !== null &&
+        (part as { type?: unknown }).type === "tool-error",
+    )
+    .map(describeToolInput);
+};

--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -342,6 +342,153 @@ describe("finish reason instrumentation", () => {
   });
 });
 
+// Issue #421: the finish reason says a tool call was rejected, not what the
+// model emitted. Both run paths record `tool-error` parts into step content,
+// so both are covered from the one step-finished callback.
+describe("rejected tool input instrumentation", () => {
+  let runner: AgentRunner;
+  beforeEach(() => {
+    runner = new AgentRunner();
+    vi.clearAllMocks();
+    streamHarness.queue = null;
+    streamHarness.onStepFinish = undefined;
+    streamHarness.onFinish = undefined;
+  });
+
+  const failureLogs = () =>
+    vi
+      .mocked(logger.debug)
+      .mock.calls.filter((call) => call[1] === "Tool call failed")
+      .map((call) => call[0] as Record<string, unknown>);
+
+  const stepWith = (content: unknown[]) => ({
+    toolCalls: [{ toolName: "writeFile" }],
+    usage: { inputTokens: 1, outputTokens: 1 },
+    finishReason: "tool-calls",
+    rawFinishReason: "tool_use",
+    content,
+  });
+
+  const generateWithStep = async (content: unknown[]) => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    mockGenerateText.mockImplementationOnce(
+      (args: { onStepFinish: (s: unknown) => void }) => {
+        args.onStepFinish(stepWith(content));
+        return fakeGenerateResult;
+      },
+    );
+    await runner.generate({
+      scope,
+      input: baseInput,
+      sink: new RecordingSink(),
+    });
+  };
+
+  it("records a truncated payload on the unattended path", async () => {
+    const raw = '{"path":"notes.md","body":"the first half of a very l';
+    await generateWithStep([
+      {
+        type: "tool-error",
+        toolCallId: "call_1",
+        toolName: "writeFile",
+        input: raw,
+        error: "AI_InvalidToolInputError: Invalid input for tool writeFile",
+      },
+    ]);
+
+    expect(failureLogs()[0]).toMatchObject({
+      runId: "run-1",
+      step: 1,
+      toolCallId: "call_1",
+      toolName: "writeFile",
+      inputType: "string",
+      inputKind: "unparseable",
+      inputLength: raw.length,
+      inputPrefix: raw,
+    });
+  });
+
+  it("tells a payload the model never sent from one it sent empty", async () => {
+    await generateWithStep([
+      { type: "tool-error", toolCallId: "call_1", input: "" },
+      { type: "tool-error", toolCallId: "call_2", input: {} },
+    ]);
+
+    expect(failureLogs().map((r) => r.inputKind)).toEqual(["empty", "parsed"]);
+  });
+
+  it("says nothing about a step whose tool calls all succeeded", async () => {
+    await generateWithStep([
+      { type: "text", text: "done" },
+      {
+        type: "tool-result",
+        toolCallId: "call_1",
+        toolName: "writeFile",
+        input: { path: "notes.md", body: "secret" },
+        output: { ok: true },
+      },
+    ]);
+
+    expect(failureLogs()).toEqual([]);
+  });
+
+  it("records the same payload on the streaming path", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    streamHarness.queue = new streamHarness.AsyncQueue();
+    mockStreamText.mockImplementation(
+      (opts: { onStepFinish: (step: unknown) => void }) => {
+        streamHarness.onStepFinish = opts.onStepFinish;
+        return {
+          toUIMessageStream: () => ({ tee: () => [{}, {}] }),
+        };
+      },
+    );
+
+    await runner.stream({
+      scope,
+      input: { ...baseInput, runId: "s-rejected" },
+      sink: new RecordingSink(),
+      options: { origin: "http://test" },
+    });
+    streamHarness.onStepFinish!(
+      stepWith([
+        {
+          type: "tool-error",
+          toolCallId: "call_1",
+          toolName: "updateNotification",
+          input: { message: "far too long" },
+          error: "AI_InvalidToolInputError",
+        },
+      ]),
+    );
+
+    expect(failureLogs()[0]).toMatchObject({
+      runId: "s-rejected",
+      toolName: "updateNotification",
+      inputKind: "parsed",
+      inputPrefix: '{"message":"far too long"}',
+    });
+    runRegistry.cancel("s-rejected");
+  });
+
+  it("keeps the argument text out of the entry an Operator sees by default", async () => {
+    await generateWithStep([
+      { type: "tool-error", toolCallId: "call_1", input: '{"body":"cut' },
+    ]);
+
+    // Emitted at `debug` alone: at the default LOG_LEVEL=info the payload is
+    // never written at all.
+    const higher = [
+      ...vi.mocked(logger.info).mock.calls,
+      ...vi.mocked(logger.warn).mock.calls,
+      ...vi.mocked(logger.error).mock.calls,
+    ];
+    expect(higher.some((call) => JSON.stringify(call[0]).includes("cut"))).toBe(
+      false,
+    );
+  });
+});
+
 describe("AgentRunner.generate", () => {
   let runner: AgentRunner;
   beforeEach(() => {

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -19,6 +19,7 @@ import {
   type ToolActivityEvent,
 } from "../services/chat-execution.ts";
 import { logger } from "../logger.ts";
+import { rejectedToolInputs } from "../rejected-tool-input.ts";
 import { actorUserId, type WorkspaceScope } from "../scope.ts";
 import type { PlatypusUIMessage } from "../types.ts";
 import {
@@ -328,6 +329,12 @@ export class AgentRunner {
       // provider actually said (issue #406).
       finishReason?: string;
       rawFinishReason?: string;
+      /**
+       * The step's parts, read only for the tool calls that failed. Both the
+       * streaming and the unattended path record a `tool-error` here, so one
+       * callback covers both — `onChunk` would cover only streaming.
+       */
+      content?: unknown;
     }): void => {
       handle.bumpStep();
       accumulateStepStats(state.stats, step);
@@ -350,6 +357,16 @@ export class AgentRunner {
             rawFinishReason: step.rawFinishReason,
           },
           "Step truncated at the output token limit",
+        );
+      }
+      // What the model actually emitted for a tool call that failed. At `debug`
+      // because tool arguments are model and user data: at the default
+      // `LOG_LEVEL=info` nothing is written, and an Operator diagnosing a
+      // recurrence raises the level (issue #421).
+      for (const rejected of rejectedToolInputs(step.content)) {
+        logger.debug(
+          { runId: input.runId, step: state.stats.steps, ...rejected },
+          "Tool call failed",
         );
       }
       // Sink decides write cadence (FlushScheduler in ChatSink).

--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -68,8 +68,10 @@ vi.mock("ai", async () => {
 });
 
 vi.mock("../logger.ts", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
+
+import { logger } from "../logger.ts";
 
 describe("createSubAgentTool", () => {
   const baseOptions = {
@@ -483,6 +485,73 @@ describe("createSubAgentTool", () => {
         status: "error",
         error: "Connection refused",
       });
+    });
+
+    // Issue #421: the activity entry keeps only the error text, so a sub-agent
+    // run — the least observable surface there is — recorded nothing about the
+    // arguments the model actually emitted.
+    it("logs what the model emitted for a rejected tool call", async () => {
+      const raw = '{"url":"https://example.com/a-page","selecto';
+      mockStream.mockResolvedValue({
+        fullStream: createMockFullStream([
+          { type: "tool-input-start", toolName: "web-fetch", id: "tc1" },
+          {
+            type: "tool-error",
+            toolCallId: "tc1",
+            toolName: "web-fetch",
+            input: raw,
+            error: "AI_InvalidToolInputError: Invalid input for tool web-fetch",
+          },
+        ]),
+        text: Promise.resolve(""),
+      });
+
+      const { tool } = createSubAgentTool(baseOptions);
+      await consumeGenerator(
+        tool.execute(
+          { task: "Do something" },
+          {} as ToolExecutionOptions<Record<string, unknown>>,
+        ) as AsyncGenerator<SubAgentActivity>,
+      );
+
+      const logged = vi
+        .mocked(logger.debug)
+        .mock.calls.find((call) => call[1] === "Sub-agent tool call failed");
+      expect(logged?.[0]).toMatchObject({
+        subAgentName: "Research Agent",
+        toolCallId: "tc1",
+        toolName: "web-fetch",
+        inputType: "string",
+        inputKind: "unparseable",
+        inputLength: raw.length,
+        inputPrefix: raw,
+      });
+    });
+
+    it("says nothing about a sub-agent tool call that succeeded", async () => {
+      mockStream.mockResolvedValue({
+        fullStream: createMockFullStream([
+          { type: "tool-input-start", toolName: "web-fetch", id: "tc1" },
+          {
+            type: "tool-result",
+            toolCallId: "tc1",
+            toolName: "web-fetch",
+            input: { url: "https://example.com" },
+            output: "page text",
+          },
+        ]),
+        text: Promise.resolve(""),
+      });
+
+      const { tool } = createSubAgentTool(baseOptions);
+      await consumeGenerator(
+        tool.execute(
+          { task: "Do something" },
+          {} as ToolExecutionOptions<Record<string, unknown>>,
+        ) as AsyncGenerator<SubAgentActivity>,
+      );
+
+      expect(vi.mocked(logger.debug)).not.toHaveBeenCalled();
     });
 
     it("passes abortSignal to agent.stream", async () => {

--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -514,10 +514,13 @@ describe("createSubAgentTool", () => {
         ) as AsyncGenerator<SubAgentActivity>,
       );
 
+      // The same message the run driver logs, so an Operator greps once and
+      // the sub-agent fields say which run it came from.
       const logged = vi
         .mocked(logger.debug)
-        .mock.calls.find((call) => call[1] === "Sub-agent tool call failed");
+        .mock.calls.find((call) => call[1] === "Tool call failed");
       expect(logged?.[0]).toMatchObject({
+        subAgentId: "agent-1",
         subAgentName: "Research Agent",
         toolCallId: "tc1",
         toolName: "web-fetch",

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -117,6 +117,7 @@ interface SubAgentToolOptions {
  */
 export const createSubAgentTool = (options: SubAgentToolOptions) => {
   const {
+    id,
     name,
     description,
     instructions,
@@ -226,8 +227,12 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
               // record is worth the most (issue #421). `debug`, because tool
               // arguments are model and user data.
               logger.debug(
-                { subAgentName: name, ...describeToolInput(part) },
-                "Sub-agent tool call failed",
+                {
+                  subAgentId: id,
+                  subAgentName: name,
+                  ...describeToolInput(part),
+                },
+                "Tool call failed",
               );
               break;
             }

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -7,6 +7,7 @@ import {
 } from "ai";
 import { z } from "zod";
 import { logger } from "../logger.ts";
+import { describeToolInput } from "../rejected-tool-input.ts";
 import { renderSecurityGuardrails } from "../security-prompt.ts";
 import { withNormalizedResults } from "../services/tool-result.ts";
 import {
@@ -219,6 +220,15 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
                 entry.status = "error";
                 entry.error = String(part.error);
               }
+              // The activity entry keeps only the error text, so without this
+              // the arguments the sub-agent emitted are gone. A sub-agent run
+              // is the least observable surface there is, which is where the
+              // record is worth the most (issue #421). `debug`, because tool
+              // arguments are model and user data.
+              logger.debug(
+                { subAgentName: name, ...describeToolInput(part) },
+                "Sub-agent tool call failed",
+              );
               break;
             }
             case "reasoning-start":


### PR DESCRIPTION
Closes #421.

## The problem

Two different failures reach production with one symptom (#406): arguments cut off mid-JSON, and an `AI_InvalidToolInputError` whose value is `{}`. Nothing recorded what the model actually emitted, so they were indistinguishable from the logs.

`Value: {}` is the worse of the two, because the SDK validates an *empty* argument string against the schema as `{}` — so that message means either "the model emitted `{}`" or "the model emitted nothing at all". #419's finish reasons narrow the cause but cannot separate these.

## The discriminator

The SDK already carries it. When a tool call fails to parse it builds `input = parsedInput.success ? parsedInput.value : toolCall.input`, so unparseable JSON leaves the raw string in place while a parsed-but-rejected value arrives as the parsed object. Reading the runtime type classifies the failure without reading the payload.

A rejected tool call now emits one `debug` record:

| `inputKind` | what arrived | means |
| --- | --- | --- |
| `unparseable` | string, length > 0 | JSON cut off mid-generation |
| `empty` | string, length 0 | the model emitted no arguments at all |
| `parsed` | any parsed value | valid JSON the schema rejected |
| `unserializable` / `absent` | — | degraded cases, named rather than silent |

alongside `inputType` (the runtime type as seen), the character length, and a prefix capped at `MAX_TOOL_INPUT_PREFIX = 512` with an `[omitted: N characters]` marker when it cut.

## Where it reads

The run driver's shared step-finished callback — both the streaming and the unattended path record `tool-error` parts into step content, so one callback covers both where `onChunk` would cover only streaming. Also the sub-agent stream loop, which kept only `String(part.error)` and is the least observable surface there is.

Emitted at `debug` because tool arguments are model and user data: at the default `LOG_LEVEL=info` nothing is written, and an Operator diagnosing a recurrence raises the level. No new configuration. The prefix reuses the existing cap and `omitted()` marker, so a cut is never silent.

## Judgement calls

- **Every `tool-error` is described, not only input rejections.** A tool whose `execute` throws has its (valid) arguments recorded too. Gating on the error's text would couple a *decision* to the SDK's message format, and that drifting fails silently — the exact state this issue exists to end. Broader than the issue asked; capped and `debug`-gated.
- **`inputLength` on a `parsed` value measures the re-serialization**, not the emitted text — the SDK keeps no copy once it has parsed. Documented on the field, since only an `unparseable` length can be held against a suspected output ceiling.
- **The sub-agent record carries `subAgentId`/`subAgentName`, not the parent `runId`.** Threading that through means plumbing run context into the sub-agent factory, which is wider than this change.

## Out of scope, per the issue

`experimental_repairToolCall` (this instrumentation is what tells us whether there is anything repairable), the user- and model-facing error text settled by #419, the streaming truncation notice (#420), and any docs change — `LOG_LEVEL` is already present and documented, and no row of the docs contract is triggered.

## Testing

- 16 new tests: each classification, the over-cap truncation marker, the unserializable case, silence on success, and the record on all three surfaces.
- Full suite green: 1531 backend tests, typecheck and lint clean.
- The SDK seam verified against the installed `ai@7.0.48`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)