### PR TITLE
feat(provider): cap a model's output tokens per model

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,6 +57,10 @@ _Avoid_: context size, token limit, max tokens (that names an output cap).
 How full a model's **Context window** was on the most recent Chat turn — the input-token count the vendor reported for the last model call of that turn, inclusive of cached tokens. A last value, not a running total: the conversation is re-sent in full on every Chat turn, so occupancy replaces rather than accumulates. Unknown where the Provider reports no token usage, in which case Platypus estimates nothing. Distinct from token **usage**, which is the count of tokens billed across a turn or run and legitimately is a sum.
 _Avoid_: context size, context usage, tokens used, running total.
 
+**Output ceiling**:
+The most a `(Provider, model)` pair may produce in a single reply, declared by an Org Admin on the Provider's model entry and surfaced as **Max output tokens**. Unlike the **Context window** it is enforced: it is sent as the output limit on every **Chat turn** and delegated **Sub-Agent** run against that model. The Provider's own one-shot executions — Chat metadata and memory extraction, which run against its pointer-settings — do not carry it. Optional; a model without one is sent no limit at all, leaving the vendor's own default in force, which on Bedrock is far below the model's real capability. Bounds a reply, never the conversation.
+_Avoid_: max tokens, token limit, context window (that names the total capacity), output budget.
+
 **Tool set**:
 A named bundle of Tools an Agent can be granted. Either contributed by a Plugin (registered in code) or backed by an MCP server.
 
@@ -156,6 +160,7 @@ The record binding a Conversation locus to a Chat (which carries the Workspace +
 - An **Agent** references one **Provider**, zero-or-more **Tool sets** (static or **MCP**-backed), zero-or-more **Skills**, and zero-or-more **Sub-Agents**.
 - A **Provider** belongs to either an **Organization** (shared) or a **Workspace** (private).
 - Each model a **Provider** exposes may declare a **Context window**. A **Chat turn** against that model yields a **Context occupancy**, measured from the tokens the vendor reports and meaningful only where a **Context window** was declared.
+- Each model a **Provider** exposes may also declare an **Output ceiling**, which a **Chat turn** — or a **Sub-Agent** run — against that model is generated under. Independent of the **Context window**: one bounds the reply and is enforced, the other describes the whole capacity and is not.
 - An **Agent**, **Skill**, **MCP**, or **Provider** is a **Scoped resource**: its row carries either an `organizationId` or a `workspaceId`, never both. Resolved relative to a **Workspace**, an Organization-scoped one is a **Shared resource**, visible only through an **Attachment**; a Sandbox-backed **Tool set** instead rebinds to the invoking **Workspace**'s **Sandbox** at Chat-turn time.
 - A **Blueprint** names a set of **Shared resources** and, applied to a **Workspace**, creates their **Attachments** in one step.
 - **Workspaces** are created only by **Org Admins** — directly, or auto-provisioned for a member when they accept an invitation. An invitation carries an ordered set of zero-or-more **Blueprints**; on accept they are applied to the new Workspace in order (Attachments union; later Blueprints win on any single-valued pointer-setting). Members do not create their own Workspaces.

--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -1367,6 +1367,75 @@ describe("AgentRunner.stream — message metadata", () => {
   });
 });
 
+// Issue #454: the ceiling the Provider declares for the model has to reach the
+// generation call itself. Amazon Bedrock omits `inferenceConfig.maxTokens`
+// entirely when the SDK is passed nothing, so a value stopping short of the
+// call is a value that changes nothing.
+describe("model output ceiling", () => {
+  let runner: AgentRunner;
+  beforeEach(() => {
+    runner = new AgentRunner();
+    vi.clearAllMocks();
+    resetStreamHarness();
+  });
+
+  const turnWithCeiling = (maxOutputTokens?: number) => {
+    const turn = fakeTurn();
+    return { ...turn, stream: { ...turn.stream, maxOutputTokens } };
+  };
+
+  it("passes the declared ceiling to the unattended generation call", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(turnWithCeiling(64000));
+    mockGenerateText.mockResolvedValueOnce(fakeGenerateResult);
+
+    await runner.generate({
+      scope,
+      input: baseInput,
+      sink: new RecordingSink(),
+    });
+
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({ maxOutputTokens: 64000 }),
+    );
+  });
+
+  it("passes the declared ceiling to the streaming call", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(turnWithCeiling(32000));
+    streamHarness.queue = new streamHarness.AsyncQueue();
+    primeStreamText();
+
+    await runner.stream({
+      scope,
+      input: { ...baseInput, runId: "s-ceiling" },
+      sink: new RecordingSink(),
+      options: { origin: "http://test" },
+    });
+
+    expect(mockStreamText).toHaveBeenCalledWith(
+      expect.objectContaining({ maxOutputTokens: 32000 }),
+    );
+  });
+
+  // Undeclared has to stay undeclared: the SDK reads an absent key and an
+  // `undefined` value the same way, and anything else would move the ceiling
+  // for every Provider that has never set one.
+  it("sends no ceiling when the model declares none", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(turnWithCeiling(undefined));
+    mockGenerateText.mockResolvedValueOnce(fakeGenerateResult);
+
+    await runner.generate({
+      scope,
+      input: baseInput,
+      sink: new RecordingSink(),
+    });
+
+    const args = mockGenerateText.mock.calls[0][0] as {
+      maxOutputTokens?: number;
+    };
+    expect(args.maxOutputTokens).toBeUndefined();
+  });
+});
+
 // Smoke test the TimeoutError export so the type stays public-importable
 describe("AgentRunner timeout types", () => {
   it("TimeoutError remains an Error subclass", () => {

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -400,6 +400,11 @@ export class AgentRunner {
         ? [stepCountIs(state.turn.stream.maxSteps), noProgress.stopCondition]
         : [stepCountIs(state.turn.stream.maxSteps)],
       abortSignal: handle.signal,
+      // The Provider's declared ceiling for this model, or undefined when it
+      // declares none — which is what Bedrock needs, since its Converse request
+      // carries no `inferenceConfig.maxTokens` at all unless one is passed
+      // (issue #454).
+      maxOutputTokens: state.turn.stream.maxOutputTokens,
       temperature: state.turn.stream.temperature,
       topP: state.turn.stream.topP,
       topK: state.turn.stream.topK,

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -511,6 +511,76 @@ describe("chat-execution", () => {
       expect(turn.resolved.seed).toBe(99);
     });
 
+    // The output ceiling comes off the PROVIDER's model entry, not the Agent or
+    // the request — it is a property of the (Provider, model) pair (issue #454).
+    it("streams the model's declared maxOutputTokens", async () => {
+      const cappedProvider = {
+        ...baseProvider,
+        modelIds: [
+          { id: "gpt-4", passthroughFileTypes: [], maxOutputTokens: 64000 },
+        ],
+      };
+      const queries = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        agents: [baseAgent],
+        providers: [cappedProvider],
+      });
+
+      const turn = await prepareChatTurn(
+        { ...baseInput, request: { agentId: baseAgent.id } },
+        queries,
+      );
+
+      expect(turn.stream.maxOutputTokens).toBe(64000);
+    });
+
+    // Undeclared must stay undefined all the way to the SDK: any default of
+    // ours would change generation for every existing Provider.
+    it("leaves maxOutputTokens undefined when the model declares none", async () => {
+      const queries = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        providers: [baseProvider],
+      });
+
+      const turn = await prepareChatTurn(
+        {
+          ...baseInput,
+          request: { providerId: baseProvider.id, modelId: "gpt-4" },
+        },
+        queries,
+      );
+
+      expect(turn.stream.maxOutputTokens).toBeUndefined();
+    });
+
+    // An alias reference resolves to the entry, so the ceiling follows a
+    // repoint rather than being looked up by the stored string.
+    it("takes maxOutputTokens from the entry an alias reference resolves to", async () => {
+      const aliasProvider = {
+        ...baseProvider,
+        modelIds: [
+          {
+            id: "gpt-4",
+            alias: "flagship",
+            passthroughFileTypes: [],
+            maxOutputTokens: 32000,
+          },
+        ],
+      };
+      const queries = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        agents: [{ ...baseAgent, modelId: "alias:flagship" }],
+        providers: [aliasProvider],
+      });
+
+      const turn = await prepareChatTurn(
+        { ...baseInput, request: { agentId: baseAgent.id } },
+        queries,
+      );
+
+      expect(turn.stream.maxOutputTokens).toBe(32000);
+    });
+
     it("Agent without an explicit maxSteps falls back to the default (15), not 1", async () => {
       const agentNoMaxSteps = { ...baseAgent, maxSteps: null };
       const queries = createInMemoryChatTurnQueries({

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -44,6 +44,7 @@ import { buildMcpTransportConfig } from "./mcp-oauth-provider.ts";
 import { inlineFileUrls } from "../storage/utils.ts";
 import {
   maxExtractedTextCharsForModel,
+  maxOutputTokensForModel,
   passthroughFileTypesForModel,
   resolveModelId,
 } from "./model-capability.ts";
@@ -149,6 +150,14 @@ export type ChatTurn = {
     system: string;
     messages: PlatypusUIMessage[];
     maxSteps: number;
+    /**
+     * The Provider's declared output ceiling for the model in use, or undefined
+     * when it declares none (issue #454). A property of the (Provider, model)
+     * pair rather than of the Agent or the request, unlike the sampling params
+     * below — which is why it is never mirrored into `resolved` and never
+     * persisted onto the Chat row.
+     */
+    maxOutputTokens?: number;
     temperature?: number;
     topP?: number;
     topK?: number;
@@ -660,6 +669,7 @@ export const prepareChatTurn = async (
       system: systemPrompt,
       messages: inlinedMessages,
       maxSteps: resolvedMaxSteps,
+      maxOutputTokens: maxOutputTokensForModel(provider, resolvedModelId),
       temperature: generation.temperature,
       topP: generation.topP,
       topK: generation.topK,
@@ -1142,6 +1152,9 @@ const loadSubAgents = async (
       return {
         model: openProvider(subProvider).languageModel(subModelId),
         securityGuardrails: subProvider.securityGuardrails ?? null,
+        // Read off the sub-agent's OWN Provider, not the parent's: a delegated
+        // run is a run on that model and truncates at its ceiling (issue #454).
+        maxOutputTokens: maxOutputTokensForModel(subProvider, subModelId),
       };
     },
     async (subAgentId: string, toolSetIds: string[]) => {

--- a/apps/backend/src/services/model-capability.test.ts
+++ b/apps/backend/src/services/model-capability.test.ts
@@ -6,6 +6,7 @@ import {
   providerModelReferences,
   passthroughFileTypesForModel,
   maxExtractedTextCharsForModel,
+  maxOutputTokensForModel,
   dedupeModelConfigs,
   resolveModelId,
 } from "./model-capability.ts";
@@ -192,6 +193,35 @@ describe("maxExtractedTextCharsForModel", () => {
     expect(maxExtractedTextCharsForModel(p, concrete("legacy"))).toBe(
       DEFAULT_MAX_EXTRACTED_TEXT_CHARS,
     );
+  });
+});
+
+describe("maxOutputTokensForModel", () => {
+  it("returns the model's declared ceiling", () => {
+    const p = provider({
+      modelIds: [
+        { id: "qwen", passthroughFileTypes: [], maxOutputTokens: 64000 },
+      ],
+    });
+    expect(maxOutputTokensForModel(p, concrete("qwen"))).toBe(64000);
+  });
+
+  // Undefined rather than a default of our own: the whole point is that an
+  // undeclared model behaves exactly as it did before the field existed, with
+  // the provider SDK's own default left in place.
+  it("returns undefined when undeclared or unknown", () => {
+    const p = provider({
+      modelIds: [{ id: "qwen", passthroughFileTypes: [] }],
+    });
+    expect(maxOutputTokensForModel(p, concrete("qwen"))).toBeUndefined();
+    expect(maxOutputTokensForModel(p, concrete("ghost"))).toBeUndefined();
+  });
+
+  it("survives a legacy string[] model list", () => {
+    const p = provider({
+      modelIds: ["legacy"] as unknown as Provider["modelIds"],
+    });
+    expect(maxOutputTokensForModel(p, concrete("legacy"))).toBeUndefined();
   });
 });
 

--- a/apps/backend/src/services/model-capability.ts
+++ b/apps/backend/src/services/model-capability.ts
@@ -116,6 +116,17 @@ export const pointerSettingModelId = (value: string): ConcreteModelId =>
   value as ConcreteModelId;
 
 /**
+ * The resolved entry for a model, or undefined when this Provider has no such
+ * model. Every per-model accessor below goes through it, so "what does this
+ * Provider say about this model?" is asked in exactly one place.
+ */
+const modelEntry = (
+  provider: Provider,
+  modelId: ConcreteModelId,
+): ModelConfig | undefined =>
+  resolveProviderModels(provider).find((m) => m.id === modelId);
+
+/**
  * The media types the given model ingests natively. Falls back to the
  * provider-type default when the model isn't found (defensive — callers should
  * validate the model id first).
@@ -124,7 +135,7 @@ export const passthroughFileTypesForModel = (
   provider: Provider,
   modelId: ConcreteModelId,
 ): string[] => {
-  const model = resolveProviderModels(provider).find((m) => m.id === modelId);
+  const model = modelEntry(provider, modelId);
   return model
     ? model.passthroughFileTypes
     : defaultPassthroughFileTypes(provider);
@@ -139,7 +150,20 @@ export const maxExtractedTextCharsForModel = (
   provider: Provider,
   modelId: ConcreteModelId,
 ): number =>
-  resolveExtractedTextCap(
-    resolveProviderModels(provider).find((m) => m.id === modelId)
-      ?.maxExtractedTextChars,
-  );
+  resolveExtractedTextCap(modelEntry(provider, modelId)?.maxExtractedTextChars);
+
+/**
+ * The output-token ceiling declared for this model, or `undefined` when the
+ * Provider declares none (issue #454).
+ *
+ * No default of its own, deliberately — unlike the extracted-text cap. An
+ * undeclared model must reach the SDK with no ceiling at all, exactly as it did
+ * before the field existed, because the sane value differs per provider and per
+ * model and only the vendor knows it. Declaring one is what rescues Amazon
+ * Bedrock, whose Converse API silently applies a low default when the field is
+ * absent.
+ */
+export const maxOutputTokensForModel = (
+  provider: Provider,
+  modelId: ConcreteModelId,
+): number | undefined => modelEntry(provider, modelId)?.maxOutputTokens;

--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -649,6 +649,24 @@ describe("createSubAgentTool", () => {
       }
     });
 
+    // The ceiling is not a sampling parameter — it comes off the sub-agent's
+    // OWN Provider model entry, not its Agent row (issue #454). Without it a
+    // delegated run truncates one level down, on Bedrock especially, with the
+    // Org Admin's declared ceiling applying only to the parent turn.
+    it("passes the sub-agent model's output ceiling to its agent", () => {
+      createSubAgentTool({ ...baseOptions, maxOutputTokens: 64000 });
+
+      expect(settingsPassedToAgent()).toMatchObject({
+        maxOutputTokens: 64000,
+      });
+    });
+
+    it("sends no ceiling when the sub-agent's model declares none", () => {
+      createSubAgentTool({ ...baseOptions });
+
+      expect(settingsPassedToAgent()).not.toHaveProperty("maxOutputTokens");
+    });
+
     it("cannot have sampling override the model, instructions or tools", () => {
       createSubAgentTool({
         ...baseOptions,
@@ -795,6 +813,26 @@ describe("createSubAgentTools", () => {
     expect(result.failures).toEqual([]);
     expect(createModelFn).toHaveBeenCalledTimes(2);
     expect(loadToolsFn).toHaveBeenCalledTimes(2);
+  });
+
+  // The ceiling belongs to the sub-agent's own (Provider, model) pair, which
+  // only the resolver has, so it rides back with the model it applies to.
+  it("forwards the resolved model's output ceiling to the sub-agent's agent", async () => {
+    const createModelFn = vi.fn().mockResolvedValue({
+      model: {},
+      securityGuardrails: null,
+      maxOutputTokens: 32000,
+    });
+
+    await createSubAgentTools(
+      [{ id: "sa-1", name: "Research", providerId: "p1", modelId: "m1" }],
+      createModelFn,
+      vi.fn().mockResolvedValue({}),
+    );
+
+    expect(agentConstructorSpy.mock.calls[0][0]).toMatchObject({
+      maxOutputTokens: 32000,
+    });
   });
 
   it("continues when a sub-agent fails to initialize, and reports it as a failure", async () => {

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -103,6 +103,14 @@ interface SubAgentToolOptions {
    * a delegated run is tuned exactly as the same Agent would be on a Chat.
    */
   sampling?: SamplingSettings;
+  /**
+   * The output ceiling THIS sub-agent's model declares, or undefined for none
+   * (issue #454). Not a sampling parameter: it comes off the sub-agent's own
+   * Provider model entry rather than its Agent row, which is why it arrives
+   * separately from `sampling`. Omitted when undefined so the SDK is passed
+   * nothing at all.
+   */
+  maxOutputTokens?: number;
   /** Called on each activity update from the sub-agent. Used to reset the parent run's per-step timeout. */
   onProgress?: () => void;
 }
@@ -126,6 +134,7 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
     maxSteps = 50,
     securityGuardrails,
     sampling,
+    maxOutputTokens,
     onProgress,
   } = options;
 
@@ -146,6 +155,9 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
 
   const agent = new ToolLoopAgent({
     ...sampling,
+    // Spread rather than assigned, so an undeclared ceiling leaves the key off
+    // entirely instead of sending `maxOutputTokens: undefined`.
+    ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
     model,
     instructions: composedInstructions,
     // The sub-agent's own tools never pass through the parent turn's
@@ -362,7 +374,16 @@ export const createSubAgentTools = async (
   createModelFn: (
     providerId: string,
     modelId: string,
-  ) => Promise<{ model: LanguageModel; securityGuardrails: string | null }>,
+  ) => Promise<{
+    model: LanguageModel;
+    securityGuardrails: string | null;
+    /**
+     * The output ceiling the resolved `(Provider, model)` pair declares, if any.
+     * Rides back with the model because resolving it needs the sub-agent's own
+     * Provider row, which only the caller's resolver has (issue #454).
+     */
+    maxOutputTokens?: number;
+  }>,
   loadToolsFn: (
     subAgentId: string,
     toolSetIds: string[],
@@ -377,11 +398,10 @@ export const createSubAgentTools = async (
 
   for (const subAgent of subAgents) {
     try {
-      // Get the sub-agent's model and its provider's security directives.
-      const { model, securityGuardrails } = await createModelFn(
-        subAgent.providerId,
-        subAgent.modelId,
-      );
+      // Get the sub-agent's model, its provider's security directives, and
+      // the output ceiling that model declares.
+      const { model, securityGuardrails, maxOutputTokens } =
+        await createModelFn(subAgent.providerId, subAgent.modelId);
 
       // Load the sub-agent's tools
       const subAgentTools = await loadToolsFn(
@@ -400,6 +420,7 @@ export const createSubAgentTools = async (
         maxSteps: subAgent.maxSteps || 50,
         securityGuardrails,
         sampling: resolveSamplingSettings(subAgent),
+        maxOutputTokens,
         onProgress,
       });
 

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -69,11 +69,11 @@ It is only there when the resolved Provider supports it. It is **absent** when:
 - nothing has resolved yet, because no Agent or model is selected.
 
 <Callout type="warning">
-  The toggle resets itself when you pick a different Provider or model directly —
-  the new endpoint may not support search, so it starts off. It does **not** reset
-  when you switch from one Agent to another, even though that changes Provider
-  too. So search you turned on for one Agent silently stays on for the next one;
-  turn it off yourself if you don't want it.
+  The toggle resets itself when you pick a different Provider or model directly
+  — the new endpoint may not support search, so it starts off. It does **not**
+  reset when you switch from one Agent to another, even though that changes
+  Provider too. So search you turned on for one Agent silently stays on for the
+  next one; turn it off yourself if you don't want it.
 </Callout>
 
 This is the vendor's search, not a tool you grant. An Agent that should read
@@ -124,6 +124,11 @@ output limit.**
 Everything above the marker is a real answer; there is no more of it. The marker
 is stored with the message, so it is still there when you reload the Chat.
 
+The ceiling itself is **Max output tokens** on the Provider's model, which an
+Org Admin sets — see
+[Capping a single reply](/self-hosting/providers-and-auth#capping-a-single-reply)
+if replies keep stopping short of what the model can write.
+
 <Callout type="warning">
   **Nothing resumes a cut-short reply.** **Regenerate** re-runs the whole turn
   from the beginning against the same ceiling; it does not carry on from where
@@ -135,12 +140,12 @@ is stored with the message, so it is still there when you reload the Chat.
 
 Hover a message for its actions:
 
-| Action         | On                      | Does                                                                       |
-| -------------- | ----------------------- | -------------------------------------------------------------------------- |
-| **Edit**       | Your own messages       | Rewrites the message and re-runs from there — see the warning below         |
-| **Copy**       | Any message             | Copies the message text to the clipboard                                   |
-| **Delete**     | Any message             | Removes it from the view                                                   |
-| **Regenerate** | The last assistant reply | Runs the turn again, same message, fresh response                          |
+| Action         | On                       | Does                                                                |
+| -------------- | ------------------------ | ------------------------------------------------------------------- |
+| **Edit**       | Your own messages        | Rewrites the message and re-runs from there — see the warning below |
+| **Copy**       | Any message              | Copies the message text to the clipboard                            |
+| **Delete**     | Any message              | Removes it from the view                                            |
+| **Regenerate** | The last assistant reply | Runs the turn again, same message, fresh response                   |
 
 The actions are hidden while the last reply is still streaming.
 
@@ -148,14 +153,14 @@ The actions are hidden while the last reply is still streaming.
   **Edit discards everything after the message you edited.** Submitting the edit
   drops that message and every message below it, then sends your new text as a
   fresh turn. That is usually what you want — you're correcting a wrong turn and
-  re-running from there — but there is no undo, so an edit near the top of a long
-  conversation throws away the rest of it.
+  re-running from there — but there is no undo, so an edit near the top of a
+  long conversation throws away the rest of it.
 </Callout>
 
 <Callout type="warning">
   **Delete removes the message from the view, and the next thing you send makes
-  that permanent.** Nothing is written when you click it, so reloading before you
-  send anything brings the message back. Send a message afterwards and the
+  that permanent.** Nothing is written when you click it, so reloading before
+  you send anything brings the message back. Send a message afterwards and the
   shortened conversation is what gets stored — the deletion you thought was
   cosmetic is now the history. Reload first if you want it back.
 </Callout>
@@ -214,8 +219,9 @@ Chat.
 
 <Callout type="info">
   Pressing stop **cancels the run on the server**, not only your connection to
-  it. The Agent stops working, the tokens stop being spent, and the partial reply
-  is kept. Closing the tab does none of that — the run carries on and finishes.
+  it. The Agent stops working, the tokens stop being spent, and the partial
+  reply is kept. Closing the tab does none of that — the run carries on and
+  finishes.
 </Callout>
 
 ## Per-Chat settings, and when they exist

--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -125,6 +125,11 @@ model's output limit.**
   a full transcript, one Board rather than every Board.
 </Callout>
 
+The ceiling itself is **Max output tokens** on the Provider's model, which an
+Org Admin sets — see
+[Capping a single reply](/self-hosting/providers-and-auth#capping-a-single-reply).
+Worth checking before rewriting the Instruction.
+
 ## Where to next
 
 - **[Agents & sub-agents](/building-with-platypus/agents)** — the Agent a Trigger

--- a/apps/docs/content/self-hosting/providers-and-auth.mdx
+++ b/apps/docs/content/self-hosting/providers-and-auth.mdx
@@ -27,12 +27,12 @@ code — there is no "custom vendor" type.
 That is not the same as five supported endpoints. Anything speaking the OpenAI
 API is reached through the **OpenAI** type with `baseUrl` pointed at it:
 
-| You want to run… | Provider type | What you set                                                                    |
-| ---------------- | ------------- | --------------------------------------------------------------------------------- |
-| Ollama           | OpenAI        | `baseUrl` → your Ollama host's `/v1`; any non-empty API key                      |
-| vLLM             | OpenAI        | `baseUrl` → your vLLM server; usually `apiMode: "chat"`                          |
-| Azure OpenAI     | OpenAI        | `baseUrl` → your Azure deployment endpoint                                       |
-| LiteLLM / a proxy| OpenAI        | `baseUrl` → the gateway (see [Fronting a Provider with a proxy](#fronting-a-provider-with-a-proxy)) |
+| You want to run…  | Provider type | What you set                                                                                        |
+| ----------------- | ------------- | --------------------------------------------------------------------------------------------------- |
+| Ollama            | OpenAI        | `baseUrl` → your Ollama host's `/v1`; any non-empty API key                                         |
+| vLLM              | OpenAI        | `baseUrl` → your vLLM server; usually `apiMode: "chat"`                                             |
+| Azure OpenAI      | OpenAI        | `baseUrl` → your Azure deployment endpoint                                                          |
+| LiteLLM / a proxy | OpenAI        | `baseUrl` → the gateway (see [Fronting a Provider with a proxy](#fronting-a-provider-with-a-proxy)) |
 
 So "is my stack supported?" comes down to: does it speak the OpenAI API? If yes,
 it works through the OpenAI type. If it speaks only a bespoke protocol, put a
@@ -40,17 +40,17 @@ translating gateway in front of it.
 
 ### What a Provider holds
 
-| Field                | Meaning                                                                                                                                                         |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`               | A human label for the connection.                                                                                                                               |
-| `providerType`       | The vendor (`OpenAI`, `OpenRouter`, `Bedrock`, `Google`, `Anthropic`).                                                                                          |
-| `apiKey`             | The vendor credential.                                                                                                                                          |
-| `baseUrl`            | Optional override for OpenAI-compatible / self-hosted endpoints.                                                                                                |
+| Field                | Meaning                                                                                                                                                                                                     |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`               | A human label for the connection.                                                                                                                                                                           |
+| `providerType`       | The vendor (`OpenAI`, `OpenRouter`, `Bedrock`, `Google`, `Anthropic`).                                                                                                                                      |
+| `apiKey`             | The vendor credential.                                                                                                                                                                                      |
+| `baseUrl`            | Optional override for OpenAI-compatible / self-hosted endpoints.                                                                                                                                            |
 | `headers`            | Optional extra HTTP headers, as a JSON object, sent with every request to this Provider. On OpenRouter, setting any [app attribution](#openrouter-app-attribution) header here replaces all three defaults. |
-| `region`             | Required for Bedrock (AWS region).                                                                                                                              |
-| `modelIds`           | The models this Provider exposes for selection (at least one). Each entry is an object carrying that model's own settings — see [What each model entry holds](#what-each-model-entry-holds). |
-| `taskModelId`        | The model used for one-shot internal tasks (e.g. generating a chat title), not chat turns. Must be a real model id — a Model alias is rejected.                  |
-| `securityGuardrails` | Optional free-text security directives appended last in the system prompt for every run on this Provider.                                                       |
+| `region`             | Required for Bedrock (AWS region).                                                                                                                                                                          |
+| `modelIds`           | The models this Provider exposes for selection (at least one). Each entry is an object carrying that model's own settings — see [What each model entry holds](#what-each-model-entry-holds).                |
+| `taskModelId`        | The model used for one-shot internal tasks (e.g. generating a chat title), not chat turns. Must be a real model id — a Model alias is rejected.                                                             |
+| `securityGuardrails` | Optional free-text security directives appended last in the system prompt for every run on this Provider.                                                                                                   |
 
 A Provider also carries the models used for **Memory** (extraction and
 embeddings), so background memory features have a model to call. Like
@@ -69,11 +69,11 @@ OpenRouter credits each request to an app, and that credit is what puts an app o
 its public model pages and rankings. Platypus claims that credit for the project
 by default: every request from an **OpenRouter** Provider carries
 
-| Header                     | Value                                   |
-| -------------------------- | --------------------------------------- |
-| `HTTP-Referer`             | `https://github.com/willdady/platypus`  |
-| `X-OpenRouter-Title`       | `Platypus`                              |
-| `X-OpenRouter-Categories`  | `personal-agent,general-chat`           |
+| Header                    | Value                                  |
+| ------------------------- | -------------------------------------- |
+| `HTTP-Referer`            | `https://github.com/willdady/platypus` |
+| `X-OpenRouter-Title`      | `Platypus`                             |
+| `X-OpenRouter-Categories` | `personal-agent,general-chat`          |
 
 So out of the box, your usage counts toward the Platypus project's public
 ranking. Nothing else changes: requests go to the same endpoint, on your own API
@@ -105,11 +105,11 @@ Attribution is per Provider, not per deployment, so two OpenRouter Providers in
 the same Organization can attribute differently.
 
 <Callout type="warning">
-  Leaving **Headers** empty does not opt out — that's what gives you the Platypus
-  defaults. To send no attribution at all, set `HTTP-Referer` to an empty string.
-  That drops all three headers — including a title or categories you set
-  yourself, since OpenRouter cannot attribute those without a referer. Your
-  other custom headers are still sent.
+  Leaving **Headers** empty does not opt out — that's what gives you the
+  Platypus defaults. To send no attribution at all, set `HTTP-Referer` to an
+  empty string. That drops all three headers — including a title or categories
+  you set yourself, since OpenRouter cannot attribute those without a referer.
+  Your other custom headers are still sent.
 </Callout>
 
 ### What each model entry holds
@@ -120,18 +120,19 @@ and behind a proxy Platypus has no way to infer any of them — model names ther
 are whatever the operator chose. So each entry in `modelIds` is an object, and
 everything on it beyond the id is **declared, not guessed**:
 
-| Per-model field         | Meaning                                                                                                                                                                        |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                    | The model id sent to the vendor.                                                                                                                                               |
-| `alias`                 | Optional stable name an Agent or Chat selects this model by, so repointing it upgrades them all at once. See [Model aliases](/concepts/providers#model-aliases).                |
-| `contextWindow`         | The vendor's published **total** token capacity for this model — the whole window, not a cap on the reply. 1,000–10,000,000 tokens. Empty means undeclared, which is normal.    |
+| Per-model field         | Meaning                                                                                                                                                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                    | The model id sent to the vendor.                                                                                                                                                                  |
+| `alias`                 | Optional stable name an Agent or Chat selects this model by, so repointing it upgrades them all at once. See [Model aliases](/concepts/providers#model-aliases).                                  |
+| `contextWindow`         | The vendor's published **total** token capacity for this model — the whole window, not a cap on the reply. 1,000–10,000,000 tokens. Empty means undeclared, which is normal.                      |
 | `passthroughFileTypes`  | The media types this model ingests **natively**. Comma-separated in the UI; wildcards like `image/*` allowed. Empty inherits the [provider-type default](#file-handling-what-each-model-accepts). |
-| `maxExtractedTextChars` | Cap on the text a single extracted document may add to a turn. Empty uses the default (50,000 characters).                                                                     |
+| `maxExtractedTextChars` | Cap on the text a single extracted document may add to a turn. Empty uses the default (50,000 characters).                                                                                        |
+| `maxOutputTokens`       | The most this model may produce in a single reply. Empty sends nothing and leaves the vendor's own default in place. See [Capping a single reply](#capping-a-single-reply).                       |
 
 Every field is optional except the id, and a Provider set up before any of them
 existed keeps working with none of them set.
 
-In the form, **Context window** sits on the model row itself; the last two sit
+In the form, **Context window** sits on the model row itself; the last three sit
 behind **Advanced** on each row — collapsed unless that model already has one of
 them set. Every field carries an **i** you can hover or focus for the same
 explanation.
@@ -154,6 +155,30 @@ down.
   the field does is tell Platypus a capacity it has no way to look up. Leaving
   it empty breaks nothing.
 </Callout>
+
+#### Capping a single reply
+
+**Max output tokens** is the ceiling on one reply — the answer, not the whole
+conversation. Reach it and the reply stops wherever it got to, and the Chat or
+run is marked cut short at the model's output limit.
+
+Leave it empty and Platypus sends no ceiling at all, so whatever the vendor does
+by default applies. Set it to the model's published output maximum when you want
+long answers, or lower to hold replies (and spend) down. The same ceiling
+applies when that model runs as a sub-Agent.
+
+<Callout type="warning">
+  **On Amazon Bedrock, empty is not "the model's maximum".** Bedrock applies a
+  default of its own when no ceiling is sent — AWS does not document the figure,
+  and in practice it lands around 4,000 tokens, far below what an Opus-class
+  model can write. Long agentic runs stop mid-answer for no visible reason. Set
+  **Max output tokens** on every Bedrock model to the figure the vendor
+  publishes for it. Other provider types carry sane defaults of their own and
+  only need this field when you want a different ceiling.
+</Callout>
+
+Ask for more than the model allows and the vendor rejects the turn — Platypus
+sends the number as typed and does not check it against the model.
 
 ### File handling: what each model accepts
 

--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -101,6 +101,7 @@ describe("ProviderForm model rows", () => {
       "Context window",
       "Native file types",
       "Max extracted text characters",
+      "Max output tokens",
     ]) {
       expect(
         screen.getByRole("button", { name: `About ${label}` }),
@@ -113,6 +114,7 @@ describe("ProviderForm model rows", () => {
 
     expect(screen.queryByLabelText("Native file types")).toBeNull();
     expect(screen.queryByLabelText("Max extracted text characters")).toBeNull();
+    expect(screen.queryByLabelText("Max output tokens")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Advanced" }));
 
@@ -120,6 +122,7 @@ describe("ProviderForm model rows", () => {
     expect(
       screen.getByLabelText("Max extracted text characters"),
     ).toBeInTheDocument();
+    expect(screen.getByLabelText("Max output tokens")).toBeInTheDocument();
   });
 
   // Unlike the file-handling pair, this one is visible on a collapsed row: an
@@ -245,6 +248,59 @@ describe("ProviderForm model rows", () => {
     expect(screen.getByLabelText("Max extracted text characters")).toHaveValue(
       1000,
     );
+  });
+
+  // Same rule as the file-handling pair: a ceiling someone declared must not be
+  // hidden behind a collapsed section where the next reader won't find it.
+  it("opens a row whose only Advanced setting is a declared output ceiling", () => {
+    renderEditForm([
+      { id: "gpt-4o", passthroughFileTypes: [], maxOutputTokens: 64000 },
+    ]);
+
+    expect(screen.getByLabelText("Max output tokens")).toHaveValue(64000);
+  });
+
+  it("sends a declared output ceiling back unchanged, so it survives a save", async () => {
+    const fetchMock = mockAcceptedSave();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditForm([
+      { id: "gpt-4o", passthroughFileTypes: [], maxOutputTokens: 64000 },
+    ]);
+    save();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(savedModelIds(fetchMock)[0].maxOutputTokens).toBe(64000);
+  });
+
+  // Emptying the input has to actually clear the stored value. The whole
+  // `modelIds` array is replaced on save, so an absent key is a real removal —
+  // but only if the form stops sending the old number.
+  it("clears a declared output ceiling when the input is emptied", async () => {
+    const fetchMock = mockAcceptedSave();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditForm([
+      { id: "gpt-4o", passthroughFileTypes: [], maxOutputTokens: 64000 },
+    ]);
+    fireEvent.change(screen.getByLabelText("Max output tokens"), {
+      target: { value: "" },
+    });
+    save();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(savedModelIds(fetchMock)[0]).not.toHaveProperty("maxOutputTokens");
+  });
+
+  it("declares no output ceiling for a row that was left alone", async () => {
+    const fetchMock = mockAcceptedSave();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditForm([{ id: "gpt-4o", passthroughFileTypes: [] }]);
+    save();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(savedModelIds(fetchMock)[0].maxOutputTokens).toBeUndefined();
   });
 
   it("expands only the row that has config, leaving its neighbours collapsed", () => {
@@ -398,6 +454,30 @@ describe("ProviderForm validation errors on model rows", () => {
       ).toBeInTheDocument(),
     );
     expect(screen.getByText("Too small")).toBeInTheDocument();
+  });
+
+  it("opens a collapsed row when the server rejects its output ceiling", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockRejectedSave([
+        {
+          path: ["modelIds", 0, "maxOutputTokens"],
+          message: "Too small: expected number to be >0",
+        },
+      ]),
+    );
+
+    renderEditForm([{ id: "a", passthroughFileTypes: [] }]);
+    expect(screen.queryByLabelText("Max output tokens")).toBeNull();
+
+    save();
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Max output tokens")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText("Too small: expected number to be >0"),
+    ).toBeInTheDocument();
   });
 
   // The window sits outside Advanced, so its rejection needs no disclosure

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -401,9 +401,8 @@ const ModelRow = ({
                 <>
                   The most this model may produce in a{" "}
                   <strong>single reply</strong> — a cap on the answer, not the
-                  window. Leave empty to use the vendor’s own default, which on{" "}
-                  <strong>Amazon Bedrock</strong> is far below what the model
-                  can actually write and cuts long answers short.
+                  window. Leave empty to use the vendor’s own default, which may
+                  be well below what the model can actually write.
                 </>
               }
               error={errors.fields.maxOutputTokens}

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -164,7 +164,8 @@ const ModelRow = ({
 }) => {
   const [showAdvanced, setShowAdvanced] = useState(
     model.passthroughFileTypes.length > 0 ||
-      model.maxExtractedTextChars !== undefined,
+      model.maxExtractedTextChars !== undefined ||
+      model.maxOutputTokens !== undefined,
   );
 
   // Whether the Context window is being typed rather than picked. State as well
@@ -192,7 +193,8 @@ const ModelRow = ({
   // server is complaining about.
   const hasAdvancedError =
     !!errors.fields.passthroughFileTypes ||
-    !!errors.fields.maxExtractedTextChars;
+    !!errors.fields.maxExtractedTextChars ||
+    !!errors.fields.maxOutputTokens;
   const advancedOpen = showAdvanced || hasAdvancedError;
 
   // Passthrough types are edited as a comma-separated string of media types.
@@ -202,9 +204,13 @@ const ModelRow = ({
       .map((t) => t.trim())
       .filter((t) => t.length > 0);
 
-  // An empty (or nonsense) cap means "use the shared default" rather than 0 —
-  // sending 0 would truncate every extracted document to nothing (issue #342).
-  const parseExtractedTextCap = (value: string): number | undefined => {
+  // Shared by the two numeric Advanced fields. An empty (or nonsense) value
+  // means "unset, use the default" rather than 0 — sending 0 would truncate
+  // every extracted document to nothing (issue #342), and would cap every reply
+  // at nothing (issue #454). Undefined is also what clears a value already
+  // stored: the whole `modelIds` array is replaced on save, so the key simply
+  // stops being sent.
+  const parsePositiveInt = (value: string): number | undefined => {
     const parsed = Number.parseInt(value, 10);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
   };
@@ -381,9 +387,37 @@ const ModelRow = ({
                 value={model.maxExtractedTextChars ?? ""}
                 onChange={(e) =>
                   onChange({
-                    maxExtractedTextChars: parseExtractedTextCap(
-                      e.target.value,
-                    ),
+                    maxExtractedTextChars: parsePositiveInt(e.target.value),
+                  })
+                }
+                disabled={disabled}
+              />
+            </ModelField>
+
+            <ModelField
+              htmlFor={`max-output-tokens-${index}`}
+              label="Max output tokens"
+              hint={
+                <>
+                  The most this model may produce in a{" "}
+                  <strong>single reply</strong> — a cap on the answer, not the
+                  window. Leave empty to use the vendor’s own default, which on{" "}
+                  <strong>Amazon Bedrock</strong> is far below what the model
+                  can actually write and cuts long answers short.
+                </>
+              }
+              error={errors.fields.maxOutputTokens}
+            >
+              <Input
+                id={`max-output-tokens-${index}`}
+                type="number"
+                min={1}
+                placeholder="Provider default"
+                value={model.maxOutputTokens ?? ""}
+                aria-invalid={!!errors.fields.maxOutputTokens}
+                onChange={(e) =>
+                  onChange({
+                    maxOutputTokens: parsePositiveInt(e.target.value),
                   })
                 }
                 disabled={disabled}

--- a/apps/frontend/lib/model-config.test.ts
+++ b/apps/frontend/lib/model-config.test.ts
@@ -41,6 +41,25 @@ describe("getModelConfigs", () => {
       passthroughFileTypes: [],
     });
   });
+
+  it("carries a declared maxOutputTokens through", () => {
+    const configs = getModelConfigs(
+      provider([
+        { id: "gpt-4", passthroughFileTypes: [], maxOutputTokens: 64000 },
+      ]),
+    );
+    expect(configs[0].maxOutputTokens).toBe(64000);
+  });
+
+  it("leaves maxOutputTokens undefined for an undeclared or legacy entry", () => {
+    expect(
+      getModelConfigs(provider([{ id: "gpt-4", passthroughFileTypes: [] }]))[0]
+        .maxOutputTokens,
+    ).toBeUndefined();
+    expect(
+      getModelConfigs(provider(["gpt-4"]))[0].maxOutputTokens,
+    ).toBeUndefined();
+  });
 });
 
 describe("getModelOptions", () => {

--- a/apps/frontend/lib/model-config.ts
+++ b/apps/frontend/lib/model-config.ts
@@ -27,6 +27,11 @@ export type ModelConfigView = {
   /** Cap on injected extracted-document text; undefined uses the shared default. */
   maxExtractedTextChars?: number;
   /**
+   * Ceiling on a single reply from this model. Undefined sends nothing and
+   * leaves the provider's own default in place (issue #454).
+   */
+  maxOutputTokens?: number;
+  /**
    * The vendor's published total token capacity, declared by an Org Admin
    * (ADR-0018). Undefined means undeclared, which is the normal state.
    */
@@ -49,6 +54,7 @@ export const getModelConfigs = (
           alias: m.alias,
           passthroughFileTypes: m.passthroughFileTypes ?? [],
           maxExtractedTextChars: m.maxExtractedTextChars,
+          maxOutputTokens: m.maxOutputTokens,
           contextWindow: m.contextWindow,
         },
   );

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -530,6 +530,69 @@ describe("Provider modelIds (per-model config)", () => {
     }
   });
 
+  it("accepts a per-model maxOutputTokens override", () => {
+    const result = providerCreateSchema.safeParse({
+      ...base,
+      modelIds: [{ id: "qwen", maxOutputTokens: 64000 }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelIds[0].maxOutputTokens).toBe(64000);
+    }
+  });
+
+  // Optional on BOTH paths for the same reason the window is: a Provider saved
+  // untouched through the update schema must not become a 400.
+  it.each([
+    ["create", providerCreateSchema],
+    ["update", providerUpdateSchema],
+  ])(
+    "leaves maxOutputTokens undefined on %s when not declared",
+    (_, schema) => {
+      const result = schema.safeParse({ ...base, modelIds: [{ id: "qwen" }] });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.modelIds).toHaveLength(1);
+        expect(result.data.modelIds![0].maxOutputTokens).toBeUndefined();
+      }
+    },
+  );
+
+  it("rejects a non-positive or fractional maxOutputTokens", () => {
+    for (const value of [0, -1, 1.5]) {
+      expect(
+        providerCreateSchema.safeParse({
+          ...base,
+          modelIds: [{ id: "qwen", maxOutputTokens: value }],
+        }).success,
+        `maxOutputTokens ${value} should be rejected`,
+      ).toBe(false);
+    }
+  });
+
+  // No upper bound, unlike the Context window: the ceiling that matters is the
+  // model's own, Platypus cannot know it, and a value above it is the vendor's
+  // to reject.
+  it("accepts a maxOutputTokens far above any published ceiling", () => {
+    expect(
+      providerCreateSchema.safeParse({
+        ...base,
+        modelIds: [{ id: "qwen", maxOutputTokens: 10_000_000 }],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("survives the legacy string[] coercion as undefined", () => {
+    const result = providerCreateSchema.safeParse({
+      ...base,
+      modelIds: ["gpt-4"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.modelIds[0].maxOutputTokens).toBeUndefined();
+    }
+  });
+
   it("accepts a declared contextWindow", () => {
     const result = providerCreateSchema.safeParse({
       ...base,

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -588,6 +588,17 @@ export type ProviderApiMode = z.infer<typeof providerApiModeSchema>;
 // model, declared by an Org Admin because nothing can discover it — see
 // ADR-0018. Optional always, and nothing reads it yet.
 //
+// `maxOutputTokens` caps a SINGLE reply, and unlike `contextWindow` it is
+// enforced: it becomes the generation call's output ceiling for every turn on
+// this model. Omitted means Platypus sends nothing and the provider's own
+// default applies — which is fine for the direct Anthropic provider (it carries
+// a per-model fallback table) and silently truncating on Amazon Bedrock, whose
+// Converse API omits `inferenceConfig.maxTokens` entirely when nothing is
+// passed and falls back to a default far below the model's real ceiling (issue
+// #454). Deliberately unbounded above: the only meaningful ceiling is the
+// model's own, Platypus cannot know it behind a proxy, and a value the model
+// won't take is the vendor's to reject.
+//
 // The universal wildcard (`*/*` or `*`) is an advanced escape hatch: it sends
 // EVERY attached file to the model raw. Values are deliberately NOT validated
 // as MIME patterns, so declaring a type the endpoint can't actually ingest is
@@ -746,6 +757,7 @@ export const modelConfigSchema = z.object({
     .optional(),
   passthroughFileTypes: z.array(z.string()).default([]),
   maxExtractedTextChars: z.number().int().positive().optional(),
+  maxOutputTokens: z.number().int().positive().optional(),
   contextWindow: z
     .number()
     .int()


### PR DESCRIPTION
Closes #454

## What

A Provider's per-model entry gains an optional **Max output tokens**, sent as the generation call's output limit for every Chat turn, unattended run, and delegated sub-Agent run against that model. Leaving it empty sends nothing, so every existing Provider behaves exactly as it does today.

The field sits in the same **Advanced** section on each model row as **Native file types** and **Max extracted text characters** — not promoted to the top level the way **Context window** is.

## Why

Platypus never set an output limit on any provider call. That is harmless for the direct Anthropic provider, which carries a per-model fallback table. It is not harmless for Amazon Bedrock: `@ai-sdk/amazon-bedrock` only emits `inferenceConfig.maxTokens` when a value is explicitly passed, so the field was omitted from the Converse request entirely and Bedrock applied a default of its own — undocumented by AWS, in practice around 4,000 tokens — regardless of the model's real ceiling. Long agentic runs stopped mid-answer, with only the reactive "cut short at the model's output limit" notice to show for it.

## Notes

- **Deliberately unbounded above**, unlike the Context window. The only meaningful ceiling is the model's own, Platypus cannot know it behind a proxy, and a value the model won't take is the vendor's to reject. Consistent with the issue's "passed through as-is".
- **No default of our own.** An undeclared model reaches the SDK with no ceiling at all, exactly as before the field existed — the sane value differs per provider and per model.
- **Sub-Agents included.** Delegation builds its own `ToolLoopAgent` rather than going through `streamText`/`generateText`, so it needed wiring separately, from each sub-Agent's *own* Provider model entry. Without it #454 would have persisted one level down.
- **Not included:** the Provider's one-shot executions (Chat metadata, memory extraction) run against its pointer-settings rather than a Chat turn and carry no ceiling. `CONTEXT.md` says so explicitly rather than implying coverage.

## Verification

`pnpm typecheck`, `pnpm lint` and `pnpm test` all pass (1593 backend / 116 frontend / 112 schemas / 25 docs-contract).

The Bedrock leg is **not verified against a live Provider** — it rests on the AI SDK source plus the runner tests asserting the value reaches `streamText`/`generateText`. Worth a real-world confirmation before relying on it.

## Docs

`self-hosting/providers-and-auth.mdx` gains the field row and a **Capping a single reply** section carrying the Bedrock trap; `chat.mdx` and `triggers.mdx` link to it from their existing cut-short sections. `CONTEXT.md` gains an **Output ceiling** term, distinguished from **Context window** — one bounds the reply and is enforced, the other describes the whole capacity and is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
