### PR TITLE
feat(frontend): link the website and docs site from About and ⌘K

### DIFF
--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -194,7 +194,8 @@ the command palette. Type to filter.
 It offers **Actions** — home, switch org, new chat, new agent, new skill, new
 board, new dashboard, new trigger, add webhook, and the settings screens — and
 then your **Agents**, **Boards** and **Triggers** by name. Selecting an Agent
-opens a new Chat already set to it.
+opens a new Chat already set to it. **Docs** opens this documentation site in a
+new tab.
 
 ## Closing the tab mid-run
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/about/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/about/page.tsx
@@ -33,6 +33,28 @@ const AboutPage = () => {
           willdady/platypus <ExternalLink className="size-4" />
         </Link>
       </div>
+      <div className="mb-4">
+        <p className="text-sm text-muted-foreground mb-2">Website</p>
+        <Link
+          href="https://platypus.chat"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline inline-flex items-center gap-1"
+        >
+          platypus.chat <ExternalLink className="size-4" />
+        </Link>
+      </div>
+      <div className="mb-4">
+        <p className="text-sm text-muted-foreground mb-2">Documentation</p>
+        <Link
+          href="https://docs.platypus.chat"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline inline-flex items-center gap-1"
+        >
+          docs.platypus.chat <ExternalLink className="size-4" />
+        </Link>
+      </div>
     </div>
   );
 };

--- a/apps/frontend/components/command-menu.tsx
+++ b/apps/frontend/components/command-menu.tsx
@@ -17,6 +17,7 @@ import {
   Zap,
   Radio,
   LayoutDashboard,
+  BookOpen,
 } from "lucide-react";
 
 import {
@@ -251,6 +252,21 @@ export function CommandMenu({ orgId, workspaceId }: CommandMenuProps) {
           >
             <Wrench />
             <span>MCP</span>
+          </CommandItem>
+          <CommandItem
+            className="cursor-pointer"
+            onSelect={() => {
+              runCommand(() =>
+                window.open(
+                  "https://docs.platypus.chat",
+                  "_blank",
+                  "noopener,noreferrer",
+                ),
+              );
+            }}
+          >
+            <BookOpen />
+            <span>Docs</span>
           </CommandItem>
           <CommandItem
             className="cursor-pointer"


### PR DESCRIPTION
## What

- **About page** (`settings/about`) — new **Website** (platypus.chat) and **Documentation** (docs.platypus.chat) rows, following the existing external-link pattern used by the Version and GitHub rows.
- **⌘K command palette** — new **Docs** action, placed above About, which opens docs.platypus.chat in a new tab rather than navigating in place.
- **Docs** — `building-with-platypus/chat.mdx` now mentions the Docs entry in the command-palette section.

## Verification

Driven with Playwright against a running dev stack:

- About page renders all four links with the expected `href` and `target="_blank"`.
- Typing "Docs" in ⌘K matches a single item; Enter opens `https://docs.platypus.chat/` in a new tab and leaves the current tab where it was.

`pnpm --filter frontend typecheck` and the docs contract tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)