### PR TITLE
fix(chat): deliver tool durations on the turn that measured them

### DIFF
--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -462,7 +462,7 @@ describe("rejected tool input instrumentation", () => {
       (opts: { onStepFinish: (step: unknown) => void }) => {
         streamHarness.onStepFinish = opts.onStepFinish;
         return {
-          toUIMessageStream: () => ({ tee: () => [{}, {}] }),
+          toUIMessageStream: () => emptyUIStream(),
         };
       },
     );
@@ -897,6 +897,20 @@ const resetStreamHarness = (): void => {
   streamHarness.messageMetadata = undefined;
 };
 
+/**
+ * A stand-in for what `toUIMessageStream` returns.
+ *
+ * A real (empty) `ReadableStream` rather than a `{ tee }` literal, because the
+ * runner pipes it through the tool-duration transform before teeing — a literal
+ * with only the methods used today silently becomes a lie the moment the
+ * pipeline changes. Nothing reads the branches: `readUIMessageStream` is mocked
+ * to the harness queue and the response is a sentinel.
+ */
+const emptyUIStream = () =>
+  new ReadableStream({
+    start: (controller) => controller.close(),
+  });
+
 // Make streamText return a fake result whose UI-stream callbacks the test can
 // drive by hand: `onStepFinish` (per step), `onFinish` (completion), and
 // `messageMetadata` (per stream part).
@@ -918,7 +932,7 @@ const primeStreamText = () => {
         }) => {
           streamHarness.onFinish = uiOpts.onFinish;
           streamHarness.messageMetadata = uiOpts.messageMetadata;
-          return { tee: () => [{}, {}] };
+          return emptyUIStream();
         },
       };
     },
@@ -1116,7 +1130,7 @@ describe("AgentRunner.stream — success & interruption", () => {
             onFinish: (ctx: { messages: unknown[] }) => Promise<void> | void;
           }) => {
             streamHarness.onFinish = uiOpts.onFinish;
-            return { tee: () => [{}, {}] };
+            return emptyUIStream();
           },
         };
       },

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -462,8 +462,9 @@ export class AgentRunner {
     logger.debug({ systemPrompt: modelArgs.system }, "System prompt for chat");
 
     // How long each locally-executed tool took, keyed by `toolCallId`. The SDK
-    // has already measured it; we only hold onto it until the finished messages
-    // exist to stamp it onto (see `applyToolDurations`). Provider-executed tools
+    // has already measured it; we only hold onto it long enough to stamp it onto
+    // the outgoing chunks and onto the finished messages (see
+    // `injectToolDurations` and `applyToolDurations`). Provider-executed tools
     // never reach this callback and so carry no duration.
     const toolDurations = new Map<string, number>();
 
@@ -492,12 +493,16 @@ export class AgentRunner {
     const uiStream = result.toUIMessageStream<PlatypusUIMessage>({
       originalMessages: input.messages,
       generateMessageId: createIdGenerator({ prefix: "msg", size: 16 }),
-      messageMetadata: createMessageMetadata(state.turn?.resolved.agentId),
+      messageMetadata: createMessageMetadata(
+        state.turn?.resolved.agentId,
+        toolDurations,
+      ),
       onError: (error) => formatStreamError(error),
       onFinish: async ({ messages: finalMessages }) => {
-        // Stamped here rather than on the snapshot branch below, which sees no
-        // durations at all. Setting the flag first closes that branch's window
-        // to overwrite this, so the sink's terminal write observes the patch.
+        // Stamped onto the parts here as well as travelling out as metadata:
+        // this is the per-part form the persisted messages use, and the one a
+        // reload reads. Setting the flag first closes the snapshot branch's
+        // window to overwrite this, so the sink's terminal write observes it.
         finalMessagesReceived = true;
         state.messages = applyToolDurations(finalMessages, toolDurations);
         let status: RunStatus = "succeeded";

--- a/apps/backend/src/runs/message-metadata.test.ts
+++ b/apps/backend/src/runs/message-metadata.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from "vitest";
-import { readUIMessageStream, stepCountIs, streamText, tool } from "ai";
+import {
+  isToolUIPart,
+  readUIMessageStream,
+  stepCountIs,
+  streamText,
+  tool,
+} from "ai";
 import { MockLanguageModelV4, simulateReadableStream } from "ai/test";
 import { z } from "zod";
 
@@ -266,5 +272,98 @@ describe("Context occupancy over a real multi-step stream", () => {
       inputTokens: 4_200,
       outputTokens: null,
     });
+  });
+});
+
+/**
+ * Tool durations over a real stream.
+ *
+ * The point of driving the real SDK here is that the mechanism this feature
+ * depends on is entirely the SDK's. `applyToolDurations` stamps the figure onto
+ * the tool part, but the stream's tool reducer rebuilds that part from its
+ * stored invocation and discards the stamp — so a unit test of the stamp passes
+ * while the browser shows nothing (issue #353). Only a real stream can tell the
+ * two apart, and these tests assert on the message a client actually reduces.
+ */
+describe("tool durations over a real multi-step stream", () => {
+  /** Takes long enough that a rounded millisecond figure is non-zero. */
+  const slowPing = tool({
+    description: "Ping a service.",
+    inputSchema: z.object({}),
+    execute: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return "pong";
+    },
+  });
+
+  /** Runs a two-step turn, wiring the durations exactly as the runner does. */
+  const runToolTurn = async (tools: Record<string, typeof slowPing>) => {
+    const toolDurations = new Map<string, number>();
+    const result = streamText({
+      model: mockModel([
+        toolCallStep(usage(1_000, 30)),
+        answerStep(usage(4_200, 70)),
+      ]),
+      prompt: "Ping the service and tell me what it said.",
+      tools,
+      stopWhen: [stepCountIs(5)],
+      onToolExecutionEnd: ({ toolCall, toolExecutionMs }) => {
+        toolDurations.set(toolCall.toolCallId, toolExecutionMs);
+      },
+    });
+
+    const message = await lastSnapshot(
+      result.toUIMessageStream({
+        messageMetadata: createMessageMetadata("agent-1", toolDurations),
+      }),
+    );
+    return { message, toolDurations };
+  };
+
+  it("delivers the executed tool's duration on the reduced message", async () => {
+    const { message } = await runToolTurn({ ping: slowPing });
+
+    const delivered = message?.metadata?.toolDurations?.["call-1"];
+    expect(typeof delivered).toBe("number");
+    expect(delivered).toBeGreaterThanOrEqual(15);
+  });
+
+  // The reason the duration travels as message metadata at all: the SDK gives
+  // the tool part back without it, so this asserts the gap the metadata fills.
+  // If a future SDK starts honouring the output chunk's `toolMetadata`, this
+  // test failing is the signal that the metadata channel is now redundant.
+  it("confirms the SDK leaves the tool part itself without a duration", async () => {
+    const { message } = await runToolTurn({ ping: slowPing });
+
+    const toolPart = message?.parts.find((part) => isToolUIPart(part));
+    expect(toolPart).toBeDefined();
+    expect(
+      (toolPart as { toolMetadata?: Record<string, unknown> }).toolMetadata
+        ?.durationMs,
+    ).toBeUndefined();
+  });
+
+  it("agrees with the figure the SDK measured", async () => {
+    const { message, toolDurations } = await runToolTurn({ ping: slowPing });
+
+    expect(message?.metadata?.toolDurations?.["call-1"]).toBe(
+      Math.round(toolDurations.get("call-1")!),
+    );
+  });
+
+  it("records no durations for a turn that ran no tools", async () => {
+    const result = streamText({
+      model: mockModel([answerStep(usage(1_000, 30))]),
+      prompt: "Just answer.",
+      stopWhen: [stepCountIs(5)],
+    });
+
+    const message = await lastSnapshot(
+      result.toUIMessageStream({
+        messageMetadata: createMessageMetadata("agent-1", new Map()),
+      }),
+    );
+
+    expect(message?.metadata?.toolDurations).toBeUndefined();
   });
 });

--- a/apps/backend/src/runs/message-metadata.ts
+++ b/apps/backend/src/runs/message-metadata.ts
@@ -20,8 +20,15 @@ import type { ChatMessageMetadata } from "../types.ts";
  * `agentId` is read once, here, rather than off the run state when the `start`
  * part arrives: the turn resolves during setup, before the stream is built, and
  * nothing reassigns the resolved agent mid-run.
+ *
+ * `toolDurations` is the live map the runner fills from `onToolExecutionEnd`.
+ * It is read rather than copied: this extractor runs per part, and each read
+ * happens after the entry it wants has been written.
  */
-export const createMessageMetadata = (agentId: string | undefined) => {
+export const createMessageMetadata = (
+  agentId: string | undefined,
+  toolDurations: ReadonlyMap<string, number> = new Map(),
+) => {
   // Whether any step of this turn has reported an input-token count. Only
   // read to erase a reading, never to synthesise one — see the `finish-step`
   // branch below.
@@ -66,6 +73,28 @@ export const createMessageMetadata = (agentId: string | undefined) => {
           outputTokens: typeof outputTokens === "number" ? outputTokens : null,
         },
       };
+    }
+    // How long the tool that just finished took. This is the ONLY way the
+    // figure reaches the browser: the stream's tool reducer rebuilds the tool
+    // part from the stored invocation and discards the `toolMetadata` an output
+    // chunk carried, so the per-part stamp `applyToolDurations` writes is
+    // invisible until the message is re-fetched (issue #353).
+    //
+    // Read on the tool's own result part rather than gathered at the end, so
+    // each duration lands with the output it describes instead of the whole set
+    // arriving after the reply. The SDK awaits `onToolExecutionEnd` inside
+    // `executeToolCall` and only emits the result afterwards, so the map
+    // already holds this call's figure — ordering, not luck.
+    //
+    // One key per call, merged: the SDK's deep merge recurses into plain
+    // objects, so each part contributes its own entry and the accumulated map
+    // survives. A call absent from the map was executed by the Provider, never
+    // locally, and so was never measured.
+    if (part.type === "tool-result" || part.type === "tool-error") {
+      const durationMs = toolDurations.get(part.toolCallId);
+      return durationMs === undefined
+        ? undefined
+        : { toolDurations: { [part.toolCallId]: Math.round(durationMs) } };
     }
     // The terminal finish only. A step inside a tool loop can end at the
     // ceiling and the run still recover and complete normally; flagging those

--- a/apps/backend/src/runs/tool-durations.ts
+++ b/apps/backend/src/runs/tool-durations.ts
@@ -2,13 +2,22 @@ import { isToolUIPart } from "ai";
 import type { PlatypusUIMessage } from "../types.ts";
 
 /**
- * Folds recorded tool execution times into the run's final messages.
+ * Folds recorded tool execution times into the run's final messages — the copy
+ * the sink persists, and therefore what a later reload reads.
  *
- * Kept pure and separate from the runner because the SDK gives no seam for
- * writing this while streaming: the UI message stream's `tool-output-available`
- * reducer keeps the *stored* invocation's `toolMetadata` and drops whatever the
- * output chunk carried. So the duration is stamped once, on the finished
- * messages, just before the sink writes them.
+ * This is the stamp of record, but it is not how the figure reaches the browser.
+ * Nothing can put a measured duration on the tool part while streaming: the UI
+ * message stream's `tool-output-available` reducer rebuilds the part from the
+ * *stored* invocation and passes `toolMetadata: toolInvocation.toolMetadata`,
+ * discarding whatever the output chunk carried (verified in `ai@7.0.48`, and the
+ * same gotcha #353 recorded against `ai@6.x`). Writing it on
+ * `tool-input-available`, which the reducer does read, is no good either — the
+ * tool has not run yet.
+ *
+ * So the live figure travels as message metadata instead, keyed by
+ * `toolCallId` (see `createMessageMetadata`), and this stamp keeps the per-part
+ * form that every message persisted so far already uses. The frontend reads the
+ * part first and falls back to the metadata.
  *
  * Durations are keyed by `toolCallId`, which both static (`tool-*`) and dynamic
  * tool parts carry. Existing metadata is merged, not replaced — the field is

--- a/apps/backend/src/types.ts
+++ b/apps/backend/src/types.ts
@@ -23,6 +23,21 @@ export type ChatMessageMetadata = {
    */
   truncatedByTokenLimit?: true;
   /**
+   * How long each of the turn's locally-executed tools took, in whole
+   * milliseconds, keyed by `toolCallId`.
+   *
+   * A delivery channel, not the record: the same figures are stamped onto the
+   * tool parts themselves (`toolMetadata.durationMs`), which is what a reload
+   * reads and what every message persisted so far carries. They live here as
+   * well because the UI message stream's tool reducer discards metadata an
+   * output chunk carries, leaving message metadata as the only seam that
+   * reaches the browser mid-turn (issue #353).
+   *
+   * Absent for a turn that ran no local tools. A single call is absent where the
+   * Provider executed it in its own service, which Platypus never measures.
+   */
+  toolDurations?: Record<string, number>;
+  /**
    * How full the model's Context window was when this message was produced
    * (ADR-0018): the input-token count the Provider reported for the **last**
    * model call of the turn — inclusive of cached reads and writes, so the true

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -92,10 +92,10 @@ card. Its header shows the Tool's name, a status — **Pending**, **Running**,
 **Completed**, **Error** — and how long the Tool took: `<1ms`, `842ms`, `1.2s`,
 or `1m 03s` past a minute.
 
-The time is the Tool's own work, measured on the server, so it appears a moment
-after the reply finishes rather than while the Tool is running. It is stored
-with the message and does not change afterwards. A Tool that failed still shows
-the time it spent before failing.
+The time is the Tool's own work, measured on the server, so it appears the
+moment the Tool finishes rather than counting up while it runs. It is stored
+with the message and does not change afterwards — the number you first see is
+final. A Tool that failed still shows the time it spent before failing.
 
 Read it against the reply as a whole: most Tools land in single milliseconds, so
 a turn that felt slow and shows nothing above `1.2s` spent its time in the

--- a/apps/frontend/components/chat-message.test.tsx
+++ b/apps/frontend/components/chat-message.test.tsx
@@ -156,4 +156,32 @@ describe("ChatMessage tool duration", () => {
     expect(screen.getByText("Completed")).toBeInTheDocument();
     expect(screen.queryByText(/\d+ms|\d+\.\d+s/)).toBeNull();
   });
+
+  // The live case, and the one that was broken: mid-turn the SDK hands back a
+  // tool part stripped of its metadata, so the figure has to come off the
+  // message. Without this the duration was blank until the chat was re-fetched
+  // — and the next turn then overwrote it out of the database.
+  it.each([
+    ["a static tool", staticToolPart()],
+    ["a dynamic tool", dynamicToolPart()],
+  ])("renders the duration delivered on the message for %s", (_, part) => {
+    const message = withToolPart(part);
+    message.metadata = { toolDurations: { "call-1": 1234 } };
+
+    renderMessage(message);
+
+    expect(screen.getByText(/1\.2s/)).toBeInTheDocument();
+  });
+
+  it("shows the same figure whichever carrier holds it", () => {
+    const fromMessage = withToolPart(staticToolPart());
+    fromMessage.metadata = { toolDurations: { "call-1": 1234 } };
+    const { unmount } = renderMessage(fromMessage);
+    const live = screen.getByText(/1\.2s/).textContent;
+    unmount();
+
+    renderMessage(withToolPart(staticToolPart({ durationMs: 1234 })));
+
+    expect(screen.getByText(/1\.2s/).textContent).toBe(live);
+  });
 });

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -46,7 +46,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { Textarea } from "./ui/textarea";
-import { toolDurationMs } from "@/lib/tool-duration";
+import { toolCallDurationMs } from "@/lib/tool-duration";
 import { CutShortNotice } from "./cut-short-notice";
 import { LoadSkillTool } from "./load-skill-tool";
 import { SubAgentTool } from "./sub-agent-tool";
@@ -221,7 +221,11 @@ export const ChatMessage = memo(function ChatMessage({
               <DynamicToolHeader
                 state={toolPart.state}
                 title={toolPart.toolName}
-                durationMs={toolDurationMs(toolPart.toolMetadata)}
+                durationMs={toolCallDurationMs(
+                  toolPart.toolMetadata,
+                  message.metadata,
+                  toolPart.toolCallId,
+                )}
               />
               <ToolContent>
                 <ToolInput input={toolPart.input} />
@@ -239,7 +243,13 @@ export const ChatMessage = memo(function ChatMessage({
           part.type.startsWith("tool-delegateTo")
         ) {
           // Sub-agent tools get custom UI with robot icon and nested chat
-          return <SubAgentTool key={`${message.id}-${i}`} toolPart={part} />;
+          return (
+            <SubAgentTool
+              key={`${message.id}-${i}`}
+              toolPart={part}
+              messageMetadata={message.metadata}
+            />
+          );
         } else if (isToolUIPart(part)) {
           // Plugin- and MCP-contributed tools aren't enumerated in the part
           // union (see `CustomUITools`), so they land on the generic renderer.
@@ -252,7 +262,11 @@ export const ChatMessage = memo(function ChatMessage({
                 state={part.state}
                 type={part.type}
                 label={toolLabel}
-                durationMs={toolDurationMs(part.toolMetadata)}
+                durationMs={toolCallDurationMs(
+                  part.toolMetadata,
+                  message.metadata,
+                  part.toolCallId,
+                )}
               />
               <ToolContent>
                 <ToolInput input={part.input} />

--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -292,6 +292,62 @@ describe("ProviderForm model rows", () => {
     expect(savedModelIds(fetchMock)[0]).not.toHaveProperty("maxOutputTokens");
   });
 
+  // `Number.parseInt` truncated at the first unreadable character, so `1e5` and
+  // `1.9` both saved as 1 — accepted by the schema, and every reply on the model
+  // then stopped after one token. A ceiling must reach the server as typed or
+  // not at all.
+  it("reads an exponent in the output ceiling as the number it denotes", async () => {
+    const fetchMock = mockAcceptedSave();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditForm([
+      { id: "gpt-4o", passthroughFileTypes: [], maxOutputTokens: 64000 },
+    ]);
+    fireEvent.change(screen.getByLabelText("Max output tokens"), {
+      target: { value: "1e5" },
+    });
+    save();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(savedModelIds(fetchMock)[0].maxOutputTokens).toBe(100_000);
+  });
+
+  // Passed through as typed rather than floored to 1: the schema's `.int()`
+  // rejects it with a message the reader can act on, which is the whole point of
+  // not coercing here.
+  it("sends a fractional output ceiling as typed, for the schema to reject", async () => {
+    const fetchMock = mockAcceptedSave();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditForm([
+      { id: "gpt-4o", passthroughFileTypes: [], maxOutputTokens: 64000 },
+    ]);
+    fireEvent.change(screen.getByLabelText("Max output tokens"), {
+      target: { value: "1.9" },
+    });
+    save();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(savedModelIds(fetchMock)[0].maxOutputTokens).toBe(1.9);
+  });
+
+  // The extracted-text cap shares the parser, so it shares the fix.
+  it("reads an exponent in the extracted-text cap as the number it denotes", async () => {
+    const fetchMock = mockAcceptedSave();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderEditForm([
+      { id: "gpt-4o", passthroughFileTypes: [], maxExtractedTextChars: 1000 },
+    ]);
+    fireEvent.change(screen.getByLabelText("Max extracted text characters"), {
+      target: { value: "2e4" },
+    });
+    save();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(savedModelIds(fetchMock)[0].maxExtractedTextChars).toBe(20_000);
+  });
+
   it("declares no output ceiling for a row that was left alone", async () => {
     const fetchMock = mockAcceptedSave();
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -210,8 +210,16 @@ const ModelRow = ({
   // at nothing (issue #454). Undefined is also what clears a value already
   // stored: the whole `modelIds` array is replaced on save, so the key simply
   // stops being sent.
-  const parsePositiveInt = (value: string): number | undefined => {
-    const parsed = Number.parseInt(value, 10);
+  //
+  // `Number`, never `Number.parseInt`: parseInt truncates at the first
+  // character it cannot read, so `1e5` and `1.9` both became 1 — a value the
+  // schema accepts, which then capped every reply on the model at one token
+  // with nothing on screen pointing at the field. Anything numeric is passed
+  // through EXACTLY as typed and a non-integer is left for the schema to reject
+  // with a message, matching `parseContextWindowInput`. Silently coercing input
+  // into something storable is the one outcome neither field can afford.
+  const parsePositiveNumber = (value: string): number | undefined => {
+    const parsed = Number(value);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
   };
 
@@ -388,7 +396,7 @@ const ModelRow = ({
                 value={model.maxExtractedTextChars ?? ""}
                 onChange={(e) =>
                   onChange({
-                    maxExtractedTextChars: parsePositiveInt(e.target.value),
+                    maxExtractedTextChars: parsePositiveNumber(e.target.value),
                   })
                 }
                 disabled={disabled}
@@ -417,7 +425,7 @@ const ModelRow = ({
                 aria-invalid={!!errors.fields.maxOutputTokens}
                 onChange={(e) =>
                   onChange({
-                    maxOutputTokens: parsePositiveInt(e.target.value),
+                    maxOutputTokens: parsePositiveNumber(e.target.value),
                   })
                 }
                 disabled={disabled}

--- a/apps/frontend/components/sub-agent-tool.tsx
+++ b/apps/frontend/components/sub-agent-tool.tsx
@@ -27,7 +27,7 @@ import {
 } from "./ai-elements/message";
 import { Shimmer } from "./ai-elements/shimmer";
 import { ToolDuration } from "./tool-duration";
-import { toolDurationMs } from "@/lib/tool-duration";
+import { toolCallDurationMs } from "@/lib/tool-duration";
 import { useMemo, type ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 
@@ -235,13 +235,22 @@ const ResponseBlock = ({
 
 interface SubAgentToolProps {
   toolPart: ToolUIPart;
+  /**
+   * The metadata of the message this invocation sits on, which is where a
+   * duration arrives from mid-turn. Passed in rather than read here: resolving
+   * it needs both carriers, and the composing message already holds them.
+   */
+  messageMetadata?: unknown;
 }
 
 /**
  * Renders a sub-agent tool invocation. Shows a real-time activity log while the
  * sub-agent runs, then the plain-text result when complete.
  */
-export const SubAgentTool = ({ toolPart }: SubAgentToolProps) => {
+export const SubAgentTool = ({
+  toolPart,
+  messageMetadata,
+}: SubAgentToolProps) => {
   const input = toolPart.input as { task?: string };
   const output = toolPart.output as SubAgentActivity | string | null;
   const errorText = toolPart.errorText;
@@ -280,7 +289,13 @@ export const SubAgentTool = ({ toolPart }: SubAgentToolProps) => {
         <div className="flex items-center gap-2">
           <BotIcon className="size-4 text-muted-foreground" />
           <span className="font-medium text-sm">{subAgentName}</span>
-          <ToolDuration durationMs={toolDurationMs(toolPart.toolMetadata)} />
+          <ToolDuration
+            durationMs={toolCallDurationMs(
+              toolPart.toolMetadata,
+              messageMetadata,
+              toolPart.toolCallId,
+            )}
+          />
           {getStatusBadge(effectiveState)}
         </div>
         <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]/subagent:rotate-180" />

--- a/apps/frontend/lib/tool-duration.test.ts
+++ b/apps/frontend/lib/tool-duration.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { formatToolDuration, toolDurationMs } from "./tool-duration";
+import {
+  formatToolDuration,
+  toolCallDurationMs,
+  toolDurationMs,
+} from "./tool-duration";
 
 describe("formatToolDuration", () => {
   it("renders sub-second durations in milliseconds", () => {
@@ -43,5 +47,78 @@ describe("toolDurationMs", () => {
     expect(toolDurationMs({})).toBeUndefined();
     expect(toolDurationMs({ durationMs: "1234" })).toBeUndefined();
     expect(toolDurationMs({ durationMs: null })).toBeUndefined();
+  });
+});
+
+describe("toolCallDurationMs", () => {
+  it("prefers the part's own recorded duration", () => {
+    expect(
+      toolCallDurationMs(
+        { durationMs: 500 },
+        { toolDurations: { "call-1": 999 } },
+        "call-1",
+      ),
+    ).toBe(500);
+  });
+
+  // The live case: during the turn that produced it, the SDK hands back a tool
+  // part with no metadata, so the message's map is the only carrier.
+  it("falls back to the message's map when the part carries nothing", () => {
+    expect(
+      toolCallDurationMs(
+        undefined,
+        { toolDurations: { "call-1": 842 } },
+        "call-1",
+      ),
+    ).toBe(842);
+  });
+
+  it("reads the entry for the right tool call", () => {
+    const metadata = { toolDurations: { "call-1": 10, "call-2": 20 } };
+
+    expect(toolCallDurationMs(undefined, metadata, "call-2")).toBe(20);
+  });
+
+  it("has no duration for a call absent from the map", () => {
+    expect(
+      toolCallDurationMs(
+        undefined,
+        { toolDurations: { "call-1": 10 } },
+        "call-9",
+      ),
+    ).toBeUndefined();
+  });
+
+  // Messages written before either carrier existed, which the docs promise
+  // render no time rather than a zero.
+  it("has no duration when neither carrier has one", () => {
+    expect(toolCallDurationMs(undefined, undefined, "call-1")).toBeUndefined();
+    expect(toolCallDurationMs({}, {}, "call-1")).toBeUndefined();
+    expect(
+      toolCallDurationMs(undefined, { agentId: "agent-1" }, "call-1"),
+    ).toBeUndefined();
+  });
+
+  it("ignores a non-numeric value in either carrier", () => {
+    expect(
+      toolCallDurationMs({ durationMs: "500" }, undefined, "call-1"),
+    ).toBeUndefined();
+    expect(
+      toolCallDurationMs(
+        undefined,
+        { toolDurations: { "call-1": "842" } },
+        "call-1",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("keeps a zero from the map rather than reading it as absent", () => {
+    expect(
+      toolCallDurationMs(
+        undefined,
+        { toolDurations: { "call-1": 0 } },
+        "call-1",
+      ),
+    ).toBe(0);
   });
 });

--- a/apps/frontend/lib/tool-duration.ts
+++ b/apps/frontend/lib/tool-duration.ts
@@ -15,6 +15,13 @@ export function formatToolDuration(ms: number): string {
   return `${Math.floor(totalSeconds / 60)}m ${String(seconds).padStart(2, "0")}s`;
 }
 
+/** Reads a numeric property off a value that may be anything at all. */
+const numberAt = (source: unknown, key: string): number | undefined => {
+  if (typeof source !== "object" || source === null) return undefined;
+  const value = (source as Record<string, unknown>)[key];
+  return typeof value === "number" ? value : undefined;
+};
+
 /**
  * Pulls the run pipeline's recorded duration out of a tool invocation's
  * `toolMetadata`. The field is a free-form JSON object a provider may also
@@ -22,7 +29,34 @@ export function formatToolDuration(ms: number): string {
  * number reads as "no duration", which renders as nothing at all.
  */
 export function toolDurationMs(metadata: unknown): number | undefined {
-  if (typeof metadata !== "object" || metadata === null) return undefined;
-  const value = (metadata as Record<string, unknown>).durationMs;
-  return typeof value === "number" ? value : undefined;
+  return numberAt(metadata, "durationMs");
+}
+
+/**
+ * How long a tool call took, from whichever of the two carriers has it.
+ *
+ * The part's own `toolMetadata` is the record and is preferred; the message's
+ * `toolDurations` map is how the figure arrives mid-turn, because the AI SDK's
+ * tool reducer rebuilds each tool part from its stored invocation and discards
+ * metadata the output chunk carried. So during the turn that produced it only
+ * the map has it, and after a reload the part does — the same number either way,
+ * which is why there is no visible change when one takes over from the other.
+ *
+ * Messages written before both carriers existed have neither and render no time,
+ * which is the documented behaviour for older Chats.
+ */
+export function toolCallDurationMs(
+  toolMetadata: unknown,
+  messageMetadata: unknown,
+  toolCallId: string,
+): number | undefined {
+  const fromPart = toolDurationMs(toolMetadata);
+  if (fromPart !== undefined) return fromPart;
+  if (typeof messageMetadata !== "object" || messageMetadata === null) {
+    return undefined;
+  }
+  return numberAt(
+    (messageMetadata as Record<string, unknown>).toolDurations,
+    toolCallId,
+  );
 }


### PR DESCRIPTION
Two defects found reviewing `main` against `v2.5.0`, both in features from that range.

## Tool durations were measured, persisted, then destroyed (#435)

A tool's duration was stamped only onto the run's finished messages — the copy the sink persists — and nothing put it on the stream. So the browser never got it. In a Chat that already has a title nothing revalidates the chat record after a run (`refreshInterval` reads the cached terminal status and cannot re-arm; the title poll returns early once the title is real), and the next turn then posted the history back without durations, which `ChatSink.onStart` wrote over the stored ones.

Net effect: the durations only ever showed on the first turn of a new Chat, where the title poll happens to revalidate — and sending another message without reloading deleted them permanently. `chat.mdx` shipped in the same range promising the number "appears a moment after the reply finishes", which was false for every turn in an established Chat.

### Why the fix is not "stamp it on the stream"

That was tried first and reverted. The UI message stream's tool reducer rebuilds the tool part from its **stored** invocation and passes `toolMetadata: toolInvocation.toolMetadata`, discarding whatever the output chunk carried. That is the gotcha #353 recorded against `ai@6.x`, and it is still true in `ai@7.0.48` — a test driving the real SDK is what caught it. Stamping `tool-input-available`, which the reducer *does* read, is no better: the tool has not run yet.

So the figure travels as message metadata, which is deep-merged and survives. It is emitted on each tool's own `tool-result` part rather than collected at the end, so a duration lands with the output it describes; the SDK awaits `onToolExecutionEnd` inside `executeToolCall` and only emits the result afterwards, so ordering is guaranteed rather than lucky. The per-part stamp stays as the record every message persisted so far already uses, and the frontend reads the part first and falls back to the metadata — the same number either way, so nothing visibly changes when one takes over from the other.

**Decisions kept:** still the server's measurement, appearing once and never changing. The browser-side clock #353 asked for stays abandoned for the reasons #435 gave. It now appears as each Tool finishes rather than after the reply, which is strictly better, so `chat.mdx` says that instead.

## `Max output tokens` silently coerced to 1 (#456)

`Number.parseInt` stops at the first character it cannot read, so `1e5` and `1.9` both saved as **1**. `modelConfigSchema` accepts 1, and `maxOutputTokensForModel` passes it to the generation call with no floor — so every reply on that model stopped after one token and was flagged as cut short, with nothing pointing at the mistyped field.

`Number` instead, matching the `contextWindow` control's own parser: the value reaches the schema exactly as typed and a non-integer is rejected there with a message. Empty and non-positive input still mean "unset, use the default", which is what #342 and #454 need. The field is deliberately still unbounded above, per #454.

## Verification

`pnpm typecheck`, `pnpm lint` and `pnpm test` pass (1614 backend / 142 frontend / 116 schemas / 25 docs-contract).

Verified against a running instance driving a real turn that calls a Tool:

- the `tool-output-available` chunk carries no `toolMetadata` — the defect, in live data
- the next chunk delivers `{"toolDurations":{"<toolCallId>":3}}`, mid-stream
- both carriers persist, and the duration survives a follow-up turn
- replaying the pre-fix client copy wipes it from the row, so the fix is load-bearing rather than incidental

The output ceiling was checked against `modelConfigSchema` directly: `100000` accepted, `1.9` rejected as "expected int", where the old parser produced `1` — which is accepted.

## Two things worth a reviewer's attention

**One new test asserts the SDK *does not* stamp the part.** It pins the behaviour the whole design rests on. If a future SDK starts honouring the output chunk's `toolMetadata`, that test fails, and the failure is the signal that the metadata channel has become redundant and can go.

**Two unrelated fixes, two commits.** Squash-merging collapses them into one changelog entry and the provider-form fix loses its line. Rebase-merge, or split this into two PRs, if that matters for the next release.

## Docs

`building-with-platypus/chat.mdx` — the sentence promising the time appears after the reply now says it appears as the Tool finishes, and that the first number you see is final. The blank-card callout is unchanged and still accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
