### PR TITLE
fix(backend): name the failing field when a union tool input is rejected

### DIFF
--- a/apps/backend/src/log-serializers.ts
+++ b/apps/backend/src/log-serializers.ts
@@ -1,6 +1,5 @@
 import {
   findIssues,
-  flattenIssues,
   formatIssues,
   truncate,
   type ZodLikeIssue,
@@ -98,9 +97,7 @@ const serializeLink = (
   // empty. Suppressing the message on the mere *presence* of issues would let a
   // tree that summarises to nothing take the only readable line with it.
   const summary =
-    ownIssues && ownIssues.length > 0
-      ? formatIssues(flattenIssues(ownIssues))
-      : "";
+    ownIssues && ownIssues.length > 0 ? formatIssues(ownIssues) : "";
 
   if (typeof source.message === "string") {
     const message = wrapsZod

--- a/apps/backend/src/runs/stream-error.test.ts
+++ b/apps/backend/src/runs/stream-error.test.ts
@@ -7,6 +7,7 @@ import {
   TypeValidationError,
 } from "ai";
 import { z } from "zod";
+import { serializeLoggedError } from "../log-serializers.ts";
 import { formatStreamError, TRUNCATED_BY_TOKEN_LIMIT } from "./stream-error.ts";
 
 vi.mock("../logger.ts", () => ({
@@ -128,6 +129,48 @@ describe("formatStreamError", () => {
       const formatted = formatStreamError(error);
       expect(formatted).toContain("mysteryTool");
       expect(formatted).toContain("unparseable");
+    });
+  });
+
+  // Where the two surfaces used to disagree. A union reports why every branch
+  // failed, and only a descent that concatenates the union's path with the
+  // branch's produces the one path worth reading. The log serializer flattened
+  // and this did not, so the log named the field while the user — and, on a
+  // failed step, the model asked to correct itself — got `payload: Invalid
+  // input`.
+  describe("invalid tool input rejected by a union", () => {
+    const schema = z.object({
+      payload: z.union([
+        z.object({
+          kind: z.literal("a"),
+          items: z.array(z.object({ id: z.string() })),
+        }),
+        z.object({ kind: z.literal("b"), value: z.number() }),
+      ]),
+    });
+    const value = { payload: { kind: "a", items: [{ id: 42 }] } };
+    const rejected = () =>
+      invalidToolInput({ toolName: "recordPayload", schema, value });
+
+    it("names the field the union rejected rather than the union", () => {
+      const formatted = formatStreamError(rejected());
+
+      expect(formatted).toContain("recordPayload");
+      expect(formatted).toContain("payload.items[0].id");
+      expect(formatted).not.toContain("payload: Invalid input");
+      expect(formatted).not.toContain("invalid_union");
+    });
+
+    it("tells the log exactly what it tells the user", () => {
+      const error = rejected();
+
+      const streamed = formatStreamError(error);
+      const logged = JSON.stringify(serializeLoggedError(error));
+
+      const line =
+        "payload.items[0].id: Invalid input: expected string, received number";
+      expect(streamed).toContain(line);
+      expect(logged).toContain(line);
     });
   });
 

--- a/apps/backend/src/zod-issues.test.ts
+++ b/apps/backend/src/zod-issues.test.ts
@@ -178,6 +178,38 @@ describe("flattenIssues", () => {
 });
 
 describe("formatIssues", () => {
+  it("descends a union so the line names the field that failed", () => {
+    // Rendering the raw tree gives `payload: Invalid input`, which names the
+    // union node and nothing a caller can act on. Every surface wants the
+    // descent, so it belongs here rather than at each call site.
+    const schema = z.object({
+      payload: z.union([
+        z.object({
+          kind: z.literal("a"),
+          items: z.array(z.object({ id: z.string() })),
+        }),
+        z.object({ kind: z.literal("b"), value: z.number() }),
+      ]),
+    });
+
+    expect(
+      formatIssues(
+        issuesFor(schema, { payload: { kind: "a", items: [{ id: 42 }] } }),
+      ),
+    ).toBe(
+      "payload.items[0].id: Invalid input: expected string, received number",
+    );
+  });
+
+  it("renders an already-flattened list the same way", () => {
+    // The log serializer flattened before calling this. Flattening twice has
+    // to be identity, or moving the descent inside would have changed it.
+    const schema = z.object({ rows: z.array(z.object({ at: z.string() })) });
+    const issues = issuesFor(schema, { rows: [{ at: 1 }] });
+
+    expect(formatIssues(flattenIssues(issues))).toBe(formatIssues(issues));
+  });
+
   it("marks the issues it dropped rather than trimming silently", () => {
     const many = Array.from({ length: 9 }, (_, index) => ({
       path: ["rows", index, "at"],

--- a/apps/backend/src/zod-issues.ts
+++ b/apps/backend/src/zod-issues.ts
@@ -193,18 +193,25 @@ export const flattenIssues = (issues: ZodLikeIssue[]): FlatIssue[] =>
 /**
  * Render issues as one capped line per failing field.
  *
+ * Flattens first, so a union renders as the absolute path of the field that
+ * actually failed rather than the useless `payload: Invalid input` the union
+ * node carries. Doing it here rather than at the call sites is what keeps the
+ * two surfaces — the log entry and the text the user and the model read — from
+ * disagreeing about the same failure.
+ *
  * Deliberately does NOT include the rejected value. The SDK's own message
  * embeds the entire value plus the serialized `ZodError`, which is how a
  * single over-long field became several thousand characters of unreadable
  * output for the user and the model alike (issue #406).
  */
 export const formatIssues = (issues: ZodLikeIssue[]): string => {
-  const shown = issues
+  const flat = flattenIssues(issues);
+  const shown = flat
     .slice(0, MAX_ISSUES)
     .map(
       (issue) =>
         `${formatPath(issue.path)}: ${truncate(issueText(issue), MAX_ISSUE_LENGTH)}`,
     );
-  const omitted = issues.length - shown.length;
+  const omitted = flat.length - shown.length;
   return shown.join("; ") + (omitted > 0 ? ` (+${omitted} more)` : "");
 };


### PR DESCRIPTION
## The defect

`formatIssues` in `apps/backend/src/zod-issues.ts` renders one line per issue
from the list it is handed. It never descended the tree. `flattenIssues` — the
function that does descend, picking the branch that got furthest into the value
and concatenating the union's path with the branch's — sat next to it and had
to be called separately.

Only one of the two call sites called it. The log serializer flattened; the
stream error formatter did not. So for the same rejected tool call the log
named the field and the text that reaches the user — and, on a failed step, the
model being asked to correct itself — named the union node instead:

```
before : payload: Invalid input
after  : payload.items[0].id: Invalid input: expected string, received number
```

The first line is not actionable. A model handed it cannot tell which field to
fix, and a union sitting anywhere in a tool's input schema was enough to
trigger it.

## The fix

`formatIssues` flattens its own input. The correction lands in the function
rather than at the call sites, so a third surface cannot reintroduce the
disagreement by forgetting to ask.

`flattenIssues` stays exported and directly tested. Flattening is idempotent —
the flattened form carries no `code`, so a second pass finds no union to
descend — which makes this a no-op for the log serializer, and its now
redundant `flattenIssues(...)` wrap is dropped.

## Tests

- `formatIssues` renders a nested union as the absolute path of the offending
  field, and renders an already-flattened list identically.
- `formatStreamError` and `serializeLoggedError`, given the same
  `InvalidToolInputError`, both carry the same line.

No existing test changed: the `formatIssues` tests use non-union issues with
explicit paths, which flatten to themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
