### PR TITLE
feat(provider): declare a Context window per model

### DIFF
--- a/apps/docs/content/administering/workspaces.mdx
+++ b/apps/docs/content/administering/workspaces.mdx
@@ -43,7 +43,7 @@ service is called, which team owns it, house terminology.
   Workspace's and reaches everyone in it; theirs is private to them. Personal
   preferences ("answer terse, no preamble") belong in theirs — putting them here
   imposes them on every Chat in the Workspace. See
-  [Memory & context](/concepts/memory-and-context#two-different-things-are-called-context).
+  [Memory & context](/concepts/memory-and-context#three-different-things-are-called-context).
 </Callout>
 
 ## The three Provider dropdowns

--- a/apps/docs/content/concepts/memory-and-context.mdx
+++ b/apps/docs/content/concepts/memory-and-context.mdx
@@ -63,7 +63,7 @@ standing facts: who you are, how you like answers formatted, what a project is
 about. It reaches every Agent you use, so there's no need to repeat it in any
 Agent's Instructions.
 
-### Two different things are called Context
+### Three different things are called Context
 
 <Callout type="warning">
   Your Workspace Context and the Workspace's **Context** field are not the same
@@ -79,6 +79,12 @@ Agent's Instructions.
   Workspace's field. Writing the first one into the second inflicts your
   preferences on everyone.
 </Callout>
+
+The third is the model's own **Context window**: how many tokens a model can be
+sent at once, which an Org Admin declares on the Provider's model entry because
+no vendor publishes it in a form Platypus can read. It has nothing to do with
+either of the two above — it is a capacity, not something you write. See
+[What each model entry holds](/self-hosting/providers-and-auth#what-each-model-entry-holds).
 
 **Memory vs. Context:** Memory is built up automatically from your activity;
 Context is written deliberately by you. They work together — Memory remembers,

--- a/apps/docs/content/docs-contract.test.ts
+++ b/apps/docs/content/docs-contract.test.ts
@@ -39,6 +39,7 @@ import {
   DEFAULT_MAX_EXTRACTED_TEXT_CHARS,
   kanbanBoardSchema,
   mcpSchema,
+  modelConfigSchema,
   skillSchema,
   triggerSchema,
   webhookEventSchema,
@@ -583,30 +584,38 @@ describe("core plugins", () => {
 
 // --- field limits ------------------------------------------------------------
 
+type ZodBounds = {
+  minLength?: number | null;
+  maxLength?: number | null;
+  minValue?: number | null;
+  maxValue?: number | null;
+};
+
 /**
- * Unwrap `.optional()` / `.nullable()` so the string checks underneath are
+ * Unwrap `.optional()` / `.nullable()` so the bound accessors underneath are
  * reachable.
  */
-const unwrap = (
-  schema: unknown,
-): { minLength?: number; maxLength?: number } => {
+const unwrap = (schema: unknown): ZodBounds => {
   let current = schema as { unwrap?: () => unknown };
   while (typeof current?.unwrap === "function") {
     current = current.unwrap() as { unwrap?: () => unknown };
   }
-  return current as { minLength?: number; maxLength?: number };
+  return current as ZodBounds;
 };
 
 /**
- * The `min`/`max` a Zod string field enforces, whatever it is wrapped in.
+ * The bounds a Zod field enforces, read off whichever pair of accessors its
+ * type uses — `minLength`/`maxLength` for a string, `minValue`/`maxValue` for a
+ * number.
  *
  * Throws rather than returning empty bounds. If Zod moves these accessors, an
  * expectation of `{}` would satisfy every claim below and the whole section
  * would go quietly green — the exact failure this file exists to prevent.
  */
-const stringField = (
+const boundedField = (
   schema: { shape: Record<string, unknown> },
   field: string,
+  accessors: { min: keyof ZodBounds; max: keyof ZodBounds },
 ): { min?: number; max?: number } => {
   if (schema.shape[field] === undefined) {
     throw new Error(
@@ -615,16 +624,35 @@ const stringField = (
     );
   }
   const bounds = unwrap(schema.shape[field]);
-  const min = bounds.minLength ?? undefined;
-  const max = bounds.maxLength ?? undefined;
+  const min = bounds[accessors.min] ?? undefined;
+  const max = bounds[accessors.max] ?? undefined;
   if (min === undefined && max === undefined) {
     throw new Error(
       `Read no min or max off the Zod field \`${field}\`. Either the schema stopped ` +
-        `bounding it, or Zod moved minLength/maxLength — fix this helper before trusting the suite.`,
+        `bounding it, or Zod moved ${accessors.min}/${accessors.max} — fix this helper before trusting the suite.`,
     );
   }
   return { min, max };
 };
+
+/** The `min`/`max` a Zod string field enforces, whatever it is wrapped in. */
+const stringField = (
+  schema: { shape: Record<string, unknown> },
+  field: string,
+): { min?: number; max?: number } =>
+  boundedField(schema, field, { min: "minLength", max: "maxLength" });
+
+/**
+ * The `min`/`max` a Zod number field enforces. A number's bounds live on
+ * different accessors from a string's, and reading a number through
+ * `stringField` throws rather than quietly reporting no bounds — which is why
+ * this sibling exists rather than one helper guessing.
+ */
+const numberField = (
+  schema: { shape: Record<string, unknown> },
+  field: string,
+): { min?: number; max?: number } =>
+  boundedField(schema, field, { min: "minValue", max: "maxValue" });
 
 type LimitClaim = {
   doc: string;
@@ -724,6 +752,12 @@ const LIMIT_CLAIMS: LimitClaim[] = [
     source: "packages/schemas/index.ts (DEFAULT_MAX_EXTRACTED_TEXT_CHARS)",
     expected: { max: DEFAULT_MAX_EXTRACTED_TEXT_CHARS },
   },
+  {
+    doc: "self-hosting/providers-and-auth.mdx",
+    anchor: "`contextWindow`",
+    source: "packages/schemas/index.ts (modelConfigSchema.contextWindow)",
+    expected: numberField(modelConfigSchema, "contextWindow"),
+  },
 ];
 
 // A claim with no bound to compare is a test that always passes. Catch it here,
@@ -769,13 +803,24 @@ const normaliseNumbers = (text: string): string =>
     // following separator needs, or `1,234,567` strips to `1234,567`.
     .replace(/(\d),(?=\d)/g, "$1");
 
+/**
+ * The units a limit can be stated in. A character count and a token count are
+ * both bounds a reader is rejected by, and neither page would thank us for
+ * restating its number in the other's unit.
+ */
+const LIMIT_UNIT = "(?:characters|tokens)";
+
 const readClaimedLimits = (
   text: string,
 ): { min?: number; max?: number } | undefined => {
   const normalised = normaliseNumbers(text);
-  const range = normalised.match(/(\d+)\s*-\s*(\d+)\s*characters/);
+  const range = normalised.match(
+    new RegExp(`(\\d+)\\s*-\\s*(\\d+)\\s*${LIMIT_UNIT}`),
+  );
   if (range) return { min: Number(range[1]), max: Number(range[2]) };
-  const upTo = normalised.match(/(?:up to|default)[^.]*?(\d+)\s*characters/);
+  const upTo = normalised.match(
+    new RegExp(`(?:up to|default)[^.]*?(\\d+)\\s*${LIMIT_UNIT}`),
+  );
   if (upTo) return { max: Number(upTo[1]) };
   return undefined;
 };

--- a/apps/docs/content/getting-started/index.mdx
+++ b/apps/docs/content/getting-started/index.mdx
@@ -154,8 +154,9 @@ Fill in the form:
 - **API Key** — your credential from that vendor.
 - **Models** — a repeatable list, not a text box. Click **Add model** for each
   one and type its id into the **Model ID** field (e.g. `gpt-4o`,
-  `claude-sonnet-4-6`). Leave **Alias** empty and **Advanced** collapsed for
-  now.
+  `claude-sonnet-4-6`). Leave **Alias** empty, **Context window** on **Not set**,
+  and **Advanced** collapsed for now — every one of them is optional, and you can
+  come back to them.
 
 Click **Save**.
 

--- a/apps/docs/content/self-hosting/providers-and-auth.mdx
+++ b/apps/docs/content/self-hosting/providers-and-auth.mdx
@@ -149,9 +149,10 @@ down.
 
 <Callout type="warning">
   A Context window is a **statement**, not a budget. Platypus does not enforce
-  it, warn on it, or trim a conversation to fit, and declaring one changes
-  nothing about how a turn is assembled or sent. It tells Platypus a capacity it
-  has no way to look up — nothing more. Leaving it empty breaks nothing.
+  it: nothing warns, trims a conversation to fit, or blocks a turn for
+  approaching it, and a turn is assembled and sent exactly as it was before. All
+  the field does is tell Platypus a capacity it has no way to look up. Leaving
+  it empty breaks nothing.
 </Callout>
 
 ### File handling: what each model accepts

--- a/apps/docs/content/self-hosting/providers-and-auth.mdx
+++ b/apps/docs/content/self-hosting/providers-and-auth.mdx
@@ -48,7 +48,7 @@ translating gateway in front of it.
 | `baseUrl`            | Optional override for OpenAI-compatible / self-hosted endpoints.                                                                                                |
 | `headers`            | Optional extra HTTP headers, as a JSON object, sent with every request to this Provider. On OpenRouter, setting any [app attribution](#openrouter-app-attribution) header here replaces all three defaults. |
 | `region`             | Required for Bedrock (AWS region).                                                                                                                              |
-| `modelIds`           | The models this Provider exposes for selection (at least one). Each entry carries its own config: file capability — see [File handling](#file-handling-what-each-model-accepts) — and an optional [Model alias](/concepts/providers#model-aliases). |
+| `modelIds`           | The models this Provider exposes for selection (at least one). Each entry is an object carrying that model's own settings — see [What each model entry holds](#what-each-model-entry-holds). |
 | `taskModelId`        | The model used for one-shot internal tasks (e.g. generating a chat title), not chat turns. Must be a real model id — a Model alias is rejected.                  |
 | `securityGuardrails` | Optional free-text security directives appended last in the system prompt for every run on this Provider.                                                       |
 
@@ -112,23 +112,53 @@ the same Organization can attribute differently.
   other custom headers are still sent.
 </Callout>
 
+### What each model entry holds
+
+A model is more than its id. What a model can read, how big its window is, and
+what an Agent selects it by are all properties of the `(Provider, model)` pair,
+and behind a proxy Platypus has no way to infer any of them — model names there
+are whatever the operator chose. So each entry in `modelIds` is an object, and
+everything on it beyond the id is **declared, not guessed**:
+
+| Per-model field         | Meaning                                                                                                                                                                        |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                    | The model id sent to the vendor.                                                                                                                                               |
+| `alias`                 | Optional stable name an Agent or Chat selects this model by, so repointing it upgrades them all at once. See [Model aliases](/concepts/providers#model-aliases).                |
+| `contextWindow`         | The vendor's published **total** token capacity for this model — the whole window, not a cap on the reply. 1,000–10,000,000 tokens. Empty means undeclared, which is normal.    |
+| `passthroughFileTypes`  | The media types this model ingests **natively**. Comma-separated in the UI; wildcards like `image/*` allowed. Empty inherits the [provider-type default](#file-handling-what-each-model-accepts). |
+| `maxExtractedTextChars` | Cap on the text a single extracted document may add to a turn. Empty uses the default (50,000 characters).                                                                     |
+
+Every field is optional except the id, and a Provider set up before any of them
+existed keeps working with none of them set.
+
+In the form, **Context window** sits on the model row itself; the last two sit
+behind **Advanced** on each row — collapsed unless that model already has one of
+them set. Every field carries an **i** you can hover or focus for the same
+explanation.
+
+#### Declaring a Context window
+
+Pick a size from the list, or choose **Custom** and type an exact number for a
+model behind a proxy whose capacity isn't one of the common ones. The listed
+sizes are decimal, so **128k** stores 128,000 — a model whose real window is
+131,072 forfeits 3k and nothing else.
+
+Declaring less than the vendor's real capacity is safe; declaring more is not,
+because the vendor rejects the turn outright. So when you aren't sure, round
+down.
+
+<Callout type="warning">
+  A Context window is a **statement**, not a budget. Platypus does not enforce
+  it, warn on it, or trim a conversation to fit, and declaring one changes
+  nothing about how a turn is assembled or sent. It tells Platypus a capacity it
+  has no way to look up — nothing more. Leaving it empty breaks nothing.
+</Callout>
+
 ### File handling: what each model accepts
 
 Whether a model can read an attached file is a property of the
-`(Provider, model)` pair, and behind a proxy Platypus has no way to infer it —
-model names there are whatever the operator chose. So capability is **declared,
-not guessed**: each entry in `modelIds` is a per-model object.
-
-| Per-model field         | Meaning                                                                                                                                                       |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                    | The model id sent to the vendor.                                                                                                                              |
-| `alias`                 | Optional stable name an Agent or Chat selects this model by, so repointing it upgrades them all at once. See [Model aliases](/concepts/providers#model-aliases). |
-| `passthroughFileTypes`  | The media types this model ingests **natively**. Comma-separated in the UI; wildcards like `image/*` allowed. Empty inherits the provider-type default below. |
-| `maxExtractedTextChars` | Cap on the text a single extracted document may add to a turn. Empty uses the default (50,000 characters).                                                    |
-
-In the form, the last two sit behind **Advanced** on each model row — collapsed
-unless that model already has one of them set. Every field carries an **i** you
-can hover or focus for the same explanation.
+`(Provider, model)` pair — `passthroughFileTypes` and `maxExtractedTextChars`
+above are how you declare it.
 
 On every chat turn, each attached file takes exactly one of these routes:
 

--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -156,6 +156,25 @@ describe("ProviderForm model rows", () => {
     );
   });
 
+  // Rows are keyed by index, so removing one shifts the row above's local state
+  // onto its neighbour. The control has to survive that: a trigger reading
+  // "Custom" beside no input would leave a declared window invisible and
+  // uneditable until the page was reloaded.
+  it("keeps a Custom value editable after the row above it is removed", () => {
+    renderEditForm([
+      { id: "gpt-4o", passthroughFileTypes: [] },
+      { id: "qwen", passthroughFileTypes: [], contextWindow: 131072 },
+    ]);
+
+    fireEvent.click(screen.getByLabelText("Remove model 1"));
+
+    expect(screen.getByLabelText("Model ID")).toHaveValue("qwen");
+    expect(screen.getByLabelText("Context window")).toHaveTextContent("Custom");
+    expect(screen.getByLabelText("Context window in tokens")).toHaveValue(
+      131072,
+    );
+  });
+
   it("leaves a legacy string model row loadable with no window declared", () => {
     renderEditForm(["gpt-4o"] as unknown as Provider["modelIds"]);
 

--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -60,6 +60,21 @@ function mockRejectedSave(issues: Array<{ path: unknown[]; message: string }>) {
   } as unknown as Response);
 }
 
+/** An accepted save, so the payload the form sent can be read back. */
+function mockAcceptedSave() {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ id: "p1", aliasRepoints: [] }),
+  } as unknown as Response);
+}
+
+/** The `modelIds` the form put on the wire for the last save. */
+function savedModelIds(fetchMock: ReturnType<typeof vi.fn>) {
+  const [, init] = fetchMock.mock.calls.at(-1) as [string, RequestInit];
+  return JSON.parse(String(init.body)).modelIds;
+}
+
 const save = () =>
   fireEvent.click(screen.getByRole("button", { name: "Update" }));
 
@@ -83,6 +98,7 @@ describe("ProviderForm model rows", () => {
     for (const label of [
       "Model ID",
       "Alias",
+      "Context window",
       "Native file types",
       "Max extracted text characters",
     ]) {
@@ -104,6 +120,95 @@ describe("ProviderForm model rows", () => {
     expect(
       screen.getByLabelText("Max extracted text characters"),
     ).toBeInTheDocument();
+  });
+
+  // Unlike the file-handling pair, this one is visible on a collapsed row: an
+  // Org Admin who never opens Advanced still has to find out the field exists,
+  // because nothing else can tell Platypus a model's capacity.
+  it("shows the Context window control without expanding Advanced", () => {
+    renderEditForm([{ id: "gpt-4o", passthroughFileTypes: [] }]);
+
+    expect(screen.getByLabelText("Context window")).toBeInTheDocument();
+    expect(screen.getByLabelText("Context window")).toHaveTextContent(
+      "Not set",
+    );
+  });
+
+  it("shows a stored listed size on the closed control", () => {
+    renderEditForm([
+      { id: "gpt-4o", passthroughFileTypes: [], contextWindow: 128000 },
+    ]);
+
+    expect(screen.getByLabelText("Context window")).toHaveTextContent("128k");
+    expect(screen.queryByLabelText("Context window in tokens")).toBeNull();
+  });
+
+  // A proxied model with an unusual capacity comes back in the number input
+  // rather than snapping to whichever preset happens to be nearest.
+  it("shows a stored unlisted size as a Custom value in the number input", () => {
+    renderEditForm([
+      { id: "qwen", passthroughFileTypes: [], contextWindow: 131072 },
+    ]);
+
+    expect(screen.getByLabelText("Context window")).toHaveTextContent("Custom");
+    expect(screen.getByLabelText("Context window in tokens")).toHaveValue(
+      131072,
+    );
+  });
+
+  it("leaves a legacy string model row loadable with no window declared", () => {
+    renderEditForm(["gpt-4o"] as unknown as Provider["modelIds"]);
+
+    expect(screen.getByLabelText("Model ID")).toHaveValue("gpt-4o");
+    expect(screen.getByLabelText("Context window")).toHaveTextContent(
+      "Not set",
+    );
+  });
+
+  it("sends a declared window back unchanged, so it survives a save", async () => {
+    const fetchMock = mockAcceptedSave();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditForm([
+      { id: "gpt-4o", passthroughFileTypes: [], contextWindow: 200000 },
+    ]);
+    save();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(savedModelIds(fetchMock)).toEqual([
+      { id: "gpt-4o", passthroughFileTypes: [], contextWindow: 200000 },
+    ]);
+  });
+
+  // The field is optional on both create and update: a row that never touches
+  // it must not start sending a number the Org Admin did not declare.
+  it("declares no window for a row that was left alone", async () => {
+    const fetchMock = mockAcceptedSave();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditForm([{ id: "gpt-4o", passthroughFileTypes: [] }]);
+    save();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(savedModelIds(fetchMock)[0].contextWindow).toBeUndefined();
+  });
+
+  // Editing a Custom value types straight through, bounds included, so a `128`
+  // meant as 128k is rejected by the server rather than silently swallowed.
+  it("sends a typed Custom value exactly as typed", async () => {
+    const fetchMock = mockAcceptedSave();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditForm([
+      { id: "qwen", passthroughFileTypes: [], contextWindow: 131072 },
+    ]);
+    fireEvent.change(screen.getByLabelText("Context window in tokens"), {
+      target: { value: "128" },
+    });
+    save();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(savedModelIds(fetchMock)[0].contextWindow).toBe(128);
   });
 
   it("opens a row already carrying file-handling config, so nothing set is hidden", () => {
@@ -274,5 +379,32 @@ describe("ProviderForm validation errors on model rows", () => {
       ).toBeInTheDocument(),
     );
     expect(screen.getByText("Too small")).toBeInTheDocument();
+  });
+
+  // The window sits outside Advanced, so its rejection needs no disclosure
+  // opened — it lands on a control the reader is already looking at.
+  it("shows a rejected Context window against the control itself", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockRejectedSave([
+        {
+          path: ["modelIds", 0, "contextWindow"],
+          message: "Too small: expected number to be >=1000",
+        },
+      ]),
+    );
+
+    renderEditForm([{ id: "a", passthroughFileTypes: [], contextWindow: 128 }]);
+    save();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Too small: expected number to be >=1000"),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByLabelText("Context window")).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
   });
 });

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -53,6 +53,8 @@ import { ConfirmDialog } from "@/components/confirm-dialog";
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import {
+  CONTEXT_WINDOW_MAX,
+  CONTEXT_WINDOW_MIN,
   DEFAULT_MAX_EXTRACTED_TEXT_CHARS,
   type AliasRepoint,
   type Provider,
@@ -72,13 +74,11 @@ import {
 } from "@/lib/model-config";
 import {
   CONTEXT_WINDOW_CUSTOM,
-  CONTEXT_WINDOW_MAX,
-  CONTEXT_WINDOW_MIN,
   CONTEXT_WINDOW_PRESETS,
   CONTEXT_WINDOW_UNSET,
-  contextWindowSelectValue,
+  contextWindowForOption,
+  optionForContextWindow,
   parseContextWindowInput,
-  selectedContextWindow,
 } from "@/lib/context-window";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
@@ -173,7 +173,7 @@ const ModelRow = ({
   // control straight back to "Not set" and the input the reader just asked for
   // would never appear.
   const [customContextWindow, setCustomContextWindow] = useState(
-    contextWindowSelectValue(model.contextWindow) === CONTEXT_WINDOW_CUSTOM,
+    optionForContextWindow(model.contextWindow) === CONTEXT_WINDOW_CUSTOM,
   );
 
   // A rejected row is no use collapsed: the reader has to see the field the
@@ -265,12 +265,12 @@ const ModelRow = ({
               value={
                 customContextWindow
                   ? CONTEXT_WINDOW_CUSTOM
-                  : contextWindowSelectValue(model.contextWindow)
+                  : optionForContextWindow(model.contextWindow)
               }
               onValueChange={(value) => {
                 setCustomContextWindow(value === CONTEXT_WINDOW_CUSTOM);
                 onChange({
-                  contextWindow: selectedContextWindow(
+                  contextWindow: contextWindowForOption(
                     value,
                     model.contextWindow,
                   ),

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -70,12 +70,22 @@ import {
   defaultPassthroughFileTypes,
   type ModelConfigView,
 } from "@/lib/model-config";
+import {
+  CONTEXT_WINDOW_CUSTOM,
+  CONTEXT_WINDOW_MAX,
+  CONTEXT_WINDOW_MIN,
+  CONTEXT_WINDOW_PRESETS,
+  CONTEXT_WINDOW_UNSET,
+  contextWindowSelectValue,
+  parseContextWindowInput,
+  selectedContextWindow,
+} from "@/lib/context-window";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 
 /**
- * Per-field help for a model row. The four fields each need a paragraph of
+ * Per-field help for a model row. The fields each need a paragraph of
  * explanation, which as one block under the list was a wall nobody read and
  * left the reader matching sentences to fields by hand.
  */
@@ -157,6 +167,15 @@ const ModelRow = ({
       model.maxExtractedTextChars !== undefined,
   );
 
+  // Whether the Context window is being typed rather than picked. Local state
+  // rather than derived from the value, because choosing Custom on a row with
+  // no window declared leaves the value undefined — deriving it would snap the
+  // control straight back to "Not set" and the input the reader just asked for
+  // would never appear.
+  const [customContextWindow, setCustomContextWindow] = useState(
+    contextWindowSelectValue(model.contextWindow) === CONTEXT_WINDOW_CUSTOM,
+  );
+
   // A rejected row is no use collapsed: the reader has to see the field the
   // server is complaining about.
   const hasAdvancedError =
@@ -220,6 +239,80 @@ const ModelRow = ({
             }
             disabled={disabled}
           />
+        </ModelField>
+
+        {/*
+          Above Advanced, unlike the other optional per-model fields: this one
+          is the only thing that can tell Platypus a capacity it has no way to
+          discover, so a reader adding a model has to see that it exists.
+        */}
+        <ModelField
+          htmlFor={`context-window-${index}`}
+          label="Context window"
+          hint={
+            <>
+              The vendor&apos;s published <strong>total</strong> token capacity
+              for this model — the whole window, not a cap on the reply. Sizes
+              in the list are decimal, so <code>128k</code> is 128,000.
+              Optional: without it, the context meter in a Chat is hidden for
+              this model.
+            </>
+          }
+          error={errors.fields.contextWindow}
+        >
+          <div className="flex items-center gap-2">
+            <Select
+              value={
+                customContextWindow
+                  ? CONTEXT_WINDOW_CUSTOM
+                  : contextWindowSelectValue(model.contextWindow)
+              }
+              onValueChange={(value) => {
+                setCustomContextWindow(value === CONTEXT_WINDOW_CUSTOM);
+                onChange({
+                  contextWindow: selectedContextWindow(
+                    value,
+                    model.contextWindow,
+                  ),
+                });
+              }}
+              disabled={disabled}
+            >
+              <SelectTrigger
+                id={`context-window-${index}`}
+                aria-invalid={!!errors.fields.contextWindow}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={CONTEXT_WINDOW_UNSET}>Not set</SelectItem>
+                {CONTEXT_WINDOW_PRESETS.map((preset) => (
+                  <SelectItem key={preset.tokens} value={String(preset.tokens)}>
+                    {preset.label}
+                  </SelectItem>
+                ))}
+                <SelectItem value={CONTEXT_WINDOW_CUSTOM}>Custom</SelectItem>
+              </SelectContent>
+            </Select>
+            {customContextWindow && (
+              <Input
+                aria-label="Context window in tokens"
+                type="number"
+                min={CONTEXT_WINDOW_MIN}
+                max={CONTEXT_WINDOW_MAX}
+                placeholder="e.g. 131072"
+                className="flex-1"
+                value={model.contextWindow ?? ""}
+                aria-invalid={!!errors.fields.contextWindow}
+                onChange={(e) =>
+                  onChange({
+                    contextWindow: parseContextWindowInput(e.target.value),
+                  })
+                }
+                disabled={disabled}
+              />
+            )}
+          </div>
         </ModelField>
 
         <Collapsible open={advancedOpen} onOpenChange={setShowAdvanced}>

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -167,14 +167,26 @@ const ModelRow = ({
       model.maxExtractedTextChars !== undefined,
   );
 
-  // Whether the Context window is being typed rather than picked. Local state
-  // rather than derived from the value, because choosing Custom on a row with
-  // no window declared leaves the value undefined — deriving it would snap the
-  // control straight back to "Not set" and the input the reader just asked for
-  // would never appear.
+  // Whether the Context window is being typed rather than picked. State as well
+  // as derivation, because neither alone is enough: Custom chosen on a row with
+  // no window declared leaves the value undefined, so a purely derived control
+  // would snap back to "Not set" and the input the reader just asked for would
+  // vanish the moment they cleared it.
   const [customContextWindow, setCustomContextWindow] = useState(
     optionForContextWindow(model.contextWindow) === CONTEXT_WINDOW_CUSTOM,
   );
+
+  // The trigger and the number input read one value, so they cannot disagree.
+  // Model rows are keyed by index, so removing a row shifts the state above
+  // onto its neighbour; folding the stored value back in means a shifted row
+  // holding an unlisted size still renders the input holding it, rather than a
+  // "Custom" trigger beside no input at all — which would leave a declared
+  // window invisible and uneditable until reload.
+  const storedContextWindowOption = optionForContextWindow(model.contextWindow);
+  const contextWindowOption =
+    customContextWindow || storedContextWindowOption === CONTEXT_WINDOW_CUSTOM
+      ? CONTEXT_WINDOW_CUSTOM
+      : storedContextWindowOption;
 
   // A rejected row is no use collapsed: the reader has to see the field the
   // server is complaining about.
@@ -254,19 +266,15 @@ const ModelRow = ({
               The vendor&apos;s published <strong>total</strong> token capacity
               for this model — the whole window, not a cap on the reply. Sizes
               in the list are decimal, so <code>128k</code> is 128,000.
-              Optional: without it, the context meter in a Chat is hidden for
-              this model.
+              Optional: nothing reads it yet, and leaving it unset breaks
+              nothing — it records a capacity Platypus has no way to look up.
             </>
           }
           error={errors.fields.contextWindow}
         >
           <div className="flex items-center gap-2">
             <Select
-              value={
-                customContextWindow
-                  ? CONTEXT_WINDOW_CUSTOM
-                  : optionForContextWindow(model.contextWindow)
-              }
+              value={contextWindowOption}
               onValueChange={(value) => {
                 setCustomContextWindow(value === CONTEXT_WINDOW_CUSTOM);
                 onChange({
@@ -294,7 +302,7 @@ const ModelRow = ({
                 <SelectItem value={CONTEXT_WINDOW_CUSTOM}>Custom</SelectItem>
               </SelectContent>
             </Select>
-            {customContextWindow && (
+            {contextWindowOption === CONTEXT_WINDOW_CUSTOM && (
               <Input
                 aria-label="Context window in tokens"
                 type="number"

--- a/apps/frontend/lib/context-window.test.ts
+++ b/apps/frontend/lib/context-window.test.ts
@@ -4,9 +4,9 @@ import {
   CONTEXT_WINDOW_CUSTOM,
   CONTEXT_WINDOW_PRESETS,
   CONTEXT_WINDOW_UNSET,
-  contextWindowSelectValue,
+  optionForContextWindow,
   parseContextWindowInput,
-  selectedContextWindow,
+  contextWindowForOption,
 } from "./context-window";
 
 describe("CONTEXT_WINDOW_PRESETS", () => {
@@ -37,35 +37,35 @@ describe("CONTEXT_WINDOW_PRESETS", () => {
   });
 });
 
-describe("contextWindowSelectValue", () => {
+describe("optionForContextWindow", () => {
   it("reads an undeclared window as the unset option", () => {
-    expect(contextWindowSelectValue(undefined)).toBe(CONTEXT_WINDOW_UNSET);
+    expect(optionForContextWindow(undefined)).toBe(CONTEXT_WINDOW_UNSET);
   });
 
   it("reads a listed size as that size", () => {
-    expect(contextWindowSelectValue(128_000)).toBe("128000");
+    expect(optionForContextWindow(128_000)).toBe("128000");
   });
 
   // A proxied model whose real capacity is unusual is stored as a plain
   // integer, so the control has to come back showing Custom rather than
   // silently rounding to the nearest option it recognises.
   it("reads any other value as Custom", () => {
-    expect(contextWindowSelectValue(131_072)).toBe(CONTEXT_WINDOW_CUSTOM);
+    expect(optionForContextWindow(131_072)).toBe(CONTEXT_WINDOW_CUSTOM);
     // Out of bounds still reads as Custom: the row is showing a value the
     // server rejected, and the reader has to see it to fix it.
-    expect(contextWindowSelectValue(128)).toBe(CONTEXT_WINDOW_CUSTOM);
+    expect(optionForContextWindow(128)).toBe(CONTEXT_WINDOW_CUSTOM);
   });
 });
 
-describe("selectedContextWindow", () => {
+describe("contextWindowForOption", () => {
   it("maps a listed size to its integer", () => {
-    expect(selectedContextWindow("128000", undefined)).toBe(128_000);
-    expect(selectedContextWindow("1000000", 8_000)).toBe(1_000_000);
+    expect(contextWindowForOption("128000", undefined)).toBe(128_000);
+    expect(contextWindowForOption("1000000", 8_000)).toBe(1_000_000);
   });
 
   it("clears the window when the unset option is chosen", () => {
     expect(
-      selectedContextWindow(CONTEXT_WINDOW_UNSET, 128_000),
+      contextWindowForOption(CONTEXT_WINDOW_UNSET, 128_000),
     ).toBeUndefined();
   });
 
@@ -73,9 +73,11 @@ describe("selectedContextWindow", () => {
   // number. Keeping what was there lets them edit 128,000 into 131,072 rather
   // than retype it, and clears nothing they had set.
   it("keeps the current value when switching to Custom", () => {
-    expect(selectedContextWindow(CONTEXT_WINDOW_CUSTOM, 128_000)).toBe(128_000);
+    expect(contextWindowForOption(CONTEXT_WINDOW_CUSTOM, 128_000)).toBe(
+      128_000,
+    );
     expect(
-      selectedContextWindow(CONTEXT_WINDOW_CUSTOM, undefined),
+      contextWindowForOption(CONTEXT_WINDOW_CUSTOM, undefined),
     ).toBeUndefined();
   });
 });

--- a/apps/frontend/lib/context-window.test.ts
+++ b/apps/frontend/lib/context-window.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { CONTEXT_WINDOW_MAX, CONTEXT_WINDOW_MIN } from "@platypus/schemas";
+import {
+  CONTEXT_WINDOW_CUSTOM,
+  CONTEXT_WINDOW_PRESETS,
+  CONTEXT_WINDOW_UNSET,
+  contextWindowSelectValue,
+  parseContextWindowInput,
+  selectedContextWindow,
+} from "./context-window";
+
+describe("CONTEXT_WINDOW_PRESETS", () => {
+  // Decimal, not binary: under-declaring costs a sliver of a window that a
+  // vendor hard-fails on when over-declared, so 128k is 128,000 and a genuine
+  // 131,072-token model simply forfeits 3k.
+  it("reads its sizes as decimal thousands", () => {
+    const byLabel = new Map(
+      CONTEXT_WINDOW_PRESETS.map((p) => [p.label, p.tokens]),
+    );
+    expect(byLabel.get("128k")).toBe(128_000);
+    expect(byLabel.get("8k")).toBe(8_000);
+    expect(byLabel.get("1M")).toBe(1_000_000);
+  });
+
+  it("offers only sizes the schema accepts", () => {
+    for (const preset of CONTEXT_WINDOW_PRESETS) {
+      expect(Number.isInteger(preset.tokens)).toBe(true);
+      expect(preset.tokens).toBeGreaterThanOrEqual(CONTEXT_WINDOW_MIN);
+      expect(preset.tokens).toBeLessThanOrEqual(CONTEXT_WINDOW_MAX);
+    }
+  });
+
+  it("lists each size once, ascending", () => {
+    const sizes = CONTEXT_WINDOW_PRESETS.map((p) => p.tokens);
+    expect(new Set(sizes).size).toBe(sizes.length);
+    expect([...sizes].sort((a, b) => a - b)).toEqual(sizes);
+  });
+});
+
+describe("contextWindowSelectValue", () => {
+  it("reads an undeclared window as the unset option", () => {
+    expect(contextWindowSelectValue(undefined)).toBe(CONTEXT_WINDOW_UNSET);
+  });
+
+  it("reads a listed size as that size", () => {
+    expect(contextWindowSelectValue(128_000)).toBe("128000");
+  });
+
+  // A proxied model whose real capacity is unusual is stored as a plain
+  // integer, so the control has to come back showing Custom rather than
+  // silently rounding to the nearest option it recognises.
+  it("reads any other value as Custom", () => {
+    expect(contextWindowSelectValue(131_072)).toBe(CONTEXT_WINDOW_CUSTOM);
+    // Out of bounds still reads as Custom: the row is showing a value the
+    // server rejected, and the reader has to see it to fix it.
+    expect(contextWindowSelectValue(128)).toBe(CONTEXT_WINDOW_CUSTOM);
+  });
+});
+
+describe("selectedContextWindow", () => {
+  it("maps a listed size to its integer", () => {
+    expect(selectedContextWindow("128000", undefined)).toBe(128_000);
+    expect(selectedContextWindow("1000000", 8_000)).toBe(1_000_000);
+  });
+
+  it("clears the window when the unset option is chosen", () => {
+    expect(
+      selectedContextWindow(CONTEXT_WINDOW_UNSET, 128_000),
+    ).toBeUndefined();
+  });
+
+  // Switching to Custom is the reader opening a text box, not entering a
+  // number. Keeping what was there lets them edit 128,000 into 131,072 rather
+  // than retype it, and clears nothing they had set.
+  it("keeps the current value when switching to Custom", () => {
+    expect(selectedContextWindow(CONTEXT_WINDOW_CUSTOM, 128_000)).toBe(128_000);
+    expect(
+      selectedContextWindow(CONTEXT_WINDOW_CUSTOM, undefined),
+    ).toBeUndefined();
+  });
+});
+
+describe("parseContextWindowInput", () => {
+  it("reads a typed number", () => {
+    expect(parseContextWindowInput("131072")).toBe(131_072);
+  });
+
+  it("reads an empty field as no declaration", () => {
+    expect(parseContextWindowInput("")).toBeUndefined();
+    expect(parseContextWindowInput("   ")).toBeUndefined();
+  });
+
+  // Deliberately NOT clamped to the schema's bounds. A `128` typed where
+  // 128,000 was meant has to reach the server and be rejected with a message,
+  // not be quietly swallowed into "no window declared".
+  it("passes a nonsense value through so the schema rejects it", () => {
+    expect(parseContextWindowInput("128")).toBe(128);
+    expect(parseContextWindowInput("0")).toBe(0);
+    expect(parseContextWindowInput("-5")).toBe(-5);
+    expect(parseContextWindowInput("1.5")).toBe(1.5);
+  });
+
+  it("reads an unparseable field as no declaration", () => {
+    expect(parseContextWindowInput("abc")).toBeUndefined();
+  });
+});

--- a/apps/frontend/lib/context-window.ts
+++ b/apps/frontend/lib/context-window.ts
@@ -1,5 +1,3 @@
-import { CONTEXT_WINDOW_MAX, CONTEXT_WINDOW_MIN } from "@platypus/schemas";
-
 /**
  * The Context window control's preset list and the mapping between what it
  * shows and the integer that gets stored (ADR-0018).
@@ -45,27 +43,26 @@ export const CONTEXT_WINDOW_UNSET = "unset";
 export const CONTEXT_WINDOW_CUSTOM = "custom";
 
 /**
- * Which option a stored window selects. Anything that is not one of the presets
- * reads as Custom, including a value the schema would reject: a row showing a
- * number the server refused has to keep showing it, or the reader cannot see
- * what to fix.
+ * Window → option. Which option a stored window selects; anything that is not
+ * one of the presets reads as Custom, including a value the schema would
+ * reject, because a row showing a number the server refused has to keep showing
+ * it or the reader cannot see what to fix.
  */
-export const contextWindowSelectValue = (
-  window: number | undefined,
-): string => {
+export const optionForContextWindow = (window: number | undefined): string => {
   if (window === undefined) return CONTEXT_WINDOW_UNSET;
   const preset = CONTEXT_WINDOW_PRESETS.find((p) => p.tokens === window);
   return preset ? String(preset.tokens) : CONTEXT_WINDOW_CUSTOM;
 };
 
 /**
- * The window a chosen option means, given what the row currently holds.
+ * Option → window. What a chosen option means, given what the row currently
+ * holds.
  *
  * Custom keeps the current value rather than clearing it — choosing it is the
  * reader opening a text box to edit 128,000 into 131,072, not discarding what
  * they had.
  */
-export const selectedContextWindow = (
+export const contextWindowForOption = (
   selection: string,
   current: number | undefined,
 ): number | undefined => {
@@ -86,6 +83,3 @@ export const parseContextWindowInput = (value: string): number | undefined => {
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : undefined;
 };
-
-/** The bounds the field enforces, for the control's hint and input attributes. */
-export { CONTEXT_WINDOW_MIN, CONTEXT_WINDOW_MAX };

--- a/apps/frontend/lib/context-window.ts
+++ b/apps/frontend/lib/context-window.ts
@@ -1,0 +1,91 @@
+import { CONTEXT_WINDOW_MAX, CONTEXT_WINDOW_MIN } from "@platypus/schemas";
+
+/**
+ * The Context window control's preset list and the mapping between what it
+ * shows and the integer that gets stored (ADR-0018).
+ *
+ * Pure and separate from the component on purpose: the mapping is the part with
+ * a wrong answer — decimal vs binary thousands, what Custom does to a value
+ * already set — and no test can drive a Radix select open in this suite's jsdom
+ * setup. Storage is always a plain integer; the presets are an affordance, so a
+ * proxied model with an odd capacity is never unrepresentable.
+ */
+
+export type ContextWindowPreset = {
+  /** What the option reads as, e.g. `128k`. */
+  label: string;
+  /** The integer that option stores. */
+  tokens: number;
+};
+
+/**
+ * Common published window sizes, read as DECIMAL thousands — `128k` is 128,000,
+ * not 131,072.
+ *
+ * Under-declaring is harmless (the meter simply reads conservatively) while
+ * over-declaring hard-fails at the vendor, so decimal is the safe reading of an
+ * ambiguous label: a genuine 131,072-token model declared as 128k forfeits 3k
+ * and nothing else.
+ */
+export const CONTEXT_WINDOW_PRESETS: ContextWindowPreset[] = [
+  { label: "8k", tokens: 8_000 },
+  { label: "16k", tokens: 16_000 },
+  { label: "32k", tokens: 32_000 },
+  { label: "64k", tokens: 64_000 },
+  { label: "128k", tokens: 128_000 },
+  { label: "200k", tokens: 200_000 },
+  { label: "256k", tokens: 256_000 },
+  { label: "1M", tokens: 1_000_000 },
+];
+
+/** The option meaning "no window declared" — the default for every model. */
+export const CONTEXT_WINDOW_UNSET = "unset";
+
+/** The option that swaps the select for a plain number input. */
+export const CONTEXT_WINDOW_CUSTOM = "custom";
+
+/**
+ * Which option a stored window selects. Anything that is not one of the presets
+ * reads as Custom, including a value the schema would reject: a row showing a
+ * number the server refused has to keep showing it, or the reader cannot see
+ * what to fix.
+ */
+export const contextWindowSelectValue = (
+  window: number | undefined,
+): string => {
+  if (window === undefined) return CONTEXT_WINDOW_UNSET;
+  const preset = CONTEXT_WINDOW_PRESETS.find((p) => p.tokens === window);
+  return preset ? String(preset.tokens) : CONTEXT_WINDOW_CUSTOM;
+};
+
+/**
+ * The window a chosen option means, given what the row currently holds.
+ *
+ * Custom keeps the current value rather than clearing it — choosing it is the
+ * reader opening a text box to edit 128,000 into 131,072, not discarding what
+ * they had.
+ */
+export const selectedContextWindow = (
+  selection: string,
+  current: number | undefined,
+): number | undefined => {
+  if (selection === CONTEXT_WINDOW_UNSET) return undefined;
+  if (selection === CONTEXT_WINDOW_CUSTOM) return current;
+  const parsed = Number.parseInt(selection, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+/**
+ * What a typed Custom value means. An empty or unreadable field is "no window
+ * declared"; anything numeric is passed through EXACTLY as typed, bounds
+ * included, so a `128` meant as 128k is rejected by the schema with a message
+ * rather than silently becoming no declaration at all.
+ */
+export const parseContextWindowInput = (value: string): number | undefined => {
+  if (value.trim() === "") return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+/** The bounds the field enforces, for the control's hint and input attributes. */
+export { CONTEXT_WINDOW_MIN, CONTEXT_WINDOW_MAX };

--- a/apps/frontend/lib/model-config.ts
+++ b/apps/frontend/lib/model-config.ts
@@ -26,6 +26,11 @@ export type ModelConfigView = {
   passthroughFileTypes: string[];
   /** Cap on injected extracted-document text; undefined uses the shared default. */
   maxExtractedTextChars?: number;
+  /**
+   * The vendor's published total token capacity, declared by an Org Admin
+   * (ADR-0018). Undefined means undeclared, which is the normal state.
+   */
+  contextWindow?: number;
 };
 
 /** Normalize a provider's models to objects, tolerating the legacy `string[]`. */
@@ -44,6 +49,7 @@ export const getModelConfigs = (
           alias: m.alias,
           passthroughFileTypes: m.passthroughFileTypes ?? [],
           maxExtractedTextChars: m.maxExtractedTextChars,
+          contextWindow: m.contextWindow,
         },
   );
 

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -22,6 +22,8 @@ import {
   extractableDocumentFormat,
   resolveExtractedTextCap,
   DEFAULT_MAX_EXTRACTED_TEXT_CHARS,
+  CONTEXT_WINDOW_MIN,
+  CONTEXT_WINDOW_MAX,
   MODEL_ALIAS_PREFIX,
   isAliasReference,
   aliasNameFromReference,
@@ -526,6 +528,81 @@ describe("Provider modelIds (per-model config)", () => {
         }).success,
       ).toBe(false);
     }
+  });
+
+  it("accepts a declared contextWindow", () => {
+    const result = providerCreateSchema.safeParse({
+      ...base,
+      modelIds: [{ id: "qwen", contextWindow: 128000 }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelIds[0].contextWindow).toBe(128000);
+    }
+  });
+
+  it("leaves contextWindow undefined when not declared", () => {
+    const result = providerCreateSchema.safeParse({
+      ...base,
+      modelIds: [{ id: "qwen" }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelIds[0].contextWindow).toBeUndefined();
+    }
+  });
+
+  it("rejects a contextWindow that is zero, negative, fractional or out of bounds", () => {
+    // 128 is the case the floor exists for: an Org Admin typing the number of
+    // thousands. Silently accepting it would cripple every reading taken
+    // against it rather than fail where the mistake was made.
+    for (const value of [0, -1, 1.5, 128, 999, 10_000_001]) {
+      expect(
+        providerCreateSchema.safeParse({
+          ...base,
+          modelIds: [{ id: "qwen", contextWindow: value }],
+        }).success,
+        `contextWindow ${value} should be rejected`,
+      ).toBe(false);
+    }
+  });
+
+  it("accepts the exact bounds", () => {
+    for (const value of [CONTEXT_WINDOW_MIN, CONTEXT_WINDOW_MAX]) {
+      expect(
+        providerCreateSchema.safeParse({
+          ...base,
+          modelIds: [{ id: "qwen", contextWindow: value }],
+        }).success,
+        `contextWindow ${value} should be accepted`,
+      ).toBe(true);
+    }
+  });
+
+  it("keeps the alias namespace rule unaffected by a declared contextWindow", () => {
+    // The window rides on the same entry as the alias (ADR-0017), so a repoint
+    // moves it — but it is not part of what makes two entries clash.
+    const aliased = providerCreateSchema.safeParse({
+      ...base,
+      modelIds: [{ id: "qwen", alias: "flagship", contextWindow: 200000 }],
+    });
+    expect(aliased.success).toBe(true);
+    if (aliased.success) {
+      expect(aliased.data.modelIds[0]).toMatchObject({
+        alias: "flagship",
+        contextWindow: 200000,
+      });
+    }
+
+    expect(
+      providerCreateSchema.safeParse({
+        ...base,
+        modelIds: [
+          { id: "qwen", alias: "flagship", contextWindow: 200000 },
+          { id: "qwen-2", alias: "FLAGSHIP", contextWindow: 8000 },
+        ],
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -541,14 +541,20 @@ describe("Provider modelIds (per-model config)", () => {
     }
   });
 
-  it("leaves contextWindow undefined when not declared", () => {
-    const result = providerCreateSchema.safeParse({
-      ...base,
-      modelIds: [{ id: "qwen" }],
-    });
+  // Optional on BOTH paths, and deliberately so: a Provider configured before
+  // the field existed is edited through the update schema, and a
+  // create-vs-update divergence would make saving it untouched a 400.
+  it.each([
+    ["create", providerCreateSchema],
+    ["update", providerUpdateSchema],
+  ])("leaves contextWindow undefined on %s when not declared", (_, schema) => {
+    const result = schema.safeParse({ ...base, modelIds: [{ id: "qwen" }] });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.modelIds[0].contextWindow).toBeUndefined();
+      // Asserted, not optional-chained: a schema that dropped `modelIds`
+      // entirely would satisfy an `undefined` expectation vacuously.
+      expect(result.data.modelIds).toHaveLength(1);
+      expect(result.data.modelIds![0].contextWindow).toBeUndefined();
     }
   });
 

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -573,13 +573,20 @@ export type ProviderApiMode = z.infer<typeof providerApiModeSchema>;
 // security allow-list: an attached file whose type is absent is converted to
 // text where possible (extracted for PDF/DOCX, see issue #342) — it is never
 // blocked for safety. Absent / legacy rows fall back to a provider-type default
-// at resolve time on the backend. This object is also the intended home for
-// future per-model metadata (e.g. max input/output tokens) — out of scope here.
+// at resolve time on the backend. This object is the home for per-model
+// metadata generally, which is why `contextWindow` lands here too.
 //
 // `maxExtractedTextChars` caps how much text a converted document may inject,
 // protecting small local contexts; omitted means the shared
-// `DEFAULT_MAX_EXTRACTED_TEXT_CHARS` default. A char budget rather than tokens
-// for v1 — it becomes derivable once per-model `maxInputTokens` lands.
+// `DEFAULT_MAX_EXTRACTED_TEXT_CHARS` default. It stays a character budget and
+// is deliberately NOT derived from `contextWindow`: the derivation needs a
+// chars-per-token ratio, which is exactly the estimate ADR-0018 rejects, and it
+// would silently change file handling for every Provider that declares a
+// window.
+//
+// `contextWindow` is the vendor's published TOTAL token capacity for this
+// model, declared by an Org Admin because nothing can discover it — see
+// ADR-0018. Optional always, and nothing reads it yet.
 //
 // The universal wildcard (`*/*` or `*`) is an advanced escape hatch: it sends
 // EVERY attached file to the model raw. Values are deliberately NOT validated
@@ -710,6 +717,20 @@ const pointerModelIdSchema = z
     message: "Must be a concrete model id, not a Model alias",
   });
 
+/**
+ * Bounds on a declared Context window (ADR-0018). The floor rejects the number
+ * of *thousands* — a `128` meaning 128k — because an under-declaration by three
+ * orders of magnitude is indistinguishable from a deliberate one at read time
+ * and would cripple every reading taken against it. The ceiling sits well above
+ * today's largest published window without leaving the field unbounded.
+ *
+ * Exported because the documentation contract test pins the numbers the
+ * Operator-facing docs quote to these, and the provider form's preset list has
+ * to stay inside them.
+ */
+export const CONTEXT_WINDOW_MIN = 1_000;
+export const CONTEXT_WINDOW_MAX = 10_000_000;
+
 export const modelConfigSchema = z.object({
   id: z.string().min(1),
   // The bare alias name. Absent means the model is referenced by its id.
@@ -725,6 +746,12 @@ export const modelConfigSchema = z.object({
     .optional(),
   passthroughFileTypes: z.array(z.string()).default([]),
   maxExtractedTextChars: z.number().int().positive().optional(),
+  contextWindow: z
+    .number()
+    .int()
+    .min(CONTEXT_WINDOW_MIN)
+    .max(CONTEXT_WINDOW_MAX)
+    .optional(),
 });
 
 export type ModelConfig = z.infer<typeof modelConfigSchema>;


### PR DESCRIPTION
Closes #447.

An Org Admin can now declare a model's **Context window** — the vendor's published *total* token capacity — on the Provider that exposes it. Optional always, and **nothing reads it yet**: this ships the declaration and its documentation only, per ADR-0018.

## What changed

**Schema** — `contextWindow` on the per-model config object, an optional integer bounded 1,000–10,000,000. The floor rejects a `128` meant as 128k, which would otherwise cripple every reading taken against it; the ceiling clears today's largest models without leaving the field unbounded. Because it lives on the model entry, a Model alias carries its window and repointing the alias moves it (ADR-0017). Legacy bare-string model lists normalise as before, with no value present.

The stale comment anticipating a derived `maxInputTokens` is corrected rather than honoured — deriving the extracted-text cap from the window needs a chars-per-token ratio, which is the estimate ADR-0018 rejects.

**Provider form** — a preset select (8k … 1M, decimal, so **128k** stores 128,000) with a **Custom** escape to a number input for a model behind a proxy whose capacity is unusual. It sits **above** the Advanced disclosure, unlike the other optional per-model fields: this is the only thing that can tell Platypus a capacity it has no way to discover, so a reader adding a model has to see it exists. Carries an **i** hint like every other model field.

A typed Custom value goes to the server exactly as typed, bounds included, so a nonsense number is rejected with a message rather than swallowed into "no window declared".

**The preset↔integer mapping is a pure helper** (`apps/frontend/lib/context-window.ts`) rather than inline in the component, so it is testable without driving a Radix select open — which no frontend test here can currently do.

**Docs contract gate** — could not express a numeric field's bounds: the limit parser only recognised character counts, and the schema reader threw on a number field. It gains a `numberField` sibling reading `minValue`/`maxValue`, and the parser takes a `characters|tokens` alternation. The new field's bounds are pinned through both, owned in exactly one place.

**Docs** — the per-model field table is lifted into its own section above file handling, leaving the file-handling heading and its anchor untouched (two pages link to it). The sentence enumerating what a model entry carries no longer reads as exhaustive, the concepts page that disambiguated two meanings of "Context" now disambiguates three, and the getting-started walkthrough accounts for the extra control.

## Tests

- Schema: accept, omit on both create and update, and each rejection case (zero, negative, fractional, below the floor, above the ceiling); the Model alias namespace rule confirmed unaffected.
- The mapping helper as a pure unit, including that the listed sizes are decimal and stay inside the schema's bounds.
- Provider form: the control renders on a collapsed row, a stored preset shows on the closed trigger, an unlisted size returns as **Custom**, a legacy row loads clean, the save payload round-trips, and a server rejection lands on the control itself.
- The docs contract gate's existing pinned claims still pass.

## Deliberately not here

Context occupancy, the Chat composer meter, Trigger run stats, and the backend per-model resolver all belong to the measurement half of #446.

## Two things worth a reviewer's eye

1. The form hint states today's consequence — "without it, the context meter in a Chat is hidden" — which is the wording #447 specifies for a meter that lands in the sibling ticket. Until then it reads as a forward reference. The docs callout is worded to claim only what is true today.
2. Model rows are keyed by index, so deleting a row shifts per-row UI state onto its neighbour. The new "is Custom" mode inherits the same wrinkle the existing `showAdvanced` state already has. It is cosmetic — no stored value changes, and it self-corrects on reload — and fixing it properly means giving rows stable identity, which reaches past this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)