### PR TITLE
chore: record Context window domain model and ADR-0018

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,6 +49,14 @@ A configured connection to an AI vendor (OpenAI, OpenRouter, Bedrock, Anthropic,
 A stable name a Provider assigns to one of its enabled models, which an Agent or Chat may select in place of a concrete model id. Repointing the alias at a different model upgrades every Agent and Chat using it at once. Provider-scoped: an alias never spans Providers, and the Provider's own pointer-settings (`taskModelId`, `memoryExtractionModelId`, `embeddingModelId`) always name a concrete model, never an alias.
 _Avoid_: model alias name, model shortcut.
 
+**Context window**:
+The total token capacity of a `(Provider, model)` pair, declared by an Org Admin on the Provider's model entry. Asserted, never discovered: no vendor exposes it through the model API and no standard exists, so Platypus cannot query it — and a model reached through a proxy may not have the capacity its name implies. Optional; a model without one runs normally, but its **Context occupancy** cannot be judged against anything. Unrelated to **Context** (User Context) despite the shared word.
+_Avoid_: context size, token limit, max tokens (that names an output cap).
+
+**Context occupancy**:
+How full a model's **Context window** was on the most recent Chat turn — the input-token count the vendor reported for the last model call of that turn, inclusive of cached tokens. A last value, not a running total: the conversation is re-sent in full on every Chat turn, so occupancy replaces rather than accumulates. Unknown where the Provider reports no token usage, in which case Platypus estimates nothing. Distinct from token **usage**, which is the count of tokens billed across a turn or run and legitimately is a sum.
+_Avoid_: context size, context usage, tokens used, running total.
+
 **Tool set**:
 A named bundle of Tools an Agent can be granted. Either contributed by a Plugin (registered in code) or backed by an MCP server.
 
@@ -80,7 +88,7 @@ Deployment-wide configuration and credentials for a Plugin, set by the Operator 
 A persisted summary of prior activity, retrieved per-User per-Workspace and rendered into the system prompt on **every** Chat turn once the Workspace has a memory-extraction Provider set — not gated on the Agent's Tool sets. The `memory` Tool set is a separate, additive thing: it grants `memorySearch` / `memoryGet` for reaching beyond the summaries already in the prompt.
 
 **Context** (User Context):
-Free-text notes a User attaches at global or per-Workspace scope, rendered into the system prompt.
+Free-text notes a User attaches at global or per-Workspace scope, rendered into the system prompt. Nothing to do with the model's **Context window** — the word carries both meanings and they are never interchangeable.
 
 **Operator**:
 The actor who controls a Platypus deployment — process environment, compose files, and infrastructure. Equivalent to the platform super-admin (`user.role = "admin"`), who bypasses all in-app authorization. Installs and enables Plugins and sets their deploy-time Plugin config, and declares deployment-time allowlists (e.g. the eligible Docker Sandbox networks) that bound what an Org Admin can configure in-app.
@@ -147,6 +155,7 @@ The record binding a Conversation locus to a Chat (which carries the Workspace +
 - A **Chat turn** renders one **System prompt**, whose first fragment is the **Instructions** of the selected **Agent** — or of the **Chat** itself, where no Agent is selected.
 - An **Agent** references one **Provider**, zero-or-more **Tool sets** (static or **MCP**-backed), zero-or-more **Skills**, and zero-or-more **Sub-Agents**.
 - A **Provider** belongs to either an **Organization** (shared) or a **Workspace** (private).
+- Each model a **Provider** exposes may declare a **Context window**. A **Chat turn** against that model yields a **Context occupancy**, measured from the tokens the vendor reports and meaningful only where a **Context window** was declared.
 - An **Agent**, **Skill**, **MCP**, or **Provider** is a **Scoped resource**: its row carries either an `organizationId` or a `workspaceId`, never both. Resolved relative to a **Workspace**, an Organization-scoped one is a **Shared resource**, visible only through an **Attachment**; a Sandbox-backed **Tool set** instead rebinds to the invoking **Workspace**'s **Sandbox** at Chat-turn time.
 - A **Blueprint** names a set of **Shared resources** and, applied to a **Workspace**, creates their **Attachments** in one step.
 - **Workspaces** are created only by **Org Admins** — directly, or auto-provisioned for a member when they accept an invitation. An invitation carries an ordered set of zero-or-more **Blueprints**; on accept they are applied to the new Workspace in order (Attachments union; later Blueprints win on any single-valued pointer-setting). Members do not create their own Workspaces.

--- a/docs/adr/0018-context-windows-are-declared-not-discovered.md
+++ b/docs/adr/0018-context-windows-are-declared-not-discovered.md
@@ -1,0 +1,122 @@
+---
+status: accepted
+---
+
+# Context windows are declared, not discovered
+
+## Context
+
+Auto-compaction needs to know how close a Chat is to its model's limit, and
+nothing in the stack can tell it. `LanguageModelV4` — the complete model
+interface in `@ai-sdk/provider@4.0.4`, as used by `ai@7.0.48` — has exactly five
+members (`specificationVersion`, `provider`, `modelId`, `supportedUrls`,
+`doGenerate`, `doStream`). There is no capability metadata: grepping
+`maxInputTokens|contextWindow|contextLength` across `@ai-sdk/provider`,
+`@ai-sdk/openai` and `@ai-sdk/anthropic` returns nothing, and the only
+token-limit field anywhere in the SDK is `maxOutputTokens`, a request setting.
+Nor is there a token counter — the SDK's own compaction example hand-rolls
+`JSON.stringify(messages).length / 4`. Vendors publish context lengths as prose
+on marketing pages, in no common format, and a model reached through a proxy
+such as LiteLLM may not have the capacity its name implies.
+
+## Decision
+
+An Org Admin **declares** a model's Context window as an optional
+`contextWindow` integer on the per-model config object inside `provider.modelIds`
+— the same place `alias`, `passthroughFileTypes` and `maxExtractedTextChars`
+live. No new table, no new column, no discovery call.
+
+It is a single number meaning the vendor's **published total** window, not a
+separate input cap. Reserving output headroom from that total is left to
+auto-compaction, which is the only thing that needs it.
+
+Context occupancy is **measured, never estimated**, from the input-token count
+the vendor reports for the **last model call of a turn**. Where a Provider
+reports no usage, occupancy is unknown and Platypus computes nothing.
+
+## Considered options
+
+- **A separate `maxInputTokens` alongside `maxOutputTokens`** — rejected. It is
+  the quantity auto-compaction actually wants, and an earlier code comment in
+  `packages/schemas` anticipated exactly that name. But no vendor publishes it as
+  a distinct figure, so the field would be filled in by guesswork; the total is
+  the only number an Org Admin can look up and verify. The comment has been
+  corrected rather than honoured.
+- **Making the field required** — rejected. `modelIds` is a jsonb column and
+  `drizzle-kit push` applies DDL only, so existing rows would need a backfill —
+  and there is no correct value to backfill with. Inventing context windows for
+  models you cannot query is the precise problem this ADR exists to avoid. A
+  narrower "required only for newly added model entries" rule was designed
+  (diffing incoming against stored `modelIds` by `id`, reusing the machinery in
+  `model-alias-migration.ts`) and then dropped as machinery disproportionate to
+  the benefit.
+- **A closed enum of preset sizes** — rejected as the storage type, kept as the
+  UI affordance. Under-declaring is harmless and over-declaring hard-fails at the
+  vendor, so a proxy exposing a model whose true window sits _below_ the nearest
+  preset must remain expressible. Presets plus a Custom escape; the stored value
+  is always a plain integer.
+- **Falling back to a `length / 4` estimate when a Provider reports no usage** —
+  rejected. An estimate feeding a compaction trigger produces either surprise
+  truncation or surprise vendor errors, and neither is attributable after the
+  fact. Unknown stays unknown and the meter hides, matching the existing
+  `truncatedByTokenLimit` convention of making a degraded state visible.
+- **Deriving `maxExtractedTextChars` from the declared window** — rejected. The
+  derivation needs a chars-per-token ratio, which is the estimate rejected above,
+  and it would silently change file-handling behaviour for every Provider that
+  gains a `contextWindow`.
+
+## Consequences
+
+- **Occupancy is a last value, not a sum, and the wrong number looks right.**
+  The conversation is re-sent in full on every Chat turn, so occupancy replaces
+  rather than accumulates; summing across turns over-counts badly. Worse, two
+  plausible-looking figures inside a single turn are also sums:
+  `addLanguageModelUsage` (`ai/dist/index.js:2636`) folds `inputTokens` across
+  steps, so the terminal `finish` part's `totalUsage.inputTokens` is a sum of
+  context sizes — on a twenty-step agent turn it reads roughly an order of
+  magnitude high — and `RunStats.inputTokens` accumulates the same way. Both are
+  correct as billing figures. Neither is occupancy. Occupancy comes from the last
+  `finish-step` part's `usage.inputTokens`, which is confirmed inclusive of cache
+  reads and writes (Anthropic computes
+  `total: inputTokens + cacheCreationTokens + cacheReadTokens`; OpenAI
+  `total: promptTokens`) and is therefore the true full context size.
+- **Occupancy is emitted per step, not once at the end, for abort resilience.**
+  `messageMetadata` receives the raw `TextStreamPart` union and fires on every
+  part, and its return value is deep-merged, so returning the figure on each
+  `finish-step` leaves the last one standing. The terminal `finish` part is never
+  emitted on an aborted run, and cancelling a long turn is exactly when the
+  context got large — so emitting once on `finish` would lose the reading that
+  matters most. The cost is that `mergeObjects` skips `undefined` overrides, so a
+  later step reporting no usage would leave an earlier value looking current;
+  guarded by only returning when the count is a number and always writing every
+  key as a concrete value.
+- **Optional means auto-compaction will silently not engage.** When compaction
+  lands, a model with no declared window simply will not compact. The provider
+  form's hint on the field is the only guardrail against that being a mystery,
+  which makes it load-bearing rather than decorative. It states today's
+  consequence — the meter is hidden — rather than forward-referencing a feature
+  that does not exist yet.
+- **Users will under-declare, and the meter must not treat that as a fault.**
+  Because under-declaring is the safe direction, a 128k declaration against a
+  real 200k model is expected. The meter clamps its bar at 100% and shows the
+  true numbers rather than reporting 117% or clipping.
+- **The meter is one turn stale, and hides for two different reasons.** It cannot
+  account for an unsent draft, because nothing can count tokens locally. It hides
+  when the window is undeclared _or_ when occupancy is unknown — one state, two
+  causes, rather than a third display mode showing a numerator with no
+  denominator, which answers none of the questions a meter exists to answer.
+- **Trigger runs get their own field rather than a reinterpretation.**
+  `trigger_run.stats` already carries `inputTokens`/`outputTokens` as cross-step
+  sums, rendered on the trigger runs page. Those are legitimate billing figures;
+  repurposing them would silently change a displayed number's meaning, so
+  occupancy is added alongside, sourced from the final step.
+- **Sub-Agent turns and one-shot Provider executions are out of scope.** A
+  sub-Agent holds a separate context that no parent-level meter can meaningfully
+  display, and one-shot calls (metadata generation, memory extraction) are
+  single-turn by construction and cannot grow. The declared field still applies
+  wherever those resolve a model; only the measurement is scoped.
+- **"Context" now carries a third meaning.** The glossary already distinguished
+  User Context from the composed System prompt; a model's Context window is a
+  third. `CONTEXT.md` defines Context window and Context occupancy and disclaims
+  the collision on the existing Context entry, and the user-facing docs extend
+  their own "two different things are called Context" section to three.


### PR DESCRIPTION
Documentation only — glossary and ADR. No schema, backend, frontend or user-facing docs changes; those ship with the implementation, per the docs rule in `CLAUDE.md`.

## What this records

The outcome of a design session on letting an Org Admin declare a model's total context size, as a precursor to auto-compaction.

**`CONTEXT.md`** gains two terms:

- **Context window** — the total token capacity of a `(Provider, model)` pair, declared by an Org Admin. Asserted, never discovered.
- **Context occupancy** — how full that window was on the most recent Chat turn. A last value, not a running total.

The existing **Context** (User Context) entry now disclaims the collision, since "context" carries both meanings and they are never interchangeable.

**ADR-0018** records why declaration is forced and why occupancy is measured the way it is.

## The two findings worth the read

**Nothing in the stack can tell us a model's context length.** `LanguageModelV4` — the complete model interface in `@ai-sdk/provider@4.0.4`, as used by `ai@7.0.48` — has five members and no capability metadata. Grepping `maxInputTokens|contextWindow|contextLength` across `@ai-sdk/provider`, `@ai-sdk/openai` and `@ai-sdk/anthropic` returns nothing; the only token-limit field in the SDK is `maxOutputTokens`, a request setting. There is no token counter either — the SDK's own compaction example hand-rolls `JSON.stringify(messages).length / 4`. Declaring it is not a shortcut, it is the only option.

**Occupancy is a last value, not a sum, and the wrong number looks right.** The conversation is re-sent in full every turn, so occupancy replaces rather than accumulates. Two plausible-looking figures inside a single turn are also sums: `addLanguageModelUsage` folds `inputTokens` across steps, so the terminal `finish` part's `totalUsage.inputTokens` is a sum of context sizes — on a twenty-step agent turn it reads roughly an order of magnitude high — and `RunStats.inputTokens` accumulates the same way. Both are correct as billing figures; neither is occupancy.

## Related

#354 (per-response metrics panel) targets the same seam — token counts in assistant-message `metadata`. Not closed by this, but the two need to agree: that issue wants the provider's **summed** usage for a cost/latency panel, while occupancy needs the **last step's** input tokens. Same JSONB object, different keys, different meanings. Overloading one key would give whichever feature ships second a number that is silently wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)