### PR TITLE
fix(backend): scope workspace memory-provider pointers to the workspace

### DIFF
--- a/apps/backend/src/routes/workspace.test.ts
+++ b/apps/backend/src/routes/workspace.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
 import app from "../server.ts";
+import { resolveScoped } from "../services/scoped-resource.ts";
+
+// The memory pointer-settings must resolve through the Scoped resource
+// authority, not a bare id lookup (GHSA-qg7h-g2rm-37qh). Spy on it so the tests
+// assert the route delegates the scoping decision — the chained mockDb ignores
+// WHERE predicates and cannot itself tell a scoped lookup from a global one.
+vi.mock("../services/scoped-resource.ts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../services/scoped-resource.ts")>()),
+  resolveScoped: vi.fn(),
+}));
+const resolveScopedMock = vi.mocked(resolveScoped);
 
 describe("Workspace Routes", () => {
   beforeEach(() => {
@@ -233,6 +244,72 @@ describe("Workspace Routes", () => {
       const setArg = mockDb.set.mock.calls.at(-1)?.[0];
       expect(setArg).not.toHaveProperty("providerSelfManagement");
       expect(setArg).not.toHaveProperty("mcpSelfManagement");
+    });
+
+    // Security (GHSA-qg7h-g2rm-37qh): a memory Provider pointer must resolve
+    // through the Scoped resource authority, scoped to this Workspace, so a
+    // Provider not visible here — e.g. one owned by another Organization —
+    // resolves to null and is rejected, never stamped. Asserting the delegation
+    // (not just the 404) is what pins the fix: the vulnerable code did a bare id
+    // lookup and never called resolveScoped.
+    it("rejects a memory provider not visible in the workspace", async () => {
+      mockSession({ id: "user-1", role: "user" });
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      resolveScopedMock.mockResolvedValueOnce(null); // not visible in (org-1, ws-1)
+
+      const res = await app.request("/organizations/org-1/workspaces/ws-1", {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "My Workspace",
+          memoryExtractionProviderId: "provider-other-org",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({
+        error: "Memory extraction provider not found",
+      });
+      expect(resolveScopedMock).toHaveBeenCalledWith(
+        expect.anything(),
+        "provider",
+        "provider-other-org",
+        { orgId: "org-1", wsId: "ws-1" },
+      );
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("accepts a workspace-visible memory provider that has the model", async () => {
+      mockSession({ id: "user-1", role: "user" });
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+      resolveScopedMock.mockResolvedValueOnce({
+        row: {
+          id: "provider-1",
+          memoryExtractionModelId: "model-x",
+        } as never,
+        scope: "workspace",
+      });
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "ws-1", name: "My Workspace" },
+      ]);
+
+      const res = await app.request("/organizations/org-1/workspaces/ws-1", {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "My Workspace",
+          memoryExtractionProviderId: "provider-1",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockDb.update).toHaveBeenCalled();
     });
 
     it("lets an org admin set delegation flags", async () => {

--- a/apps/backend/src/routes/workspace.ts
+++ b/apps/backend/src/routes/workspace.ts
@@ -4,7 +4,6 @@ import { nanoid } from "nanoid";
 import { db } from "../index.ts";
 import {
   workspace as workspaceTable,
-  provider as providerTable,
   organizationMember,
 } from "../db/schema.ts";
 import {
@@ -17,6 +16,7 @@ import {
   requireOrgAccess,
   requireWorkspaceAccess,
 } from "../middleware/authorization.ts";
+import { resolveScoped } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 import { destroyWorkspaceSandboxes } from "../sandbox/teardown.ts";
 
@@ -126,6 +126,7 @@ workspace.put(
   requireWorkspaceAccess,
   sValidator("json", workspaceUpdateSchema),
   async (c) => {
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId");
     const data = c.req.valid("json");
 
@@ -139,19 +140,25 @@ workspace.put(
       delete data.mcpSelfManagement;
     }
 
-    // Validate memoryExtractionProviderId if set
+    // Resolve memory pointer-settings through the Scoped resource authority
+    // (ADR-0007): a Provider is settable only if it is visible in this
+    // Workspace — its own, or an Organization-scoped one Attached to it. A bare
+    // id lookup would let an owner stamp any Organization's Provider onto their
+    // Workspace, which the memory-extraction job and memorySearch then use with
+    // that Provider's credentials.
     if (data.memoryExtractionProviderId) {
-      const provider = await db
-        .select()
-        .from(providerTable)
-        .where(eq(providerTable.id, data.memoryExtractionProviderId))
-        .limit(1);
+      const resolved = await resolveScoped(
+        db,
+        "provider",
+        data.memoryExtractionProviderId,
+        { orgId, wsId: workspaceId },
+      );
 
-      if (provider.length === 0) {
+      if (!resolved) {
         return c.json({ error: "Memory extraction provider not found" }, 404);
       }
 
-      if (!provider[0].memoryExtractionModelId) {
+      if (!resolved.row.memoryExtractionModelId) {
         return c.json(
           {
             error:
@@ -162,19 +169,19 @@ workspace.put(
       }
     }
 
-    // Validate memoryEmbeddingProviderId if set
     if (data.memoryEmbeddingProviderId) {
-      const provider = await db
-        .select()
-        .from(providerTable)
-        .where(eq(providerTable.id, data.memoryEmbeddingProviderId))
-        .limit(1);
+      const resolved = await resolveScoped(
+        db,
+        "provider",
+        data.memoryEmbeddingProviderId,
+        { orgId, wsId: workspaceId },
+      );
 
-      if (provider.length === 0) {
+      if (!resolved) {
         return c.json({ error: "Memory embedding provider not found" }, 404);
       }
 
-      if (!provider[0].embeddingModelId) {
+      if (!resolved.row.embeddingModelId) {
         return c.json(
           {
             error:


### PR DESCRIPTION
## Problem

`PUT /:orgId/workspace/:workspaceId` validated `memoryExtractionProviderId` and `memoryEmbeddingProviderId` with a bare primary-key lookup — `eq(providerTable.id, ...)` with no `organizationId` / `workspaceId` / Attachment predicate. A Workspace Owner (reachable via `requireWorkspaceAccess`, no org-admin role needed) could therefore point their Workspace's memory extraction/embedding at **any** Provider row, including one owned by another Organization.

Those pointers are later consumed with credentials:

- `services/memory-extraction.ts` — the scheduled batch loads the Provider by id and runs extraction/embedding against it.
- `tools/memory.ts` — loads the embedding Provider by id for `memorySearch`.

Result: cross-tenant use of another Organization's Provider credentials (quota/billing under the victim's keys; routing of chat content through a Provider `baseUrl` the victim controls), and a break of intra-Organization scoping (pointing at a Shared Provider not Attached to the Workspace, contrary to ADR-0007).

Tracked in security advisory GHSA-qg7h-g2rm-37qh.

## Fix

Resolve both pointers through the Scoped resource authority (`services/scoped-resource.ts` `resolveScoped`) at write time, so only a Provider visible in the target Workspace — its own, or an attached Organization-scoped one — can be stamped. This is the authorization boundary and matches how other Scoped references are validated. The now-unused `providerTable` import is dropped.

The Blueprint authoring path (`routes/org-blueprint.ts`) already scopes its identical validation by `organizationId` and is Org-Admin-authored, so it was not affected and is unchanged.

## Tests

Two regression tests spy on `resolveScoped` and assert the route delegates the scoping decision with the correct `{ orgId, wsId }`. Both fail against the pre-fix source and pass against this change. Full backend suite (1652 tests), `typecheck`, and `lint` pass.

## Note

The consumption sites still trust the validated stored pointer (load by id). The write-time gate closes the reported issue; a defense-in-depth re-check at read (guarding a pointer left stale by a later re-scope/detach) is a possible follow-up, left out here to keep the change tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)