### PR TITLE
fix(frontend): reset the Web-search backend latch between Providers

### DIFF
--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -599,9 +599,8 @@ describe("ProviderForm Web-search backend selector", () => {
     { backend: "acme-search.searx", name: "SearXNG", plugin: "acme-search" },
   ];
 
-  /** Renders the edit form and opens the Advanced settings section the field sits in. */
-  const renderWithAdvancedOpen = (overrides: Partial<Provider>) => {
-    loadedProvider = {
+  const aProvider = (overrides: Partial<Provider>) =>
+    ({
       id: "p1",
       name: "vLLM",
       providerType: "OpenAI",
@@ -612,7 +611,11 @@ describe("ProviderForm Web-search backend selector", () => {
       taskModelId: "qwen",
       memoryExtractionModelId: "qwen",
       ...overrides,
-    } as unknown as Provider;
+    }) as unknown as Provider;
+
+  /** Renders the edit form and opens the Advanced settings section the field sits in. */
+  const renderWithAdvancedOpen = (overrides: Partial<Provider>) => {
+    loadedProvider = aProvider(overrides);
     const result = render(<ProviderForm orgId="org1" providerId="p1" />);
     fireEvent.click(screen.getByRole("button", { name: "Toggle" }));
     return result;
@@ -762,6 +765,28 @@ describe("ProviderForm Web-search backend selector", () => {
 
     expect(webBackendSelect()).not.toBeNull();
     expect(webBackendSelect()).toHaveTextContent("None");
+  });
+
+  // The form is reused across Providers within one mount, and the latch above is
+  // scoped to the Provider whose stale id was cleared. Carried into the next one,
+  // it holds the selector open on a deployment with nothing installed — the dead
+  // "None" the visibility rule exists to avoid.
+  it("drops the latch when the form switches to another Provider", async () => {
+    const { rerender } = renderWithAdvancedOpen({
+      webBackend: "gone.searx",
+    } as Partial<Provider>);
+
+    await selectNoBackend();
+    expect(webBackendSelect()).not.toBeNull();
+
+    loadedProvider = aProvider({
+      id: "p2",
+      name: "Ollama",
+      webBackend: null,
+    } as Partial<Provider>);
+    rerender(<ProviderForm orgId="org1" providerId="p2" />);
+
+    await waitFor(() => expect(webBackendSelect()).toBeNull());
   });
 
   it("round-trips the stored backend through a save", async () => {

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -84,6 +84,7 @@ import {
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 
 /**
  * Per-field help for a model row. The fields each need a paragraph of
@@ -489,11 +490,6 @@ const ProviderForm = ({
 
   const formScope = workspaceId ? "workspace" : "organization";
 
-  // Reset initialization when providerId changes
-  useEffect(() => {
-    hasInitialized.current = false;
-  }, [providerId]);
-
   const [formData, setFormData] = useState<ProviderFormData>({
     providerType: "OpenAI",
     name: "",
@@ -611,6 +607,16 @@ const ProviderForm = ({
   // thing that turns `webBackendFieldApplies` false.
   const [webBackendEdited, setWebBackendEdited] = useState(false);
   const showWebBackendField = webBackendFieldApplies || webBackendEdited;
+
+  // Drop everything the previous Provider left behind, so switching Providers
+  // within one mount starts the form over: the initialisation flag the effect
+  // below reads, and the latch above — which belongs to the Provider whose field
+  // was edited, and carried into the next one would hold the selector open for an
+  // edit that Provider never had.
+  useResetOnChange(providerId, () => {
+    hasInitialized.current = false;
+    setWebBackendEdited(false);
+  });
 
   useEffect(() => {
     if (provider && !hasInitialized.current) {


### PR DESCRIPTION
Closes #470

## Problem

`webBackendEdited` was never reset when `providerId` changed, so the latch outlived the Provider it was set for. Edit Provider A, clear a stale Web-search backend id (setting the latch), switch to Provider B in the same mount, and the backend selector stayed mounted for B even on a deployment with no search plugins installed — the dead "None" the visibility rule exists to avoid, and the state the docs describe as impossible ("it appears only once at least one is installed").

## Fix

The issue proposed resetting the latch inside the existing `providerId` effect, but that effect cannot call `setState`: `react-hooks/set-state-in-effect` rejects it as a hard lint error. The reset moves to `useResetOnChange` instead — the hook the rest of the forms already use for this, which applies the reset during render rather than in an effect:

```ts
useResetOnChange(providerId, () => {
  hasInitialized.current = false;
  setWebBackendEdited(false);
});
```

This replaces the hand-rolled effect rather than sitting beside it, so the per-Provider reset lives in one place. The hook's `UNINITIALIZED` sentinel also means the reset fires on the first render, so a Provider served synchronously from SWR's warm cache is covered alongside the cold-load path.

## Test

A regression test walks the sequence from the issue: load a Provider with a stale `gone.searx`, clear it to None (latching the field open), rerender with a different `providerId` whose Provider has nothing stored and no catalog installed, and assert the selector is gone. It was checked to fail both against the original boolean latch and against this fix with the reset line removed.

## Verification

- `provider-form.test.tsx` 42/42; full suite 1,999 tests green
- `pnpm lint`, `pnpm typecheck`, Prettier all clean

No docs change: `concepts/providers.mdx` already states the invariant this restores, so the code was the side that was out of step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)