### PR TITLE
fix(backend): redact Provider and MCP credentials on read

### DIFF
--- a/apps/backend/src/middleware/authorization.ts
+++ b/apps/backend/src/middleware/authorization.ts
@@ -1,3 +1,4 @@
+import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import { eq, and } from "drizzle-orm";
 import {
@@ -263,51 +264,95 @@ export const requireWorkspaceAccess = createMiddleware<Env>(async (c, next) => {
  * mcp.post("/", requireAuth, requireOrgAccess(), requireWorkspaceAccess, requireWorkspaceConfigAccess("mcpSelfManagement"), handler);
  * ```
  */
-export const requireWorkspaceConfigAccess = (
-  delegationFlag?: "providerSelfManagement" | "mcpSelfManagement",
-) =>
+export const requireWorkspaceConfigAccess = (delegationFlag?: DelegationFlag) =>
   createMiddleware<Env>(async (c, next) => {
-    const user = c.get("user");
-    const orgMembership = c.get("orgMembership");
+    const access = await workspaceConfigAccess(c, delegationFlag);
 
-    // Super admins and org admins always manage credential-bearing config.
-    if (isSuperAdmin(user) || orgMembership?.role === "admin") {
-      await next();
-      return;
-    }
-
-    // Past requireWorkspaceAccess, a non-admin can only be the workspace owner.
-    if (!c.get("isWorkspaceOwner")) {
-      return c.json({ error: "Admin access required" }, 403);
-    }
-
-    if (!delegationFlag) {
-      return c.json(
-        { error: "Only an organization admin can configure this resource" },
-        403,
-      );
-    }
-
-    const db = c.get("db");
-    const workspaceId = c.req.param("workspaceId");
-    const [ws] = await db
-      .select({ flag: workspaceTable[delegationFlag] })
-      .from(workspaceTable)
-      .where(eq(workspaceTable.id, workspaceId!))
-      .limit(1);
-
-    if (!ws?.flag) {
-      return c.json(
-        {
-          error:
-            "Self-management of this resource is not enabled for this workspace",
-        },
-        403,
-      );
+    if (!access.allowed) {
+      return c.json({ error: CONFIG_ACCESS_DENIED[access.reason] }, 403);
     }
 
     await next();
   });
+
+/** The workspace columns that let an Org Admin delegate a resource to its Owner. */
+export type DelegationFlag = "providerSelfManagement" | "mcpSelfManagement";
+
+/**
+ * Why a caller may not configure a credential- and reach-bearing resource.
+ * Carried rather than thrown so read paths can redact on the same rule the
+ * write paths reject on.
+ */
+export type ConfigAccessDenial =
+  /** Not an admin, and not even the Workspace Owner. */
+  | "not-owner"
+  /** Owner, but the resource is admin-only and never delegatable. */
+  | "not-delegatable"
+  /** Owner of a workspace where this resource's delegation flag is off. */
+  | "not-delegated";
+
+export type WorkspaceConfigAccess =
+  { allowed: true } | { allowed: false; reason: ConfigAccessDenial };
+
+const CONFIG_ACCESS_DENIED: Record<ConfigAccessDenial, string> = {
+  "not-owner": "Admin access required",
+  "not-delegatable": "Only an organization admin can configure this resource",
+  "not-delegated":
+    "Self-management of this resource is not enabled for this workspace",
+};
+
+/**
+ * The single authority on ADR-0006's question: may this caller configure a
+ * credential- and reach-bearing resource in this Workspace?
+ *
+ * Two callers, two shapes of the same rule — which is why the decision is
+ * returned rather than enforced here:
+ * - {@link requireWorkspaceConfigAccess} maps a denial to a 403 on write routes.
+ * - the Provider and MCP read routes map it to *redaction*, revealing stored
+ *   credentials only to a caller who is allowed to manage them. Gating the reads
+ *   outright is not an option: a Workspace Owner has to see which Providers and
+ *   MCPs exist in order to select one on an Agent or Chat, delegated or not.
+ *
+ * **Prerequisites:** must run after `requireOrgAccess` and
+ * `requireWorkspaceAccess` (reads `orgMembership` and `isWorkspaceOwner`).
+ *
+ * @param delegationFlag - Omit for admin-only resources that are never delegatable.
+ */
+export const workspaceConfigAccess = async (
+  c: Context<Env>,
+  delegationFlag?: DelegationFlag,
+): Promise<WorkspaceConfigAccess> => {
+  const user = c.get("user");
+  const orgMembership = c.get("orgMembership");
+
+  // Super admins and org admins always manage credential-bearing config.
+  if (isSuperAdmin(user) || orgMembership?.role === "admin") {
+    return { allowed: true };
+  }
+
+  // Past requireWorkspaceAccess, a non-admin can only be the workspace owner.
+  if (!c.get("isWorkspaceOwner")) {
+    return { allowed: false, reason: "not-owner" };
+  }
+
+  if (!delegationFlag) {
+    return { allowed: false, reason: "not-delegatable" };
+  }
+
+  const db = c.get("db");
+  const workspaceId = c.req.param("workspaceId");
+  const [ws] = await db
+    .select({ flag: workspaceTable[delegationFlag] })
+    .from(workspaceTable)
+    .where(eq(workspaceTable.id, workspaceId!))
+    .limit(1);
+
+  if (!ws?.flag) {
+    return { allowed: false, reason: "not-delegated" };
+  }
+
+  return { allowed: true };
+};
 
 /**
  * Middleware that restricts access to super admins only.

--- a/apps/backend/src/routes/mcp.test.ts
+++ b/apps/backend/src/routes/mcp.test.ts
@@ -145,6 +145,8 @@ describe("MCP Routes", () => {
         .mockReturnValueOnce(mockDb) // requireWorkspaceAccess
         .mockResolvedValueOnce(workspaceMcps) // route: workspace-scoped query
         .mockResolvedValueOnce(orgMcps); // route: attached org-scoped query
+      // workspaceConfigAccess — mcpSelfManagement not delegated
+      mockDb.limit.mockResolvedValueOnce([{ flag: false }]);
 
       const res = await app.request(baseUrl);
       expect(res.status).toBe(200);
@@ -159,6 +161,61 @@ describe("MCP Routes", () => {
   });
 
   describe("GET /:mcpId", () => {
+    it("redacts bearerToken when the owner has no mcpSelfManagement", async () => {
+      // ADR-0006: an MCP stays listable and grantable without the delegation,
+      // but its stored request credentials must not be returned.
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "mcp-1",
+          name: "WS MCP",
+          workspaceId,
+          organizationId: null,
+          authType: "Bearer",
+          bearerToken: "tok-secret",
+          headers: { "X-Api-Key": "hdr-secret" },
+        },
+      ]);
+      mockDb.limit.mockResolvedValueOnce([{ flag: false }]); // not delegated
+
+      const res = await app.request(`${baseUrl}/mcp-1`);
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).not.toContain("tok-secret");
+      expect(body).not.toContain("hdr-secret");
+      const parsed = JSON.parse(body) as Record<string, unknown>;
+      expect(parsed).not.toHaveProperty("bearerToken");
+      expect(parsed.bearerTokenSet).toEqual({ configured: true });
+    });
+
+    it("reveals bearerToken to an org admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "mcp-1",
+          name: "WS MCP",
+          workspaceId,
+          organizationId: null,
+          authType: "Bearer",
+          bearerToken: "tok-secret",
+        },
+      ]);
+      // No delegation lookup: an org admin short-circuits workspaceConfigAccess.
+
+      const res = await app.request(`${baseUrl}/mcp-1`);
+      expect(res.status).toBe(200);
+      const parsed = (await res.json()) as Record<string, unknown>;
+      expect(parsed.bearerToken).toBe("tok-secret");
+    });
+
     it("returns a workspace-scoped MCP tagged scope workspace", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
@@ -169,6 +226,8 @@ describe("MCP Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { id: "mcp-1", name: "WS MCP", workspaceId, organizationId: null },
       ]);
+      // workspaceConfigAccess — mcpSelfManagement not delegated
+      mockDb.limit.mockResolvedValueOnce([{ flag: false }]);
 
       const res = await app.request(`${baseUrl}/mcp-1`);
       expect(res.status).toBe(200);
@@ -194,6 +253,8 @@ describe("MCP Routes", () => {
       ]);
       // attachment check → attached here, so visible
       mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]);
+      // workspaceConfigAccess — mcpSelfManagement not delegated
+      mockDb.limit.mockResolvedValueOnce([{ flag: false }]);
 
       const res = await app.request(`${baseUrl}/mcp-org`);
       expect(res.status).toBe(200);

--- a/apps/backend/src/routes/mcp.ts
+++ b/apps/backend/src/routes/mcp.ts
@@ -18,7 +18,9 @@ import {
   requireOrgAccess,
   requireWorkspaceAccess,
   requireWorkspaceConfigAccess,
+  workspaceConfigAccess,
 } from "../middleware/authorization.ts";
+import { redactMcpSecrets } from "../services/credential-redaction.ts";
 import {
   listScoped,
   requireScoped,
@@ -107,8 +109,12 @@ mcp.get(
     // Workspace-scoped MCPs plus the Shared (org-scoped) MCPs attached here
     // (ADR-0007), each tagged with its scope for the frontend.
     const scoped = await listScoped(db, "mcp", { orgId, wsId: workspaceId });
+    // Request credentials are revealed only to a caller who may manage this MCP
+    // (ADR-0006) — the same rule the write routes reject on. The rows still list,
+    // because granting an MCP to an Agent does not require self-management.
+    const { allowed } = await workspaceConfigAccess(c, "mcpSelfManagement");
     const results = scoped.map(({ row, scope }) => ({
-      ...sanitizeMcpResponse(row),
+      ...redactMcpSecrets(sanitizeMcpResponse(row), { reveal: allowed }),
       scope,
     }));
 
@@ -130,7 +136,12 @@ mcp.get(
       orgId,
       wsId: workspaceId,
     });
-    return c.json({ ...sanitizeMcpResponse(row), scope });
+    // See the list route: redacted unless this caller may manage the MCP.
+    const { allowed } = await workspaceConfigAccess(c, "mcpSelfManagement");
+    return c.json({
+      ...redactMcpSecrets(sanitizeMcpResponse(row), { reveal: allowed }),
+      scope,
+    });
   },
 );
 

--- a/apps/backend/src/routes/org-mcp.ts
+++ b/apps/backend/src/routes/org-mcp.ts
@@ -26,6 +26,7 @@ import {
   buildMcpTransportConfig,
 } from "../services/mcp-oauth-provider.ts";
 import { OAUTH_TOKEN_CLEAR_FIELDS, sanitizeMcpResponse } from "./mcp.ts";
+import { redactMcpSecrets } from "../services/credential-redaction.ts";
 import { NotFoundError } from "../errors.ts";
 
 // Org-scoped MCPs are Shared resources (ADR-0007). They introduce credentials
@@ -65,7 +66,14 @@ orgMcp.get("/", requireAuth, requireOrgAccess(), async (c) => {
     .select()
     .from(mcpTable)
     .where(eq(mcpTable.organizationId, orgId));
-  return c.json({ results: results.map(sanitizeMcpResponse) });
+  // This route admits any Organization member — a Shared MCP has to be listable
+  // to be granted. Only an Org Admin sees its request credentials (ADR-0006).
+  const isAdmin = c.get("orgMembership")?.role === "admin";
+  return c.json({
+    results: results.map((row) =>
+      redactMcpSecrets(sanitizeMcpResponse(row), { reveal: isAdmin }),
+    ),
+  });
 });
 
 /** Get an org-scoped MCP by ID */
@@ -80,7 +88,11 @@ orgMcp.get("/:mcpId", requireAuth, requireOrgAccess(), async (c) => {
   if (record.length === 0) {
     throw new NotFoundError("MCP not found");
   }
-  return c.json(sanitizeMcpResponse(record[0]));
+  // See the list route: request credentials are Org-Admin-only (ADR-0006).
+  const isAdmin = c.get("orgMembership")?.role === "admin";
+  return c.json(
+    redactMcpSecrets(sanitizeMcpResponse(record[0]), { reveal: isAdmin }),
+  );
 });
 
 /** Update an org-scoped MCP by ID (admin only) */

--- a/apps/backend/src/routes/org-provider.test.ts
+++ b/apps/backend/src/routes/org-provider.test.ts
@@ -115,7 +115,51 @@ describe("Organization Provider Routes", () => {
 
       const res = await app.request(baseUrl);
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ results: mockProviders });
+      // A plain member may list Shared Providers — it is how one is selected —
+      // but credentials are Org-Admin-only (ADR-0006), so the row comes back
+      // with the secret fields replaced by presence flags.
+      expect(await res.json()).toEqual({
+        results: [
+          {
+            id: "p1",
+            name: "Org OpenAI",
+            apiKeySet: { configured: false },
+            headersSet: { configured: false },
+          },
+        ],
+      });
+    });
+
+    it("redacts apiKey for a non-admin member", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([
+          { id: "p1", name: "Org OpenAI", apiKey: "sk-secret" },
+        ]);
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).not.toContain("sk-secret");
+    });
+
+    it("reveals apiKey to an org admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([
+          { id: "p1", name: "Org OpenAI", apiKey: "sk-secret" },
+        ]);
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { results: Record<string, unknown>[] };
+      expect(data.results[0].apiKey).toBe("sk-secret");
     });
   });
 
@@ -132,7 +176,12 @@ describe("Organization Provider Routes", () => {
 
       const res = await app.request(`${baseUrl}/p1`);
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual(mockProvider);
+      // Credentials are Org-Admin-only (ADR-0006); see the list route.
+      expect(await res.json()).toEqual({
+        ...mockProvider,
+        apiKeySet: { configured: false },
+        headersSet: { configured: false },
+      });
     });
   });
 

--- a/apps/backend/src/routes/org-provider.ts
+++ b/apps/backend/src/routes/org-provider.ts
@@ -14,6 +14,7 @@ import {
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { requireSharedDeletable } from "../services/scoped-resource.ts";
+import { redactProviderSecrets } from "../services/credential-redaction.ts";
 import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
@@ -52,10 +53,17 @@ orgProvider.post(
 /** List all organization providers */
 orgProvider.get("/", requireAuth, requireOrgAccess(), async (c) => {
   const orgId = c.req.param("orgId")!;
-  const results = await db
+  const rows = await db
     .select()
     .from(providerTable)
     .where(eq(providerTable.organizationId, orgId));
+
+  // This route admits any Organization member — a Shared Provider has to be
+  // listable to be selected. Only an Org Admin sees its credentials (ADR-0006).
+  const isAdmin = c.get("orgMembership")?.role === "admin";
+  const results = rows.map((row) =>
+    redactProviderSecrets(row, { reveal: isAdmin }),
+  );
 
   return c.json({ results });
 });
@@ -80,7 +88,9 @@ orgProvider.get("/:providerId", requireAuth, requireOrgAccess(), async (c) => {
     throw new NotFoundError("Provider not found");
   }
 
-  return c.json(record[0]);
+  // See the list route: credentials are Org-Admin-only (ADR-0006).
+  const isAdmin = c.get("orgMembership")?.role === "admin";
+  return c.json(redactProviderSecrets(record[0], { reveal: isAdmin }));
 });
 
 /** Update an organization provider by ID (admin only) */

--- a/apps/backend/src/routes/provider.test.ts
+++ b/apps/backend/src/routes/provider.test.ts
@@ -170,10 +170,19 @@ describe("Provider Routes", () => {
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
 
-      const workspaceProviders = [{ id: "p1", name: "WS OpenAI" }];
+      const workspaceProviders = [
+        { id: "p1", name: "WS OpenAI", apiKey: "sk-ws" },
+      ];
       // Org-scoped query is an inner join on attachment → rows nest under `provider`.
       const orgProviders = [
-        { provider: { id: "p2", name: "Org OpenAI", organizationId: orgId } },
+        {
+          provider: {
+            id: "p2",
+            name: "Org OpenAI",
+            organizationId: orgId,
+            apiKey: "sk-org",
+          },
+        },
       ];
 
       mockDb.where
@@ -181,6 +190,8 @@ describe("Provider Routes", () => {
         .mockReturnValueOnce(mockDb) // requireWorkspaceAccess
         .mockResolvedValueOnce(workspaceProviders)
         .mockResolvedValueOnce(orgProviders);
+      // workspaceConfigAccess — providerSelfManagement not delegated
+      mockDb.limit.mockResolvedValueOnce([{ flag: false }]);
 
       const res = await app.request(baseUrl);
       expect(res.status).toBe(200);
@@ -192,6 +203,85 @@ describe("Provider Routes", () => {
           expect.objectContaining({ id: "p2", scope: "organization" }),
         ]),
       );
+    });
+
+    it("redacts apiKey when the owner has no providerSelfManagement", async () => {
+      // ADR-0006: a Workspace Owner who was not delegated Provider management
+      // may still LIST providers — selecting one on an Agent does not need the
+      // delegation — but must not receive the stored credential.
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([
+          {
+            id: "p1",
+            name: "WS OpenAI",
+            apiKey: "sk-secret",
+            headers: { Authorization: "Bearer nope" },
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      mockDb.limit.mockResolvedValueOnce([{ flag: false }]);
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { results: Record<string, unknown>[] };
+      const [row] = data.results;
+      expect(row).not.toHaveProperty("apiKey");
+      expect(row).not.toHaveProperty("headers");
+      expect(row.apiKeySet).toEqual({ configured: true });
+      expect(row.headersSet).toEqual({ configured: true });
+      expect(JSON.stringify(data)).not.toContain("sk-secret");
+    });
+
+    it("reveals apiKey to an org admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([
+          { id: "p1", name: "WS OpenAI", apiKey: "sk-secret" },
+        ])
+        .mockResolvedValueOnce([]);
+      // No delegation lookup: an org admin short-circuits workspaceConfigAccess.
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { results: Record<string, unknown>[] };
+      expect(data.results[0].apiKey).toBe("sk-secret");
+    });
+
+    it("reveals apiKey to an owner who was delegated providerSelfManagement", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([
+          { id: "p1", name: "WS OpenAI", apiKey: "sk-secret" },
+        ])
+        .mockResolvedValueOnce([]);
+      mockDb.limit.mockResolvedValueOnce([{ flag: true }]);
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { results: Record<string, unknown>[] };
+      expect(data.results[0].apiKey).toBe("sk-secret");
     });
   });
 
@@ -205,10 +295,35 @@ describe("Provider Routes", () => {
 
       const mockProvider = { id: "p1", name: "OpenAI", workspaceId };
       mockDb.limit.mockResolvedValueOnce([mockProvider]);
+      // workspaceConfigAccess — providerSelfManagement not delegated
+      mockDb.limit.mockResolvedValueOnce([{ flag: false }]);
 
       const res = await app.request(`${baseUrl}/p1`);
       expect(res.status).toBe(200);
-      expect(await res.json()).toEqual({ ...mockProvider, scope: "workspace" });
+      expect(await res.json()).toEqual({
+        ...mockProvider,
+        apiKeySet: { configured: false },
+        headersSet: { configured: false },
+        scope: "workspace",
+      });
+    });
+
+    it("redacts apiKey when the owner has no providerSelfManagement", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "p1", name: "OpenAI", workspaceId, apiKey: "sk-secret" },
+      ]); // resolveScoped
+      mockDb.limit.mockResolvedValueOnce([{ flag: false }]); // not delegated
+
+      const res = await app.request(`${baseUrl}/p1`);
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).not.toContain("sk-secret");
+      expect(JSON.parse(body)).not.toHaveProperty("apiKey");
     });
 
     it("should 404 for an org-scoped provider not attached here", async () => {

--- a/apps/backend/src/routes/provider.ts
+++ b/apps/backend/src/routes/provider.ts
@@ -16,7 +16,9 @@ import {
   requireOrgAccess,
   requireWorkspaceAccess,
   requireWorkspaceConfigAccess,
+  workspaceConfigAccess,
 } from "../middleware/authorization.ts";
+import { redactProviderSecrets } from "../services/credential-redaction.ts";
 import {
   listScoped,
   requireScoped,
@@ -76,7 +78,18 @@ provider.get(
       orgId,
       wsId: workspaceId,
     });
-    const results = scoped.map(({ row, scope }) => ({ ...row, scope }));
+    // Credentials are revealed only to a caller who may manage this Provider
+    // (ADR-0006) — the same rule the write routes reject on. The rows themselves
+    // still list, because selecting a Provider on an Agent or Chat does not
+    // require self-management.
+    const { allowed } = await workspaceConfigAccess(
+      c,
+      "providerSelfManagement",
+    );
+    const results = scoped.map(({ row, scope }) => ({
+      ...redactProviderSecrets(row, { reveal: allowed }),
+      scope,
+    }));
     return c.json({ results });
   },
 );
@@ -96,7 +109,15 @@ provider.get(
       orgId,
       wsId: workspaceId,
     });
-    return c.json({ ...found.row, scope: found.scope });
+    // See the list route: redacted unless this caller may manage the Provider.
+    const { allowed } = await workspaceConfigAccess(
+      c,
+      "providerSelfManagement",
+    );
+    return c.json({
+      ...redactProviderSecrets(found.row, { reveal: allowed }),
+      scope: found.scope,
+    });
   },
 );
 

--- a/apps/backend/src/services/credential-redaction.test.ts
+++ b/apps/backend/src/services/credential-redaction.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import {
+  redactMcpSecrets,
+  redactProviderSecrets,
+} from "./credential-redaction.ts";
+
+describe("redactProviderSecrets", () => {
+  const row = {
+    id: "p1",
+    name: "OpenAI",
+    apiKey: "sk-secret",
+    headers: { Authorization: "Bearer secret" },
+    baseUrl: "https://api.openai.com",
+  };
+
+  it("returns the row untouched when the caller may manage it", () => {
+    expect(redactProviderSecrets(row, { reveal: true })).toBe(row);
+  });
+
+  it("fails closed when no option is passed", () => {
+    // A new call site that forgets the flag must redact, not leak.
+    expect(redactProviderSecrets(row)).not.toHaveProperty("apiKey");
+  });
+
+  it("removes the credential fields and keeps the rest", () => {
+    const out = redactProviderSecrets(row, { reveal: false });
+    expect(out).not.toHaveProperty("apiKey");
+    expect(out).not.toHaveProperty("headers");
+    expect(out).toMatchObject({
+      id: "p1",
+      name: "OpenAI",
+      baseUrl: "https://api.openai.com",
+    });
+    expect(JSON.stringify(out)).not.toContain("sk-secret");
+    expect(JSON.stringify(out)).not.toContain("Bearer secret");
+  });
+
+  it("reports whether a credential is configured without revealing it", () => {
+    expect(redactProviderSecrets(row, { reveal: false })).toMatchObject({
+      apiKeySet: { configured: true },
+      headersSet: { configured: true },
+    });
+    expect(
+      redactProviderSecrets({ ...row, apiKey: "", headers: null }, {}),
+    ).toMatchObject({
+      apiKeySet: { configured: false },
+      headersSet: { configured: false },
+    });
+  });
+
+  it("treats an empty header object as unconfigured", () => {
+    // `{}` round-trips out of jsonb for a Provider saved with no custom headers;
+    // reporting it as configured would send the form hunting for a value that
+    // isn't there.
+    expect(redactProviderSecrets({ ...row, headers: {} }, {})).toMatchObject({
+      headersSet: { configured: false },
+    });
+  });
+});
+
+describe("redactMcpSecrets", () => {
+  const row = {
+    id: "mcp-1",
+    name: "Rovo",
+    authType: "Bearer",
+    bearerToken: "tok-secret",
+    headers: { "X-Api-Key": "hdr-secret" },
+  };
+
+  it("returns the row untouched when the caller may manage it", () => {
+    expect(redactMcpSecrets(row, { reveal: true })).toBe(row);
+  });
+
+  it("fails closed when no option is passed", () => {
+    expect(redactMcpSecrets(row)).not.toHaveProperty("bearerToken");
+  });
+
+  it("removes the request credentials and keeps the rest", () => {
+    const out = redactMcpSecrets(row, { reveal: false });
+    expect(out).not.toHaveProperty("bearerToken");
+    expect(out).not.toHaveProperty("headers");
+    expect(out).toMatchObject({
+      id: "mcp-1",
+      name: "Rovo",
+      authType: "Bearer",
+    });
+    expect(JSON.stringify(out)).not.toContain("tok-secret");
+    expect(JSON.stringify(out)).not.toContain("hdr-secret");
+  });
+
+  it("reports presence for an OAuth MCP that has no bearer token", () => {
+    const out = redactMcpSecrets(
+      { id: "m", authType: "OAuth", bearerToken: null },
+      {},
+    );
+    expect(out).toMatchObject({ bearerTokenSet: { configured: false } });
+  });
+});

--- a/apps/backend/src/services/credential-redaction.ts
+++ b/apps/backend/src/services/credential-redaction.ts
@@ -1,0 +1,91 @@
+/**
+ * The single home for "which fields of a Scoped resource may this caller read?".
+ *
+ * Providers and MCPs are the credential- and reach-bearing resources of ADR-0006:
+ * an Org Admin configures them, and a Workspace Owner may self-manage them only
+ * where the Organization delegated it. That rule gated every *write* route and no
+ * *read* route, so the stored credential was returned to any caller who could see
+ * the resource at all — including a plain Organization member on the Organization
+ * surface, where the read routes take `requireOrgAccess()` with no role.
+ *
+ * Redaction, not gating, is the fix: a Workspace Owner has to list Providers and
+ * MCPs to select one on an Agent or Chat whether or not credentials were delegated
+ * to them, so the rows must keep flowing with the secrets removed.
+ *
+ * `reveal` defaults to `false` on both helpers so a new call site fails closed.
+ */
+
+/** Replaces a redacted secret so a caller can tell "unset" from "not shown". */
+export type SecretPresence = {
+  /** True when a value is stored, whatever it is. Never the value itself. */
+  configured: boolean;
+};
+
+const presence = (value: unknown): SecretPresence => ({
+  configured:
+    value !== null &&
+    value !== undefined &&
+    value !== "" &&
+    !(typeof value === "object" && Object.keys(value).length === 0),
+});
+
+type ProviderSecretFields = {
+  apiKey: string;
+  headers?: Record<string, string> | null;
+};
+
+/**
+ * Strips a Provider's stored credentials unless the caller may manage it.
+ *
+ * `headers` goes with `apiKey`: a custom header block is where a self-hosted or
+ * proxied Provider carries its own `Authorization`, so revealing it while hiding
+ * `apiKey` would leak the same class of secret through the other field.
+ */
+export const redactProviderSecrets = <T extends ProviderSecretFields>(
+  row: T,
+  opts: { reveal?: boolean } = {},
+):
+  | T
+  | (Omit<T, "apiKey" | "headers"> & {
+      apiKeySet: SecretPresence;
+      headersSet: SecretPresence;
+    }) => {
+  if (opts.reveal) return row;
+  const { apiKey, headers, ...rest } = row;
+  return {
+    ...rest,
+    apiKeySet: presence(apiKey),
+    headersSet: presence(headers),
+  };
+};
+
+type McpSecretFields = {
+  bearerToken?: string | null;
+  headers?: Record<string, string> | null;
+};
+
+/**
+ * Strips an MCP's stored request credentials unless the caller may manage it.
+ *
+ * Distinct from the OAuth token strip in `sanitizeMcpResponse`, which is
+ * unconditional: those tokens are minted by Platypus and never belong in a
+ * response, whereas `bearerToken` and `headers` are Operator-entered config that
+ * the edit form legitimately reads back for whoever may edit it.
+ */
+export const redactMcpSecrets = <T extends McpSecretFields>(
+  row: T,
+  opts: { reveal?: boolean } = {},
+):
+  | T
+  | (Omit<T, "bearerToken" | "headers"> & {
+      bearerTokenSet: SecretPresence;
+      headersSet: SecretPresence;
+    }) => {
+  if (opts.reveal) return row;
+  const { bearerToken, headers, ...rest } = row;
+  return {
+    ...rest,
+    bearerTokenSet: presence(bearerToken),
+    headersSet: presence(headers),
+  };
+};

--- a/apps/docs/content/building-with-platypus/mcp.mdx
+++ b/apps/docs/content/building-with-platypus/mcp.mdx
@@ -104,6 +104,11 @@ again at the Organization level.
   one.
 </Callout>
 
+A registered MCP's bearer token and custom headers are readable only by someone
+who can manage it. Everyone else still sees the server and can grant its tool
+set to an Agent; the credential fields come back empty, flagged only as set or
+unset.
+
 ## Where to next
 
 - **[Agents & sub-agents](/building-with-platypus/agents)** — grant the tool set

--- a/apps/docs/content/concepts/providers.mdx
+++ b/apps/docs/content/concepts/providers.mdx
@@ -45,6 +45,11 @@ A Provider lives at one of two levels:
   authentication](/self-hosting/providers-and-auth) for setup.
 </Callout>
 
+Stored credentials — the API key and any custom headers — are readable only by
+someone who can manage the Provider. Everyone else still sees the Provider and
+can select its models; the credential fields come back empty, flagged only as
+set or unset.
+
 **Why this matters to you:** the models you can pick on a Chat or an Agent come
 from the Providers available in your Workspace. If a model you expect isn't
 there, it's because no available Provider has it enabled — an Org Admin controls

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -537,7 +537,11 @@ const ProviderForm = ({
       setFormData({
         providerType: provider.providerType,
         name: provider.name,
-        apiKey: provider.apiKey,
+        // The API is free to withhold the stored key: it is returned only to a
+        // caller who may manage this Provider (ADR-0006). Anyone else lands here
+        // read-only, so an empty field is the honest rendering — and keeps the
+        // input controlled either way.
+        apiKey: provider.apiKey ?? "",
         region: provider.region || "",
         baseUrl: provider.baseUrl || "",
         headers: provider.headers || {},


### PR DESCRIPTION
## Summary

Provider and MCP read routes returned the full row — stored credentials included — to any caller who could see the resource. ADR-0006 governs who may *manage* these two resources; this makes it govern who may *read* their secrets too.

Affected fields: `provider.apiKey`, `mcp.bearerToken`, and the `headers` block on both. `sanitizeMcpResponse` already stripped the Platypus-minted `oauth*` tokens; Provider had no redaction at all.

## Approach

**Redact rather than gate.** A Workspace Owner has to list Providers and MCPs to select one on an Agent or Chat whether or not credentials were delegated to them, so gating the reads would break ordinary use. The rows keep flowing with secrets replaced by a `{ configured: boolean }` presence flag.

- `services/credential-redaction.ts` (new) — `redactProviderSecrets` / `redactMcpSecrets`. `reveal` defaults to `false`, so a new call site fails closed rather than open.
- `middleware/authorization.ts` — `workspaceConfigAccess` extracts the ADR-0006 decision out of `requireWorkspaceConfigAccess`, which becomes a thin mapping of a denial to a 403. One rule, two adapters: reject on write, redact on read.
- The Provider and MCP read routes on both the Workspace and Organization surfaces consult it.

`headers` travels with the primary credential on both resources: a custom header block is where a proxied Provider or a self-hosted MCP carries its own `Authorization`, so revealing it while hiding the key would leak the same secret under another name.

## Behaviour change

Clients reading `apiKey` / `bearerToken` back from a list or get now receive `apiKeySet` / `bearerTokenSet` instead, unless the caller may manage the resource. `provider-form.tsx` is updated to tolerate this; `mcp-form.tsx` already did.

## Tests

Four existing tests asserted the full row came back for a non-managing caller; those are now regression tests in the other direction. New coverage for redact-vs-reveal on both resources and both surfaces, plus a unit suite for the redaction module.

Backend `1627 passed`; lint, typecheck and test all green locally.

## Known limitation, not addressed here

`providerUpdateSchema` picks `apiKey` off the base as required, so there is no "leave the field blank to keep the stored key". It doesn't bite today — anyone who can update also gets the key revealed — but the write-only-credential shape needs a schema change. A docs sentence claiming otherwise was removed rather than documenting something unimplemented.

## Follow-up

The same per-route redaction judgement applies to other Scoped resources. A single redaction authority per resource type is the natural next step.

Docs ship here per `CLAUDE.md` — `concepts/providers.mdx` and `building-with-platypus/mcp.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)