### PR TITLE
feat(chat): show Context occupancy in the composer and on Trigger runs

### DIFF
--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -538,6 +538,85 @@ describe("AgentRunner.generate", () => {
     expect(dispose).toHaveBeenCalledTimes(1);
   });
 
+  // ADR-0018: an unattended run's only record of how full the context got is
+  // the stats it hands the sink, and the two plausible-looking figures beside
+  // occupancy — `totalUsage.inputTokens` and the accumulated `stats.inputTokens`
+  // — are both cross-step sums.
+  it("records Context occupancy from the final step, not the sum across steps", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    mockGenerateText.mockResolvedValueOnce({
+      text: "ok",
+      steps: [
+        { toolCalls: [], usage: { inputTokens: 1_000, outputTokens: 40 } },
+        { toolCalls: [], usage: { inputTokens: 3_500, outputTokens: 60 } },
+      ],
+      totalUsage: { inputTokens: 4_500, outputTokens: 100 },
+    });
+
+    const sink = new RecordingSink();
+    const result = await runner.generate({ scope, input: baseInput, sink });
+
+    expect(result.stats.contextOccupancy).toBe(3_500);
+    const finish = sink.events.at(-1) as Extract<
+      LifecycleEvent,
+      { name: "onFinish" }
+    >;
+    expect(finish.stats?.contextOccupancy).toBe(3_500);
+    // The billing sums keep their existing meaning.
+    expect(finish.stats?.inputTokens).toBe(4_500);
+    expect(finish.stats?.outputTokens).toBe(100);
+  });
+
+  // The interim stats a long run flushes mid-flight are what the Operator reads
+  // while it is still going, so a step that reports nothing must not leave an
+  // earlier, smaller step's figure looking current.
+  it("clears the interim occupancy when a step reports no usage", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    const progressed: Array<number | undefined> = [];
+    mockGenerateText.mockImplementationOnce(
+      async ({
+        onStepFinish,
+      }: {
+        onStepFinish: (s: unknown) => void | Promise<void>;
+      }) => {
+        await onStepFinish({
+          toolCalls: [],
+          usage: { inputTokens: 1_000, outputTokens: 40 },
+        });
+        await onStepFinish({ toolCalls: [] });
+        return { text: "ok", steps: [{ toolCalls: [] }], totalUsage: {} };
+      },
+    );
+
+    const sink = new RecordingSink();
+    const recorded = sink.onProgress.bind(sink);
+    // Read at call time: the runner passes one mutated stats object every time,
+    // so the figure has to be copied out as each flush happens.
+    sink.onProgress = (ctx: { runId: string; stats?: RunStats }) => {
+      progressed.push(ctx.stats?.contextOccupancy);
+      return recorded(ctx);
+    };
+    await runner.generate({ scope, input: baseInput, sink });
+
+    expect(progressed).toEqual([1_000, undefined]);
+  });
+
+  it("records no occupancy when the Provider reports no usage", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    mockGenerateText.mockResolvedValueOnce({
+      text: "ok",
+      steps: [{ toolCalls: [] }],
+      totalUsage: {},
+    });
+
+    const sink = new RecordingSink();
+    const result = await runner.generate({ scope, input: baseInput, sink });
+
+    // Unknown stays unknown: nothing is estimated, and 0 would read as a
+    // measurement of an empty context.
+    expect(result.stats.contextOccupancy).toBeUndefined();
+  });
+
   it("invariant: reaches onFinish even when prepareChatTurn throws", async () => {
     mockPrepareChatTurn.mockRejectedValueOnce(new Error("Agent not found"));
 

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -62,6 +62,15 @@ export type GenerateResult = {
 };
 
 /**
+ * One step's Context occupancy: the input tokens the vendor reported for it,
+ * which is the whole conversation as that call sent it (ADR-0018). `undefined`
+ * where the step reported none — nothing is estimated, and 0 would read as a
+ * measurement of an empty context.
+ */
+const stepOccupancy = (usage?: { inputTokens?: number }): number | undefined =>
+  typeof usage?.inputTokens === "number" ? usage.inputTokens : undefined;
+
+/**
  * Folds a single step's tool calls and usage into a running `RunStats`
  * accumulator. Mutates `stats` in place. Used by `onStepFinish` so the
  * sink can observe partial progress without waiting for the final result.
@@ -87,6 +96,13 @@ const accumulateStepStats = (
     stats.outputTokens =
       (stats.outputTokens ?? 0) + (step.usage.outputTokens ?? 0);
   }
+  // REPLACED, not summed, and outside the guard above: the whole conversation
+  // is in every step's input count, so the latest step is the current context
+  // size while the running totals are sums of context sizes (ADR-0018). A step
+  // that reports nothing — no count, or no usage object at all — clears the
+  // figure rather than leaving an earlier, smaller step's standing as if it
+  // were current, which is what a mid-run stats flush would otherwise publish.
+  stats.contextOccupancy = stepOccupancy(step.usage);
 };
 
 /**
@@ -94,7 +110,10 @@ const accumulateStepStats = (
  * `totalUsage`. Works for both stream and generate paths.
  */
 const computeStats = (result: {
-  steps: Array<{ toolCalls: Array<{ toolName: string }> }>;
+  steps: Array<{
+    toolCalls: Array<{ toolName: string }>;
+    usage?: { inputTokens?: number };
+  }>;
   totalUsage: { inputTokens?: number; outputTokens?: number };
 }): RunStats => {
   const toolCallCounts = new Map<string, number>();
@@ -106,11 +125,19 @@ const computeStats = (result: {
       );
     }
   }
+  // The FINAL step only. Scanning back for the most recent step that did report
+  // a count would answer with a smaller, earlier context as though it were the
+  // one the run ended on.
+  const contextOccupancy = stepOccupancy(result.steps.at(-1)?.usage);
   return {
     steps: result.steps.length,
     toolCalls: Array.from(toolCallCounts, ([name, count]) => ({ name, count })),
     inputTokens: result.totalUsage.inputTokens ?? 0,
     outputTokens: result.totalUsage.outputTokens ?? 0,
+    // Spread so a run whose Provider reported no usage stores no key at all,
+    // matching the schema's optional field: absent means unknown, and 0 would
+    // read as a measurement of an empty context.
+    ...(contextOccupancy === undefined ? {} : { contextOccupancy }),
   };
 };
 

--- a/apps/backend/src/runs/sinks/trigger-sink.test.ts
+++ b/apps/backend/src/runs/sinks/trigger-sink.test.ts
@@ -162,6 +162,49 @@ describe("TriggerSink", () => {
       expect(setArg.completedAt).toBeInstanceOf(Date);
     });
 
+    // Issue #446 / ADR-0018: an Operator reading the runs page can see a
+    // scheduled Agent heading for the limit only if the figure is recorded.
+    it("persists Context occupancy alongside the unchanged token sums", async () => {
+      const sink = new TriggerSink({ triggerId: "trigger-1" });
+
+      await sink.onFinish({
+        runId: "run-1",
+        status: "succeeded",
+        messages: [],
+        stats: {
+          steps: 4,
+          toolCalls: [{ name: "tool1", count: 3 }],
+          inputTokens: 100,
+          outputTokens: 50,
+          contextOccupancy: 42,
+        },
+      });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.stats).toEqual({
+        steps: 4,
+        toolCalls: [{ name: "tool1", count: 3 }],
+        inputTokens: 100,
+        outputTokens: 50,
+        contextOccupancy: 42,
+      });
+    });
+
+    it("omits occupancy for a Provider that reported no usage", async () => {
+      const sink = new TriggerSink({ triggerId: "trigger-1" });
+
+      await sink.onFinish({
+        runId: "run-1",
+        status: "succeeded",
+        messages: [],
+        stats: { steps: 1, toolCalls: [], inputTokens: 0, outputTokens: 0 },
+      });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      // Absent, not 0: a zero would read as a measurement of an empty context.
+      expect(setArg.stats).not.toHaveProperty("contextOccupancy");
+    });
+
     it("maps a failed run to status 'failed' with the error message", async () => {
       const sink = new TriggerSink({ triggerId: "trigger-1" });
 

--- a/apps/backend/src/runs/sinks/trigger-sink.ts
+++ b/apps/backend/src/runs/sinks/trigger-sink.ts
@@ -35,6 +35,12 @@ const toTriggerRunStats = (stats: RunStats): TriggerRunStats | null => {
     toolCalls: stats.toolCalls ?? [],
     inputTokens: stats.inputTokens ?? 0,
     outputTokens: stats.outputTokens ?? 0,
+    // Spread rather than defaulted to 0: unlike the sums above, an absent
+    // occupancy means the Provider reported no usage, and writing 0 there would
+    // record an empty context as a measurement (ADR-0018).
+    ...(stats.contextOccupancy === undefined
+      ? {}
+      : { contextOccupancy: stats.contextOccupancy }),
     // Spread so an untruncated run stores no key at all, matching the schema's
     // `z.literal(true).optional()`.
     ...(stats.truncatedByTokenLimit

--- a/apps/backend/src/runs/types.ts
+++ b/apps/backend/src/runs/types.ts
@@ -8,8 +8,19 @@ export type RunStatus = "running" | "succeeded" | "failed" | "cancelled";
 export type RunStats = {
   steps?: number;
   toolCalls?: Array<{ name: string; count: number }>;
+  /** Cross-step SUMS of every step's usage — billing figures, not occupancy. */
   inputTokens?: number;
   outputTokens?: number;
+  /**
+   * How full the model's context got: the input tokens reported for the LAST
+   * step, which is the whole conversation as last sent (ADR-0018). A last
+   * value, never a sum — `inputTokens` above folds every step together and on a
+   * long tool-using turn reads roughly an order of magnitude high.
+   *
+   * Absent where the Provider reported no usage. Nothing is estimated, and 0 is
+   * never substituted: it would read as a measurement of an empty context.
+   */
+  contextOccupancy?: number;
   /**
    * Set only when the run stopped at the model's output ceiling. Absent rather
    * than `false`, mirroring the Chat message metadata marker.

--- a/apps/backend/src/services/model-capability.test.ts
+++ b/apps/backend/src/services/model-capability.test.ts
@@ -7,6 +7,7 @@ import {
   passthroughFileTypesForModel,
   maxExtractedTextCharsForModel,
   maxOutputTokensForModel,
+  contextWindowForModel,
   dedupeModelConfigs,
   resolveModelId,
 } from "./model-capability.ts";
@@ -222,6 +223,49 @@ describe("maxOutputTokensForModel", () => {
       modelIds: ["legacy"] as unknown as Provider["modelIds"],
     });
     expect(maxOutputTokensForModel(p, concrete("legacy"))).toBeUndefined();
+  });
+});
+
+describe("contextWindowForModel", () => {
+  it("returns the model's declared window", () => {
+    const p = provider({
+      modelIds: [
+        { id: "qwen", passthroughFileTypes: [], contextWindow: 32_000 },
+      ],
+    });
+    expect(contextWindowForModel(p, concrete("qwen"))).toBe(32_000);
+  });
+
+  it("returns undefined when undeclared or unknown", () => {
+    const p = provider({
+      modelIds: [{ id: "qwen", passthroughFileTypes: [] }],
+    });
+    // No default to fall back to: unlike the extracted-text cap, an undeclared
+    // window has no safe substitute — inventing one is what ADR-0018 forbids.
+    expect(contextWindowForModel(p, concrete("qwen"))).toBeUndefined();
+    expect(contextWindowForModel(p, concrete("ghost"))).toBeUndefined();
+  });
+
+  it("survives a legacy string[] model list", () => {
+    const p = provider({
+      modelIds: ["legacy"] as unknown as Provider["modelIds"],
+    });
+    expect(contextWindowForModel(p, concrete("legacy"))).toBeUndefined();
+  });
+
+  it("reads each Provider's own declaration for the same model id", () => {
+    const direct = provider({
+      modelIds: [
+        { id: "claude", passthroughFileTypes: [], contextWindow: 200_000 },
+      ],
+    });
+    const proxied = provider({
+      modelIds: [
+        { id: "claude", passthroughFileTypes: [], contextWindow: 32_000 },
+      ],
+    });
+    expect(contextWindowForModel(direct, concrete("claude"))).toBe(200_000);
+    expect(contextWindowForModel(proxied, concrete("claude"))).toBe(32_000);
   });
 });
 

--- a/apps/backend/src/services/model-capability.ts
+++ b/apps/backend/src/services/model-capability.ts
@@ -167,3 +167,18 @@ export const maxOutputTokensForModel = (
   provider: Provider,
   modelId: ConcreteModelId,
 ): number | undefined => modelEntry(provider, modelId)?.maxOutputTokens;
+
+/**
+ * The total token capacity an Org Admin declared for this model, or `undefined`
+ * where none was declared (ADR-0018).
+ *
+ * No default either, for a different reason from the ceiling above: nothing can
+ * discover a context window, so an undeclared one stays unknown and every reader
+ * hides rather than guesses. Keyed on `(provider, model)` because the same model
+ * reached directly and through a proxy can honestly differ, and because the
+ * declaration lives on the model entry a Model alias carries its window with it.
+ */
+export const contextWindowForModel = (
+  provider: Provider,
+  modelId: ConcreteModelId,
+): number | undefined => modelEntry(provider, modelId)?.contextWindow;

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -136,6 +136,44 @@ if replies keep stopping short of what the model can write.
   the work in smaller pieces to begin with.
 </Callout>
 
+## How full the conversation is
+
+A second limit sits alongside the one above, and it is not the same one: as well
+as a ceiling on what a model can **write**, there is a ceiling on what it can be
+**sent**. A Chat sends the whole conversation every turn, so a Chat that has been
+going a while is spending more of that room on each reply. A small meter beside
+the prompt input tells you how much of it the last turn used: a short bar, the
+percentage, and both token figures, as in `33% · 42,000/128,000`.
+
+The numbers matter as much as the bar. 33% of a 128,000-token model and 33% of
+an 8,000-token one are the same fraction and very different situations, so the
+meter always shows what it is a third _of_.
+
+It reads the **last completed turn**, which makes it one message behind: it
+cannot include what you are typing, because counting tokens is something only the
+model's vendor can do. Read it as "this is where the conversation stood", not "if
+I send this it will be that".
+
+When the meter is filling up, you have three options: prune the Chat by hand
+(see [editing and deleting
+messages](#fixing-a-conversation-instead-of-restarting-it)), start a new Chat, or
+switch to a model with a bigger window. Nothing happens automatically.
+
+<Callout type="warning">
+  **The meter appears; nothing enforces it.** Platypus does not trim, summarise,
+  warn, or block a turn for approaching the window — reaching it fails at the
+  vendor exactly as it did before, and the meter is the only thing that changed.
+  Treat a full meter as your cue to act, not as a guard rail that will catch you.
+</Callout>
+
+**No meter at all** means one of two things, and both are normal: nobody has
+declared a **Context window** for this model, or the Provider does not report
+token usage. Either way the capacity or the reading is unknown, and Platypus
+would rather show nothing than a number you cannot interpret. An Org Admin
+declares the window on the Provider's model entry — see [Declaring a Context
+window](/self-hosting/providers-and-auth#declaring-a-context-window). Switching
+model switches the meter with it, since the window belongs to the model.
+
 ## Fixing a conversation instead of restarting it
 
 Hover a message for its actions:

--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -76,7 +76,7 @@ Set **Max Runs to Keep** (how many run records to retain), optionally enable
 When a Trigger fires, Platypus runs its Agent against the **instruction** as a
 background job — there's no live Chat window. The run is captured as a
 **trigger run** record: it starts as _running_, accrues stats (steps, tool calls,
-token counts), and ends _success_ or _failed_.
+token counts, how full the Context window got), and ends _success_ or _failed_.
 
 A few details worth knowing:
 
@@ -102,6 +102,12 @@ The runs view shows each run's status (Success / Failed / Running / Pending),
 when it ran and how long it took, the event type for Event triggers, per-run
 stats, and any error message. It's the place to confirm a schedule is actually
 firing and to debug a Trigger that's failing.
+
+Among the per-run stats, **in / out** are the run's total token counts across
+every step — what the run cost — while **context** is a different quantity: how
+much of the model's Context window the conversation filled on the run's final
+step. Watch that one to see a Trigger heading for its model's limit before it
+starts failing there. It is absent for a Provider that reports no token usage.
 
 <Callout type="info">
   Anything an Agent does in a run uses that Agent's own tools — so a Trigger

--- a/apps/docs/content/concepts/memory-and-context.mdx
+++ b/apps/docs/content/concepts/memory-and-context.mdx
@@ -83,8 +83,11 @@ Agent's Instructions.
 The third is the model's own **Context window**: how many tokens a model can be
 sent at once, which an Org Admin declares on the Provider's model entry because
 no vendor publishes it in a form Platypus can read. It has nothing to do with
-either of the two above — it is a capacity, not something you write. See
-[What each model entry holds](/self-hosting/providers-and-auth#what-each-model-entry-holds).
+either of the two above — it is a capacity, not something you write. Where one is
+declared, a Chat shows how much of it the last turn used; see [How full the
+conversation is](/building-with-platypus/chat#how-full-the-conversation-is) and
+[What each model entry
+holds](/self-hosting/providers-and-auth#what-each-model-entry-holds).
 
 **Memory vs. Context:** Memory is built up automatically from your activity;
 Context is written deliberately by you. They work together — Memory remembers,

--- a/apps/docs/content/self-hosting/providers-and-auth.mdx
+++ b/apps/docs/content/self-hosting/providers-and-auth.mdx
@@ -148,12 +148,18 @@ Declaring less than the vendor's real capacity is safe; declaring more is not,
 because the vendor rejects the turn outright. So when you aren't sure, round
 down.
 
+Declaring a window makes a **context meter** appear beside the prompt input in
+every Chat on that model, showing how full the conversation got on its last turn
+— see [How full the conversation
+is](/building-with-platypus/chat#how-full-the-conversation-is). Leave it empty
+and that meter is hidden; nothing else changes.
+
 <Callout type="warning">
-  A Context window is a **statement**, not a budget. Platypus does not enforce
-  it: nothing warns, trims a conversation to fit, or blocks a turn for
-  approaching it, and a turn is assembled and sent exactly as it was before. All
-  the field does is tell Platypus a capacity it has no way to look up. Leaving
-  it empty breaks nothing.
+  A Context window is a **statement**, not a budget. Declaring it makes the
+  meter appear — it does not make Platypus enforce anything. Nothing warns, trims
+  a conversation to fit, or blocks a turn for approaching the window, and a turn
+  is assembled and sent exactly as it was before. Reaching the real limit still
+  fails at the vendor.
 </Callout>
 
 #### Capping a single reply

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.test.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.test.tsx
@@ -81,3 +81,27 @@ describe("Trigger runs truncation marker", () => {
     expect(screen.queryByText(RUN_CUT_SHORT_NOTICE)).toBeNull();
   });
 });
+
+// Without this an Operator can only see a scheduled Agent's context filling up
+// after it starts failing at the vendor (ADR-0018).
+describe("Trigger runs Context occupancy", () => {
+  it("shows how full the context got on the run's last step", async () => {
+    await renderRuns([run(stats({ contextOccupancy: 42000 }))]);
+
+    expect(screen.getByText(/42,000 context/)).toBeInTheDocument();
+  });
+
+  it("shows nothing where the Provider reported no usage", async () => {
+    await renderRuns([run(stats())]);
+
+    expect(screen.queryByText(/context/)).toBeNull();
+  });
+
+  it("leaves the existing token sums reading as they always have", async () => {
+    // These are cross-step billing sums an Operator has been reading; occupancy
+    // is a separate figure and must not be mistaken for either of them.
+    await renderRuns([run(stats({ contextOccupancy: 42000 }))]);
+
+    expect(screen.getByText(/100 in \/ 4096 out/)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.tsx
@@ -18,7 +18,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Badge } from "@/components/ui/badge";
-import { Loader2, Footprints, Wrench, MessageSquare } from "lucide-react";
+import {
+  Loader2,
+  Footprints,
+  Wrench,
+  MessageSquare,
+  Gauge,
+} from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RunCutShortNotice } from "@/components/run-cut-short-notice";
 
@@ -195,6 +201,26 @@ const TriggerRunsPage = ({
                                 {stats.inputTokens} in / {stats.outputTokens}{" "}
                                 out
                               </span>
+                              {/* How full the context got on the run's LAST
+                                  step, which is a different quantity from the
+                                  cross-step sums above (ADR-0018). Absent where
+                                  the Provider reported no usage — occupancy is
+                                  then unknown and nothing is estimated. */}
+                              {stats.contextOccupancy !== undefined && (
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <span className="flex items-center gap-1 cursor-default">
+                                      <Gauge className="h-3 w-3" />
+                                      {stats.contextOccupancy.toLocaleString()}{" "}
+                                      context
+                                    </span>
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    Tokens the conversation filled on the final
+                                    step
+                                  </TooltipContent>
+                                </Tooltip>
+                              )}
                             </div>
                           )}
                           {stats?.truncatedByTokenLimit && (

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -40,7 +40,12 @@ import { fetcher, joinUrl } from "@/lib/utils";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useChatSettings } from "@/hooks/use-chat-settings";
 import { useModelSelection } from "@/hooks/use-model-selection";
-import { getPassthroughFileTypes, resolveModelId } from "@/lib/model-config";
+import {
+  getContextWindow,
+  getPassthroughFileTypes,
+  resolveModelId,
+} from "@/lib/model-config";
+import { ContextMeter } from "./context-meter";
 import { FileCompatibilityWarning } from "./file-compatibility-warning";
 import { useMessageEditing } from "@/hooks/use-message-editing";
 import { useChatTitlePoll } from "@/hooks/use-chat-title-poll";
@@ -438,6 +443,30 @@ export const Chat = ({
       ? getPassthroughFileTypes(resolvedProvider, concreteModelId)
       : [];
 
+  // Context occupancy (ADR-0018): the capacity comes from the Org Admin's
+  // declaration on the resolved model, the reading from the latest assistant
+  // message that CARRIES one. It rides in the message metadata, so it survives a
+  // reload rather than staying blank until the next send, and a cancelled turn
+  // keeps whatever the run reported.
+  //
+  // Latest-that-carries-one rather than simply the latest: a turn in flight has
+  // no reading until its first step finishes, and blanking the meter over that
+  // gap would hide it exactly while the reader is watching. A run that reported
+  // a count and then stopped reporting writes a concrete `null`, which IS
+  // carried and hides the meter — that erasure is deliberate, so the key's
+  // presence is the test rather than its value.
+  //
+  // Either number missing hides the meter; `ContextMeter` owns that decision.
+  const contextWindow =
+    resolvedProvider && concreteModelId
+      ? getContextWindow(resolvedProvider, concreteModelId)
+      : undefined;
+  const contextOccupancy = messages
+    .filter(
+      (m) => m.role === "assistant" && "contextOccupancy" in (m.metadata ?? {}),
+    )
+    .at(-1)?.metadata?.contextOccupancy;
+
   // Treat a server-side run-in-progress as if we were locally streaming,
   // so a tab that reconnects mid-run (or an unrelated tab opened on the
   // same chat) can't kick off a second concurrent run. The submit button
@@ -679,6 +708,10 @@ export const Chat = ({
                       </Dialog>
                     )}
                   </PromptInputTools>
+                  <ContextMeter
+                    occupancy={contextOccupancy?.inputTokens}
+                    contextWindow={contextWindow}
+                  />
                   <PromptInputSubmit status={effectiveStatus} />
                 </PromptInputFooter>
               </PromptInput>

--- a/apps/frontend/components/context-meter.test.tsx
+++ b/apps/frontend/components/context-meter.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { ContextMeter } from "./context-meter";
+
+describe("ContextMeter", () => {
+  it("renders nothing when no Context window is declared", () => {
+    const { container } = render(<ContextMeter occupancy={42_000} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when occupancy is unknown", () => {
+    // Absent and null say the same thing — the Provider reported no usage for
+    // the last call of the turn — and neither is a number a reader could
+    // interpret without a denominator.
+    for (const occupancy of [undefined, null]) {
+      const { container } = render(
+        <ContextMeter occupancy={occupancy} contextWindow={128_000} />,
+      );
+      expect(container).toBeEmptyDOMElement();
+    }
+  });
+
+  it("shows the percentage and both token figures", () => {
+    render(<ContextMeter occupancy={42_000} contextWindow={128_000} />);
+
+    // Both numbers, not only a bar: 33% of 128k and 33% of 8k are different
+    // situations and a bar alone cannot tell them apart.
+    expect(screen.getByText(/42,000/)).toBeInTheDocument();
+    expect(screen.getByText(/128,000/)).toBeInTheDocument();
+    expect(screen.getByText(/33%/)).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "33",
+    );
+  });
+
+  it("clamps the bar and the percentage but not the figures when occupancy exceeds the window", () => {
+    // Under-declaring is the safe direction and therefore expected, so a
+    // deliberately conservative window must not make the meter look broken.
+    render(<ContextMeter occupancy={150_000} contextWindow={128_000} />);
+
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "100",
+    );
+    expect(screen.getByText(/100%/)).toBeInTheDocument();
+    expect(screen.queryByText(/117%/)).not.toBeInTheDocument();
+    expect(screen.getByText(/150,000/)).toBeInTheDocument();
+    expect(screen.getByText(/128,000/)).toBeInTheDocument();
+  });
+
+  it("rounds a nearly-empty window to a percentage rather than hiding", () => {
+    render(<ContextMeter occupancy={12} contextWindow={128_000} />);
+
+    expect(screen.getByText(/0%/)).toBeInTheDocument();
+    expect(screen.getByText(/12/)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/context-meter.tsx
+++ b/apps/frontend/components/context-meter.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+/**
+ * How full the model's context was on the last completed turn (ADR-0018).
+ *
+ * Purely presentational: it takes the two numbers and decides only how to show
+ * them. Picking the reading off the most recent assistant message, and the
+ * declared window off the resolved model, belongs to the composing component.
+ *
+ * Renders nothing unless BOTH numbers are known — one hidden state with two
+ * causes (no window declared, or the Provider reported no usage). A numerator
+ * with no denominator would be a third display mode answering none of the
+ * questions a meter exists for: a bare "42,000 tokens" cannot say whether that
+ * is roomy or nearly fatal.
+ */
+export const ContextMeter = ({
+  occupancy,
+  contextWindow,
+}: {
+  /**
+   * Input tokens the vendor reported for the last model call of the turn.
+   * `null` and absent both mean unknown and differ only in why.
+   */
+  occupancy?: number | null;
+  /** The window an Org Admin declared for this model, if any. */
+  contextWindow?: number;
+}) => {
+  if (occupancy == null || contextWindow == null) return null;
+
+  // Clamped, because under-declaring a window is the SAFE direction and
+  // therefore expected: a 128k declaration against a real 200k model is a
+  // deliberate choice, not a fault, and must not render as 117% or a bar
+  // overflowing its track. The figures below stay true.
+  const percent = Math.min(100, Math.round((occupancy / contextWindow) * 100));
+  const used = occupancy.toLocaleString();
+  const total = contextWindow.toLocaleString();
+
+  return (
+    <Tooltip delayDuration={300}>
+      <TooltipTrigger asChild>
+        <div className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
+          <div
+            role="progressbar"
+            aria-valuenow={percent}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label="Context used"
+            className="h-1 w-10 overflow-hidden rounded-full bg-muted"
+          >
+            <div
+              className="h-full rounded-full bg-muted-foreground/60"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+          <span className="tabular-nums whitespace-nowrap">
+            {percent}% · {used}/{total}
+          </span>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        {/* One turn stale, and said so: nothing can count the tokens of a draft
+            locally, so the reading describes the last turn that was sent. */}
+        {used} of {total} tokens after the last turn.
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -272,8 +272,9 @@ const ModelRow = ({
               The vendor&apos;s published <strong>total</strong> token capacity
               for this model — the whole window, not a cap on the reply. Sizes
               in the list are decimal, so <code>128k</code> is 128,000.
-              Optional: nothing reads it yet, and leaving it unset breaks
-              nothing — it records a capacity Platypus has no way to look up.
+              Optional, and leaving it unset breaks nothing: without it, the
+              context meter in a Chat is hidden for this model, because Platypus
+              has no way to look the capacity up.
             </>
           }
           error={errors.fields.contextWindow}

--- a/apps/frontend/lib/model-config.test.ts
+++ b/apps/frontend/lib/model-config.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "vitest";
-import type { Provider } from "@platypus/schemas";
+import type { ConcreteModelId, Provider } from "@platypus/schemas";
 import {
   getModelConfigs,
   getModelOptions,
   findModelOption,
   resolveModelId,
   getPassthroughFileTypes,
+  getContextWindow,
 } from "./model-config";
 
 const provider = (modelIds: unknown, over: Partial<Provider> = {}) =>
@@ -131,5 +132,37 @@ describe("getPassthroughFileTypes", () => {
     ]);
     const resolved = resolveModelId(p, "alias:flagship")!;
     expect(getPassthroughFileTypes(p, resolved)).toEqual(["image/*"]);
+  });
+});
+
+describe("getContextWindow", () => {
+  it("returns the declared window for an aliased model", () => {
+    // The window lives on the model ENTRY, so repointing an alias moves it —
+    // no special handling required (ADR-0017 + ADR-0018).
+    const p = provider([
+      {
+        id: "claude-sonnet",
+        passthroughFileTypes: [],
+        alias: "flagship",
+        contextWindow: 200_000,
+      },
+    ]);
+    const resolved = resolveModelId(p, "alias:flagship")!;
+    expect(getContextWindow(p, resolved)).toBe(200_000);
+  });
+
+  it("returns undefined when undeclared, unknown, or on a legacy list", () => {
+    const declaredNone = provider([{ id: "gpt-4", passthroughFileTypes: [] }]);
+    expect(
+      getContextWindow(declaredNone, resolveModelId(declaredNone, "gpt-4")!),
+    ).toBeUndefined();
+    expect(
+      getContextWindow(declaredNone, "ghost" as ConcreteModelId),
+    ).toBeUndefined();
+
+    const legacy = provider(["legacy-model"]);
+    expect(
+      getContextWindow(legacy, resolveModelId(legacy, "legacy-model")!),
+    ).toBeUndefined();
   });
 });

--- a/apps/frontend/lib/model-config.ts
+++ b/apps/frontend/lib/model-config.ts
@@ -129,6 +129,21 @@ export const getPassthroughFileTypes = (
 };
 
 /**
+ * The total token capacity declared for a model, or `undefined` where none was
+ * declared (ADR-0018) — which is the normal state and the reason the context
+ * meter has a hidden mode.
+ *
+ * No default to fall back to, unlike the passthrough types above: nothing can
+ * discover a context window, so an undeclared one stays unknown rather than
+ * being guessed at.
+ */
+export const getContextWindow = (
+  provider: Pick<Provider, "modelIds">,
+  modelId: ConcreteModelId,
+): number | undefined =>
+  getModelConfigs(provider).find((m) => m.id === modelId)?.contextWindow;
+
+/**
  * Classify an attachment against a model's passthrough set — the metadata-only
  * mirror of the backend gate. `reject` means the turn would be blocked: the file
  * is neither native, text-like, nor an extractable document. `extract` (PDF /

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -30,6 +30,7 @@ import {
   modelReferenceFor,
   modelLabelFor,
   findModelEntry,
+  triggerRunStatsSchema,
 } from "./index";
 
 describe("Organization Schema", () => {
@@ -1066,5 +1067,52 @@ describe("Model reference helpers", () => {
 
   it("never resolves an alias reference to a like-named concrete id", () => {
     expect(findModelEntry(models, "alias:gpt-4")).toBeUndefined();
+  });
+});
+
+describe("triggerRunStatsSchema", () => {
+  const base = {
+    steps: 3,
+    toolCalls: [{ name: "search", count: 2 }],
+    inputTokens: 900,
+    outputTokens: 120,
+  };
+
+  it("accepts a run that recorded Context occupancy", () => {
+    const result = triggerRunStatsSchema.safeParse({
+      ...base,
+      contextOccupancy: 42_000,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.contextOccupancy).toBe(42_000);
+  });
+
+  it("leaves occupancy undefined for a Provider that reported no usage", () => {
+    const result = triggerRunStatsSchema.safeParse(base);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.contextOccupancy).toBeUndefined();
+  });
+
+  it("keeps the cross-step token sums meaning what they meant", () => {
+    // Occupancy is a separate field precisely so these two keep their billing
+    // meaning — a reader of the trigger runs page must not find the same name
+    // holding a different quantity (ADR-0018).
+    const result = triggerRunStatsSchema.safeParse({
+      ...base,
+      contextOccupancy: 42_000,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.inputTokens).toBe(900);
+      expect(result.data.outputTokens).toBe(120);
+    }
+  });
+
+  it("rejects a negative or fractional occupancy", () => {
+    for (const contextOccupancy of [-1, 1.5]) {
+      expect(
+        triggerRunStatsSchema.safeParse({ ...base, contextOccupancy }).success,
+      ).toBe(false);
+    }
   });
 });

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -586,7 +586,8 @@ export type ProviderApiMode = z.infer<typeof providerApiModeSchema>;
 //
 // `contextWindow` is the vendor's published TOTAL token capacity for this
 // model, declared by an Org Admin because nothing can discover it — see
-// ADR-0018. Optional always, and nothing reads it yet.
+// ADR-0018. Optional always: where it is absent, the Chat's context meter is
+// hidden and nothing else changes.
 //
 // `maxOutputTokens` caps a SINGLE reply, and unlike `contextWindow` it is
 // enforced: it becomes the generation call's output ceiling for every turn on
@@ -1557,8 +1558,19 @@ export type TriggerRunStatus = z.infer<typeof triggerRunStatusSchema>;
 export const triggerRunStatsSchema = z.object({
   steps: z.number(),
   toolCalls: z.array(z.object({ name: z.string(), count: z.number() })),
+  // Cross-step SUMS, and billing figures: every step's usage folded together.
+  // They are rendered on the trigger runs page and deliberately keep that
+  // meaning — occupancy gets its own field below rather than reinterpreting a
+  // number an Operator already reads (ADR-0018).
   inputTokens: z.number(),
   outputTokens: z.number(),
+  /**
+   * How full the model's context got: the input tokens reported for the FINAL
+   * step of the run, which is the whole conversation as last sent. A last
+   * value, never a sum. Absent where the Provider reported no usage — occupancy
+   * is then unknown and nothing is estimated.
+   */
+  contextOccupancy: z.number().int().nonnegative().optional(),
   /**
    * Set only when the run stopped because it hit the model's output ceiling.
    * Absent rather than `false` so an untruncated run stores nothing, matching


### PR DESCRIPTION
Completes #446, on top of #452 (the declaration) and #453 (the measurement). Read [ADR-0018](https://github.com/willdady/platypus/blob/main/docs/adr/0018-context-windows-are-declared-not-discovered.md) first — it names the trap that makes the wrong implementation look correct.

## What this adds

**A meter in the Chat composer.** Where a model has a declared Context window and its Provider reports token usage, the composer footer shows how full the context was on the last turn: a bar, the percentage, and both token figures (`33% · 42,000/128,000`). Both numbers are shown because 33% of 128k and 33% of 8k are very different situations.

- Hidden when the window is undeclared **or** occupancy is unknown — one hidden state, two causes. A numerator with no denominator answers none of the questions a meter exists for, so it is never rendered.
- The bar and percentage clamp at 100% while the true figures stay honest. Under-declaring is the safe direction and therefore expected; a conservative 128k against a real 200k model must not look like a bug.
- The reading comes from the latest assistant message that *carries* one, not simply the latest. A turn in flight has no reading until its first step finishes, and blanking the meter across that gap would hide it exactly while the reader is watching. A run that reported a count and then stopped writes a concrete `null`, which **is** carried and does hide the meter — that erasure is deliberate, so the key's presence is the test rather than its value.
- It rides in message metadata, so it survives a reload and a cancelled turn keeps whatever the run reported.

**Occupancy on Trigger runs.** `contextOccupancy` is its own field on the run stats schema, sourced from the final step, and rendered beside the existing counts. The existing `in / out` figures are legitimately cross-step sums and keep their meaning exactly — repurposing a number an Operator already reads would silently change what it says. Occupancy is absent rather than `0` where no usage was reported: a zero would read as a measurement of an empty context.

**Per-model resolvers** on both sides of the wire, and the provider form's hint now states what leaving the field empty actually costs instead of "nothing reads it yet".

## The trap

Three numbers look like occupancy and two are sums. `totalUsage.inputTokens` and the accumulated `RunStats.inputTokens` both fold input tokens across every step, so a twenty-step turn reads roughly an order of magnitude high. Both are correct as billing figures; neither is occupancy. Only the last step's `usage.inputTokens` is. The generate path reads `steps.at(-1)` and a test asserts the figure equals the final step's `3,500` and specifically **not** the `4,500` sum.

Relatedly, a step that reports no usage now clears the interim figure rather than leaving an earlier, smaller step's standing — otherwise a long run's mid-flight stats flush publishes a stale occupancy as though it were current.

## Deliberately not in this change

Nothing compacts, prunes, warns, or blocks. This is a readout, and the docs say so in a warning callout on both the Chat and Provider pages — declaring a window makes the meter appear, it does not make Platypus enforce a budget. Auto-compaction is the follow-up this unblocks.

## Docs

Ship in this PR: a Chat page section for the meter, the Providers callout and the three-meanings-of-Context section repointed now that a declaration makes something appear, and the Triggers page updated for the new figure.

## Tests

Green across the workspace: 1590 backend, 119 frontend, 110 schemas, 25 docs contract. `typecheck` and `lint` clean.

New coverage: the per-model resolvers (declared, absent, unknown, legacy bare-string lists, and the same model differing across two Providers); the trigger run stats schema and sink; the generate path's final-step sourcing and the interim-clearing case; and the meter component in isolation — hidden with no window, hidden with no reading, both figures rendered, and clamped-bar-but-true-numbers on overflow.

One note for review: `contextWindowForModel` on the backend has no production consumer yet — the meter resolves the window client-side. #446 specifies it as a seam with tests, and ADR-0018 names auto-compaction as its consumer, so it is here as asked; happy to drop it if you would rather it arrived with its caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)