### PR TITLE
fix(backend): propagate tool set factory errors

### DIFF
--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -98,6 +98,7 @@ import {
   composeWebBackend,
   registerWebBackend,
 } from "../web-backends/index.ts";
+import { registerToolSet } from "../tools/index.ts";
 import { logger } from "../logger.ts";
 import { FileValidationError } from "./file-gate.ts";
 import { resetExtractedTextCache } from "./file-extraction.ts";
@@ -1049,6 +1050,34 @@ describe("chat-execution", () => {
           /\[extracted text truncated: first 20 of \d+ characters\]/,
         );
       });
+    });
+  });
+
+  describe("Static tool-set resolution", () => {
+    it("propagates factory errors without falling back to MCP lookup", async () => {
+      const factoryError = new Error("tool-set factory failed");
+      const toolSetId = "test.throwing-factory";
+      registerToolSet(toolSetId, {
+        name: "Throwing test Tool set",
+        category: "Test",
+        tools: vi.fn().mockRejectedValue(factoryError),
+      });
+
+      const agentWithToolSet = { ...baseAgent, toolSetIds: [toolSetId] };
+      const queries = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        agents: [agentWithToolSet],
+        providers: [baseProvider],
+      });
+      const getMcp = vi.spyOn(queries, "getMcp");
+
+      await expect(
+        prepareChatTurn(
+          { ...baseInput, request: { agentId: agentWithToolSet.id } },
+          queries,
+        ),
+      ).rejects.toBe(factoryError);
+      expect(getMcp).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -994,19 +994,9 @@ const loadTools = async (
   }
 
   for (const toolSetId of agent.toolSetIds) {
+    let toolSet: ReturnType<typeof getToolSet>;
     try {
-      const toolSet = getToolSet(toolSetId);
-      const resolvedTools =
-        typeof toolSet.tools === "function"
-          ? await toolSet.tools({
-              workspaceId,
-              agentId: agent.id,
-              orgId,
-              frontendUrl,
-              userId: userId || "",
-            })
-          : toolSet.tools;
-      Object.assign(tools, resolvedTools);
+      toolSet = getToolSet(toolSetId);
     } catch {
       // Static tool set not found — fall back to MCP lookup.
       const mcp = await queries.getMcp(toolSetId, orgId, workspaceId);
@@ -1035,7 +1025,20 @@ const loadTools = async (
           `Tool set with id '${toolSetId}' not found as static tool set or MCP`,
         );
       }
+      continue;
     }
+
+    const resolvedTools =
+      typeof toolSet.tools === "function"
+        ? await toolSet.tools({
+            workspaceId,
+            agentId: agent.id,
+            orgId,
+            frontendUrl,
+            userId: userId || "",
+          })
+        : toolSet.tools;
+    Object.assign(tools, resolvedTools);
   }
 
   return { tools, mcpClients };


### PR DESCRIPTION
## Summary

- limit the static tool-set lookup catch to registry misses
- preserve MCP fallback for unknown tool-set IDs
- propagate tool-set factory failures with their original error
- add regression coverage proving factory failures do not query MCPs

## Validation

- `pnpm --filter @platypus/backend test chat-execution.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- Prettier check on changed files

Fixes #443