### PR TITLE
fix(backend): resolve sub-agent maxSteps to the shared default

### DIFF
--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -31,6 +31,7 @@ import {
 } from "./memory-retrieval.ts";
 import {
   aliasNameFromReference,
+  DEFAULT_AGENT_MAX_STEPS,
   providerHasNativeSearch,
 } from "@platypus/schemas";
 import type { ConcreteModelId, Provider, Skill } from "@platypus/schemas";
@@ -55,14 +56,6 @@ import {
 } from "./file-gate.ts";
 import type { PlatypusUIMessage } from "../types.ts";
 import { listScopedByIds, resolveScoped } from "./scoped-resource.ts";
-
-/**
- * Default agentic step ceiling for an agent that has no explicit `maxSteps`.
- * Mirrors the new-agent create-form default. Keeps API-created agents sane
- * (a single step never lets a tool-calling agent finish its work) while
- * staying low enough to bound a model that fails to converge.
- */
-export const DEFAULT_AGENT_MAX_STEPS = 15;
 
 // --- Errors ---
 

--- a/apps/backend/src/tools/agent-management.ts
+++ b/apps/backend/src/tools/agent-management.ts
@@ -34,7 +34,12 @@ export function createAgentManagementTools(
       providerId: z.string().describe("Provider ID to use"),
       modelId: z.string().describe(MODEL_ID_DESCRIPTION),
       instructions: z.string().optional().describe(INSTRUCTIONS_DESCRIPTION),
-      maxSteps: z.number().optional().describe("Max agentic steps"),
+      maxSteps: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe("Max agentic steps, at least 1"),
       temperature: z.number().optional().describe("Sampling temperature"),
       topP: z.number().optional().describe("Top-p sampling"),
       topK: z.number().optional().describe("Top-k sampling"),
@@ -135,7 +140,12 @@ export function createAgentManagementTools(
       providerId: z.string().optional().describe("Provider ID to use"),
       modelId: z.string().optional().describe(MODEL_ID_DESCRIPTION),
       instructions: z.string().optional().describe(INSTRUCTIONS_DESCRIPTION),
-      maxSteps: z.number().optional().describe("Max agentic steps"),
+      maxSteps: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe("Max agentic steps, at least 1"),
       temperature: z.number().optional().describe("Sampling temperature"),
       topP: z.number().optional().describe("Top-p sampling"),
       topK: z.number().optional().describe("Top-k sampling"),

--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -1124,16 +1124,16 @@ describe("createSubAgentTools", () => {
     expect(stepCeilingOf(0)).toBe(DEFAULT_AGENT_MAX_STEPS);
   });
 
-  // `||` would turn an explicit zero into the fallback, silently giving a
-  // "0 steps" Agent a full budget. `??` must honor zero as a real ceiling.
-  it("honors an explicit maxSteps of 0 instead of the fallback default", async () => {
+  // A delegated Agent runs on its own ceiling, not the parent's and not the
+  // fallback — the whole point of reading `maxSteps` off the row.
+  it("forwards an explicit maxSteps instead of the fallback default", async () => {
     const subAgents = [
       {
         id: "sa-1",
         name: "Agent",
         providerId: "p1",
         modelId: "m1",
-        maxSteps: 0,
+        maxSteps: 3,
       },
     ];
 
@@ -1144,7 +1144,7 @@ describe("createSubAgentTools", () => {
 
     await createSubAgentTools(subAgents, createModelFn, loadToolsFn);
 
-    expect(stepCeilingOf(0)).toBe(0);
+    expect(stepCeilingOf(0)).toBe(3);
   });
 
   it("forwards each sub-agent's stored sampling parameters, treating null as unset", async () => {

--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -6,7 +6,7 @@ import {
   SUB_AGENT_TRUNCATION_NOTE,
 } from "./sub-agent.ts";
 import type { SubAgentActivity } from "./sub-agent.ts";
-import { DEFAULT_AGENT_MAX_STEPS } from "../services/chat-execution.ts";
+import { DEFAULT_AGENT_MAX_STEPS } from "@platypus/schemas";
 
 // Helper to consume an async generator and collect all yielded values.
 // Deep-copies each yield since the generator reuses mutable objects.

--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -6,6 +6,7 @@ import {
   SUB_AGENT_TRUNCATION_NOTE,
 } from "./sub-agent.ts";
 import type { SubAgentActivity } from "./sub-agent.ts";
+import { DEFAULT_AGENT_MAX_STEPS } from "../services/chat-execution.ts";
 
 // Helper to consume an async generator and collect all yielded values.
 // Deep-copies each yield since the generator reuses mutable objects.
@@ -91,6 +92,20 @@ vi.mock("../logger.ts", () => ({
 }));
 
 import { logger } from "../logger.ts";
+
+// A constructed sub-agent carries `stopWhen: [stepCountIs(n)]`, where `n` is
+// the resolved step ceiling. `stepCountIs` closes over `n` and offers no
+// introspection, so recover the ceiling by probing the condition against
+// incrementally longer (empty) step arrays until it fires.
+const stepCeilingOf = (callIndex: number): number => {
+  const { stopWhen } = agentConstructorSpy.mock.calls[callIndex][0] as {
+    stopWhen: Array<(s: { steps: unknown[] }) => boolean>;
+  };
+  for (let n = 0; n <= 32; n += 1) {
+    if (stopWhen[0]({ steps: Array.from({ length: n }) })) return n;
+  }
+  throw new Error("no step ceiling found in stopWhen");
+};
 
 describe("createSubAgentTool", () => {
   const baseOptions = {
@@ -1106,6 +1121,30 @@ describe("createSubAgentTools", () => {
     );
 
     expect(Object.keys(result.tools)).toHaveLength(1);
+    expect(stepCeilingOf(0)).toBe(DEFAULT_AGENT_MAX_STEPS);
+  });
+
+  // `||` would turn an explicit zero into the fallback, silently giving a
+  // "0 steps" Agent a full budget. `??` must honor zero as a real ceiling.
+  it("honors an explicit maxSteps of 0 instead of the fallback default", async () => {
+    const subAgents = [
+      {
+        id: "sa-1",
+        name: "Agent",
+        providerId: "p1",
+        modelId: "m1",
+        maxSteps: 0,
+      },
+    ];
+
+    const createModelFn = vi
+      .fn()
+      .mockResolvedValue({ model: {}, securityGuardrails: null });
+    const loadToolsFn = vi.fn().mockResolvedValue({});
+
+    await createSubAgentTools(subAgents, createModelFn, loadToolsFn);
+
+    expect(stepCeilingOf(0)).toBe(0);
   });
 
   it("forwards each sub-agent's stored sampling parameters, treating null as unset", async () => {

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -16,6 +16,7 @@ import {
   type SamplingSettings,
   type SamplingSource,
 } from "../services/sampling-settings.ts";
+import { DEFAULT_AGENT_MAX_STEPS } from "../services/chat-execution.ts";
 
 /**
  * Single source of truth for the sub-agent delegation tool name.
@@ -147,7 +148,7 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
     instructions,
     model,
     tools,
-    maxSteps = 50,
+    maxSteps = DEFAULT_AGENT_MAX_STEPS,
     securityGuardrails,
     sampling,
     maxOutputTokens,
@@ -482,7 +483,7 @@ export const createSubAgentTools = async (
         instructions: subAgent.instructions || undefined,
         model,
         tools: subAgentTools,
-        maxSteps: subAgent.maxSteps || 50,
+        maxSteps: subAgent.maxSteps ?? DEFAULT_AGENT_MAX_STEPS,
         securityGuardrails,
         sampling: resolveSamplingSettings(subAgent),
         maxOutputTokens,

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -16,7 +16,7 @@ import {
   type SamplingSettings,
   type SamplingSource,
 } from "../services/sampling-settings.ts";
-import { DEFAULT_AGENT_MAX_STEPS } from "../services/chat-execution.ts";
+import { DEFAULT_AGENT_MAX_STEPS } from "@platypus/schemas";
 
 /**
  * Single source of truth for the sub-agent delegation tool name.

--- a/apps/docs/content/building-with-platypus/agents.mdx
+++ b/apps/docs/content/building-with-platypus/agents.mdx
@@ -76,11 +76,11 @@ the Agent later without you editing it.
 Two levels of control over how the model generates:
 
 - **Max steps** — how many steps a tool-calling loop may run before it stops.
-  This lives in the main form (default `15`). Raise it for Agents that chain many
-  tool calls; lower it to cap runaway loops. Unattended runs (triggers and
-  scheduled Agents) also stop early if the model makes no progress — repeating
-  the same tool call for the same result — so a stuck run won't burn its whole
-  step budget.
+  This lives in the main form (default `15`, and never below `1`). Raise it for
+  Agents that chain many tool calls; lower it to cap runaway loops. Unattended
+  runs (triggers and scheduled Agents) also stop early if the model makes no
+  progress — repeating the same tool call for the same result — so a stuck run
+  won't burn its whole step budget.
 - **Advanced settings** — expand this section for the optional sampling
   parameters. Leave any blank to use the Provider's default.
 

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -42,6 +42,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
+  DEFAULT_AGENT_MAX_STEPS,
   type ToolSet,
   type Agent,
   type Provider,
@@ -148,7 +149,7 @@ const AgentForm = ({
     instructions: "",
     providerId: "",
     modelId: "",
-    maxSteps: 15,
+    maxSteps: DEFAULT_AGENT_MAX_STEPS,
     temperature: undefined as number | undefined,
     toolSetIds: [] as string[],
     skillIds: [] as string[],
@@ -199,7 +200,7 @@ const AgentForm = ({
         instructions: agent.instructions || "",
         providerId: agent.providerId,
         modelId: agent.modelId,
-        maxSteps: agent.maxSteps || 15,
+        maxSteps: agent.maxSteps || DEFAULT_AGENT_MAX_STEPS,
         temperature: agent.temperature ?? undefined,
         topP: agent.topP ?? undefined,
         topK: agent.topK ?? undefined,

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -301,6 +301,24 @@ describe("Agent Schema", () => {
     const result = agentSchema.safeParse(agentWithOptionals);
     expect(result.success).toBe(true);
   });
+
+  // A maxSteps below 1 reaches `stepCountIs(n)`, which compares `n` against a
+  // step count that is never less than 1 — so it silently removes the ceiling
+  // instead of tightening it. Reject it here rather than at the run.
+  it.each([0, -1, 2.5])("should reject a maxSteps of %s", (maxSteps) => {
+    const result = agentSchema.safeParse({
+      id: "789",
+      workspaceId: "456",
+      providerId: "provider-123",
+      name: "Test Agent",
+      description: "A test agent",
+      modelId: "gpt-4",
+      maxSteps,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("Provider Create Schema", () => {

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -189,6 +189,19 @@ export type ChatList = z.infer<typeof chatListSchema>;
 
 // Agent
 
+/**
+ * Default agentic step ceiling for an agent that has no explicit `maxSteps`.
+ * Mirrors the new-agent create-form default. Keeps API-created agents sane
+ * (a single step never lets a tool-calling agent finish its work) while
+ * staying low enough to bound a model that fails to converge.
+ *
+ * Lives here rather than beside either consumer: both the Chat-turn path and
+ * the Sub-Agent delegation path resolve an unset `maxSteps` through it, and
+ * homing it in one of them makes the other import a module it has no other
+ * reason to load.
+ */
+export const DEFAULT_AGENT_MAX_STEPS = 15;
+
 // An Agent is scoped to either a Workspace or an Organization (mutually
 // exclusive), mirroring the dual-scope shape of `provider`/`mcp`/`skill`.
 // Org-scoped Agents are Shared resources managed by Org Admins (ADR-0007);

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -203,7 +203,13 @@ const agentBaseSchema = z.object({
   description: z.string().min(1).max(128),
   instructions: z.string().optional(),
   modelId: z.string(),
-  maxSteps: z.number().optional(),
+  // Bounded because the value reaches `stepCountIs(n)`, whose predicate is
+  // `steps.length === n`, evaluated only after a step has completed. A `0` (or
+  // any negative, or a fraction the integer column would never match) is
+  // therefore never equal to a real step count, so the loop runs unbounded —
+  // the opposite of the ceiling the operator asked for. `min(1)` matches the
+  // `min="1"` the Agent form already puts on the input.
+  maxSteps: z.number().int().min(1).optional(),
   // Sampling params are nullable so the UI can clear them back to "unset"
   // (null) — without null, JSON.stringify drops the cleared `undefined` key
   // and the column keeps its previous value (#263). null is treated as "unset"

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -190,10 +190,10 @@ export type ChatList = z.infer<typeof chatListSchema>;
 // Agent
 
 /**
- * Default agentic step ceiling for an agent that has no explicit `maxSteps`.
- * Mirrors the new-agent create-form default. Keeps API-created agents sane
- * (a single step never lets a tool-calling agent finish its work) while
- * staying low enough to bound a model that fails to converge.
+ * Default agentic step ceiling for an agent that has no explicit `maxSteps`,
+ * and the value the Agent form prefills. Keeps API-created agents sane (a
+ * single step never lets a tool-calling agent finish its work) while staying
+ * low enough to bound a model that fails to converge.
  *
  * Lives here rather than beside either consumer: both the Chat-turn path and
  * the Sub-Agent delegation path resolve an unset `maxSteps` through it, and


### PR DESCRIPTION
## Summary

`agent.maxSteps` is a nullable column with no DB default. The Chat-turn path resolves an unset value to `DEFAULT_AGENT_MAX_STEPS` (15), but the Sub-Agent delegation path used a bare `50` literal and `||` instead of `??`. The same Agent row therefore got a 15-step ceiling on a Chat and a 50-step ceiling when delegated to — and an explicit `maxSteps: 0` also silently became 50.

## Changes

- Import the existing `DEFAULT_AGENT_MAX_STEPS` export (`apps/backend/src/services/chat-execution.ts`) into `apps/backend/src/tools/sub-agent.ts`.
- Replace the duplicated `50` literal in both the `createSubAgentTool` default and the `createSubAgentTools` resolution with `DEFAULT_AGENT_MAX_STEPS`.
- Use `??` instead of `||` so an explicit `maxSteps: 0` is honored as a zero-step ceiling.

No change to the numeric default value (15) or to the create-form default/validation.

## Verification

- `pnpm --filter backend typecheck` — passes
- `pnpm --filter backend lint` — passes
- `pnpm --filter backend test` — 112 files, 1611 tests pass (includes new regression tests asserting `maxSteps: null` → default and `maxSteps: 0` → 0)

Closes #441