### PR TITLE
fix(docs): state all three Web-search backend visibility cases

### DIFF
--- a/apps/docs/content/concepts/providers.mdx
+++ b/apps/docs/content/concepts/providers.mdx
@@ -137,12 +137,21 @@ and up to two fields under **Advanced settings** decide it.
 
 **Web-search backend** picks _which_ search runs. It lists the search backends
 your deployment has installed as plugins — SearXNG, a headless browser, whatever
-the Operator added — and it appears only once at least one is installed.
-Selecting one takes precedence over the model's own search, and it gives the
-Search toggle to Providers that never had it: a self-hosted vLLM or LiteLLM
-endpoint, or Bedrock. **None** means the built-in search on a Provider that has
-one, and no web search at all on a Provider that doesn't; the option says which
-you're getting.
+the Operator added. Selecting one takes precedence over the model's own search,
+and it gives the Search toggle to Providers that never had it: a self-hosted
+vLLM or LiteLLM endpoint, or Bedrock. **None** means the built-in search on a
+Provider that has one, and no web search at all on a Provider that doesn't; the
+option says which you're getting.
+
+The field is on the form when any one of these holds:
+
+- **A backend is installed** on your deployment — the ordinary case.
+- **This Provider already has one selected** — it stays visible even when the
+  installed list doesn't have it, so you can clear a selection that no longer
+  runs instead of leaving the Provider pointed at it. Once Platypus has the
+  installed list to check against, such a selection reads **(not installed)**.
+- **Platypus couldn't load the installed backends** — the field tells you so,
+  and leaves your stored selection alone.
 
 **Native web search** decides whether _any_ search is allowed on this Provider.
 Switching it off currently disables a selected backend too, not only the built-in


### PR DESCRIPTION
Closes #471

## What

The Providers page said the **Web-search backend** field

> appears only once at least one is installed

That covers one of three paths the form supports. An Operator can also meet the field with nothing installed, so the sentence is replaced with a short list of all three cases:

- a backend is installed — the ordinary case
- this Provider already has one selected, so a selection whose Plugin has gone stays visible and clearable
- the installed-backend list couldn't be loaded, so a transient failure doesn't hide the field

Written in Operator terms, without naming the form's state variables.

## Notes

Two accuracy points came out of reviewing the first draft against `provider-form.tsx`, and are reflected in the wording:

- The **(not installed)** marker on a stale selection is gated on the catalog having loaded. In the load-failure case the field renders the stored id without that claim, so the docs qualify it rather than promising a label that isn't there.
- The unlisted-selection branch isn't only "the Plugin was removed" — it also fires for an id that was never installed, set through the Provider API. The wording covers both.

The `webBackendEdited` latch is deliberately undocumented: it keeps the field mounted mid-interaction so clearing a stale id doesn't unmount the control, which isn't a rule an Operator can reason about.

## Testing

`pnpm test` passes (8 tasks; 197 frontend, 25 docs-contract). Docs-only change — nothing TypeScript changed, so no typecheck run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)