### PR TITLE
fix(frontend): gate the dead-backend warning on a selected backend

### DIFF
--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -751,6 +751,31 @@ describe("ProviderForm Web-search backend selector", () => {
     expect(screen.queryByText(/Native web search is off/)).toBeNull();
   });
 
+  // Turning the switch off is exactly what its own description tells a vLLM /
+  // Ollama Operator to do. With no backend selected there is nothing the warning
+  // could be about, and "this backend" names something that is not there.
+  it("says nothing about a backend that is not selected when the switch is off", () => {
+    webBackendCatalog = CATALOG;
+    renderWithAdvancedOpen({ nativeSearchEnabled: false });
+
+    expect(webBackendSelect()).not.toBeNull();
+    expect(screen.queryByText(/Native web search is off/)).toBeNull();
+  });
+
+  it("says nothing about an absent backend where the switch is not shown", () => {
+    webBackendCatalog = CATALOG;
+    renderWithAdvancedOpen({
+      providerType: "Bedrock",
+      nativeSearchEnabled: false,
+    } as Partial<Provider>);
+
+    expect(webBackendSelect()).not.toBeNull();
+    expect(screen.queryByText(/Native web search is off/)).toBeNull();
+    expect(
+      screen.queryByText(/set back on through the Provider API/),
+    ).toBeNull();
+  });
+
   // The recovery path for a stale id on a deployment where nothing is installed:
   // choosing None empties `webBackend`, which is the same value the field's own
   // visibility condition reads. Unlatched, the control unmounted here — mid-

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -1451,8 +1451,11 @@ const ProviderForm = ({
                   the switch — and says so instead.
                   On a Provider whose switch is not rendered the same warning must
                   not point at it: the only way into that state, and out of it, is
-                  the Provider API. */}
-                  {!formData.nativeSearchEnabled && (
+                  the Provider API.
+                  Both need a backend actually selected. The field renders for every
+                  Provider once a search plugin is installed, so without this gate
+                  "this backend" names something that is not there. */}
+                  {!!formData.webBackend && !formData.nativeSearchEnabled && (
                     <FieldDescription className="text-destructive">
                       {nativeSearchSwitchShown ? (
                         <>


### PR DESCRIPTION
Closes #468

## Problem

The warning

> Native web search is off, so this backend will not run

was gated only on `!formData.nativeSearchEnabled`, without checking that a
Web-search backend was actually selected.

The Web-search backend field renders for every Provider once a deployment has a
search plugin installed. So an Operator editing a vLLM / Ollama / LiteLLM
Provider who turned **Native web search** off — exactly what the switch's own
description tells them to do — got a red, destructive-styled message about a
backend that was never there.

## Fix

Both arms of the warning now require `formData.webBackend` to be set.

The issue describes "two branches"; they are the two arms of one ternary inside
a single `FieldDescription` — the switch-shown copy and the Bedrock copy that
points at the Provider API instead. One guard covers both.

A stale id whose plugin has since been uninstalled still counts as selected, and
still warns: that Provider genuinely has a dead selection.

## Tests

Two cases added to `provider-form.test.tsx`, written failing first:

- switch off, no backend selected → no warning
- same on Bedrock (switch not rendered) → no warning

`pnpm test` (1843 tests), `pnpm typecheck`, and `pnpm lint` all pass.

## Docs

No docs change owed. `apps/docs/content/concepts/providers.mdx` already scopes
the claim to a selected backend — "a backend you selected will not run until it
is back on. The form warns you where you make the selection." The code was the
thing out of step. No visible label or field text changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
