### PR TITLE
fix(backend): validate tool set contributions

### DIFF
--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -357,6 +357,66 @@ describe("loadPlugins", () => {
     ).rejects.toThrow(/@empty\/plugin.*manifest/s);
   });
 
+  it.each([
+    [
+      "a non-object entry",
+      null,
+      /@platypus\/bad.*tool set contribution must be an object/s,
+    ],
+    [
+      "a string entry",
+      "broken",
+      /@platypus\/bad.*tool set contribution must be an object/s,
+    ],
+    [
+      "an array entry",
+      [],
+      /@platypus\/bad.*tool set contribution must be an object/s,
+    ],
+    [
+      "a missing id",
+      { name: "Broken", category: "Test", tools: {} },
+      /@platypus\/bad.*non-empty "id"/s,
+    ],
+    [
+      "a missing name",
+      { id: "broken", category: "Test", tools: {} },
+      /@platypus\/bad.*tool set "broken".*non-empty "name"/s,
+    ],
+    [
+      "missing tools",
+      { id: "broken", name: "Broken", category: "Test" },
+      /@platypus\/bad.*tool set "broken".*"tools" object or function/s,
+    ],
+  ])(
+    "aborts (fail-loud, plugin-named) on %s",
+    async (_label, contribution, expected) => {
+      const { register, calls } = makeRegister();
+      await expect(
+        loadPlugins({
+          pluginNames: ["@platypus/bad"],
+          builtinPlugins: {
+            "@platypus/bad": () =>
+              Promise.resolve({
+                plugin: {
+                  name: "@platypus/bad",
+                  version: "0.1.0",
+                  apiVersion: 1,
+                  contributes: {
+                    toolSets: [
+                      contribution,
+                    ] as unknown as ToolSetContribution[],
+                  },
+                },
+              }),
+          },
+          register,
+        }),
+      ).rejects.toThrow(expected);
+      expect(calls).toHaveLength(0);
+    },
+  );
+
   it("aborts (fail-loud) on a duplicate id, naming both owning plugins", async () => {
     const { register } = makeRegister();
     // Two core plugins keep bare ids, so a shared `time` id collides directly.

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -379,13 +379,33 @@ describe("loadPlugins", () => {
       /@platypus\/bad.*non-empty "id"/s,
     ],
     [
+      "a whitespace-only id",
+      { id: "   ", name: "Broken", category: "Test", tools: {} },
+      /@platypus\/bad.*non-empty "id"/s,
+    ],
+    [
       "a missing name",
       { id: "broken", category: "Test", tools: {} },
       /@platypus\/bad.*tool set "broken".*non-empty "name"/s,
     ],
     [
+      "a missing category",
+      { id: "broken", name: "Broken", tools: {} },
+      /@platypus\/bad.*tool set "broken".*non-empty "category"/s,
+    ],
+    [
+      "a whitespace-only category",
+      { id: "broken", name: "Broken", category: "   ", tools: {} },
+      /@platypus\/bad.*tool set "broken".*non-empty "category"/s,
+    ],
+    [
       "missing tools",
       { id: "broken", name: "Broken", category: "Test" },
+      /@platypus\/bad.*tool set "broken".*"tools" object or function/s,
+    ],
+    [
+      "an array tools",
+      { id: "broken", name: "Broken", category: "Test", tools: [] },
       /@platypus\/bad.*tool set "broken".*"tools" object or function/s,
     ],
   ])(
@@ -416,6 +436,54 @@ describe("loadPlugins", () => {
       expect(calls).toHaveLength(0);
     },
   );
+
+  it("names the array index when a malformed entry has no usable id", async () => {
+    const { register, calls } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@platypus/bad"],
+        builtinPlugins: {
+          "@platypus/bad": () =>
+            Promise.resolve({
+              plugin: {
+                name: "@platypus/bad",
+                version: "0.1.0",
+                apiVersion: 1,
+                contributes: {
+                  toolSets: [
+                    toolSet("fine"),
+                    null,
+                  ] as unknown as ToolSetContribution[],
+                },
+              },
+            }),
+        },
+        register,
+      }),
+    ).rejects.toThrow(/at index 1/);
+    // Entries validate and register in the same pass, so the good entry ahead of
+    // the bad one is already in the registry. That is not a leak: the throw
+    // aborts boot, so the half-filled registry never serves a turn.
+    expect(calls.map((c) => c.id)).toEqual(["fine"]);
+  });
+
+  it("trims a padded id before namespacing it", async () => {
+    const { register, calls } = makeRegister();
+    const loaded = await loadPlugins({
+      pluginNames: ["@third/party"],
+      builtinPlugins: {},
+      importPlugin: () =>
+        Promise.resolve({
+          plugin: manifest("padded", [
+            { ...toolSet("spaced"), id: "  spaced  " },
+          ]),
+        }),
+      register,
+    });
+    // `acme. my set ` must never reach the registry or `agent.toolSetIds`.
+    expect(calls.map((c) => c.id)).toEqual(["padded.spaced"]);
+    expect(loaded[0].toolSetIds).toEqual(["padded.spaced"]);
+  });
 
   it("aborts (fail-loud) on a duplicate id, naming both owning plugins", async () => {
     const { register } = makeRegister();

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -378,18 +378,24 @@ export async function loadPlugins(
 
     const toolSetIds: string[] = [];
 
-    for (const contribution of manifest.contributes.toolSets ?? []) {
+    for (const [index, contribution] of (
+      manifest.contributes.toolSets ?? []
+    ).entries()) {
       // TypeScript protects in-repo plugins, but a third-party JS package can
       // put any value inside the array. Validate identity before namespacing:
       // `contributionId(undefined)` otherwise mints a plausible-looking
       // `"acme.undefined"` Tool set and exposes it through the catalog.
+      //
+      // The two checks that run before an id is known carry the array index —
+      // on a plugin contributing several tool sets it is the only thing an
+      // Operator can use to find the offending entry.
       if (
         typeof contribution !== "object" ||
         contribution === null ||
         Array.isArray(contribution)
       ) {
         throw new Error(
-          `Plugin "${manifest.name}": every tool set contribution must be an object.`,
+          `Plugin "${manifest.name}": every tool set contribution must be an object (at index ${index}).`,
         );
       }
       if (
@@ -397,7 +403,7 @@ export async function loadPlugins(
         contribution.id.trim() === ""
       ) {
         throw new Error(
-          `Plugin "${manifest.name}": every tool set must declare a non-empty "id".`,
+          `Plugin "${manifest.name}": every tool set must declare a non-empty "id" (at index ${index}).`,
         );
       }
       if (
@@ -406,6 +412,14 @@ export async function loadPlugins(
       ) {
         throw new Error(
           `Plugin "${manifest.name}": tool set "${contribution.id}" must declare a non-empty "name".`,
+        );
+      }
+      if (
+        typeof contribution.category !== "string" ||
+        contribution.category.trim() === ""
+      ) {
+        throw new Error(
+          `Plugin "${manifest.name}": tool set "${contribution.id}" must declare a non-empty "category".`,
         );
       }
       if (
@@ -419,8 +433,12 @@ export async function loadPlugins(
         );
       }
 
-      const { id, name: tsName, category, description, tools } = contribution;
-      const effectiveId = contributionId(id);
+      const { name: tsName, category, description, tools } = contribution;
+      // Trimmed before namespacing: the id is half of a composed
+      // `${manifest.name}.${id}` that gets persisted into `agent.toolSetIds`,
+      // and the other half is held to a url-safe slug above for exactly that
+      // reason. `" my set "` must not reach the registry as `acme. my set `.
+      const effectiveId = contributionId(contribution.id.trim());
 
       const existingOwner = owners.get(effectiveId);
       if (existingOwner) {
@@ -497,7 +515,9 @@ export async function loadPlugins(
         );
       }
 
-      const effectiveBackend = contributionId(contribution.backend);
+      // Trimmed before namespacing, as in the tool set loop: this id is
+      // persisted into `sandbox.backend` and must not carry stray whitespace.
+      const effectiveBackend = contributionId(contribution.backend.trim());
 
       const existingOwner = sandboxOwners.get(effectiveBackend);
       if (existingOwner) {
@@ -621,7 +641,8 @@ export async function loadPlugins(
         );
       }
 
-      const effectiveBackend = contributionId(contribution.backend);
+      // Trimmed before namespacing, as in the tool set loop.
+      const effectiveBackend = contributionId(contribution.backend.trim());
 
       const existingOwner = webOwners.get(effectiveBackend);
       if (existingOwner) {

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -379,6 +379,46 @@ export async function loadPlugins(
     const toolSetIds: string[] = [];
 
     for (const contribution of manifest.contributes.toolSets ?? []) {
+      // TypeScript protects in-repo plugins, but a third-party JS package can
+      // put any value inside the array. Validate identity before namespacing:
+      // `contributionId(undefined)` otherwise mints a plausible-looking
+      // `"acme.undefined"` Tool set and exposes it through the catalog.
+      if (
+        typeof contribution !== "object" ||
+        contribution === null ||
+        Array.isArray(contribution)
+      ) {
+        throw new Error(
+          `Plugin "${manifest.name}": every tool set contribution must be an object.`,
+        );
+      }
+      if (
+        typeof contribution.id !== "string" ||
+        contribution.id.trim() === ""
+      ) {
+        throw new Error(
+          `Plugin "${manifest.name}": every tool set must declare a non-empty "id".`,
+        );
+      }
+      if (
+        typeof contribution.name !== "string" ||
+        contribution.name.trim() === ""
+      ) {
+        throw new Error(
+          `Plugin "${manifest.name}": tool set "${contribution.id}" must declare a non-empty "name".`,
+        );
+      }
+      if (
+        typeof contribution.tools !== "function" &&
+        (typeof contribution.tools !== "object" ||
+          contribution.tools === null ||
+          Array.isArray(contribution.tools))
+      ) {
+        throw new Error(
+          `Plugin "${manifest.name}": tool set "${contribution.id}" must provide a "tools" object or function.`,
+        );
+      }
+
       const { id, name: tsName, category, description, tools } = contribution;
       const effectiveId = contributionId(id);
 

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -58,6 +58,12 @@ what the caps are, what happens at boot. For the exact shape of an interface,
 read it from the package you have installed. A signature pasted onto a docs page
 drifts silently; the one in your `node_modules` cannot.
 
+Every Contribution is validated before it is registered. A Tool set with a
+blank `id` or `name`, or with `tools` that is neither a map nor a factory,
+aborts startup with an error naming the Plugin. The package types catch these
+mistakes in TypeScript; the same checks protect deployments that load JavaScript
+or a malformed package.
+
 ## Web-search backends
 
 A **Web-search backend** fills the **Search** toggle in Chat for Providers whose

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -59,10 +59,13 @@ read it from the package you have installed. A signature pasted onto a docs page
 drifts silently; the one in your `node_modules` cannot.
 
 Every Contribution is validated before it is registered. A Tool set with a
-blank `id` or `name`, or with `tools` that is neither a map nor a factory,
-aborts startup with an error naming the Plugin. The package types catch these
-mistakes in TypeScript; the same checks protect deployments that load JavaScript
-or a malformed package.
+blank `id`, `name`, or `category`, or with `tools` that is neither a map nor a
+factory, aborts startup with an error naming the Plugin and the entry that
+failed. The package types catch these mistakes in TypeScript; the same checks
+protect deployments that load JavaScript or a malformed package.
+
+Contribution ids are trimmed before they are namespaced, so surrounding
+whitespace never reaches a stored id.
 
 ## Web-search backends
 

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -144,9 +144,11 @@ empty list unless it says otherwise, and silently runs without web-fetch.
   remove it.
 - **An empty list yields the always-on core tool sets only** — never zero tools.
   The gate-able plugins (web-fetch, docker, third-party) are simply absent.
-- **Boot is fail-loud.** A listed plugin that can't be resolved or exports an
-  invalid manifest, or two plugins whose tool-set ids collide, aborts startup
-  with a plugin-named error — a misconfigured plugin never silently drops tools.
+- **Boot is fail-loud.** A listed plugin that can't be resolved, exports an
+  invalid manifest, or declares a malformed Contribution aborts startup with a
+  plugin-named error. This includes a Tool set with no usable `id`, `name`, or
+  `tools`; a misconfigured plugin never silently drops or invents tools. Two
+  plugins whose Tool set ids collide also abort startup.
 - **New gate-able core plugins in a later release are not auto-enabled** — add
   them to your pinned list to opt in.
 

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -146,9 +146,9 @@ empty list unless it says otherwise, and silently runs without web-fetch.
   The gate-able plugins (web-fetch, docker, third-party) are simply absent.
 - **Boot is fail-loud.** A listed plugin that can't be resolved, exports an
   invalid manifest, or declares a malformed Contribution aborts startup with a
-  plugin-named error. This includes a Tool set with no usable `id`, `name`, or
-  `tools`; a misconfigured plugin never silently drops or invents tools. Two
-  plugins whose Tool set ids collide also abort startup.
+  plugin-named error. This includes a Tool set with no usable `id`, `name`,
+  `category`, or `tools`; a misconfigured plugin never silently drops or invents
+  tools. Two plugins whose Tool set ids collide also abort startup.
 - **New gate-able core plugins in a later release are not auto-enabled** — add
   them to your pinned list to opt in.
 


### PR DESCRIPTION
## Summary

- validate every Tool set Contribution before id namespacing and registration
- abort startup with a plugin-attributed error for malformed entries, blank identity fields, or invalid tools
- document the runtime validation and fail-loud self-hosting contract

Fixes #444

## Validation

- RED: the new loader regression table failed before the production change; malformed entries either threw an unattributed destructuring error or reached registration
- `pnpm --filter @platypus/backend test loader` — 76 passed
- `pnpm typecheck` — 7/7 tasks passed
- `pnpm test` — 8/8 tasks passed; backend 1574 passed
- `pnpm lint` — 4/4 tasks passed
- `pnpm --filter @platypus/docs test` — 24 passed
- `pnpm build` — 5/5 tasks passed, including all 46 documentation pages
- targeted Prettier and `git diff --check` passed

Local validation used Node 26.5.0 and pnpm 10.26.1; repository CI remains the pinned Node 24 check.