### PR TITLE
feat(chat): show how long each tool call took

### DIFF
--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -52,6 +52,14 @@ const {
       onStepFinish: undefined as ((step: unknown) => void) | undefined,
       onFinish: undefined as
         ((ctx: { messages: unknown[] }) => Promise<void> | void) | undefined,
+      // Fires once per completed tool execution; the runner folds these into
+      // the finished messages.
+      onToolExecutionEnd: undefined as
+        | ((ctx: {
+            toolCall: { toolCallId: string };
+            toolExecutionMs: number;
+          }) => void)
+        | undefined,
       // `toUIMessageStream`'s metadata extractor. The SDK calls it per stream
       // part; the tests call it by hand with the part they care about.
       messageMetadata: undefined as
@@ -796,6 +804,7 @@ const resetStreamHarness = (): void => {
   streamHarness.queue = null;
   streamHarness.onStepFinish = undefined;
   streamHarness.onFinish = undefined;
+  streamHarness.onToolExecutionEnd = undefined;
   streamHarness.messageMetadata = undefined;
 };
 
@@ -804,8 +813,15 @@ const resetStreamHarness = (): void => {
 // `messageMetadata` (per stream part).
 const primeStreamText = () => {
   mockStreamText.mockImplementation(
-    (opts: { onStepFinish?: (step: unknown) => void }) => {
+    (opts: {
+      onStepFinish?: (step: unknown) => void;
+      onToolExecutionEnd?: (ctx: {
+        toolCall: { toolCallId: string };
+        toolExecutionMs: number;
+      }) => void;
+    }) => {
       streamHarness.onStepFinish = opts.onStepFinish;
+      streamHarness.onToolExecutionEnd = opts.onToolExecutionEnd;
       return {
         toUIMessageStream: (uiOpts: {
           onFinish: (ctx: { messages: unknown[] }) => Promise<void> | void;
@@ -877,6 +893,123 @@ describe("AgentRunner.stream — success & interruption", () => {
     expect(finish.messages).toEqual(finalMessages);
     expect(dispose).toHaveBeenCalledTimes(1);
     expect(runRegistry.has("s-ok")).toBe(false);
+  });
+
+  it("persists each tool call's execution time on the finished messages", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    const queue = new streamHarness.AsyncQueue();
+    streamHarness.queue = queue;
+    primeStreamText();
+
+    const sink = new RecordingSink();
+    await runner.stream({
+      scope,
+      input: { ...baseInput, runId: "s-durations" },
+      sink,
+      options: { origin: "http://test" },
+    });
+
+    streamHarness.onToolExecutionEnd!({
+      toolCall: { toolCallId: "call-1" },
+      toolExecutionMs: 1234,
+    });
+    await streamHarness.onFinish!({
+      messages: [
+        {
+          id: "m1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-getCard",
+              toolCallId: "call-1",
+              state: "output-available",
+              input: {},
+              output: {},
+            },
+          ],
+        },
+      ],
+    });
+    queue.end();
+    await tick();
+
+    const finish = sink.events.at(-1) as Extract<
+      LifecycleEvent,
+      { name: "onFinish" }
+    >;
+    const message = finish.messages![0] as { parts: unknown[] };
+    expect(message.parts[0]).toMatchObject({
+      toolMetadata: { durationMs: 1234 },
+    });
+  });
+
+  // The two branches of the teed UI stream race: `onFinish` fires on the source
+  // while the server-side snapshot branch may still have buffered chunks, and
+  // disposing the turn is real I/O that gives that branch time to drain. A
+  // snapshot landing in that window used to overwrite the finished messages —
+  // silently costing them their durations, since a snapshot carries none.
+  it("keeps the final messages when a snapshot lands during teardown", async () => {
+    const queue = new streamHarness.AsyncQueue();
+    streamHarness.queue = queue;
+    const dispose = vi.fn().mockImplementation(async () => {
+      queue.push({
+        id: "m1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-getCard",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: {},
+            output: {},
+          },
+        ],
+      });
+      await tick();
+    });
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn({ dispose }));
+    primeStreamText();
+
+    const sink = new RecordingSink();
+    await runner.stream({
+      scope,
+      input: { ...baseInput, runId: "s-late-snapshot" },
+      sink,
+      options: { origin: "http://test" },
+    });
+
+    streamHarness.onToolExecutionEnd!({
+      toolCall: { toolCallId: "call-1" },
+      toolExecutionMs: 1234,
+    });
+    await streamHarness.onFinish!({
+      messages: [
+        {
+          id: "m1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-getCard",
+              toolCallId: "call-1",
+              state: "output-available",
+              input: {},
+              output: {},
+            },
+          ],
+        },
+      ],
+    });
+    queue.end();
+    await tick();
+
+    const finish = sink.events.at(-1) as Extract<
+      LifecycleEvent,
+      { name: "onFinish" }
+    >;
+    const message = finish.messages![0] as { parts: unknown[] };
+    expect(message.parts[0]).toMatchObject({
+      toolMetadata: { durationMs: 1234 },
+    });
   });
 
   it("interactive stream runs are NOT subject to no-progress detection", async () => {

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -8,6 +8,7 @@ import {
   streamText,
 } from "ai";
 import { formatStreamError, isTruncatedByTokenLimit } from "./stream-error.ts";
+import { applyToolDurations } from "./tool-durations.ts";
 import {
   prepareChatTurn,
   validateTurnAttachments,
@@ -427,9 +428,26 @@ export class AgentRunner {
 
     logger.debug({ systemPrompt: modelArgs.system }, "System prompt for chat");
 
+    // How long each locally-executed tool took, keyed by `toolCallId`. The SDK
+    // has already measured it; we only hold onto it until the finished messages
+    // exist to stamp it onto (see `applyToolDurations`). Provider-executed tools
+    // never reach this callback and so carry no duration.
+    const toolDurations = new Map<string, number>();
+
+    // Whether `onFinish` has handed over the finished messages. The two branches
+    // of the tee below race: the source can finish while the snapshot branch
+    // still has chunks buffered, and disposing the turn is real I/O that gives
+    // that branch time to drain. A snapshot arriving after the handover is
+    // strictly worse than what it would overwrite — same content, minus the
+    // tool durations — so the snapshot stops writing once this is set.
+    let finalMessagesReceived = false;
+
     const result = streamText({
       ...modelArgs,
       onStepFinish: (step) => onStep(step),
+      onToolExecutionEnd: ({ toolCall, toolExecutionMs }) => {
+        toolDurations.set(toolCall.toolCallId, toolExecutionMs);
+      },
     });
 
     // Build the UI message stream and tee it. The response body consumes
@@ -465,7 +483,11 @@ export class AgentRunner {
       },
       onError: (error) => formatStreamError(error),
       onFinish: async ({ messages: finalMessages }) => {
-        state.messages = finalMessages;
+        // Stamped here rather than on the snapshot branch below, which sees no
+        // durations at all. Setting the flag first closes that branch's window
+        // to overwrite this, so the sink's terminal write observes the patch.
+        finalMessagesReceived = true;
+        state.messages = applyToolDurations(finalMessages, toolDurations);
         let status: RunStatus = "succeeded";
         let err: Error | undefined;
         if (handle.signal.aborted) {
@@ -498,6 +520,9 @@ export class AgentRunner {
               "Snapshot stream parse error",
             ),
         })) {
+          // Keep draining after the handover — the branch is still teed to a
+          // live source — but stop writing; `onFinish` has the better copy.
+          if (finalMessagesReceived) continue;
           state.messages = [...input.messages, message];
         }
       } catch (err) {

--- a/apps/backend/src/runs/tool-durations.test.ts
+++ b/apps/backend/src/runs/tool-durations.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { applyToolDurations } from "./tool-durations.ts";
+import type { PlatypusUIMessage } from "../types.ts";
+
+/** An assistant message carrying the given parts, cast at the seam because
+ *  the part union is wider than any single fixture needs to be. */
+const assistant = (parts: unknown[]): PlatypusUIMessage =>
+  ({
+    id: "msg-1",
+    role: "assistant",
+    parts,
+  }) as PlatypusUIMessage;
+
+const staticPart = (
+  toolCallId: string,
+  extra?: Record<string, unknown>,
+): Record<string, unknown> => ({
+  type: "tool-getCard",
+  toolCallId,
+  state: "output-available",
+  input: {},
+  output: {},
+  ...extra,
+});
+
+const dynamicPart = (
+  toolCallId: string,
+  extra?: Record<string, unknown>,
+): Record<string, unknown> => ({
+  type: "dynamic-tool",
+  toolName: "search",
+  toolCallId,
+  state: "output-available",
+  input: {},
+  output: {},
+  ...extra,
+});
+
+/** Reads back the patched metadata without restating the cast in each test. */
+const metadataOf = (message: PlatypusUIMessage, index: number) =>
+  (message.parts[index] as { toolMetadata?: Record<string, unknown> })
+    .toolMetadata;
+
+describe("applyToolDurations", () => {
+  it("writes durationMs onto a static tool part", () => {
+    const messages = [assistant([staticPart("call-1")])];
+
+    const patched = applyToolDurations(messages, new Map([["call-1", 1234]]));
+
+    expect(metadataOf(patched[0], 0)).toEqual({ durationMs: 1234 });
+  });
+
+  // The SDK measures on a high-resolution clock; nothing reads below a
+  // millisecond, so the stored figure is not sixteen significant digits.
+  it("rounds the high-resolution figure the SDK reports", () => {
+    const messages = [assistant([staticPart("call-1")])];
+
+    const patched = applyToolDurations(
+      messages,
+      new Map([["call-1", 706.9857919998467]]),
+    );
+
+    expect(metadataOf(patched[0], 0)).toEqual({ durationMs: 707 });
+  });
+
+  it("writes durationMs onto a dynamic tool part", () => {
+    const messages = [assistant([dynamicPart("call-1")])];
+
+    const patched = applyToolDurations(messages, new Map([["call-1", 42]]));
+
+    expect(metadataOf(patched[0], 0)).toEqual({ durationMs: 42 });
+  });
+
+  it("merges into existing toolMetadata rather than replacing it", () => {
+    const messages = [
+      assistant([staticPart("call-1", { toolMetadata: { cacheHit: true } })]),
+    ];
+
+    const patched = applyToolDurations(messages, new Map([["call-1", 7]]));
+
+    expect(metadataOf(patched[0], 0)).toEqual({
+      cacheHit: true,
+      durationMs: 7,
+    });
+  });
+
+  it("leaves tool calls absent from the map untouched", () => {
+    const messages = [assistant([staticPart("call-1"), dynamicPart("call-2")])];
+
+    const patched = applyToolDurations(messages, new Map([["call-1", 5]]));
+
+    expect(metadataOf(patched[0], 0)).toEqual({ durationMs: 5 });
+    expect(metadataOf(patched[0], 1)).toBeUndefined();
+  });
+
+  it("leaves non-tool parts and other messages alone", () => {
+    const messages = [
+      assistant([{ type: "text", text: "hi" }]),
+      assistant([staticPart("call-1")]),
+    ];
+
+    const patched = applyToolDurations(messages, new Map([["call-1", 5]]));
+
+    expect(patched[0]).toBe(messages[0]);
+    expect(patched[0].parts[0]).toEqual({ type: "text", text: "hi" });
+    expect(metadataOf(patched[1], 0)).toEqual({ durationMs: 5 });
+  });
+
+  it("returns the input untouched when no durations were recorded", () => {
+    const messages = [assistant([staticPart("call-1")])];
+
+    expect(applyToolDurations(messages, new Map())).toBe(messages);
+  });
+
+  it("does not mutate the input messages", () => {
+    const part = staticPart("call-1", { toolMetadata: { cacheHit: true } });
+    const messages = [assistant([part])];
+
+    applyToolDurations(messages, new Map([["call-1", 5]]));
+
+    expect(part.toolMetadata).toEqual({ cacheHit: true });
+  });
+});

--- a/apps/backend/src/runs/tool-durations.ts
+++ b/apps/backend/src/runs/tool-durations.ts
@@ -1,0 +1,46 @@
+import { isToolUIPart } from "ai";
+import type { PlatypusUIMessage } from "../types.ts";
+
+/**
+ * Folds recorded tool execution times into the run's final messages.
+ *
+ * Kept pure and separate from the runner because the SDK gives no seam for
+ * writing this while streaming: the UI message stream's `tool-output-available`
+ * reducer keeps the *stored* invocation's `toolMetadata` and drops whatever the
+ * output chunk carried. So the duration is stamped once, on the finished
+ * messages, just before the sink writes them.
+ *
+ * Durations are keyed by `toolCallId`, which both static (`tool-*`) and dynamic
+ * tool parts carry. Existing metadata is merged, not replaced — the field is
+ * provider-populated in principle even though nothing else sets it today.
+ *
+ * The SDK measures on a high-resolution clock and reports figures like
+ * `706.9857919998467`. Nothing reads below a millisecond, so the value is
+ * rounded before it goes into the message rather than storing sixteen
+ * significant digits per tool call for the lifetime of the chat.
+ */
+export const applyToolDurations = (
+  messages: PlatypusUIMessage[],
+  durations: ReadonlyMap<string, number>,
+): PlatypusUIMessage[] => {
+  if (durations.size === 0) return messages;
+
+  return messages.map((message) => {
+    let patched = false;
+    const parts = message.parts.map((part) => {
+      // Covers both static (`tool-*`) and dynamic tool invocations.
+      if (!isToolUIPart(part)) return part;
+      const durationMs = durations.get(part.toolCallId);
+      if (durationMs === undefined) return part;
+      patched = true;
+      return {
+        ...part,
+        toolMetadata: {
+          ...part.toolMetadata,
+          durationMs: Math.round(durationMs),
+        },
+      };
+    });
+    return patched ? { ...message, parts } : message;
+  });
+};

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -85,6 +85,35 @@ specific pages instead wants the **Web Fetch** Tool set — see
 A microphone button next to it transcribes speech into the input box. The text
 lands in the box rather than sending, so you can edit before pressing **Enter**.
 
+## How long a Tool took
+
+When a reply uses a Tool, the Tool appears in the conversation as a collapsible
+card. Its header shows the Tool's name, a status — **Pending**, **Running**,
+**Completed**, **Error** — and how long the Tool took: `<1ms`, `842ms`, `1.2s`,
+or `1m 03s` past a minute.
+
+The time is the Tool's own work, measured on the server, so it appears a moment
+after the reply finishes rather than while the Tool is running. It is stored
+with the message and does not change afterwards. A Tool that failed still shows
+the time it spent before failing.
+
+Read it against the reply as a whole: most Tools land in single milliseconds, so
+a turn that felt slow and shows nothing above `1.2s` spent its time in the
+model, not the Tools.
+
+A Sub-agent card carries a time too, covering the whole delegated run — every
+step that Sub-agent took, not just the handover. It is usually the largest
+number on the page and the first one to look at on a slow turn.
+
+<Callout type="warning">
+  **A card with no time is not a Tool that took no time.** A Tool that really
+  was instant reads `<1ms`; a blank means there is no measurement at all. Three
+  cards are blank by nature: a search the Provider ran inside its own service,
+  the **Loading skill** card, which draws its own header, and Chats from before
+  your deployment was upgraded. A blank never means "still running" — the status
+  badge is what tells you that.
+</Callout>
+
 ## When a reply stops early
 
 Every model has a ceiling on how much it can write in one reply. Reach it and

--- a/apps/frontend/components/ai-elements/tool.tsx
+++ b/apps/frontend/components/ai-elements/tool.tsx
@@ -35,6 +35,7 @@ import {
 import type { ComponentProps, ReactNode } from "react";
 import { createElement, isValidElement } from "react";
 import { CodeBlock } from "./code-block";
+import { ToolDuration } from "../tool-duration";
 
 /**
  * Converts a camelCase tool name (extracted from a `tool-*` type string)
@@ -172,6 +173,8 @@ export type ToolHeaderProps = {
   label?: string;
   type: ToolUIPart["type"];
   state: ToolUIPart["state"];
+  /** Recorded execution time, once the run has been persisted. */
+  durationMs?: number;
   className?: string;
 };
 
@@ -210,6 +213,7 @@ export const ToolHeader = ({
   label,
   type,
   state,
+  durationMs,
   ...props
 }: ToolHeaderProps) => {
   // getToolIcon returns a stable module-level Lucide icon; render via
@@ -236,6 +240,7 @@ export const ToolHeader = ({
             </span>
           )}
         </span>
+        <ToolDuration durationMs={durationMs} />
         {getStatusBadge(state)}
       </div>
       <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />

--- a/apps/frontend/components/chat-message.test.tsx
+++ b/apps/frontend/components/chat-message.test.tsx
@@ -106,3 +106,54 @@ describe("ChatMessage truncation marker", () => {
     expect(screen.getByText(CUT_SHORT_NOTICE)).toBeInTheDocument();
   });
 });
+
+// Issue #353: the header carries the tool's execution time so a slow reply can
+// be pinned on a specific tool rather than the model.
+describe("ChatMessage tool duration", () => {
+  const withToolPart = (part: unknown): PlatypusUIMessage =>
+    ({
+      id: "m1",
+      role: "assistant",
+      parts: [part],
+    }) as PlatypusUIMessage;
+
+  const staticToolPart = (toolMetadata?: Record<string, unknown>) => ({
+    type: "tool-getCard",
+    toolCallId: "call-1",
+    state: "output-available",
+    input: {},
+    output: {},
+    toolMetadata,
+  });
+
+  const dynamicToolPart = (toolMetadata?: Record<string, unknown>) => ({
+    type: "dynamic-tool",
+    toolName: "search",
+    toolCallId: "call-1",
+    state: "output-available",
+    input: {},
+    output: {},
+    toolMetadata,
+  });
+
+  it.each([
+    ["a static tool", staticToolPart({ durationMs: 1234 })],
+    ["a dynamic tool", dynamicToolPart({ durationMs: 1234 })],
+  ])("renders the persisted duration for %s", (_, part) => {
+    renderMessage(withToolPart(part));
+
+    expect(screen.getByText(/1\.2s/)).toBeInTheDocument();
+  });
+
+  // Tool calls recorded before this shipped carry no timing; they render the
+  // header exactly as before rather than a placeholder.
+  it.each([
+    ["a static tool", staticToolPart()],
+    ["a dynamic tool", dynamicToolPart()],
+  ])("renders no duration for %s recorded before timing existed", (_, part) => {
+    renderMessage(withToolPart(part));
+
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.queryByText(/\d+ms|\d+\.\d+s/)).toBeNull();
+  });
+});

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -47,6 +47,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { Textarea } from "./ui/textarea";
+import { toolDurationMs } from "@/lib/tool-duration";
 import { LoadSkillTool } from "./load-skill-tool";
 import { SubAgentTool } from "./sub-agent-tool";
 
@@ -220,6 +221,7 @@ export const ChatMessage = memo(function ChatMessage({
               <DynamicToolHeader
                 state={toolPart.state}
                 title={toolPart.toolName}
+                durationMs={toolDurationMs(toolPart.toolMetadata)}
               />
               <ToolContent>
                 <ToolInput input={toolPart.input} />
@@ -250,6 +252,7 @@ export const ChatMessage = memo(function ChatMessage({
                 state={part.state}
                 type={part.type}
                 label={toolLabel}
+                durationMs={toolDurationMs(part.toolMetadata)}
               />
               <ToolContent>
                 <ToolInput input={part.input} />

--- a/apps/frontend/components/dynamic-tool-header.tsx
+++ b/apps/frontend/components/dynamic-tool-header.tsx
@@ -13,10 +13,13 @@ import {
   XCircleIcon,
 } from "lucide-react";
 import type { ReactNode } from "react";
+import { ToolDuration } from "./tool-duration";
 
 export type DynamicToolHeaderProps = {
   title: string;
   state: DynamicToolUIPart["state"];
+  /** Recorded execution time, once the run has been persisted. */
+  durationMs?: number;
   className?: string;
 };
 
@@ -53,6 +56,7 @@ export const DynamicToolHeader = ({
   className,
   title,
   state,
+  durationMs,
   ...props
 }: DynamicToolHeaderProps) => (
   <CollapsibleTrigger
@@ -65,6 +69,7 @@ export const DynamicToolHeader = ({
     <div className="flex items-center gap-2">
       <WrenchIcon className="size-4 text-muted-foreground" />
       <span className="font-medium text-sm">{title}</span>
+      <ToolDuration durationMs={durationMs} />
       {getStatusBadge(state)}
     </div>
     <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />

--- a/apps/frontend/components/sub-agent-tool.test.tsx
+++ b/apps/frontend/components/sub-agent-tool.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ToolUIPart } from "ai";
+
+// Streamdown pulls in shiki and a worker-ish runtime that jsdom can't host; the
+// assertions here only care about the card's header.
+vi.mock("streamdown", () => ({
+  Streamdown: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+import { SubAgentTool } from "./sub-agent-tool";
+
+const delegateCall = (toolMetadata?: Record<string, unknown>): ToolUIPart =>
+  ({
+    type: "tool-delegateToResearchBot",
+    toolCallId: "call-1",
+    state: "output-available",
+    input: { task: "Find the release date" },
+    output: { entries: [], text: "It shipped in March." },
+    toolMetadata,
+  }) as unknown as ToolUIPart;
+
+// A delegated run is the longest thing that happens in a chat, so its card is
+// the one where the duration matters most.
+describe("SubAgentTool duration", () => {
+  it("renders the recorded duration in the header", () => {
+    render(<SubAgentTool toolPart={delegateCall({ durationMs: 42_000 })} />);
+
+    expect(screen.getByText(/42\.0s/)).toBeInTheDocument();
+  });
+
+  it("renders no duration for a delegation recorded before timing existed", () => {
+    render(<SubAgentTool toolPart={delegateCall()} />);
+
+    expect(screen.getByText("Research Bot")).toBeInTheDocument();
+    expect(screen.queryByText(/\d+(\.\d+)?(ms|s)/)).toBeNull();
+  });
+});

--- a/apps/frontend/components/sub-agent-tool.tsx
+++ b/apps/frontend/components/sub-agent-tool.tsx
@@ -25,6 +25,8 @@ import {
   MessageResponse,
 } from "./ai-elements/message";
 import { Shimmer } from "./ai-elements/shimmer";
+import { ToolDuration } from "./tool-duration";
+import { toolDurationMs } from "@/lib/tool-duration";
 import { useMemo, type ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 
@@ -236,6 +238,7 @@ export const SubAgentTool = ({ toolPart }: SubAgentToolProps) => {
         <div className="flex items-center gap-2">
           <BotIcon className="size-4 text-muted-foreground" />
           <span className="font-medium text-sm">{subAgentName}</span>
+          <ToolDuration durationMs={toolDurationMs(toolPart.toolMetadata)} />
           {getStatusBadge(effectiveState)}
         </div>
         <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]/subagent:rotate-180" />

--- a/apps/frontend/components/tool-duration.test.tsx
+++ b/apps/frontend/components/tool-duration.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ToolDuration } from "./tool-duration";
+
+describe("ToolDuration", () => {
+  it("renders the recorded duration", () => {
+    render(<ToolDuration durationMs={1234} />);
+
+    expect(screen.getByText(/1\.2s/)).toBeInTheDocument();
+  });
+
+  it("renders nothing for a tool call with no recorded duration", () => {
+    const { container } = render(<ToolDuration />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // A recorded duration always shows, however small — only an absent one is
+  // blank. Zero is a real measurement, not missing data.
+  it.each([
+    [842, /842ms/],
+    [0, /<1ms/],
+  ])("renders a %dms call", (durationMs, expected) => {
+    render(<ToolDuration durationMs={durationMs} />);
+
+    expect(screen.getByText(expected)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/tool-duration.tsx
+++ b/apps/frontend/components/tool-duration.tsx
@@ -1,0 +1,29 @@
+import { formatToolDuration } from "@/lib/tool-duration";
+
+export type ToolDurationProps = {
+  /** Duration recorded by the run pipeline, present once the run is persisted. */
+  durationMs?: number;
+};
+
+/**
+ * How long a tool call took, shown beside its name in the tool header.
+ *
+ * Only the server's figure is ever shown. The browser can't measure this
+ * itself: the gap it sees between a tool's input and output chunks also holds
+ * whatever else the model was streaming meanwhile, which for a quick tool is
+ * most of the gap. A clock built on that reads seconds for a tool the server
+ * timed in single milliseconds, and gets visibly corrected when the chat
+ * re-hydrates — so the duration appears once, when the run is persisted, and
+ * never changes afterwards.
+ */
+export const ToolDuration = ({ durationMs }: ToolDurationProps) => {
+  if (durationMs === undefined) return null;
+
+  // A sibling of the name rather than part of it: the name truncates, and the
+  // duration is the last thing that should disappear when it does.
+  return (
+    <span className="shrink-0 font-normal text-sm text-muted-foreground">
+      &mdash; {formatToolDuration(durationMs)}
+    </span>
+  );
+};

--- a/apps/frontend/lib/tool-duration.test.ts
+++ b/apps/frontend/lib/tool-duration.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { formatToolDuration, toolDurationMs } from "./tool-duration";
+
+describe("formatToolDuration", () => {
+  it("renders sub-second durations in milliseconds", () => {
+    expect(formatToolDuration(842)).toBe("842ms");
+  });
+
+  // A third of the calls on a real chat round to zero milliseconds; a bare
+  // `0ms` reads as a field that failed to populate.
+  it("renders a sub-millisecond duration as less than a millisecond", () => {
+    expect(formatToolDuration(0)).toBe("<1ms");
+    expect(formatToolDuration(1)).toBe("1ms");
+  });
+
+  it("switches from milliseconds to seconds at 1000ms", () => {
+    expect(formatToolDuration(999)).toBe("999ms");
+    expect(formatToolDuration(1000)).toBe("1.0s");
+  });
+
+  it("renders seconds to one decimal place", () => {
+    expect(formatToolDuration(1234)).toBe("1.2s");
+  });
+
+  it("switches from seconds to minutes at 60s", () => {
+    expect(formatToolDuration(59_900)).toBe("59.9s");
+    expect(formatToolDuration(60_000)).toBe("1m 00s");
+  });
+
+  it("zero-pads the seconds component of a minutes-and-seconds duration", () => {
+    expect(formatToolDuration(63_000)).toBe("1m 03s");
+    expect(formatToolDuration(754_000)).toBe("12m 34s");
+  });
+});
+
+describe("toolDurationMs", () => {
+  it("reads a numeric durationMs out of tool metadata", () => {
+    expect(toolDurationMs({ durationMs: 1234 })).toBe(1234);
+  });
+
+  it("ignores metadata that carries no usable duration", () => {
+    expect(toolDurationMs(undefined)).toBeUndefined();
+    expect(toolDurationMs({})).toBeUndefined();
+    expect(toolDurationMs({ durationMs: "1234" })).toBeUndefined();
+    expect(toolDurationMs({ durationMs: null })).toBeUndefined();
+  });
+});

--- a/apps/frontend/lib/tool-duration.ts
+++ b/apps/frontend/lib/tool-duration.ts
@@ -1,0 +1,28 @@
+/**
+ * Formats how long a tool call took, adapting the unit to the magnitude so the
+ * number stays readable at a glance: `<1ms`, `842ms`, `1.2s`, `1m 03s`.
+ *
+ * The stored figure is whole milliseconds, and plenty of local tools finish
+ * inside one — a third of the calls on a real chat round to zero. Those read as
+ * `<1ms`, because a bare `0ms` looks like a field that failed to populate.
+ */
+export function formatToolDuration(ms: number): string {
+  if (ms < 1) return "<1ms";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const totalSeconds = Math.floor(ms / 1000);
+  const seconds = totalSeconds % 60;
+  return `${Math.floor(totalSeconds / 60)}m ${String(seconds).padStart(2, "0")}s`;
+}
+
+/**
+ * Pulls the run pipeline's recorded duration out of a tool invocation's
+ * `toolMetadata`. The field is a free-form JSON object a provider may also
+ * write to, so the value is checked rather than cast: anything that isn't a
+ * number reads as "no duration", which renders as nothing at all.
+ */
+export function toolDurationMs(metadata: unknown): number | undefined {
+  if (typeof metadata !== "object" || metadata === null) return undefined;
+  const value = (metadata as Record<string, unknown>).durationMs;
+  return typeof value === "number" ? value : undefined;
+}


### PR DESCRIPTION
Closes #353

When a reply is slow there is no way from the chat to tell whether the model or a tool is responsible. Each tool card's header now carries the time its tool took, beside the name:

```
Get current time  — <1ms   Completed
Memory get        — 3ms    Completed
Memory search     — 707ms  Completed
Memory search     — 1.1s   Completed
```

Sub-agent cards carry it too, covering the whole delegated run rather than just the handover — usually the largest number on the page, and the first one to look at on a slow turn.

## How it works

`onToolExecutionEnd` already reports `toolExecutionMs` per call, so nothing new measures anything. Those figures are stamped into `toolMetadata` on the existing JSONB messages column: no schema change, no backfill, and tool calls recorded before this render no time at all.

The stamping happens on the finished messages in the UI stream's `onFinish` rather than being streamed, because the SDK's `tool-output-available` reducer keeps the *stored* invocation's `toolMetadata` and silently drops whatever the output chunk carried.

## Two things worth a reviewer's attention

**The snapshot branch could eat the durations.** The teed server-side branch kept writing `state.messages` after `onFinish` handed over the finished ones, and `finalize` awaits the turn's `dispose()` — real I/O, which gives that branch time to drain buffered chunks and overwrite the patched array with snapshot copies carrying no durations. It now stops writing once the handover happens. Covered by `keeps the final messages when a snapshot lands during teardown`, which fails without the fix.

**There is no live ticking counter, and the issue asked for one.** A browser-side clock was built and then removed. The gap the client sees between a tool's input and output chunks also holds whatever else the model was streaming meanwhile, so a tool the server timed at 3ms displayed as 1.2s — and the chat visibly corrected it seconds later when SWR re-hydrates the messages. The client cannot measure this. The number now appears once, when the run is persisted, and never changes.

That makes the issue's "visibly counts up" acceptance criterion knowingly unmet rather than missed; #353's brief should be edited to match before this merges.

## Testing

`pnpm typecheck`, `pnpm lint` and `pnpm test` (1774) pass.

Verified against a running instance with Playwright: durations persist per call, render on reload across every format branch, and no value changes on screen after it appears. Not verified end-to-end: a real delegated run — no agent in the test workspace has a sub-agent configured, so the sub-agent card is covered by a component test and by the SDK's timing semantics (the measurement wraps a generator tool's full consumption) rather than by observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)