### PR TITLE
fix(chat): flag a Sub-Agent answer cut short at the output limit

### DIFF
--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ToolExecutionOptions } from "ai";
-import { createSubAgentTool, createSubAgentTools } from "./sub-agent.ts";
+import {
+  createSubAgentTool,
+  createSubAgentTools,
+  SUB_AGENT_TRUNCATION_NOTE,
+} from "./sub-agent.ts";
 import type { SubAgentActivity } from "./sub-agent.ts";
 
 // Helper to consume an async generator and collect all yielded values.
@@ -14,6 +18,21 @@ async function consumeGenerator<T>(
   }
   return { yielded };
 }
+
+// The text the parent model actually reads for a completed delegation.
+// `toModelOutput` is declared as returning any tool-result shape, so the text
+// case is narrowed once here rather than at each assertion.
+const modelText = (
+  tool: ReturnType<typeof createSubAgentTool>["tool"],
+  output: SubAgentActivity,
+): string =>
+  (
+    tool.toModelOutput!({
+      toolCallId: "tc1",
+      input: { task: "Audit the board" },
+      output,
+    }) as { value: string }
+  ).value;
 
 // Mock stream events helper — returns a sync iterable; AsyncGenerator consumers
 // accept any iterable, so no async generator is needed here.
@@ -454,6 +473,198 @@ describe("createSubAgentTool", () => {
       await expect(consumeGenerator(gen)).rejects.toThrow(
         /Stopped before finishing: step limit/,
       );
+    });
+
+    // Issue #442. A token-limit stop is neither an `error` nor an `abort`: the
+    // stream ends normally and the partial answer was returned as if it were
+    // the whole finding. The parent has to be told it is looking at a fragment.
+    describe("truncated at the output token limit", () => {
+      const truncatedStream = () =>
+        createMockFullStream([
+          { type: "text-start", id: "t1" },
+          { type: "text-delta", id: "t1", text: "The three stale cards are" },
+          {
+            type: "finish",
+            finishReason: "length",
+            rawFinishReason: "max_tokens",
+          },
+        ]);
+
+      it("flags the delegation result as truncated", async () => {
+        mockStream.mockResolvedValue({
+          fullStream: truncatedStream(),
+          text: Promise.resolve(""),
+        });
+
+        const { tool } = createSubAgentTool(baseOptions);
+        const { yielded } = await consumeGenerator(
+          tool.execute(
+            { task: "Audit the board" },
+            {} as ToolExecutionOptions<Record<string, unknown>>,
+          ) as AsyncGenerator<SubAgentActivity>,
+        );
+        const final = yielded.at(-1)!;
+
+        expect(final.truncatedByTokenLimit).toBe(true);
+        // Not a failure: the partial answer is real work and still comes back.
+        expect(final.text).toBe("The three stale cards are");
+      });
+
+      it("tells the parent model the answer is partial", async () => {
+        mockStream.mockResolvedValue({
+          fullStream: truncatedStream(),
+          text: Promise.resolve(""),
+        });
+
+        const { tool } = createSubAgentTool(baseOptions);
+        const { yielded } = await consumeGenerator(
+          tool.execute(
+            { task: "Audit the board" },
+            {} as ToolExecutionOptions<Record<string, unknown>>,
+          ) as AsyncGenerator<SubAgentActivity>,
+        );
+
+        const value = modelText(tool, yielded.at(-1)!);
+
+        expect(value).toContain("The three stale cards are");
+        expect(value).toContain(SUB_AGENT_TRUNCATION_NOTE);
+      });
+
+      it("says only that the answer was cut off when there is no text at all", () => {
+        const { tool } = createSubAgentTool(baseOptions);
+
+        expect(
+          modelText(tool, {
+            entries: [],
+            text: "",
+            truncatedByTokenLimit: true,
+          }),
+        ).toBe(SUB_AGENT_TRUNCATION_NOTE);
+      });
+
+      it("records the cutoff in the log", async () => {
+        mockStream.mockResolvedValue({
+          fullStream: truncatedStream(),
+          text: Promise.resolve(""),
+        });
+
+        const { tool } = createSubAgentTool(baseOptions);
+        await consumeGenerator(
+          tool.execute(
+            { task: "Audit the board" },
+            {} as ToolExecutionOptions<Record<string, unknown>>,
+          ) as AsyncGenerator<SubAgentActivity>,
+        );
+
+        expect(vi.mocked(logger.warn).mock.calls[0]?.[0]).toMatchObject({
+          subAgentId: "agent-1",
+          subAgentName: "Research Agent",
+          // The provider's own word for the stop, which the unified reason
+          // would otherwise be the only record of.
+          rawFinishReason: "max_tokens",
+        });
+      });
+
+      it("leaves a cleanly finished delegation unflagged", async () => {
+        mockStream.mockResolvedValue({
+          fullStream: createMockFullStream([
+            { type: "text-start", id: "t1" },
+            { type: "text-delta", id: "t1", text: "All done." },
+            { type: "text-end", id: "t1" },
+            { type: "finish", finishReason: "stop" },
+          ]),
+          text: Promise.resolve(""),
+        });
+
+        const { tool } = createSubAgentTool(baseOptions);
+        const { yielded } = await consumeGenerator(
+          tool.execute(
+            { task: "Audit the board" },
+            {} as ToolExecutionOptions<Record<string, unknown>>,
+          ) as AsyncGenerator<SubAgentActivity>,
+        );
+        const final = yielded.at(-1)!;
+
+        expect(final).not.toHaveProperty("truncatedByTokenLimit");
+        expect(modelText(tool, final)).toBe("All done.");
+      });
+
+      // The same rule the run path applies: a step inside the tool loop can end
+      // at the ceiling and the sub-agent still recover and answer in full.
+      it("ignores a step that ended at the limit mid tool-loop", async () => {
+        mockStream.mockResolvedValue({
+          fullStream: createMockFullStream([
+            { type: "tool-input-start", toolName: "listCards", id: "tc1" },
+            { type: "finish-step", finishReason: "length" },
+            {
+              type: "tool-result",
+              toolCallId: "tc1",
+              toolName: "listCards",
+              output: [{ id: "c1" }],
+            },
+            { type: "text-start", id: "t1" },
+            { type: "text-delta", id: "t1", text: "One card." },
+            { type: "text-end", id: "t1" },
+            { type: "finish", finishReason: "stop" },
+          ]),
+          text: Promise.resolve(""),
+        });
+
+        const { tool } = createSubAgentTool(baseOptions);
+        const { yielded } = await consumeGenerator(
+          tool.execute(
+            { task: "Audit the board" },
+            {} as ToolExecutionOptions<Record<string, unknown>>,
+          ) as AsyncGenerator<SubAgentActivity>,
+        );
+
+        expect(yielded.at(-1)!).not.toHaveProperty("truncatedByTokenLimit");
+      });
+
+      // A cutoff is a fact about the answer, not an activity step, so the log
+      // the user watches must not gain a spurious row (or a spurious yield).
+      it("adds no activity entry and no extra yield for the terminal finish", async () => {
+        mockStream.mockResolvedValue({
+          fullStream: truncatedStream(),
+          text: Promise.resolve(""),
+        });
+
+        const { tool } = createSubAgentTool(baseOptions);
+        const { yielded } = await consumeGenerator(
+          tool.execute(
+            { task: "Audit the board" },
+            {} as ToolExecutionOptions<Record<string, unknown>>,
+          ) as AsyncGenerator<SubAgentActivity>,
+        );
+
+        // text-start yields once; the delta and the finish yield nothing; then
+        // the final value.
+        expect(yielded).toHaveLength(2);
+        expect(yielded.at(-1)!.entries).toHaveLength(1);
+      });
+
+      // A stream that fails after hitting the ceiling is still a failure: the
+      // parent must get a tool error, not a flagged partial answer.
+      it("still throws when the stream also reported a failure", async () => {
+        mockStream.mockResolvedValue({
+          fullStream: createMockFullStream([
+            { type: "finish", finishReason: "length" },
+            { type: "error", error: new Error("upstream reset") },
+          ]),
+          text: Promise.resolve(""),
+        });
+
+        const { tool } = createSubAgentTool(baseOptions);
+
+        await expect(
+          consumeGenerator(
+            tool.execute(
+              { task: "Audit the board" },
+              {} as ToolExecutionOptions<Record<string, unknown>>,
+            ) as AsyncGenerator<SubAgentActivity>,
+          ),
+        ).rejects.toThrow(/upstream reset/);
+      });
     });
 
     it("marks tool-call entry as error on tool-error event", async () => {

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -8,6 +8,7 @@ import {
 import { z } from "zod";
 import { logger } from "../logger.ts";
 import { describeToolInput } from "../rejected-tool-input.ts";
+import { isTruncatedByTokenLimit } from "../runs/stream-error.ts";
 import { renderSecurityGuardrails } from "../security-prompt.ts";
 import { withNormalizedResults } from "../services/tool-result.ts";
 import {
@@ -42,7 +43,22 @@ type SubAgentActivityEntry = {
 export type SubAgentActivity = {
   entries: SubAgentActivityEntry[];
   text?: string;
+  /**
+   * Set when the sub-agent's terminal finish hit its model's output ceiling, so
+   * `text` is a fragment. Named as the run path names the same fact on a Chat
+   * message, because it is the same fact one level down.
+   */
+  truncatedByTokenLimit?: true;
 };
+
+/**
+ * What the parent Agent is told when a delegate's answer stopped at the output
+ * ceiling. Addressed to the model, not the user: the parent is the one that
+ * would otherwise summarise the fragment and present it as the finding.
+ * Exported so tests assert the behaviour without restating the prose.
+ */
+export const SUB_AGENT_TRUNCATION_NOTE =
+  "[Incomplete: the sub-agent stopped at its model's output token limit, so the answer above breaks off part-way. Treat it as partial — do not present it as the sub-agent's complete finding. Delegate the remainder as a narrower task if you need it.]";
 
 /** The subset of a streamed tool-result part used to synthesize a fallback answer. */
 type ToolResultSummary = { toolName?: string; output: unknown };
@@ -181,7 +197,13 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
             "A fully self-contained task description. Include ALL necessary context, constraints, and requirements directly. The task must be understandable without any prior conversation context.",
           ),
       }),
-      execute: async function* ({ task }, { abortSignal }) {
+      // The yield type is stated rather than inferred: an optional key present
+      // on only some of the yields makes the inferred union unreadable by
+      // `toModelOutput`, which sees every yield as a possible tool output.
+      execute: async function* (
+        { task },
+        { abortSignal },
+      ): AsyncGenerator<SubAgentActivity> {
         const result = await agent.stream({ prompt: task, abortSignal });
         const entries: SubAgentActivityEntry[] = [];
 
@@ -199,6 +221,16 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
         // would return whatever text had accumulated — typically the model's
         // opening preamble — and the parent would read a crash as an answer.
         let streamFailure: string | undefined;
+        // Set when the delegate ran out of output budget. Unlike the two above
+        // this is not a failure — the text is real work — but the stream ends
+        // normally either way, so without reading the finish reason a fragment
+        // is indistinguishable from a finished answer (#442).
+        let truncatedByTokenLimit = false;
+        // What the provider itself called the ending. The unified reason
+        // collapses anything the adapter doesn't recognise, so this is the only
+        // record of the actual stop signal (#406), and a delegated run has no
+        // other observable surface at all.
+        let rawFinishReason: string | undefined;
 
         const completeLastRunning = (type: SubAgentActivityEntry["type"]) => {
           const entry = entries.findLast(
@@ -278,6 +310,18 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
                 error: streamFailure,
               });
               break;
+            // The terminal finish only, as on the run path: a step inside the
+            // tool loop can end at the ceiling and the sub-agent still recover
+            // and answer in full. A cutoff is a fact about the answer rather
+            // than a step of the work, so it adds no activity entry — hence no
+            // yield either.
+            case "finish":
+              truncatedByTokenLimit = isTruncatedByTokenLimit(
+                part.finishReason,
+              );
+              rawFinishReason = part.rawFinishReason;
+              changed = false;
+              break;
             case "abort":
               streamFailure = part.reason
                 ? `Stopped before finishing: ${part.reason}`
@@ -322,14 +366,35 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
 
         const text = aggregatedText || summarizeToolResult(lastToolResult);
 
+        if (truncatedByTokenLimit) {
+          logger.warn(
+            { subAgentId: id, subAgentName: name, rawFinishReason },
+            `Sub-agent "${name}" answer truncated at the output token limit`,
+          );
+        }
+
         // Yield (not return) the final value with text — the SDK's executeTool
         // uses for-await-of which discards generator return values.
-        yield { entries, text } satisfies SubAgentActivity;
+        yield {
+          entries,
+          text,
+          // Omitted rather than `false` when the answer is whole, so the flag's
+          // presence is the whole of its meaning wherever it is read.
+          ...(truncatedByTokenLimit ? { truncatedByTokenLimit: true } : {}),
+        } satisfies SubAgentActivity;
       },
-      toModelOutput: ({ output }) => ({
-        type: "text" as const,
-        value: output?.text ?? "Task completed.",
-      }),
+      toModelOutput: ({ output }) => {
+        const value = output?.text ?? "Task completed.";
+        return {
+          type: "text" as const,
+          // Annotated rather than thrown: the fragment is real work the parent
+          // can still use, and the run path treats a cutoff as a fact to record
+          // rather than a failure. What it must not do is read as complete.
+          value: output?.truncatedByTokenLimit
+            ? `${value}\n\n${SUB_AGENT_TRUNCATION_NOTE}`.trim()
+            : value,
+        };
+      },
     }),
   };
 };

--- a/apps/docs/content/building-with-platypus/agents.mdx
+++ b/apps/docs/content/building-with-platypus/agents.mdx
@@ -202,6 +202,22 @@ reports an **error** rather than a short answer. Anything the sub-agent had
 written before the failure comes back with it, so the parent can say what was
 done and what wasn't instead of passing a half-finished reply off as the result.
 
+### When a sub-agent answer stops early
+
+A sub-agent writes against its own model's output ceiling, the same one that cuts
+a Chat reply short. Hit it and the delegated answer breaks off wherever it got
+to. That is not treated as a failure: the fragment comes back as the delegate's
+result, the parent Agent is told in the same breath that the answer is partial,
+and expanding the sub-agent's card in the Chat shows a muted line under the
+response reading **Sub-agent response cut short at the model's output limit.**
+
+<Callout type="warning">
+  The ceiling that applies is the sub-agent's own model's, not the parent's — a
+  parent on a large model can delegate to a small one and get a fragment back.
+  Split the work into narrower tasks, or pin the sub-agent to a model whose
+  output limit fits the answer you want.
+</Callout>
+
 Click **Save** to create the Agent. You can edit every field later from the same
 form.
 

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -43,11 +43,11 @@ import {
   CopyIcon,
   TrashIcon,
   RefreshCwIcon,
-  TriangleAlertIcon,
   XIcon,
 } from "lucide-react";
 import { Textarea } from "./ui/textarea";
 import { toolDurationMs } from "@/lib/tool-duration";
+import { CutShortNotice } from "./cut-short-notice";
 import { LoadSkillTool } from "./load-skill-tool";
 import { SubAgentTool } from "./sub-agent-tool";
 
@@ -289,10 +289,7 @@ export const ChatMessage = memo(function ChatMessage({
       })}
       {message.role === "assistant" &&
         message.metadata?.truncatedByTokenLimit && (
-          <div className="flex items-center gap-1.5 pl-8 text-xs text-muted-foreground">
-            <TriangleAlertIcon className="size-3.5 shrink-0" />
-            <span>{CUT_SHORT_NOTICE}</span>
-          </div>
+          <CutShortNotice className="pl-8">{CUT_SHORT_NOTICE}</CutShortNotice>
         )}
       {!(isLastMessage && status === "streaming") &&
         (isEditing ? (

--- a/apps/frontend/components/cut-short-notice.tsx
+++ b/apps/frontend/components/cut-short-notice.tsx
@@ -1,0 +1,29 @@
+import { TriangleAlertIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The muted warning row shown wherever an answer stopped at the model's output
+ * ceiling rather than because the model was finished — under a Chat reply, under
+ * a delegated sub-agent response, and in Trigger run history.
+ *
+ * The row is shared; the wording is not. Each surface names its own subject
+ * ("Response", "Sub-agent response", "Run") and owns that sentence as an
+ * exported constant its tests assert against.
+ */
+export const CutShortNotice = ({
+  children,
+  className,
+}: {
+  children: string;
+  className?: string;
+}) => (
+  <div
+    className={cn(
+      "flex items-center gap-1.5 text-muted-foreground text-xs",
+      className,
+    )}
+  >
+    <TriangleAlertIcon className="size-3.5 shrink-0" />
+    <span>{children}</span>
+  </div>
+);

--- a/apps/frontend/components/run-cut-short-notice.tsx
+++ b/apps/frontend/components/run-cut-short-notice.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TriangleAlertIcon } from "lucide-react";
+import { CutShortNotice } from "./cut-short-notice";
 
 /**
  * What the person reading run history is told when a run stopped at the
@@ -19,8 +19,5 @@ export const RUN_CUT_SHORT_NOTICE =
  * export the fields Next recognises, and the wording has to be importable.
  */
 export const RunCutShortNotice = () => (
-  <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
-    <TriangleAlertIcon className="size-3.5 shrink-0" />
-    <span>{RUN_CUT_SHORT_NOTICE}</span>
-  </div>
+  <CutShortNotice className="mt-1">{RUN_CUT_SHORT_NOTICE}</CutShortNotice>
 );

--- a/apps/frontend/components/sub-agent-tool.test.tsx
+++ b/apps/frontend/components/sub-agent-tool.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ToolUIPart } from "ai";
 
 // Streamdown pulls in shiki and a worker-ish runtime that jsdom can't host; the
@@ -10,7 +10,7 @@ vi.mock("streamdown", () => ({
   ),
 }));
 
-import { SubAgentTool } from "./sub-agent-tool";
+import { SubAgentTool, SUB_AGENT_CUT_SHORT_NOTICE } from "./sub-agent-tool";
 
 const delegateCall = (toolMetadata?: Record<string, unknown>): ToolUIPart =>
   ({
@@ -20,6 +20,21 @@ const delegateCall = (toolMetadata?: Record<string, unknown>): ToolUIPart =>
     input: { task: "Find the release date" },
     output: { entries: [], text: "It shipped in March." },
     toolMetadata,
+  }) as unknown as ToolUIPart;
+
+const truncatedDelegateCall = (
+  entries: Array<Record<string, unknown>> = [],
+): ToolUIPart =>
+  ({
+    type: "tool-delegateToResearchBot",
+    toolCallId: "call-1",
+    state: "output-available",
+    input: { task: "Find the release date" },
+    output: {
+      entries,
+      text: "It shipped in Mar",
+      truncatedByTokenLimit: true,
+    },
   }) as unknown as ToolUIPart;
 
 // A delegated run is the longest thing that happens in a chat, so its card is
@@ -36,5 +51,39 @@ describe("SubAgentTool duration", () => {
 
     expect(screen.getByText("Research Bot")).toBeInTheDocument();
     expect(screen.queryByText(/\d+(\.\d+)?(ms|s)/)).toBeNull();
+  });
+});
+
+// Issue #442. The card shows the delegate's answer verbatim, so a fragment
+// reads as a finished finding to the person as much as to the parent Agent.
+describe("SubAgentTool cut-short marker", () => {
+  // The card is collapsed by default and the response lives inside it, so the
+  // marker is only reachable once the card is opened.
+  const renderExpanded = (toolPart: ToolUIPart) => {
+    render(<SubAgentTool toolPart={toolPart} />);
+    fireEvent.click(screen.getByRole("button"));
+  };
+
+  it("marks a response that stopped at the output limit", () => {
+    renderExpanded(truncatedDelegateCall());
+
+    expect(screen.getByText(SUB_AGENT_CUT_SHORT_NOTICE)).toBeInTheDocument();
+  });
+
+  it("marks it alongside an activity log too", () => {
+    renderExpanded(
+      truncatedDelegateCall([
+        { type: "tool-call", toolName: "webFetch", status: "completed" },
+      ]),
+    );
+
+    expect(screen.getByText(SUB_AGENT_CUT_SHORT_NOTICE)).toBeInTheDocument();
+  });
+
+  it("says nothing about a delegation that finished on its own", () => {
+    renderExpanded(delegateCall());
+
+    expect(screen.getByText("It shipped in March.")).toBeInTheDocument();
+    expect(screen.queryByText(SUB_AGENT_CUT_SHORT_NOTICE)).toBeNull();
   });
 });

--- a/apps/frontend/components/sub-agent-tool.tsx
+++ b/apps/frontend/components/sub-agent-tool.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import type { ToolUIPart } from "ai";
 import { Badge } from "@/components/ui/badge";
+import { CutShortNotice } from "./cut-short-notice";
 import {
   Collapsible,
   CollapsibleContent,
@@ -40,7 +41,18 @@ type SubAgentActivityEntry = {
 type SubAgentActivity = {
   entries: SubAgentActivityEntry[];
   text?: string;
+  truncatedByTokenLimit?: true;
 };
+
+/**
+ * What the person reading a delegated run is told when the sub-agent stopped at
+ * its model's output ceiling rather than because it had finished. The Chat
+ * counterpart of the marker a cut-short reply carries, one level down: the card
+ * shows the delegate's answer verbatim, so an unmarked fragment reads as a
+ * finished finding. A constant so tests assert the wording without restating it.
+ */
+export const SUB_AGENT_CUT_SHORT_NOTICE =
+  "Sub-agent response cut short at the model's output limit.";
 
 const isSubAgentActivity = (output: unknown): output is SubAgentActivity =>
   typeof output === "object" &&
@@ -192,6 +204,35 @@ const ActivityEntry = ({ entry }: { entry: CompactEntry }) => {
   );
 };
 
+/**
+ * The delegate's answer. One component for both call sites — with and without
+ * an activity log — so a marker can never be shown on one and missed on the
+ * other.
+ */
+const ResponseBlock = ({
+  text,
+  truncated,
+}: {
+  text: string;
+  truncated: boolean;
+}) => (
+  <div className="space-y-2 border-t p-4">
+    <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+      Response
+    </h4>
+    <Message from="assistant">
+      <MessageContent className="max-w-full">
+        <MessageResponse>{text}</MessageResponse>
+      </MessageContent>
+    </Message>
+    {truncated && (
+      <CutShortNotice className="mt-2">
+        {SUB_AGENT_CUT_SHORT_NOTICE}
+      </CutShortNotice>
+    )}
+  </div>
+);
+
 interface SubAgentToolProps {
   toolPart: ToolUIPart;
 }
@@ -212,6 +253,7 @@ export const SubAgentTool = ({ toolPart }: SubAgentToolProps) => {
   const activity = isSubAgentActivity(output) ? output : null;
   const legacyText = typeof output === "string" ? output : null;
   const responseText = activity?.text ?? legacyText;
+  const truncated = activity?.truncatedByTokenLimit ?? false;
   const compacted = useMemo(
     () => (activity ? compactEntries(activity.entries) : []),
     [activity],
@@ -280,16 +322,7 @@ export const SubAgentTool = ({ toolPart }: SubAgentToolProps) => {
               ))}
             </div>
             {responseText ? (
-              <div className="space-y-2 border-t p-4">
-                <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-                  Response
-                </h4>
-                <Message from="assistant">
-                  <MessageContent className="max-w-full">
-                    <MessageResponse>{responseText}</MessageResponse>
-                  </MessageContent>
-                </Message>
-              </div>
+              <ResponseBlock text={responseText} truncated={truncated} />
             ) : null}
           </>
         ) : !isComplete ? (
@@ -297,16 +330,7 @@ export const SubAgentTool = ({ toolPart }: SubAgentToolProps) => {
             <Shimmer className="text-sm">Working...</Shimmer>
           </div>
         ) : responseText ? (
-          <div className="space-y-2 border-t p-4">
-            <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-              Response
-            </h4>
-            <Message from="assistant">
-              <MessageContent className="max-w-full">
-                <MessageResponse>{responseText}</MessageResponse>
-              </MessageContent>
-            </Message>
-          </div>
+          <ResponseBlock text={responseText} truncated={truncated} />
         ) : null}
       </CollapsibleContent>
     </Collapsible>


### PR DESCRIPTION
Closes #442

## The bug

The Sub-Agent delegation path never read the finish reason, so a delegate that ran out of output budget returned its fragment as a normal, complete tool result — and the parent Agent could summarise it and present it to the user as the sub-agent's finding.

A token-limit stop is neither of the two failures the stream loop already knew about: `error` and `abort` both set `streamFailure` and throw, but a cutoff ends the stream normally, so the partial text was yielded as the answer.

## The fix

The loop handles the terminal `finish` part and reuses the run path's `isTruncatedByTokenLimit`. Only the **terminal** finish counts — a step inside the tool loop can end at the ceiling and the sub-agent still recover and answer in full.

A cutoff is **annotated rather than thrown**: the fragment is real work the parent can still use, and the run path already treats a cutoff as a fact to record rather than a failure. What it must not do is read as complete. So:

- The parent's tool result carries a note saying the answer breaks off part-way and must not be presented as the complete finding. It lives in `toModelOutput` — the model-facing view — so the text shown to the user stays clean.
- The delegated activity carries `truncatedByTokenLimit`, and the sub-agent card shows **Sub-agent response cut short at the model's output limit.** under the response. Issue #442 lists the UI badge as one of the three things the run path does, so this is its delegate-path counterpart.
- The cutoff is logged with the provider's own `rawFinishReason`, which is the only record of what the provider actually said — and a delegated run has no other observable surface.

The muted notice row now has one implementation shared by the Chat reply, Trigger run history and sub-agent surfaces; each keeps its own wording constant.

## Docs

`building-with-platypus/agents.mdx` gains **When a sub-agent answer stops early**, next to the existing *When a sub-agent can't run*. The trap it names: the ceiling that applies is the sub-agent's own model's, not the parent's, so a parent on a large model can delegate to a small one and get a fragment back.

## Testing

Twelve new tests, written test-first: the flag, the model-facing note, the no-text case, the log entry, a clean finish staying unflagged, a mid-tool-loop step being ignored, no spurious activity row or extra yield, and a stream that fails *after* hitting the ceiling still throwing. Plus three frontend tests for the card marker.

`pnpm test` (1589 backend, 112 frontend, 25 docs-contract), `pnpm typecheck` and `pnpm lint` all pass. Not exercised against a live model actually hitting its output ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)