### PR TITLE
fix(chat): show elapsed time on the plugin Web search card

### DIFF
--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -293,7 +293,13 @@ export const ChatMessage = memo(function ChatMessage({
           // provider-executed calls: native search registers under the same
           // `web_search` name, and its parts belong on the generic renderer, which
           // shows the vendor payload this card cannot read.
-          return <WebSearchTool key={`${message.id}-${i}`} toolPart={part} />;
+          return (
+            <WebSearchTool
+              key={`${message.id}-${i}`}
+              toolPart={part}
+              messageMetadata={message.metadata}
+            />
+          );
         } else if (
           isToolUIPart(part) &&
           part.type.startsWith("tool-delegateTo")

--- a/apps/frontend/components/web-search-tool.test.tsx
+++ b/apps/frontend/components/web-search-tool.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ToolUIPart } from "ai";
+
+import { WebSearchTool } from "./web-search-tool";
+
+const searchCall = (toolMetadata?: Record<string, unknown>): ToolUIPart =>
+  ({
+    type: "tool-web_search",
+    toolCallId: "call-1",
+    state: "output-available",
+    input: { query: "platypus habitat" },
+    output: { query: "platypus habitat", results: [] },
+    toolMetadata,
+  }) as unknown as ToolUIPart;
+
+// Issue #469. A plugin search is the tool most likely to take several seconds,
+// so the card that heads it is where the elapsed time is worth reading.
+describe("WebSearchTool duration", () => {
+  it("renders the duration recorded on the part", () => {
+    render(<WebSearchTool toolPart={searchCall({ durationMs: 4200 })} />);
+
+    expect(screen.getByText(/4\.2s/)).toBeInTheDocument();
+  });
+
+  it("renders the duration the message carries mid-turn", () => {
+    render(
+      <WebSearchTool
+        toolPart={searchCall()}
+        messageMetadata={{ toolDurations: { "call-1": 4200 } }}
+      />,
+    );
+
+    expect(screen.getByText(/4\.2s/)).toBeInTheDocument();
+  });
+
+  it("renders no duration for a search recorded before timing existed", () => {
+    render(<WebSearchTool toolPart={searchCall()} />);
+
+    expect(screen.getByText("Web search")).toBeInTheDocument();
+    expect(screen.queryByText(/^\d+(\.\d+)?(ms|s)$/)).toBeNull();
+  });
+});

--- a/apps/frontend/components/web-search-tool.tsx
+++ b/apps/frontend/components/web-search-tool.tsx
@@ -2,6 +2,7 @@
 
 import type { ToolUIPart } from "ai";
 import { isPresentableUrl, WEB_BACKEND_TOOL_MARKER } from "@platypus/schemas";
+import { toolCallDurationMs } from "@/lib/tool-duration";
 import { Tool, ToolContent, ToolHeader } from "./ai-elements/tool";
 
 /**
@@ -130,7 +131,19 @@ export const webSearchSources = (
  * what the pills cannot say — that a search ran, what was searched for, and when
  * it failed.
  */
-export const WebSearchTool = ({ toolPart }: { toolPart: ToolUIPart }) => {
+export const WebSearchTool = ({
+  toolPart,
+  messageMetadata,
+}: {
+  toolPart: ToolUIPart;
+  /**
+   * The metadata of the message this invocation sits on, which is where a
+   * duration arrives from mid-turn. Passed in rather than read here, the same
+   * way `SubAgentTool` takes it: resolving a duration needs both carriers, and
+   * the composing message already holds them.
+   */
+  messageMetadata?: unknown;
+}) => {
   const query = asRecord(toolPart.input).query;
   const output = asRecord(toolPart.output);
   // The tool's contract is a returned `{ error }`, not a rejection, so a failed
@@ -158,6 +171,11 @@ export const WebSearchTool = ({ toolPart }: { toolPart: ToolUIPart }) => {
         label={typeof query === "string" ? query : undefined}
         type="tool-web_search"
         state={errorText ? "output-error" : toolPart.state}
+        durationMs={toolCallDurationMs(
+          toolPart.toolMetadata,
+          messageMetadata,
+          toolPart.toolCallId,
+        )}
       />
       <ToolContent>
         <div className="space-y-2 p-4 text-sm">


### PR DESCRIPTION
## Problem

`WebSearchTool` passed no `durationMs` to `ToolHeader`, so a plugin-backed `web_search` call rendered with no elapsed time. Before #412 these parts landed on the generic tool renderer, which passes `toolCallDurationMs(part.toolMetadata, message.metadata, part.toolCallId)` — so this was a regression in what's shown, not missing data. Web search is also the tool most likely to take several seconds, which is where the readout matters most.

## Change

- `WebSearchTool` takes a `messageMetadata` prop and threads `toolCallDurationMs(...)` into `ToolHeader`, reproducing the generic renderer's call exactly.
- `chat-message.tsx` passes `message.metadata` in, the same way it already feeds `SubAgentTool`.

Both carriers are covered, so the time shows mid-turn (from `message.metadata.toolDurations`) and after a reload (from the part's own `toolMetadata`). Messages stored before either carrier existed still render no time, which is the documented behaviour for older Chats.

## Tests

New `apps/frontend/components/web-search-tool.test.tsx`, written first: duration from the part, duration from the message mid-turn, and no duration for a search recorded before timing existed. `pnpm typecheck`, `pnpm lint` and the full `pnpm test` suite pass.

No docs change: no `.env.example`, schema limit, or plugin surface is touched, and the elapsed-time readout is an existing card element that was simply never fed here.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
