### PR TITLE
chore: exclude agent skill docs from Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,5 @@
 CHANGELOG.md
+
+# Agent skill definitions are authored for agents to read, not Prettier to
+# reflow — its list spacing and code-fence rewrites fight the intended layout.
+.agents/skills/


### PR DESCRIPTION
`pnpm format` had drifted on `.agents/skills/**` — running it rewrote 17 files. Rather than commit that output, this excludes the directory from Prettier.

These files are authored for agents to read, and Prettier's markdown rules fight the intended layout:

- inserts a blank line after bold labels (`**Key interfaces:**`, `**Acceptance criteria:**`) and the list beneath them
- rewrites `*emphasis*` to `_emphasis_`
- reformats HTML/CSS/JS inside fenced code blocks, expanding single-line CSS rules and wrapping `mermaid.initialize({…})`

`.agents/` contains only `skills/`, so the rule covers the whole tree.

## Test plan

- [x] `pnpm format` — no longer visits any `.agents/` path; `.prettierignore` is the only change in the tree afterwards
- [ ] CI (lint, test, typecheck, gate)

Supersedes #475, which committed the formatter output instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)