### PR TITLE
fix(backend): clean up kanban card labels when a board label is deleted

### DIFF
--- a/apps/backend/src/routes/kanban.test.ts
+++ b/apps/backend/src/routes/kanban.test.ts
@@ -177,6 +177,109 @@ describe("Kanban Routes", () => {
 
       expect(res.status).toBe(404);
     });
+
+    describe("label cleanup", () => {
+      /**
+       * Queues the `where` calls made before the board's cards are read:
+       * the two authorization lookups, the board update, and the subquery that
+       * resolves the board's columns. The next `where` is the card read.
+       */
+      const queueWheresBeforeCardRead = () => {
+        mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess
+        mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess
+        mockDb.where.mockReturnValueOnce(mockDb); // board update
+        mockDb.where.mockReturnValueOnce(mockDb); // board columns subquery
+      };
+
+      const authorizeOwner = () => {
+        mockSession();
+        mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { ownerId: "user-1", organizationId: "org-1" },
+        ]); // requireWorkspaceAccess
+      };
+
+      it("should remove a deleted label from the cards using it", async () => {
+        authorizeOwner();
+        mockDb.returning.mockResolvedValueOnce([
+          { id: boardId, name: "Board 1" },
+        ]);
+        queueWheresBeforeCardRead();
+        mockDb.where.mockResolvedValueOnce([
+          { id: "card-1", labelIds: ["lbl-old", "lbl-new"] },
+          { id: "card-2", labelIds: ["lbl-new"] },
+        ]);
+
+        const res = await app.request(`${baseUrl}/${boardId}`, {
+          method: "PUT",
+          body: JSON.stringify({
+            name: "Board 1",
+            labels: [{ id: "lbl-new", name: "New", color: "#ef4444" }],
+          }),
+          headers: { "Content-Type": "application/json" },
+        });
+
+        expect(res.status).toBe(200);
+        // Only the card holding the deleted label is rewritten.
+        const labelWrites = mockDb.set.mock.calls.filter(
+          (call) =>
+            typeof call[0] === "object" &&
+            call[0] !== null &&
+            "labelIds" in call[0],
+        );
+        expect(labelWrites).toHaveLength(1);
+        expect(labelWrites[0][0]).toMatchObject({ labelIds: ["lbl-new"] });
+      });
+
+      it("should empty every card's labels when all board labels are removed", async () => {
+        authorizeOwner();
+        mockDb.returning.mockResolvedValueOnce([
+          { id: boardId, name: "Board 1" },
+        ]);
+        queueWheresBeforeCardRead();
+        mockDb.where.mockResolvedValueOnce([
+          { id: "card-1", labelIds: ["lbl-a"] },
+          { id: "card-2", labelIds: ["lbl-a", "lbl-b"] },
+        ]);
+
+        const res = await app.request(`${baseUrl}/${boardId}`, {
+          method: "PUT",
+          body: JSON.stringify({ name: "Board 1", labels: [] }),
+          headers: { "Content-Type": "application/json" },
+        });
+
+        expect(res.status).toBe(200);
+        const labelWrites = mockDb.set.mock.calls.filter(
+          (call) =>
+            typeof call[0] === "object" &&
+            call[0] !== null &&
+            "labelIds" in call[0],
+        );
+        expect(labelWrites).toHaveLength(2);
+        expect(labelWrites[0][0]).toMatchObject({ labelIds: [] });
+        expect(labelWrites[1][0]).toMatchObject({ labelIds: [] });
+      });
+
+      it("should leave card labels alone when the update omits labels", async () => {
+        authorizeOwner();
+        mockDb.returning.mockResolvedValueOnce([
+          { id: boardId, name: "Renamed" },
+        ]);
+
+        const res = await app.request(`${baseUrl}/${boardId}`, {
+          method: "PUT",
+          body: JSON.stringify({ name: "Renamed", description: "New blurb" }),
+          headers: { "Content-Type": "application/json" },
+        });
+
+        expect(res.status).toBe(200);
+        // The board's own labels are left out of the update, and no card is
+        // rewritten.
+        expect(mockDb.set).toHaveBeenCalledTimes(1);
+        expect(mockDb.set.mock.calls[0][0]).not.toHaveProperty("labels");
+        expect(mockDb.set.mock.calls[0][0]).not.toHaveProperty("labelIds");
+      });
+    });
   });
 
   describe("DELETE /:boardId", () => {
@@ -595,6 +698,83 @@ describe("Kanban Routes", () => {
       });
 
       expect(res.status).toBe(404);
+    });
+
+    describe("Label validation", () => {
+      const mockBoardLabels = (labels: { id: string }[]) => {
+        mockDb.limit.mockResolvedValueOnce([{ labels }]); // board labels lookup
+      };
+
+      it("should persist valid label IDs unchanged", async () => {
+        mockSession();
+        mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { ownerId: "user-1", organizationId: "org-1" },
+        ]); // requireWorkspaceAccess
+        mockBoardLabels([{ id: "lbl-a" }, { id: "lbl-b" }]);
+        mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
+
+        const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
+          method: "PUT",
+          body: JSON.stringify({ labelIds: ["lbl-b", "lbl-a"] }),
+          headers: { "Content-Type": "application/json" },
+        });
+
+        expect(res.status).toBe(200);
+        expect(mockDb.set).toHaveBeenCalledWith(
+          expect.objectContaining({ labelIds: ["lbl-b", "lbl-a"] }),
+        );
+      });
+
+      it("should drop unknown label IDs and apply the rest of the update", async () => {
+        mockSession();
+        mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { ownerId: "user-1", organizationId: "org-1" },
+        ]); // requireWorkspaceAccess
+        mockBoardLabels([{ id: "lbl-new" }]);
+        mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
+
+        const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
+          method: "PUT",
+          body: JSON.stringify({
+            title: "Retitled",
+            priority: "high",
+            labelIds: ["lbl-deleted", "lbl-new"],
+          }),
+          headers: { "Content-Type": "application/json" },
+        });
+
+        expect(res.status).toBe(200);
+        expect(mockDb.set).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: "Retitled",
+            priority: "high",
+            labelIds: ["lbl-new"],
+          }),
+        );
+      });
+
+      it("should end with an empty label list when every submitted ID is unknown", async () => {
+        mockSession();
+        mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { ownerId: "user-1", organizationId: "org-1" },
+        ]); // requireWorkspaceAccess
+        mockBoardLabels([]);
+        mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
+
+        const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
+          method: "PUT",
+          body: JSON.stringify({ labelIds: ["lbl-deleted"] }),
+          headers: { "Content-Type": "application/json" },
+        });
+
+        expect(res.status).toBe(200);
+        expect(mockDb.set).toHaveBeenCalledWith(
+          expect.objectContaining({ labelIds: [] }),
+        );
+      });
     });
 
     describe("Assignee validation", () => {

--- a/apps/backend/src/routes/kanban.ts
+++ b/apps/backend/src/routes/kanban.ts
@@ -36,6 +36,10 @@ import {
 } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { calculateCardPosition } from "../utils/kanban-positioning.ts";
+import {
+  filterKnownLabelIds,
+  pruneCardLabelIds,
+} from "../utils/kanban-labels.ts";
 import { listScopedByIds } from "../services/scoped-resource.ts";
 
 /**
@@ -84,6 +88,57 @@ async function validateAssignees(
   if (validUserIds.size < userIds.length) return "Invalid user assignee";
   if (agentRecords.length !== agentIds.length) return "Invalid agent assignee";
   return null;
+}
+
+// Any query executor — the top-level `db` or a transaction handle.
+type Executor = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Removes label IDs the board no longer has from every card on that board.
+ * Board labels are an array on the board record and cards reference them by ID,
+ * so deleting a label would otherwise leave cards holding an ID that resolves
+ * to nothing. Only removes IDs — a card never gains a label here.
+ */
+async function pruneCardLabelsForBoard(
+  tx: Executor,
+  boardId: string,
+  labels: { id: string }[],
+): Promise<void> {
+  const cards = await tx
+    .select({ id: kanbanCardTable.id, labelIds: kanbanCardTable.labelIds })
+    .from(kanbanCardTable)
+    .where(
+      inArray(
+        kanbanCardTable.columnId,
+        tx
+          .select({ id: kanbanColumnTable.id })
+          .from(kanbanColumnTable)
+          .where(eq(kanbanColumnTable.boardId, boardId)),
+      ),
+    );
+
+  const stale = pruneCardLabelIds(
+    cards,
+    labels.map((l) => l.id),
+  );
+
+  for (const card of stale) {
+    await tx
+      .update(kanbanCardTable)
+      .set({ labelIds: card.labelIds, updatedAt: new Date() })
+      .where(eq(kanbanCardTable.id, card.id));
+  }
+}
+
+/** The board's label IDs, or an empty list if the board has none. */
+async function getBoardLabelIds(boardId: string): Promise<string[]> {
+  const boardRecord = await db
+    .select({ labels: kanbanBoardTable.labels })
+    .from(kanbanBoardTable)
+    .where(eq(kanbanBoardTable.id, boardId))
+    .limit(1);
+
+  return (boardRecord[0]?.labels ?? []).map((l: { id: string }) => l.id);
 }
 
 const kanban = new Hono<{ Variables: Variables }>();
@@ -207,16 +262,26 @@ kanban.put(
     const workspaceId = c.req.param("workspaceId")!;
     const data = c.req.valid("json");
 
-    const record = await db
-      .update(kanbanBoardTable)
-      .set({ ...data, updatedAt: new Date() })
-      .where(
-        and(
-          eq(kanbanBoardTable.id, boardId),
-          eq(kanbanBoardTable.workspaceId, workspaceId),
-        ),
-      )
-      .returning();
+    // Labels the update drops are gone from the board, so the cards using them
+    // lose them in the same transaction — otherwise a card is left holding an
+    // ID that resolves to nothing.
+    const record = await db.transaction(async (tx) => {
+      const updated = await tx
+        .update(kanbanBoardTable)
+        .set({ ...data, updatedAt: new Date() })
+        .where(
+          and(
+            eq(kanbanBoardTable.id, boardId),
+            eq(kanbanBoardTable.workspaceId, workspaceId),
+          ),
+        )
+        .returning();
+
+      if (updated.length > 0 && data.labels !== undefined) {
+        await pruneCardLabelsForBoard(tx, boardId, data.labels);
+      }
+      return updated;
+    });
 
     if (record.length === 0) {
       return c.json({ error: "Board not found" }, 404);
@@ -689,15 +754,7 @@ kanban.post(
 
     // Validate labelIds if provided
     if (data.labelIds && data.labelIds.length > 0) {
-      const boardRecord = await db
-        .select({ labels: kanbanBoardTable.labels })
-        .from(kanbanBoardTable)
-        .where(eq(kanbanBoardTable.id, boardId))
-        .limit(1);
-
-      const boardLabelIds = new Set(
-        (boardRecord[0]?.labels ?? []).map((l: { id: string }) => l.id),
-      );
+      const boardLabelIds = new Set(await getBoardLabelIds(boardId));
       const allValid = data.labelIds.every((id: string) =>
         boardLabelIds.has(id),
       );
@@ -769,23 +826,13 @@ kanban.put(
     const data = c.req.valid("json");
     const user = c.get("user")!;
 
-    // Validate labelIds if provided
-    if (data.labelIds && data.labelIds.length > 0) {
-      const boardRecord = await db
-        .select({ labels: kanbanBoardTable.labels })
-        .from(kanbanBoardTable)
-        .where(eq(kanbanBoardTable.id, boardId))
-        .limit(1);
-
-      const boardLabelIds = new Set(
-        (boardRecord[0]?.labels ?? []).map((l: { id: string }) => l.id),
-      );
-      const allValid = data.labelIds.every((id: string) =>
-        boardLabelIds.has(id),
-      );
-      if (!allValid) {
-        return c.json({ error: "Invalid label ID" }, 400);
-      }
+    // Drop label IDs the board doesn't have rather than rejecting the update.
+    // A card can be left holding a deleted label's ID, and the dialog gives the
+    // user no way to see or deselect it — so rejecting would wedge the card.
+    // Saving it self-heals the card.
+    let labelIds = data.labelIds;
+    if (labelIds && labelIds.length > 0) {
+      labelIds = filterKnownLabelIds(labelIds, await getBoardLabelIds(boardId));
     }
 
     // Validate assignees if provided
@@ -805,6 +852,7 @@ kanban.put(
       .update(kanbanCardTable)
       .set({
         ...restData,
+        ...(labelIds !== undefined && { labelIds }),
         ...(dueDateStr !== undefined && {
           dueDate: dueDateStr ? new Date(dueDateStr) : null,
         }),

--- a/apps/backend/src/utils/kanban-labels.test.ts
+++ b/apps/backend/src/utils/kanban-labels.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { filterKnownLabelIds, pruneCardLabelIds } from "./kanban-labels.ts";
+
+describe("filterKnownLabelIds", () => {
+  it("keeps every submitted ID when all are known", () => {
+    expect(filterKnownLabelIds(["a", "b"], ["a", "b", "c"])).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  it("preserves the submitted order", () => {
+    expect(filterKnownLabelIds(["c", "a"], ["a", "b", "c"])).toEqual([
+      "c",
+      "a",
+    ]);
+  });
+
+  it("drops IDs that are not on the board", () => {
+    expect(filterKnownLabelIds(["stale", "b"], ["a", "b"])).toEqual(["b"]);
+  });
+
+  it("returns an empty list when every submitted ID is unknown", () => {
+    expect(filterKnownLabelIds(["stale"], ["a"])).toEqual([]);
+  });
+
+  it("returns an empty list when the board has no labels", () => {
+    expect(filterKnownLabelIds(["a"], [])).toEqual([]);
+  });
+});
+
+describe("pruneCardLabelIds", () => {
+  it("returns only the cards holding an unknown ID", () => {
+    const pruned = pruneCardLabelIds(
+      [
+        { id: "card-1", labelIds: ["a", "stale"] },
+        { id: "card-2", labelIds: ["a"] },
+        { id: "card-3", labelIds: [] },
+      ],
+      ["a", "b"],
+    );
+    expect(pruned).toEqual([{ id: "card-1", labelIds: ["a"] }]);
+  });
+
+  it("empties the label list of every card when no labels remain", () => {
+    const pruned = pruneCardLabelIds(
+      [
+        { id: "card-1", labelIds: ["a"] },
+        { id: "card-2", labelIds: ["a", "b"] },
+      ],
+      [],
+    );
+    expect(pruned).toEqual([
+      { id: "card-1", labelIds: [] },
+      { id: "card-2", labelIds: [] },
+    ]);
+  });
+
+  it("returns nothing when every card only holds known IDs", () => {
+    expect(
+      pruneCardLabelIds([{ id: "card-1", labelIds: ["a"] }], ["a", "b"]),
+    ).toEqual([]);
+  });
+
+  it("never adds an ID a card did not already hold", () => {
+    const pruned = pruneCardLabelIds(
+      [{ id: "card-1", labelIds: ["stale"] }],
+      ["a", "b"],
+    );
+    expect(pruned).toEqual([{ id: "card-1", labelIds: [] }]);
+  });
+});

--- a/apps/backend/src/utils/kanban-labels.ts
+++ b/apps/backend/src/utils/kanban-labels.ts
@@ -1,0 +1,36 @@
+/** A card as far as labels are concerned: its ID and the labels it holds. */
+export type CardLabelRow = { id: string; labelIds: string[] };
+
+/**
+ * Keeps only the submitted label IDs that exist on the board, in the submitted
+ * order. Board labels live in an array on the board record, so a card can hold
+ * an ID for a label that has since been deleted; dropping those keeps a save
+ * from failing over a reference the user cannot even see.
+ */
+export function filterKnownLabelIds(
+  submitted: string[],
+  known: string[],
+): string[] {
+  const knownIds = new Set(known);
+  return submitted.filter((id) => knownIds.has(id));
+}
+
+/**
+ * Given the cards on a board and the board's current label IDs, returns the
+ * cards that reference a label the board no longer has, each with its pruned
+ * label list. Cards that are already clean are left out so callers only write
+ * the rows that change. This only ever removes IDs.
+ */
+export function pruneCardLabelIds(
+  cards: CardLabelRow[],
+  known: string[],
+): CardLabelRow[] {
+  const pruned: CardLabelRow[] = [];
+  for (const card of cards) {
+    const kept = filterKnownLabelIds(card.labelIds, known);
+    if (kept.length !== card.labelIds.length) {
+      pruned.push({ id: card.id, labelIds: kept });
+    }
+  }
+  return pruned;
+}

--- a/apps/docs/content/building-with-platypus/boards.mdx
+++ b/apps/docs/content/building-with-platypus/boards.mdx
@@ -34,6 +34,12 @@ from the board's **Settings** (the gear icon).
 
 </Steps>
 
+<Callout type="warning">
+  Deleting a label from a board also removes it from every card that was using
+  it. The cards keep everything else — title, description, assignee — and there
+  is no undo for the label itself.
+</Callout>
+
 ## Work the board
 
 The board view scrolls horizontally across its **columns**. From here you:

--- a/apps/frontend/components/kanban-board.tsx
+++ b/apps/frontend/components/kanban-board.tsx
@@ -526,7 +526,7 @@ export function KanbanBoard({
       });
 
       try {
-        await fetch(joinUrl(baseUrl, `/cards/${active.id}/move`), {
+        const res = await fetch(joinUrl(baseUrl, `/cards/${active.id}/move`), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -535,6 +535,7 @@ export function KanbanBoard({
           }),
           credentials: "include",
         });
+        if (!res.ok) throw new Error("Failed to move card");
         await mutate();
       } catch {
         toast.error("Failed to move card/column");
@@ -576,15 +577,19 @@ export function KanbanBoard({
   const confirmAddCard = useCallback(async () => {
     if (!newCardTitle.trim() || !addCardColumnId) return;
     try {
-      await fetch(joinUrl(baseUrl, `/columns/${addCardColumnId}/cards`), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: newCardTitle.trim(),
-          ...(newCardLabelIds.length > 0 && { labelIds: newCardLabelIds }),
-        }),
-        credentials: "include",
-      });
+      const res = await fetch(
+        joinUrl(baseUrl, `/columns/${addCardColumnId}/cards`),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: newCardTitle.trim(),
+            ...(newCardLabelIds.length > 0 && { labelIds: newCardLabelIds }),
+          }),
+          credentials: "include",
+        },
+      );
+      if (!res.ok) throw new Error("Failed to create card");
       setAddCardDialogOpen(false);
       setNewCardTitle("");
       setNewCardLabelIds([]);
@@ -695,22 +700,27 @@ export function KanbanBoard({
       if (!column) return;
       const { columnId: targetColumnId, ...updateData } = cardData;
       try {
-        await fetch(joinUrl(baseUrl, `/cards/${cardId}`), {
+        const res = await fetch(joinUrl(baseUrl, `/cards/${cardId}`), {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(updateData),
           credentials: "include",
         });
+        if (!res.ok) throw new Error("Failed to update card");
         if (targetColumnId && targetColumnId !== column.id) {
-          await fetch(joinUrl(baseUrl, `/cards/${cardId}/move`), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              columnId: targetColumnId,
-              afterCardId: null,
-            }),
-            credentials: "include",
-          });
+          const moveRes = await fetch(
+            joinUrl(baseUrl, `/cards/${cardId}/move`),
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                columnId: targetColumnId,
+                afterCardId: null,
+              }),
+              credentials: "include",
+            },
+          );
+          if (!moveRes.ok) throw new Error("Failed to move card");
         }
         setDialogOpen(false);
         setSelectedCard(null);
@@ -730,10 +740,11 @@ export function KanbanBoard({
       );
       if (!column) return;
       try {
-        await fetch(joinUrl(baseUrl, `/cards/${cardId}`), {
+        const res = await fetch(joinUrl(baseUrl, `/cards/${cardId}`), {
           method: "DELETE",
           credentials: "include",
         });
+        if (!res.ok) throw new Error("Failed to delete card");
         setDialogOpen(false);
         setSelectedCard(null);
         updateCardIdParam(null);

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -1632,11 +1632,17 @@ export const kanbanBoardCreateSchema = kanbanBoardSchema.pick({
   labels: true,
 });
 
-export const kanbanBoardUpdateSchema = kanbanBoardSchema.pick({
-  name: true,
-  description: true,
-  labels: true,
-});
+// `labels` is optional on update (rather than defaulting to `[]`) so an update
+// that only touches the name or description leaves the board's labels — and the
+// cards referencing them — alone.
+export const kanbanBoardUpdateSchema = kanbanBoardSchema
+  .pick({
+    name: true,
+    description: true,
+  })
+  .extend({
+    labels: z.array(kanbanLabelSchema).optional(),
+  });
 
 // Kanban Column
 


### PR DESCRIPTION
Closes #439

Deleting a label from a Kanban board left every card that used it holding an ID that resolved to nothing. The card update endpoint rejected the whole request when any submitted label ID was unknown, so such a card could no longer be saved at all — not just its labels. The board UI treated the rejection as a success, so nothing surfaced to the user.

## Changes

**Backend**

- A board update that changes `labels` prunes the removed IDs from every card on that board, in the same transaction as the board write. Removal only — a card never gains a label here. Cards on other boards are untouched.
- The card update endpoint drops unknown label IDs instead of returning `400 Invalid label ID`. This self-heals cards in existing installations that already hold a dangling reference; valid IDs still persist exactly as submitted, in order. A list of entirely unknown IDs leaves the card with an empty label list.
- Card create still rejects unknown IDs — a fresh card cannot be wedged, so the tolerant path is scoped to update. Both handlers now share one board-label lookup.

**Schema**

`labels` on `kanbanBoardUpdateSchema` is optional rather than defaulting to `[]`, so a name- or description-only update leaves the board's labels — and the cards using them — alone. Note this also means a `PUT` that omits `labels` no longer clears the board's labels, which it did before. The board form always sends `labels`, so nothing in-app relied on the old behaviour.

**Frontend**

Card save, move, create and delete check `res.ok` and throw, so the existing catch shows an error toast and the card dialog stays open instead of closing and revalidating as though the save succeeded.

**Docs**

`boards.mdx` states that deleting a label also removes it from every card using it.

## Verification

Full suite green (1569 backend tests), `pnpm typecheck` and `pnpm lint` clean. New coverage: unit tests for the label filter/prune helpers, plus route tests for the board-update cleanup (one label removed, all labels removed, labels untouched) and the tolerant card update.

Also walked the reported repro against a running instance: board-update cleanup, a planted dangling reference saving successfully with the rest of the update applied, name-only update leaving labels alone, and removing all labels emptying every card.

The error-toast path was verified by typecheck and reading only, not driven in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)