### PR TITLE
fix(backend): record a trigger run that stopped at the output limit

### DIFF
--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -91,10 +91,9 @@ vi.mock("../logger.ts", () => ({
 }));
 
 import { AgentRunner } from "./agent-runner.ts";
-import { TRUNCATED_BY_TOKEN_LIMIT } from "./stream-error.ts";
 import { logger } from "../logger.ts";
 import { runRegistry, TimeoutError } from "./run-registry.ts";
-import type { ResolvedRunPlan, RunInput, RunSink } from "./types.ts";
+import type { ResolvedRunPlan, RunInput, RunSink, RunStats } from "./types.ts";
 import type { WorkspaceScope } from "../scope.ts";
 
 type LifecycleEvent =
@@ -107,6 +106,7 @@ type LifecycleEvent =
       status: string;
       error?: string;
       messages?: unknown[];
+      stats?: RunStats;
     };
 
 class RecordingSink implements RunSink {
@@ -129,6 +129,7 @@ class RecordingSink implements RunSink {
     status: string;
     error?: Error;
     messages?: unknown[];
+    stats?: RunStats;
   }): Promise<void> {
     this.events.push({
       name: "onFinish",
@@ -136,12 +137,19 @@ class RecordingSink implements RunSink {
       status: ctx.status,
       error: ctx.error?.message,
       messages: ctx.messages,
+      stats: ctx.stats,
     });
     return Promise.resolve();
   }
 
   names(): string[] {
     return this.events.map((e) => e.name);
+  }
+
+  /** The stats the run handed the sink at termination. */
+  finalStats(): RunStats | undefined {
+    const finish = this.events.find((e) => e.name === "onFinish");
+    return finish?.name === "onFinish" ? finish.stats : undefined;
   }
 }
 
@@ -280,7 +288,9 @@ describe("finish reason instrumentation", () => {
     expect(warned).toBe(true);
   });
 
-  it("tells the caller when an unattended run was cut off at the token limit", async () => {
+  // The unattended path returns its text to a caller that discards it, so the
+  // stats the sink persists are the only place a cut-short run can be recorded.
+  it("flags the stats when an unattended run stopped at the output limit", async () => {
     mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
     mockGenerateText.mockResolvedValueOnce({
       ...fakeGenerateResult,
@@ -288,33 +298,28 @@ describe("finish reason instrumentation", () => {
       finishReason: "length",
       rawFinishReason: "max_tokens",
     });
+    const sink = new RecordingSink();
 
-    const result = await runner.generate({
-      scope,
-      input: baseInput,
-      sink: new RecordingSink(),
-    });
+    const result = await runner.generate({ scope, input: baseInput, sink });
 
-    // The model that receives this text can adapt; previously it could not
-    // tell a truncated answer from a complete one.
-    expect(result.text).toContain("half an ans");
-    expect(result.text).toContain(TRUNCATED_BY_TOKEN_LIMIT);
+    expect(sink.finalStats()?.truncatedByTokenLimit).toBe(true);
+    expect(result.stats.truncatedByTokenLimit).toBe(true);
+    // The answer itself is returned as the model wrote it — no appended notice.
+    expect(result.text).toBe("half an ans");
   });
 
-  it("leaves a cleanly finished unattended run's text untouched", async () => {
+  it("leaves a cleanly finished unattended run's stats unflagged", async () => {
     mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
     mockGenerateText.mockResolvedValueOnce({
       ...fakeGenerateResult,
       finishReason: "stop",
       rawFinishReason: "end_turn",
     });
+    const sink = new RecordingSink();
 
-    const result = await runner.generate({
-      scope,
-      input: baseInput,
-      sink: new RecordingSink(),
-    });
+    const result = await runner.generate({ scope, input: baseInput, sink });
 
+    expect(sink.finalStats()).not.toHaveProperty("truncatedByTokenLimit");
     expect(result.text).toBe("ok");
   });
 

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -7,11 +7,7 @@ import {
   stepCountIs,
   streamText,
 } from "ai";
-import {
-  formatStreamError,
-  isTruncatedByTokenLimit,
-  TRUNCATED_BY_TOKEN_LIMIT,
-} from "./stream-error.ts";
+import { formatStreamError, isTruncatedByTokenLimit } from "./stream-error.ts";
 import {
   prepareChatTurn,
   validateTurnAttachments,
@@ -547,6 +543,13 @@ export class AgentRunner {
       });
 
       const stats = computeStats(result as Parameters<typeof computeStats>[0]);
+      // The terminal finish only, as on the streamed path: a step inside a tool
+      // loop can end at the ceiling and the run still recover. Set before
+      // `finalize`, which is what carries `state.stats` to `sink.onFinish` —
+      // the sink's record is the only channel an unattended run has.
+      if (isTruncatedByTokenLimit(result.finishReason)) {
+        stats.truncatedByTokenLimit = true;
+      }
       state.stats = stats;
 
       // The no-progress stop condition halts the loop cleanly (the SDK
@@ -588,14 +591,7 @@ export class AgentRunner {
       );
 
       await finalize("succeeded");
-      // A truncated answer is worse than a failed one when it's indistinguishable
-      // from a complete one: the caller stores it, and whatever reads it later
-      // has no way to know the tail is missing. Say so in the text itself, which
-      // is the only channel an unattended caller has.
-      const text = isTruncatedByTokenLimit(result.finishReason)
-        ? `${result.text}\n\n${TRUNCATED_BY_TOKEN_LIMIT}`
-        : result.text;
-      return { text, stats };
+      return { text: result.text, stats };
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       logger.error(

--- a/apps/backend/src/runs/sinks/trigger-sink.test.ts
+++ b/apps/backend/src/runs/sinks/trigger-sink.test.ts
@@ -239,28 +239,6 @@ describe("TriggerSink", () => {
       });
     });
 
-    // The steps==null guard would otherwise drop the row, and with it the only
-    // record that the run was truncated.
-    it("still writes the truncation marker when no step was ever observed", async () => {
-      const sink = new TriggerSink({ triggerId: "trigger-1" });
-
-      await sink.onFinish({
-        runId: "run-1",
-        status: "succeeded",
-        messages: [],
-        stats: { truncatedByTokenLimit: true },
-      });
-
-      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
-      expect(setArg.stats).toEqual({
-        steps: 0,
-        toolCalls: [],
-        inputTokens: 0,
-        outputTokens: 0,
-        truncatedByTokenLimit: true,
-      });
-    });
-
     it("omits the marker entirely for a run that finished cleanly", async () => {
       const sink = new TriggerSink({ triggerId: "trigger-1" });
 

--- a/apps/backend/src/runs/sinks/trigger-sink.test.ts
+++ b/apps/backend/src/runs/sinks/trigger-sink.test.ts
@@ -209,5 +209,70 @@ describe("TriggerSink", () => {
       const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
       expect(setArg.stats).toBeNull();
     });
+
+    // Without this the run lands as a plain 'success' and nothing anywhere says
+    // the answer was cut off at the model's ceiling.
+    it("persists the truncation marker on a run that hit the output limit", async () => {
+      const sink = new TriggerSink({ triggerId: "trigger-1" });
+
+      await sink.onFinish({
+        runId: "run-1",
+        status: "succeeded",
+        messages: [],
+        stats: {
+          steps: 1,
+          toolCalls: [],
+          inputTokens: 100,
+          outputTokens: 4096,
+          truncatedByTokenLimit: true,
+        },
+      });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.status).toBe("success");
+      expect(setArg.stats).toEqual({
+        steps: 1,
+        toolCalls: [],
+        inputTokens: 100,
+        outputTokens: 4096,
+        truncatedByTokenLimit: true,
+      });
+    });
+
+    // The steps==null guard would otherwise drop the row, and with it the only
+    // record that the run was truncated.
+    it("still writes the truncation marker when no step was ever observed", async () => {
+      const sink = new TriggerSink({ triggerId: "trigger-1" });
+
+      await sink.onFinish({
+        runId: "run-1",
+        status: "succeeded",
+        messages: [],
+        stats: { truncatedByTokenLimit: true },
+      });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.stats).toEqual({
+        steps: 0,
+        toolCalls: [],
+        inputTokens: 0,
+        outputTokens: 0,
+        truncatedByTokenLimit: true,
+      });
+    });
+
+    it("omits the marker entirely for a run that finished cleanly", async () => {
+      const sink = new TriggerSink({ triggerId: "trigger-1" });
+
+      await sink.onFinish({
+        runId: "run-1",
+        status: "succeeded",
+        messages: [],
+        stats: { steps: 1, toolCalls: [], inputTokens: 1, outputTokens: 1 },
+      });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.stats).not.toHaveProperty("truncatedByTokenLimit");
+    });
   });
 });

--- a/apps/backend/src/runs/sinks/trigger-sink.ts
+++ b/apps/backend/src/runs/sinks/trigger-sink.ts
@@ -23,13 +23,26 @@ export type TriggerSinkParams = {
 /** Default cadence for periodic TriggerSink stat flushes. */
 export const DEFAULT_FLUSH_INTERVAL_MS = 5_000;
 
+/**
+ * `steps == null` means no step was ever observed, and counting a run that
+ * never started as "0 steps, 0 tokens" reads as a real measurement — hence the
+ * null. The truncation marker is the exception: it is the only record that the
+ * answer was cut short, and dropping it leaves the run indistinguishable from a
+ * clean success. So a flagged run is written out even with nothing else to
+ * report, rather than making the guard weaker for every other field.
+ */
 const toTriggerRunStats = (stats: RunStats): TriggerRunStats | null => {
-  if (stats.steps == null) return null;
+  if (stats.steps == null && !stats.truncatedByTokenLimit) return null;
   return {
     steps: stats.steps ?? 0,
     toolCalls: stats.toolCalls ?? [],
     inputTokens: stats.inputTokens ?? 0,
     outputTokens: stats.outputTokens ?? 0,
+    // Spread so an untruncated run stores no key at all, matching the schema's
+    // `z.literal(true).optional()`.
+    ...(stats.truncatedByTokenLimit
+      ? { truncatedByTokenLimit: true as const }
+      : {}),
   };
 };
 

--- a/apps/backend/src/runs/sinks/trigger-sink.ts
+++ b/apps/backend/src/runs/sinks/trigger-sink.ts
@@ -24,15 +24,12 @@ export type TriggerSinkParams = {
 export const DEFAULT_FLUSH_INTERVAL_MS = 5_000;
 
 /**
- * `steps == null` means no step was ever observed, and counting a run that
- * never started as "0 steps, 0 tokens" reads as a real measurement — hence the
- * null. The truncation marker is the exception: it is the only record that the
- * answer was cut short, and dropping it leaves the run indistinguishable from a
- * clean success. So a flagged run is written out even with nothing else to
- * report, rather than making the guard weaker for every other field.
+ * `steps == null` means no step was ever observed, and writing "0 steps, 0
+ * tokens" for a run that never started reads as a real measurement — hence the
+ * null.
  */
 const toTriggerRunStats = (stats: RunStats): TriggerRunStats | null => {
-  if (stats.steps == null && !stats.truncatedByTokenLimit) return null;
+  if (stats.steps == null) return null;
   return {
     steps: stats.steps ?? 0,
     toolCalls: stats.toolCalls ?? [],

--- a/apps/backend/src/runs/stream-error.test.ts
+++ b/apps/backend/src/runs/stream-error.test.ts
@@ -7,7 +7,7 @@ import {
   TypeValidationError,
 } from "ai";
 import { z } from "zod";
-import { formatStreamError, TRUNCATED_BY_TOKEN_LIMIT } from "./stream-error.ts";
+import { formatStreamError } from "./stream-error.ts";
 
 vi.mock("../logger.ts", () => ({
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
@@ -210,12 +210,5 @@ describe("formatStreamError", () => {
         "An unexpected error occurred.".length,
       );
     });
-  });
-});
-
-describe("TRUNCATED_BY_TOKEN_LIMIT", () => {
-  it("states the cause in terms an agent can act on", () => {
-    expect(TRUNCATED_BY_TOKEN_LIMIT).toMatch(/truncated/i);
-    expect(TRUNCATED_BY_TOKEN_LIMIT).toMatch(/token limit/i);
   });
 });

--- a/apps/backend/src/runs/stream-error.ts
+++ b/apps/backend/src/runs/stream-error.ts
@@ -13,19 +13,6 @@ import {
   type ZodLikeIssue,
 } from "../zod-issues.ts";
 
-/**
- * What an unattended caller is told when a generation stopped because it ran
- * out of output budget rather than because it was finished.
- *
- * A constant so the wording is asserted in tests without restating the prose.
- * Appended only by the unattended (`generate`) path, whose one channel back to
- * the caller is the returned text. A streamed turn says the same thing to the
- * person reading it through the message metadata instead, in its own wording —
- * this notice is addressed to a model consuming the output, not to a reader.
- */
-export const TRUNCATED_BY_TOKEN_LIMIT =
-  "The response was truncated because it reached the maximum output token limit. Retry with a shorter response, or split the work across several steps.";
-
 /** The unified finish reason the SDK reports for an output-budget cutoff. */
 export const isTruncatedByTokenLimit = (
   finishReason: string | undefined,

--- a/apps/backend/src/runs/types.ts
+++ b/apps/backend/src/runs/types.ts
@@ -10,6 +10,11 @@ export type RunStats = {
   toolCalls?: Array<{ name: string; count: number }>;
   inputTokens?: number;
   outputTokens?: number;
+  /**
+   * Set only when the run stopped at the model's output ceiling. Absent rather
+   * than `false`, mirroring the Chat message metadata marker.
+   */
+  truncatedByTokenLimit?: true;
 };
 
 /**

--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -110,6 +110,21 @@ firing and to debug a Trigger that's failing.
   Agent has those tool sets granted.
 </Callout>
 
+## When a run stops early
+
+Every model has a ceiling on how much it can write in one reply. A run that
+reaches it stops wherever it got to — mid-sentence, mid-list — and still ends
+_Success_, because nothing failed; the Agent ran out of room to finish writing.
+That run carries a muted line in the runs view reading **Run cut short at the
+model's output limit.**
+
+<Callout type="warning">
+  **Nothing retries or resumes a cut-short run.** The next scheduled or event
+  run starts from the instruction again and meets the same ceiling. If a Trigger
+  keeps hitting it, ask for less in the **Instruction** — a summary rather than
+  a full transcript, one Board rather than every Board.
+</Callout>
+
 ## Where to next
 
 - **[Agents & sub-agents](/building-with-platypus/agents)** — the Agent a Trigger

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.test.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import type { TriggerRun, TriggerRunStats } from "@platypus/schemas";
+
+const runs: TriggerRun[] = [];
+
+vi.mock("swr", () => ({
+  default: (key: string | null) => ({
+    data: key?.endsWith("/runs")
+      ? { results: runs }
+      : { id: "trigger-1", name: "Nightly digest" },
+    isLoading: false,
+  }),
+}));
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "https://backend.example",
+}));
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+// Reads the browser history through the app router, which no test mounts.
+vi.mock("@/components/back-button", () => ({
+  BackButton: () => null,
+}));
+
+import TriggerRunsPage from "./page";
+import { RUN_CUT_SHORT_NOTICE } from "@/components/run-cut-short-notice";
+
+const stats = (overrides?: Partial<TriggerRunStats>): TriggerRunStats => ({
+  steps: 1,
+  toolCalls: [],
+  inputTokens: 100,
+  outputTokens: 4096,
+  ...overrides,
+});
+
+const run = (runStats: TriggerRunStats): TriggerRun => ({
+  id: "run-1",
+  triggerId: "trigger-1",
+  status: "success",
+  startedAt: new Date("2026-01-01T09:00:00Z"),
+  completedAt: new Date("2026-01-01T09:00:10Z"),
+  stats: runStats,
+  createdAt: new Date("2026-01-01T09:00:00Z"),
+});
+
+const renderRuns = async (rows: TriggerRun[]) => {
+  runs.splice(0, runs.length, ...rows);
+  // `params` is a promise the page unwraps with `use`, so the first render
+  // suspends; flush it before asserting.
+  await act(async () => {
+    render(
+      <Suspense>
+        <TriggerRunsPage
+          params={Promise.resolve({
+            orgId: "org-1",
+            workspaceId: "ws-1",
+            triggerId: "trigger-1",
+          })}
+        />
+      </Suspense>,
+    );
+  });
+  await screen.findByText("Nightly digest");
+};
+
+// A run that hit the model's output ceiling still ends as 'success', so
+// without the marker the runs view is the same for a complete answer and a
+// half-written one.
+describe("Trigger runs truncation marker", () => {
+  it("marks a run whose stats say it stopped at the output limit", async () => {
+    await renderRuns([run(stats({ truncatedByTokenLimit: true }))]);
+
+    expect(screen.getByText(RUN_CUT_SHORT_NOTICE)).toBeInTheDocument();
+  });
+
+  it("renders no marker for a run that finished cleanly", async () => {
+    await renderRuns([run(stats())]);
+
+    expect(screen.queryByText(RUN_CUT_SHORT_NOTICE)).toBeNull();
+  });
+});

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.tsx
@@ -20,6 +20,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Loader2, Footprints, Wrench, MessageSquare } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
+import { RunCutShortNotice } from "@/components/run-cut-short-notice";
 
 const TriggerRunsPage = ({
   params,
@@ -195,6 +196,9 @@ const TriggerRunsPage = ({
                                 out
                               </span>
                             </div>
+                          )}
+                          {stats?.truncatedByTokenLimit && (
+                            <RunCutShortNotice />
                           )}
                           {run.errorMessage && (
                             <p className="text-sm text-destructive mt-1">

--- a/apps/frontend/components/run-cut-short-notice.tsx
+++ b/apps/frontend/components/run-cut-short-notice.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { TriangleAlertIcon } from "lucide-react";
+
+/**
+ * What the person reading run history is told when a run stopped at the
+ * model's output ceiling rather than because the Agent had finished. A
+ * constant so tests assert the wording without restating the prose.
+ */
+export const RUN_CUT_SHORT_NOTICE =
+  "Run cut short at the model's output limit.";
+
+/**
+ * The Trigger-run counterpart of the marker a cut-short Chat reply carries.
+ * Nobody watched the run, so this line and the run's stats are the only place
+ * the cutoff shows up at all.
+ *
+ * A component rather than markup inside the runs page: a page file may only
+ * export the fields Next recognises, and the wording has to be importable.
+ */
+export const RunCutShortNotice = () => (
+  <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+    <TriangleAlertIcon className="size-3.5 shrink-0" />
+    <span>{RUN_CUT_SHORT_NOTICE}</span>
+  </div>
+);

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -1520,6 +1520,12 @@ export const triggerRunStatsSchema = z.object({
   toolCalls: z.array(z.object({ name: z.string(), count: z.number() })),
   inputTokens: z.number(),
   outputTokens: z.number(),
+  /**
+   * Set only when the run stopped because it hit the model's output ceiling.
+   * Absent rather than `false` so an untruncated run stores nothing, matching
+   * the equivalent marker on a Chat message.
+   */
+  truncatedByTokenLimit: z.literal(true).optional(),
 });
 
 export type TriggerRunStats = z.infer<typeof triggerRunStatsSchema>;


### PR DESCRIPTION
## Problem

#429 marked a streamed Chat reply that stopped at the model's output ceiling. For the unattended path it instead appended a sentence to the text `AgentRunner.generate()` returns, justified by "the caller stores it".

The caller does not store it. `trigger-execution.ts` awaits `generate()` and discards the return value, and `TriggerSink` persists status, stats and error — never message text. A Trigger run that ran out of output budget was therefore recorded as `status: "success"` with nothing anywhere to say the answer was cut short, and the test covering it asserted on `result.text` while proving nothing.

## Change

The marker now travels on the run's stats, which is the channel that actually reaches storage:

- `generate()` sets `truncatedByTokenLimit` on the stats when the **terminal** finish reason is the output ceiling — a step that ends at the ceiling mid-tool-loop and recovers is not flagged, matching the streamed path.
- `TriggerSink` carries it onto the `triggerRun` row.
- The Trigger runs view renders a muted line — **Run cut short at the model's output limit.** — beside the run's stats, mirroring the Chat treatment.

`triggerRun.stats` is `jsonb` validated by `triggerRunStatsSchema`, so there is **no migration**. The field is `z.literal(true).optional()`: absent rather than `false`, as on Chat message metadata.

### The `toTriggerRunStats` null

`toTriggerRunStats` returns `null` when no step was ever observed, because writing "0 steps, 0 tokens" for a run that never started reads as a real measurement. That guard is left exactly as it was.

An earlier revision carved out an exception to it so a flagged run would be written even with nothing else to report. That exception was unreachable and has been dropped: `computeStats` always sets `steps` to `result.steps.length`, so a null can only mean the stats are still `{}` — a run that failed in `prepare`, timed out before its first step, or threw out of `generateText`. None of those can carry a finish reason to flag.

The dead text append and its `TRUNCATED_BY_TOKEN_LIMIT` constant are removed; `isTruncatedByTokenLimit` stays.

## Tests

Replaced, not just deleted: `generate()` sets the flag when the model stops at `length` and leaves it absent otherwise; `TriggerSink` persists it onto the `triggerRun` row and omits the key entirely for a clean run; the runs page renders the marker only for a flagged run.

`pnpm typecheck`, `pnpm lint`, `pnpm test` and a frontend `next build` all pass.

## Docs

`building-with-platypus/triggers.mdx` gains a **When a run stops early** section matching the register of the Chat page's equivalent, naming the trap: a cut-short run still reads as _Success_, and nothing retries or resumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
