### PR TITLE
fix(chat): fit the context meter to narrow viewports

### DIFF
--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -143,7 +143,7 @@ as a ceiling on what a model can **write**, there is a ceiling on what it can be
 **sent**. A Chat sends the whole conversation every turn, so a Chat that has been
 going a while is spending more of that room on each reply. A small meter beside
 the prompt input tells you how much of it the last turn used: a short bar, the
-percentage, and both token figures, as in `33% · 42,000/128,000`.
+percentage, and both token figures, as in `33% · 42K/128K`.
 
 The numbers matter as much as the bar. 33% of a 128,000-token model and 33% of
 an 8,000-token one are the same fraction and very different situations, so the

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.test.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.test.tsx
@@ -88,7 +88,7 @@ describe("Trigger runs Context occupancy", () => {
   it("shows how full the context got on the run's last step", async () => {
     await renderRuns([run(stats({ contextOccupancy: 42000 }))]);
 
-    expect(screen.getByText(/42,000 context/)).toBeInTheDocument();
+    expect(screen.getByText(/42K context/)).toBeInTheDocument();
   });
 
   it("shows nothing where the Provider reported no usage", async () => {
@@ -97,11 +97,22 @@ describe("Trigger runs Context occupancy", () => {
     expect(screen.queryByText(/context/)).toBeNull();
   });
 
-  it("leaves the existing token sums reading as they always have", async () => {
+  it("keeps the token sums as their own figure beside occupancy", async () => {
     // These are cross-step billing sums an Operator has been reading; occupancy
     // is a separate figure and must not be mistaken for either of them.
     await renderRuns([run(stats({ contextOccupancy: 42000 }))]);
 
-    expect(screen.getByText(/100 in \/ 4096 out/)).toBeInTheDocument();
+    expect(screen.getByText(/100 in \/ 4\.1K out/)).toBeInTheDocument();
+  });
+
+  // The same quantity the Chat meter shows, so it is written the same way —
+  // `1M` in one place and `1,000,000` in the other reads as two measurements.
+  it("abbreviates a figure of a million tokens or more", async () => {
+    await renderRuns([
+      run(stats({ contextOccupancy: 1_048_576, inputTokens: 2_500_000 })),
+    ]);
+
+    expect(screen.getByText(/1M context/)).toBeInTheDocument();
+    expect(screen.getByText(/2\.5M in/)).toBeInTheDocument();
   });
 });

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@platypus/schemas";
 import useSWR from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { formatTokens } from "@/lib/context-window";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { format, formatDistanceToNow } from "date-fns";
@@ -198,8 +199,8 @@ const TriggerRunsPage = ({
                               )}
                               <span className="flex items-center gap-1">
                                 <MessageSquare className="h-3 w-3" />
-                                {stats.inputTokens} in / {stats.outputTokens}{" "}
-                                out
+                                {formatTokens(stats.inputTokens)} in /{" "}
+                                {formatTokens(stats.outputTokens)} out
                               </span>
                               {/* How full the context got on the run's LAST
                                   step, which is a different quantity from the
@@ -211,7 +212,9 @@ const TriggerRunsPage = ({
                                   <TooltipTrigger asChild>
                                     <span className="flex items-center gap-1 cursor-default">
                                       <Gauge className="h-3 w-3" />
-                                      {stats.contextOccupancy.toLocaleString()}{" "}
+                                      {formatTokens(
+                                        stats.contextOccupancy,
+                                      )}{" "}
                                       context
                                     </span>
                                   </TooltipTrigger>

--- a/apps/frontend/components/ai-elements/message.tsx
+++ b/apps/frontend/components/ai-elements/message.tsx
@@ -47,7 +47,9 @@ export const Message = ({
 }: MessageProps) => (
   <div
     className={cn(
-      "group flex w-full max-w-[80%] gap-2",
+      // Wider on a phone, where 80% of a narrow column costs more than the
+      // gutter it buys back.
+      "group flex w-full max-w-[85%] gap-2 sm:max-w-[80%]",
       from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
       className,
     )}

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -606,7 +606,7 @@ export const Chat = ({
                     disabled={isReconnectedToRunningRun}
                   />
                 </PromptInputBody>
-                <PromptInputFooter>
+                <PromptInputFooter className="flex-wrap">
                   <PromptInputTools>
                     <PromptInputActionMenu>
                       <PromptInputActionMenuTrigger className="cursor-pointer" />
@@ -708,7 +708,21 @@ export const Chat = ({
                       </Dialog>
                     )}
                   </PromptInputTools>
+                  {/*
+                    Two placements from one element, because the footer wraps.
+                    Narrow: ordered last onto a row of its own, so the tools and
+                    Send keep the first row to themselves and Send is never
+                    pushed off the edge. The row bleeds back over the footer's
+                    own padding — hence the negative margins and the width that
+                    adds them back — so the tint reaches the composer's edges and
+                    reads as a band rather than a chip floating in the middle.
+                    Wide: back in source order with `mr-auto` eating the free
+                    space, which reads as the last item of the tool row rather
+                    than drifting into the middle the way `justify-between`
+                    alone would leave it.
+                  */}
                   <ContextMeter
+                    className="order-last -mx-3 -mb-3 mt-1.5 w-[calc(100%+1.5rem)] justify-center rounded-b-md bg-foreground/5 px-3 py-1.5 sm:order-none sm:mx-0 sm:mt-0 sm:mb-0 sm:w-auto sm:justify-start sm:rounded-none sm:bg-transparent sm:p-0 sm:mr-auto"
                     occupancy={contextOccupancy?.inputTokens}
                     contextWindow={contextWindow}
                   />

--- a/apps/frontend/components/context-meter.test.tsx
+++ b/apps/frontend/components/context-meter.test.tsx
@@ -26,8 +26,8 @@ describe("ContextMeter", () => {
 
     // Both numbers, not only a bar: 33% of 128k and 33% of 8k are different
     // situations and a bar alone cannot tell them apart.
-    expect(screen.getByText(/42,000/)).toBeInTheDocument();
-    expect(screen.getByText(/128,000/)).toBeInTheDocument();
+    expect(screen.getByText(/42K/)).toBeInTheDocument();
+    expect(screen.getByText(/128K/)).toBeInTheDocument();
     expect(screen.getByText(/33%/)).toBeInTheDocument();
     expect(screen.getByRole("progressbar")).toHaveAttribute(
       "aria-valuenow",
@@ -46,8 +46,18 @@ describe("ContextMeter", () => {
     );
     expect(screen.getByText(/100%/)).toBeInTheDocument();
     expect(screen.queryByText(/117%/)).not.toBeInTheDocument();
-    expect(screen.getByText(/150,000/)).toBeInTheDocument();
-    expect(screen.getByText(/128,000/)).toBeInTheDocument();
+    expect(screen.getByText(/150K/)).toBeInTheDocument();
+    expect(screen.getByText(/128K/)).toBeInTheDocument();
+  });
+
+  // Which unit a given figure takes is `formatTokens`' business and tested
+  // there; what matters here is that the meter defers to it rather than
+  // printing a six- or seven-digit number into a strip of the composer.
+  it("writes both figures in units", () => {
+    render(<ContextMeter occupancy={1_100} contextWindow={2_000_000} />);
+
+    expect(screen.getByText(/1\.1K\/2M/)).toBeInTheDocument();
+    expect(screen.queryByText(/1,100/)).not.toBeInTheDocument();
   });
 
   it("rounds a nearly-empty window to a percentage rather than hiding", () => {

--- a/apps/frontend/components/context-meter.tsx
+++ b/apps/frontend/components/context-meter.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { formatTokens } from "@/lib/context-window";
+import { cn } from "@/lib/utils";
 
 /**
  * How full the model's context was on the last completed turn (ADR-0018).
@@ -22,6 +19,7 @@ import {
 export const ContextMeter = ({
   occupancy,
   contextWindow,
+  className,
 }: {
   /**
    * Input tokens the vendor reported for the last model call of the turn.
@@ -30,6 +28,8 @@ export const ContextMeter = ({
   occupancy?: number | null;
   /** The window an Org Admin declared for this model, if any. */
   contextWindow?: number;
+  /** Where the meter sits — the composing component's decision, not this one's. */
+  className?: string;
 }) => {
   if (occupancy == null || contextWindow == null) return null;
 
@@ -38,36 +38,40 @@ export const ContextMeter = ({
   // deliberate choice, not a fault, and must not render as 117% or a bar
   // overflowing its track. The figures below stay true.
   const percent = Math.min(100, Math.round((occupancy / contextWindow) * 100));
-  const used = occupancy.toLocaleString();
-  const total = contextWindow.toLocaleString();
+  const used = formatTokens(occupancy);
+  const total = formatTokens(contextWindow);
 
   return (
-    <Tooltip delayDuration={300}>
-      <TooltipTrigger asChild>
-        <div className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">
-          <div
-            role="progressbar"
-            aria-valuenow={percent}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-label="Context used"
-            className="h-1 w-10 overflow-hidden rounded-full bg-muted"
-          >
-            <div
-              className="h-full rounded-full bg-muted-foreground/60"
-              style={{ width: `${percent}%` }}
-            />
-          </div>
-          <span className="tabular-nums whitespace-nowrap">
-            {percent}% · {used}/{total}
-          </span>
-        </div>
-      </TooltipTrigger>
-      <TooltipContent>
-        {/* One turn stale, and said so: nothing can count the tokens of a draft
-            locally, so the reading describes the last turn that was sent. */}
-        {used} of {total} tokens after the last turn.
-      </TooltipContent>
-    </Tooltip>
+    <div
+      className={cn(
+        "flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground",
+        className,
+      )}
+    >
+      <div
+        role="progressbar"
+        aria-valuenow={percent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="Context used"
+        // Tinted from the foreground rather than `bg-muted`, whose dark value
+        // sits close enough to the composer's own surface that the empty part
+        // of the track disappears and the bar loses the length it is read
+        // against.
+        //
+        // Longer on a narrow screen, where the meter has a row to itself and
+        // the width no longer competes with the tools beside it — and a longer
+        // track is a finer reading, since every pixel is a percent and a bit.
+        className="h-1 w-16 overflow-hidden rounded-full bg-muted-foreground/25 sm:w-10"
+      >
+        <div
+          className="h-full rounded-full bg-muted-foreground/70"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <span className="tabular-nums whitespace-nowrap">
+        {percent}% · {used}/{total}
+      </span>
+    </div>
   );
 };

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -277,12 +277,10 @@ const ModelRow = ({
           label="Context window"
           hint={
             <>
-              The vendor&apos;s published <strong>total</strong> token capacity
-              for this model — the whole window, not a cap on the reply. Sizes
-              in the list are decimal, so <code>128k</code> is 128,000.
-              Optional, and leaving it unset breaks nothing: without it, the
-              context meter in a Chat is hidden for this model, because Platypus
-              has no way to look the capacity up.
+              The model&apos;s <strong>total</strong> token capacity, not a cap
+              on the reply. Listed sizes are decimal, so <code>128k</code> is
+              128,000. Optional; without it a Chat on this model shows no
+              context meter.
             </>
           }
           error={errors.fields.contextWindow}

--- a/apps/frontend/lib/context-window.test.ts
+++ b/apps/frontend/lib/context-window.test.ts
@@ -7,6 +7,7 @@ import {
   optionForContextWindow,
   parseContextWindowInput,
   contextWindowForOption,
+  formatTokens,
 } from "./context-window";
 
 describe("CONTEXT_WINDOW_PRESETS", () => {
@@ -104,5 +105,43 @@ describe("parseContextWindowInput", () => {
 
   it("reads an unparseable field as no declaration", () => {
     expect(parseContextWindowInput("abc")).toBeUndefined();
+  });
+});
+
+describe("formatTokens", () => {
+  it("writes a figure under a thousand in full", () => {
+    expect(formatTokens(12)).toBe("12");
+    expect(formatTokens(260)).toBe("260");
+    expect(formatTokens(999)).toBe("999");
+  });
+
+  it("abbreviates a thousand and above", () => {
+    expect(formatTokens(1_000)).toBe("1K");
+    expect(formatTokens(1_100)).toBe("1.1K");
+    expect(formatTokens(42_000)).toBe("42K");
+    expect(formatTokens(128_000)).toBe("128K");
+  });
+
+  it("abbreviates a million and above", () => {
+    expect(formatTokens(1_000_000)).toBe("1M");
+    expect(formatTokens(1_500_000)).toBe("1.5M");
+    expect(formatTokens(2_000_000)).toBe("2M");
+    expect(formatTokens(10_000_000)).toBe("10M");
+  });
+
+  // A window declared in binary thousands is still the same window as one
+  // declared in decimal, and a reader comparing two models should not have to
+  // notice a 48,576-token difference that changes nothing about the reading.
+  it("drops a trailing zero rather than showing a false precision", () => {
+    expect(formatTokens(1_048_576)).toBe("1M");
+    expect(formatTokens(1_100_000)).toBe("1.1M");
+    expect(formatTokens(1_050)).toBe("1.1K");
+  });
+
+  // Rounding at one unit must not print a figure that belongs to the next:
+  // 999,999 is a hair under a million and reads as one, never as 1000K.
+  it("promotes to the next unit when rounding carries", () => {
+    expect(formatTokens(999_999)).toBe("1M");
+    expect(formatTokens(999_949)).toBe("999.9K");
   });
 });

--- a/apps/frontend/lib/context-window.ts
+++ b/apps/frontend/lib/context-window.ts
@@ -72,6 +72,29 @@ export const contextWindowForOption = (
   return Number.isFinite(parsed) ? parsed : undefined;
 };
 
+/** A tenth of a unit, with a trailing `.0` dropped: 1.05 → `1.1`, 42.0 → `42`. */
+const toTenth = (value: number): number => Number(value.toFixed(1));
+
+/**
+ * A token figure as it is READ — abbreviated from a thousand up, because past
+ * three digits these stop being read as numbers and start being counted.
+ * `1,100` becomes `1.1K` and `1,048,576` becomes `1M`; what that rounding drops
+ * is far below what any of these readings is accurate to.
+ *
+ * Shared, because the same quantity surfaces in two places — the Chat meter and
+ * a Trigger run's stats — and a figure that reads `1M` in one and `1,000,000`
+ * in the other looks like two different measurements.
+ */
+export const formatTokens = (tokens: number): string => {
+  if (tokens < 1_000) return tokens.toLocaleString();
+  // Rounded at the unit first, then promoted if that rounding carried, so
+  // 999,999 reads `1M` rather than the `1000K` a straight threshold gives.
+  const thousands = toTenth(tokens / 1_000);
+  return thousands >= 1_000
+    ? `${toTenth(thousands / 1_000)}M`
+    : `${thousands}K`;
+};
+
 /**
  * What a typed Custom value means. An empty or unreadable field is "no window
  * declared"; anything numeric is passed through EXACTLY as typed, bounds


### PR DESCRIPTION
Polish on the Chat context meter shipped in #457, plus the Provider form hint that explains the window it reads against.

## Composer layout

The meter sat between the tool row and Send. On a phone that pushed Send off the right edge. It now takes a row of its own below `sm` — centred, on a `bg-foreground/5` band that bleeds over the footer's padding to the composer's inner edges, with a longer track (64px vs 40px) now that nothing competes for the width. Above `sm` it is back inline, held against the tool row by an auto margin so `justify-between` still pins Send right.

Messages widen to 85% below `sm`; 80% is unchanged above it.

## Token figures

`formatTokens` moves to `lib/context-window.ts` and abbreviates from a thousand up — `1,100` → `1.1K`, `42,000` → `42K`, `1,048,576` → `1M`. It rounds at the unit it prints and promotes when that rounding carries, so `999,999` reads `1M` rather than `1000K`, and `999,949` still reads `999.9K`.

The Trigger runs stats row now uses the same formatter. It was printing the same quantity unabbreviated (and its token sums with no separators at all), and one figure written two ways reads as two measurements.

## Smaller

- The meter's tooltip is gone — it restated the figures already beside it.
- The track was `bg-muted`, whose dark value sits close enough to the composer surface that the empty part of the bar disappeared. Now tinted from the foreground.
- The Provider form's **Context window** hint ran to seven lines of what the docs already cover; cut to the three facts needed at the control.

## Docs

`building-with-platypus/chat.mdx` quoted the meter's exact format as `33% · 42,000/128,000`, which this change falsifies — updated to `33% · 42K/128K`.

## Verification

Driven in the running app at 390 / 768 / 1400px, light and dark: no horizontal overflow at any width, Send stays in frame at 361px of 390, the band sits flush inside the composer border, and desktop metrics are unchanged. The `K` branch of the formatter is covered by unit tests rather than a live reading — no chat in reach had both a declared window and an occupancy above a thousand.

149 frontend tests, 25 docs-contract tests, typecheck and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)