### PR TITLE
feat(chat): measure Context occupancy on a Chat turn

### DIFF
--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
+/**
+ * As much of a stream part as the metadata extractor reads. The SDK hands it
+ * the full `TextStreamPart` union; these tests hand it the fields the part
+ * they are standing in for would carry.
+ */
+type MetadataPart = {
+  type: string;
+  finishReason?: string;
+  usage?: { inputTokens?: number; outputTokens?: number };
+};
+
 const {
   mockPrepareChatTurn,
   mockValidateTurnAttachments,
@@ -63,8 +74,7 @@ const {
       // `toUIMessageStream`'s metadata extractor. The SDK calls it per stream
       // part; the tests call it by hand with the part they care about.
       messageMetadata: undefined as
-        | ((opts: { part: { type: string; finishReason?: string } }) => unknown)
-        | undefined,
+        ((opts: { part: MetadataPart }) => unknown) | undefined,
       responseSentinel: { __isResponse: true },
     },
   };
@@ -825,9 +835,7 @@ const primeStreamText = () => {
       return {
         toUIMessageStream: (uiOpts: {
           onFinish: (ctx: { messages: unknown[] }) => Promise<void> | void;
-          messageMetadata: (opts: {
-            part: { type: string; finishReason?: string };
-          }) => unknown;
+          messageMetadata: (opts: { part: MetadataPart }) => unknown;
         }) => {
           streamHarness.onFinish = uiOpts.onFinish;
           streamHarness.messageMetadata = uiOpts.messageMetadata;
@@ -1128,10 +1136,10 @@ describe("AgentRunner.stream — success & interruption", () => {
   });
 });
 
-// Issue #420: the operator sees a truncated stream in the log, the reader saw
-// nothing. The metadata callback is the only seam for saying so on a stream
-// that has already been flushed to the client.
-describe("AgentRunner.stream — truncation metadata", () => {
+// The metadata callback is the only seam for saying anything about a stream
+// that has already been flushed to the client — issue #420's truncation flag
+// and issue #448's Context occupancy both ride on it.
+describe("AgentRunner.stream — message metadata", () => {
   let runner: AgentRunner;
   beforeEach(() => {
     runner = new AgentRunner();
@@ -1153,7 +1161,7 @@ describe("AgentRunner.stream — truncation metadata", () => {
     });
 
     return {
-      metadataFor: (part: { type: string; finishReason?: string }) =>
+      metadataFor: (part: MetadataPart) =>
         streamHarness.messageMetadata!({ part }),
       end: async () => {
         await streamHarness.onFinish!({ messages: [] });
@@ -1231,8 +1239,129 @@ describe("AgentRunner.stream — truncation metadata", () => {
     const stream = await startStream(fakeTurn());
 
     expect(
-      stream.metadataFor({ type: "finish-step", finishReason: "length" }),
+      stream.metadataFor({
+        type: "finish-step",
+        finishReason: "length",
+        usage: { inputTokens: 100, outputTokens: 20 },
+      }),
+    ).not.toHaveProperty("truncatedByTokenLimit");
+
+    await stream.end();
+  });
+
+  // Issue #448. Occupancy rides on the step-finish part, not the terminal
+  // finish: a cancelled turn never gets a terminal finish, and cancelling a
+  // long turn is exactly when the context had grown most.
+  it("records the model call's token counts on a finished step", async () => {
+    const stream = await startStream(fakeTurn());
+
+    expect(
+      stream.metadataFor({
+        type: "finish-step",
+        finishReason: "stop",
+        usage: { inputTokens: 12_400, outputTokens: 180 },
+      }),
+    ).toEqual({ contextOccupancy: { inputTokens: 12_400, outputTokens: 180 } });
+
+    await stream.end();
+  });
+
+  // The reading each step returns is that step's own context size. The merge
+  // leaves the last one standing, so a tool-using turn reports its real size
+  // rather than a multiple of it.
+  it("reports each step's own size rather than a running total", async () => {
+    const stream = await startStream(fakeTurn());
+
+    const first = stream.metadataFor({
+      type: "finish-step",
+      finishReason: "tool-calls",
+      usage: { inputTokens: 1_000, outputTokens: 30 },
+    });
+    const second = stream.metadataFor({
+      type: "finish-step",
+      finishReason: "stop",
+      usage: { inputTokens: 4_000, outputTokens: 60 },
+    });
+
+    expect(first).toEqual({
+      contextOccupancy: { inputTokens: 1_000, outputTokens: 30 },
+    });
+    expect(second).toEqual({
+      contextOccupancy: { inputTokens: 4_000, outputTokens: 60 },
+    });
+
+    await stream.end();
+  });
+
+  it("records nothing when the Provider reports no token usage", async () => {
+    const stream = await startStream(fakeTurn());
+
+    expect(
+      stream.metadataFor({
+        type: "finish-step",
+        finishReason: "stop",
+        usage: { inputTokens: undefined, outputTokens: undefined },
+      }),
     ).toBeUndefined();
+
+    await stream.end();
+  });
+
+  // The merge skips `undefined` overrides, so returning nothing here would
+  // leave the first step's figures on the message, read as this turn's size.
+  it("erases an earlier reading when a later step reports no usage", async () => {
+    const stream = await startStream(fakeTurn());
+
+    stream.metadataFor({
+      type: "finish-step",
+      finishReason: "tool-calls",
+      usage: { inputTokens: 1_000, outputTokens: 30 },
+    });
+
+    expect(
+      stream.metadataFor({
+        type: "finish-step",
+        finishReason: "stop",
+        usage: { inputTokens: undefined, outputTokens: undefined },
+      }),
+    ).toEqual({ contextOccupancy: null });
+
+    await stream.end();
+  });
+
+  // The merge skips `undefined` overrides, so an omitted output count would
+  // pair this step's input count with an earlier step's output count.
+  it("writes an absent output count as a concrete null", async () => {
+    const stream = await startStream(fakeTurn());
+
+    expect(
+      stream.metadataFor({
+        type: "finish-step",
+        finishReason: "stop",
+        usage: { inputTokens: 4_000, outputTokens: undefined },
+      }),
+    ).toEqual({ contextOccupancy: { inputTokens: 4_000, outputTokens: null } });
+
+    await stream.end();
+  });
+
+  // Each part still contributes only the key it owns, so a truncated agent
+  // turn ends up carrying all three.
+  it("keeps the agent attribution and the truncation flag alongside occupancy", async () => {
+    const stream = await startStream(fakeTurn());
+
+    const occupancy = stream.metadataFor({
+      type: "finish-step",
+      finishReason: "length",
+      usage: { inputTokens: 4_000, outputTokens: 60 },
+    });
+    expect(occupancy).not.toHaveProperty("agentId");
+    expect(stream.metadataFor({ type: "start" })).toEqual({
+      agentId: "agent-1",
+    });
+    expect(
+      stream.metadataFor({ type: "finish", finishReason: "length" }),
+    ).toEqual({ truncatedByTokenLimit: true });
 
     await stream.end();
   });

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -8,6 +8,7 @@ import {
   streamText,
 } from "ai";
 import { formatStreamError, isTruncatedByTokenLimit } from "./stream-error.ts";
+import { createMessageMetadata } from "./message-metadata.ts";
 import { applyToolDurations } from "./tool-durations.ts";
 import {
   prepareChatTurn,
@@ -459,28 +460,7 @@ export class AgentRunner {
     const uiStream = result.toUIMessageStream<PlatypusUIMessage>({
       originalMessages: input.messages,
       generateMessageId: createIdGenerator({ prefix: "msg", size: 16 }),
-      // The only seam for saying anything about a stream that has already been
-      // flushed to the client. The SDK calls this per stream part and merges
-      // what it returns into the message, so each event contributes only the
-      // key it owns and the finish chunk leaves the `agentId` from `start`
-      // standing. Returning the whole object every time would work too, but
-      // only because the SDK happens to skip `undefined` values while merging.
-      messageMetadata: ({ part }) => {
-        if (part.type === "start") {
-          const agentId = state.turn?.resolved.agentId;
-          return agentId ? { agentId } : undefined;
-        }
-        // The terminal finish only. A step inside a tool loop can end at the
-        // ceiling and the run still recover and complete normally; flagging
-        // those marks answers that were never cut short.
-        if (
-          part.type === "finish" &&
-          isTruncatedByTokenLimit(part.finishReason)
-        ) {
-          return { truncatedByTokenLimit: true };
-        }
-        return undefined;
-      },
+      messageMetadata: createMessageMetadata(state.turn?.resolved.agentId),
       onError: (error) => formatStreamError(error),
       onFinish: async ({ messages: finalMessages }) => {
         // Stamped here rather than on the snapshot branch below, which sees no

--- a/apps/backend/src/runs/message-metadata.test.ts
+++ b/apps/backend/src/runs/message-metadata.test.ts
@@ -34,6 +34,17 @@ const usage = (inputTotal: number, outputTotal: number) => ({
   outputTokens: { total: outputTotal, text: outputTotal, reasoning: undefined },
 });
 
+/** A Provider that reports an input count and no output one. */
+const inputOnlyUsage = (inputTotal: number) => ({
+  inputTokens: {
+    total: inputTotal,
+    noCache: inputTotal,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: undefined, text: undefined, reasoning: undefined },
+});
+
 /** A Provider that reports no token usage — occupancy is then unknowable. */
 const NO_USAGE = {
   inputTokens: {
@@ -234,5 +245,26 @@ describe("Context occupancy over a real multi-step stream", () => {
     const message = await lastSnapshot(uiStreamOf(result));
 
     expect(message?.metadata?.contextOccupancy).toBeNull();
+  });
+
+  // The same hazard one level down, and the merge is deep: an omitted output
+  // count would pair the last step's 4,200 with the first step's 30.
+  it("does not leave an earlier step's output count standing beside a fresh input count", async () => {
+    const result = streamText({
+      model: mockModel([
+        toolCallStep(usage(1_000, 30)),
+        answerStep(inputOnlyUsage(4_200)),
+      ]),
+      prompt: "Ping the service and tell me what it said.",
+      tools: { ping },
+      stopWhen: [stepCountIs(5)],
+    });
+
+    const message = await lastSnapshot(uiStreamOf(result));
+
+    expect(message?.metadata?.contextOccupancy).toEqual({
+      inputTokens: 4_200,
+      outputTokens: null,
+    });
   });
 });

--- a/apps/backend/src/runs/message-metadata.test.ts
+++ b/apps/backend/src/runs/message-metadata.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi } from "vitest";
+import { readUIMessageStream, stepCountIs, streamText, tool } from "ai";
+import { MockLanguageModelV4, simulateReadableStream } from "ai/test";
+import { z } from "zod";
+
+vi.mock("../logger.ts", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+import { createMessageMetadata } from "./message-metadata.ts";
+import type { PlatypusUIMessage } from "../types.ts";
+
+/**
+ * Context occupancy, driven through a real multi-step stream.
+ *
+ * The run-lifecycle suite mocks the AI SDK wholesale: the model is a sentinel
+ * and the usage numbers are whatever the test author typed, so an
+ * implementation reading the SDK's cumulative usage passes it happily. This
+ * suite is the only one that can fail on ADR-0018's central trap — three
+ * numbers look like occupancy and two of them are sums.
+ *
+ * Per-step usage is deliberately different, and deliberately not a multiple of
+ * itself, so the last step's count, the sum, and any average are three
+ * distinguishable numbers.
+ */
+
+const usage = (inputTotal: number, outputTotal: number) => ({
+  inputTokens: {
+    total: inputTotal,
+    noCache: inputTotal,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: outputTotal, text: outputTotal, reasoning: undefined },
+});
+
+/** A Provider that reports no token usage — occupancy is then unknowable. */
+const NO_USAGE = {
+  inputTokens: {
+    total: undefined,
+    noCache: undefined,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: undefined, text: undefined, reasoning: undefined },
+};
+
+/** The tool the model calls to force a second round trip. */
+const ping = tool({
+  description: "Ping a service.",
+  inputSchema: z.object({}),
+  execute: () => Promise.resolve("pong"),
+});
+
+/**
+ * The provider-level stream result and part types, reached through the mock
+ * model's own signature — `@ai-sdk/provider`, which declares them, is a
+ * transitive dependency rather than one this app imports directly.
+ */
+type StreamResult = Extract<
+  NonNullable<ConstructorParameters<typeof MockLanguageModelV4>[0]>["doStream"],
+  ReadonlyArray<unknown>
+>[number];
+type StreamPart = StreamResult extends { stream: ReadableStream<infer Part> }
+  ? Part
+  : never;
+/** What a Provider reports for one model call. */
+type ProviderUsage = Extract<StreamPart, { type: "finish" }>["usage"];
+
+const chunks = (parts: StreamPart[]): StreamResult => ({
+  stream: simulateReadableStream({ chunks: parts }),
+});
+
+/** Step one: the model calls the tool. */
+const toolCallStep = (reported: ProviderUsage) =>
+  chunks([
+    { type: "stream-start", warnings: [] },
+    { type: "tool-input-start", id: "call-1", toolName: "ping" },
+    { type: "tool-input-delta", id: "call-1", delta: "{}" },
+    { type: "tool-input-end", id: "call-1" },
+    { type: "tool-call", toolCallId: "call-1", toolName: "ping", input: "{}" },
+    {
+      type: "finish",
+      finishReason: { unified: "tool-calls", raw: "tool_use" },
+      usage: reported,
+    },
+  ]);
+
+/** Step two: the tool result is back in the prompt, and the model answers. */
+const answerStep = (reported: ProviderUsage) =>
+  chunks([
+    { type: "stream-start", warnings: [] },
+    { type: "text-start", id: "t1" },
+    { type: "text-delta", id: "t1", delta: "The service answered." },
+    { type: "text-end", id: "t1" },
+    {
+      type: "finish",
+      finishReason: { unified: "stop", raw: "end_turn" },
+      usage: reported,
+    },
+  ]);
+
+const mockModel = (steps: StreamResult[]) =>
+  new MockLanguageModelV4({
+    provider: "anthropic",
+    modelId: "claude-opus-4-5",
+    doStream: steps,
+  });
+
+/**
+ * Consume a UI message stream the way both the client and the run's own
+ * snapshot reader do, and return the message they end up with — metadata
+ * chunks merged, which is where a reading either survives or is overwritten.
+ */
+const lastSnapshot = async (
+  stream: Parameters<
+    typeof readUIMessageStream<PlatypusUIMessage>
+  >[0]["stream"],
+): Promise<PlatypusUIMessage | undefined> => {
+  let message: PlatypusUIMessage | undefined;
+  for await (const snapshot of readUIMessageStream<PlatypusUIMessage>({
+    stream,
+  })) {
+    message = snapshot;
+  }
+  return message;
+};
+
+/** The production wiring: the runner passes exactly this to the SDK. */
+const uiStreamOf = (result: {
+  toUIMessageStream: (opts: {
+    messageMetadata: ReturnType<typeof createMessageMetadata>;
+  }) => Parameters<typeof lastSnapshot>[0];
+}) =>
+  result.toUIMessageStream({
+    messageMetadata: createMessageMetadata("agent-1"),
+  });
+
+/**
+ * A two-step turn: 1,000 tokens in on the first call, 4,200 on the second
+ * because the tool call and its result are now part of the prompt. Returns the
+ * finished message alongside the SDK's own cumulative figure, so a test can
+ * name the number occupancy must not be.
+ */
+const runTurn = async () => {
+  const result = streamText({
+    model: mockModel([
+      toolCallStep(usage(1_000, 30)),
+      answerStep(usage(4_200, 70)),
+    ]),
+    prompt: "Ping the service and tell me what it said.",
+    tools: { ping },
+    stopWhen: [stepCountIs(5)],
+  });
+
+  const message = await lastSnapshot(uiStreamOf(result));
+  return { message, totalUsage: await result.totalUsage };
+};
+
+describe("Context occupancy over a real multi-step stream", () => {
+  it("records the last model call's input tokens, not the sum across steps", async () => {
+    const { message, totalUsage } = await runTurn();
+
+    expect(message?.metadata?.contextOccupancy).toEqual({
+      inputTokens: 4_200,
+      outputTokens: 70,
+    });
+    // The number the implementation must not have read. It is the SDK's
+    // cumulative usage — correct as a billing figure, and on a twenty-step
+    // turn it reads roughly an order of magnitude high.
+    expect(totalUsage.inputTokens).toBe(5_200);
+  });
+
+  it("keeps the agent attribution on the same message", async () => {
+    const { message } = await runTurn();
+
+    expect(message?.metadata?.agentId).toBe("agent-1");
+  });
+
+  // A cancelled turn never emits a terminal finish part, and cancelling a long
+  // turn is exactly when the context had grown most.
+  it("keeps the reading from a turn cancelled mid-stream", async () => {
+    const controller = new AbortController();
+    const result = streamText({
+      model: mockModel([
+        toolCallStep(usage(1_000, 30)),
+        answerStep(usage(4_200, 70)),
+      ]),
+      prompt: "Ping the service and tell me what it said.",
+      tools: { ping },
+      stopWhen: [stepCountIs(5)],
+      abortSignal: controller.signal,
+      // Cancelled the moment the first step lands, so the turn ends with one
+      // step's reading taken and no terminal finish part.
+      onStepFinish: () => controller.abort(),
+    });
+
+    const message = await lastSnapshot(uiStreamOf(result));
+
+    // The turn really did stop early: the second step's answer never arrived.
+    expect(message?.parts).not.toContainEqual(
+      expect.objectContaining({ type: "text" }),
+    );
+    expect(message?.metadata?.contextOccupancy).toEqual({
+      inputTokens: 1_000,
+      outputTokens: 30,
+    });
+  });
+
+  it("records nothing when the Provider reports no usage at all", async () => {
+    const result = streamText({
+      model: mockModel([answerStep(NO_USAGE)]),
+      prompt: "Hi.",
+    });
+
+    const message = await lastSnapshot(uiStreamOf(result));
+
+    // Attributed, but nothing estimated from the text it produced.
+    expect(message?.metadata?.agentId).toBe("agent-1");
+    expect(message?.metadata).not.toHaveProperty("contextOccupancy");
+  });
+
+  // The first step's 1,000 tokens are not this turn's context size, and the
+  // merge would keep them on the message unless something concrete replaces
+  // them.
+  it("does not leave an earlier step's figure standing when the last step reports no usage", async () => {
+    const result = streamText({
+      model: mockModel([toolCallStep(usage(1_000, 30)), answerStep(NO_USAGE)]),
+      prompt: "Ping the service and tell me what it said.",
+      tools: { ping },
+      stopWhen: [stepCountIs(5)],
+    });
+
+    const message = await lastSnapshot(uiStreamOf(result));
+
+    expect(message?.metadata?.contextOccupancy).toBeNull();
+  });
+});

--- a/apps/backend/src/runs/message-metadata.ts
+++ b/apps/backend/src/runs/message-metadata.ts
@@ -1,0 +1,74 @@
+import type { TextStreamPart, ToolSet } from "ai";
+import { isTruncatedByTokenLimit } from "./stream-error.ts";
+import type { ChatMessageMetadata } from "../types.ts";
+
+/**
+ * Builds the `messageMetadata` extractor `toUIMessageStream` calls for every
+ * stream part.
+ *
+ * It is the only seam for saying anything about a stream that has already been
+ * flushed to the client. The SDK deep-merges what it returns into the message,
+ * so each part contributes only the key it owns and a later part leaves the
+ * earlier ones standing. Returning the whole object every time would work too,
+ * but only because the merge happens to skip `undefined` values.
+ *
+ * Extracted from the runner so the Context occupancy reading can be driven
+ * through a real multi-step stream in a test — the run-lifecycle suite mocks
+ * the SDK wholesale, so the usage numbers there are whatever a test author
+ * typed and an implementation reading the cumulative sum passes it happily.
+ */
+export const createMessageMetadata = (agentId: string | undefined) => {
+  // Whether any step of this turn has reported an input-token count. Only
+  // read to erase a reading, never to synthesise one — see the `finish-step`
+  // branch below.
+  let occupancyReported = false;
+
+  return ({
+    part,
+  }: {
+    part: TextStreamPart<ToolSet>;
+  }): ChatMessageMetadata | undefined => {
+    if (part.type === "start") {
+      return agentId ? { agentId } : undefined;
+    }
+    // Context occupancy (ADR-0018), emitted per step rather than once at the
+    // end: the terminal `finish` part is never sent on an aborted run, and
+    // cancelling a long turn is exactly when the context had grown most. The
+    // merge leaves the last step's figures standing.
+    //
+    // `part.usage` here is one call's usage. The terminal finish's
+    // `totalUsage` and the run's accumulated stats both fold input tokens
+    // across every step, so on a twenty-step turn they read roughly an order
+    // of magnitude high. Correct as billing figures, wrong as occupancy.
+    if (part.type === "finish-step") {
+      const { inputTokens, outputTokens } = part.usage;
+      if (typeof inputTokens !== "number") {
+        // This step's context size is unknown, so any figure already on the
+        // message is a smaller, older call's — stale, and about to be read as
+        // this turn's. Erase it with a concrete `null`, which the merge does
+        // apply, rather than returning nothing and letting it stand. Until
+        // some step has reported a count there is nothing to erase, and the
+        // key stays absent so a Provider that reports no usage at all records
+        // no occupancy whatsoever.
+        return occupancyReported ? { contextOccupancy: null } : undefined;
+      }
+      occupancyReported = true;
+      return {
+        contextOccupancy: {
+          inputTokens,
+          // Concrete, never omitted, for the same reason: the merge skips
+          // `undefined`, so leaving the key out would pair a fresh input count
+          // with a previous step's output count.
+          outputTokens: typeof outputTokens === "number" ? outputTokens : null,
+        },
+      };
+    }
+    // The terminal finish only. A step inside a tool loop can end at the
+    // ceiling and the run still recover and complete normally; flagging those
+    // marks answers that were never cut short.
+    if (part.type === "finish" && isTruncatedByTokenLimit(part.finishReason)) {
+      return { truncatedByTokenLimit: true };
+    }
+    return undefined;
+  };
+};

--- a/apps/backend/src/runs/message-metadata.ts
+++ b/apps/backend/src/runs/message-metadata.ts
@@ -16,6 +16,10 @@ import type { ChatMessageMetadata } from "../types.ts";
  * through a real multi-step stream in a test — the run-lifecycle suite mocks
  * the SDK wholesale, so the usage numbers there are whatever a test author
  * typed and an implementation reading the cumulative sum passes it happily.
+ *
+ * `agentId` is read once, here, rather than off the run state when the `start`
+ * part arrives: the turn resolves during setup, before the stream is built, and
+ * nothing reassigns the resolved agent mid-run.
  */
 export const createMessageMetadata = (agentId: string | undefined) => {
   // Whether any step of this turn has reported an input-token count. Only

--- a/apps/backend/src/types.ts
+++ b/apps/backend/src/types.ts
@@ -10,7 +10,9 @@ import { createLoadSkillTool } from "./tools/skill.ts";
  * flag, and a truncated agent run keeps its attribution.
  *
  * A key that does not apply is absent rather than `false`, so a message's
- * metadata says only what is true of it.
+ * metadata says only what is true of it. `contextOccupancy` is the one
+ * departure: it is written as a concrete `null` where an earlier reading has to
+ * be erased, because the merge that makes the above work skips `undefined`.
  */
 export type ChatMessageMetadata = {
   /** Agent the run resolved; the chat UI renders its name and avatar. */
@@ -33,6 +35,10 @@ export type ChatMessageMetadata = {
    * estimated. `null` where a Provider reported a count for an earlier call of
    * the turn but not for the last one, which makes the earlier figure stale
    * rather than current.
+   *
+   * Absent and `null` say the same thing to a reader — occupancy is unknown,
+   * show nothing — and differ only in why. Normalise with `?? null` at the read
+   * site rather than branching on both.
    */
   contextOccupancy?: {
     /** The occupancy figure itself. */

--- a/apps/backend/src/types.ts
+++ b/apps/backend/src/types.ts
@@ -20,6 +20,30 @@ export type ChatMessageMetadata = {
    * answer stops mid-thought. The chat marks the message as cut short.
    */
   truncatedByTokenLimit?: true;
+  /**
+   * How full the model's Context window was when this message was produced
+   * (ADR-0018): the input-token count the Provider reported for the **last**
+   * model call of the turn — inclusive of cached reads and writes, so the true
+   * size of what was sent — plus that same call's output tokens, which makes
+   * the next turn's starting size derivable exactly.
+   *
+   * A last value, never a sum: the conversation is re-sent in full on every
+   * turn, so occupancy replaces rather than accumulates. Absent where the
+   * Provider reported no usage — occupancy is then unknown and nothing is
+   * estimated. `null` where a Provider reported a count for an earlier call of
+   * the turn but not for the last one, which makes the earlier figure stale
+   * rather than current.
+   */
+  contextOccupancy?: {
+    /** The occupancy figure itself. */
+    inputTokens: number;
+    /**
+     * `null` rather than absent when the Provider reported an input count and
+     * no output one, because metadata chunks are deep-merged: an omitted key
+     * would leave an earlier step's output figure looking current.
+     */
+    outputTokens: number | null;
+  } | null;
 };
 
 /**

--- a/docs/adr/0018-context-windows-are-declared-not-discovered.md
+++ b/docs/adr/0018-context-windows-are-declared-not-discovered.md
@@ -87,9 +87,15 @@ reports no usage, occupancy is unknown and Platypus computes nothing.
   emitted on an aborted run, and cancelling a long turn is exactly when the
   context got large — so emitting once on `finish` would lose the reading that
   matters most. The cost is that `mergeObjects` skips `undefined` overrides, so a
-  later step reporting no usage would leave an earlier value looking current;
-  guarded by only returning when the count is a number and always writing every
-  key as a concrete value.
+  later step reporting no usage would leave an earlier value looking current.
+  Returning nothing in that case is what _causes_ the stale reading rather than
+  preventing it — an earlier draft of this ADR named the failure and then
+  prescribed it. The guard is the opposite: a step with no input count returns a
+  concrete `contextOccupancy: null`, which the merge does apply, and a reported
+  input count with no output count writes `outputTokens: null` rather than
+  omitting the key. Only where no step of the turn has reported a count is
+  nothing returned, so a Provider that reports no usage at all still records no
+  occupancy — the key is absent, and absent and `null` both read as unknown.
 - **Optional means auto-compaction will silently not engage.** When compaction
   lands, a model with no declared window simply will not compact. The provider
   form's hint on the field is the only guardrail against that being a mystery,


### PR DESCRIPTION
Closes #448.

Every assistant message now records how large the context actually was when it was produced, so the meter (#449) and, later, auto-compaction have a real figure to work from.

## What changed

`ChatMessageMetadata` gains `contextOccupancy: { inputTokens, outputTokens } | null` — the input-token count the Provider reported for the **last model call of the turn**, inclusive of cached reads and writes, plus that same call's output tokens so the next turn's starting size is derivable exactly. It lands in the Chat's existing message blob: no new column, no migration, and the reading survives a reload for free.

Emission rides on each step-finish part rather than the terminal finish. The terminal finish is never sent on an aborted run, and cancelling a long turn is exactly when the context had grown most; the metadata callback's return is deep-merged, so the last step's values win naturally.

The metadata extractor moves out of `AgentRunner` into `runs/message-metadata.ts`. Behaviour is unchanged by the move — it is what makes the real-SDK test below possible.

Where the Provider reports no usage, occupancy is unknown. Nothing is estimated, now or ever.

## The trap (ADR-0018)

Three numbers look like occupancy and two of them are sums. The conversation is re-sent in full each turn, so occupancy replaces rather than accumulates; and *within* a turn, `totalUsage.inputTokens` and `RunStats.inputTokens` both fold input tokens across every step. Both are correct as billing figures. Neither is occupancy.

`message-metadata.test.ts` is the test that can fail on this: it drives a genuine two-step stream through a mock language model reporting 1,000 then 4,200 input tokens, asserts occupancy is `4_200`, and separately pins `totalUsage.inputTokens === 5_200` so the number it must not be is named in the test. Verified load-bearing — mutating the implementation to read `part.totalUsage` on the terminal `finish` fails it with `5200`. The existing run-lifecycle suite mocks the SDK wholesale and cannot catch this.

## One decision that needs a second opinion

The acceptance criterion *"a step reporting no usage after an earlier step reported some does not leave the earlier figure looking current"* is not satisfied by ADR-0018's guard as literally written. The ADR names this exact failure and then says it is *"guarded by only returning when the count is a number"* — but that guard is precisely what lets the stale figure survive: returning `undefined` emits no chunk, so the earlier step's figures stay on the message.

Resolved toward the acceptance criterion and the ADR's evident intent: a step reporting no count after an earlier one did returns a concrete `contextOccupancy: null`, which the merge does apply. A Provider that reports no usage on any step still records the key as absent, so *"nothing is recorded when the Provider reports no usage"* holds too. That is why the type carries `| null`.

The alternative — ADR-literal — would show step 3's size as a 20-step turn's occupancy on a partially-reporting proxy. Happy to flip it if you read the ADR as binding here; it is a two-line change plus two tests.

## Tests

- Six new cases in the existing run-lifecycle metadata suite, renamed from "truncation metadata" to "message metadata" now that it covers both.
- New `message-metadata.test.ts` following the shape of `provider-warnings.test.ts` (the existing user of the SDK test utilities): the sum-vs-last-step case, attribution surviving alongside occupancy, a turn cancelled mid-stream keeping its reading, a Provider reporting no usage recording nothing, and the erasure case above.

Full suite green — 1,579 backend, 87 frontend, docs contract, schemas — plus typecheck and lint.

## Not in this PR

The `contextWindow` declaration (#447), the composer meter (#449), and Trigger run stats occupancy (#450). No user-facing behaviour changes here, so no documentation change is required; `CONTEXT.md` already defines both terms from #440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)