### PR TITLE
fix(backend): widen the Scoped-resource authority and migrate the remaining hand-rolled lookups

### DIFF
--- a/apps/backend/src/middleware/authorization.ts
+++ b/apps/backend/src/middleware/authorization.ts
@@ -354,6 +354,42 @@ export const workspaceConfigAccess = async (
   return { allowed: true };
 };
 
+/** The Scoped resource types that store Operator-entered credentials. */
+export type CredentialResourceType = "mcp" | "provider";
+
+/**
+ * ADR-0006's delegation flag for each credential-bearing Scoped resource —
+ * written down once, so a read path cannot redact on one rule while its write
+ * path rejects on another.
+ */
+const CREDENTIAL_DELEGATION_FLAG: Record<
+  CredentialResourceType,
+  DelegationFlag
+> = {
+  mcp: "mcpSelfManagement",
+  provider: "providerSelfManagement",
+};
+
+/**
+ * The Workspace surface's answer to "may this caller see this resource's stored
+ * credentials?" — {@link workspaceConfigAccess} read as a yes/no, since a read
+ * path redacts rather than reporting *why* it refused.
+ */
+export const workspaceCredentialsVisible = async (
+  c: Context<Env>,
+  type: CredentialResourceType,
+): Promise<boolean> =>
+  (await workspaceConfigAccess(c, CREDENTIAL_DELEGATION_FLAG[type])).allowed;
+
+/**
+ * The Organization surface's twin. A Shared resource is configured only by an
+ * Org Admin (ADR-0006, ADR-0007) — there is no per-workspace delegation at org
+ * scope — so admin *is* the whole rule. Super admins arrive here as admins,
+ * because `requireOrgAccess` grants them an admin membership.
+ */
+export const orgCredentialsVisible = (c: Context<Env>): boolean =>
+  c.get("orgMembership")?.role === "admin";
+
 /**
  * Middleware that restricts access to super admins only.
  *

--- a/apps/backend/src/routes/attachment.ts
+++ b/apps/backend/src/routes/attachment.ts
@@ -2,13 +2,7 @@ import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import {
-  attachment as attachmentTable,
-  agent as agentTable,
-  mcp as mcpTable,
-  provider as providerTable,
-  skill as skillTable,
-} from "../db/schema.ts";
+import { attachment as attachmentTable } from "../db/schema.ts";
 import { attachmentCreateSchema } from "@platypus/schemas";
 import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
@@ -17,6 +11,7 @@ import {
   requireWorkspaceAccess,
 } from "../middleware/authorization.ts";
 import { isUniqueViolation } from "../errors.ts";
+import { resolveOrgScoped } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 
 // Attachment is the explicit reference that surfaces an org-scoped Shared
@@ -55,20 +50,13 @@ attachment.post(
 
     // The resource must be org-scoped and belong to this organization — you can
     // only attach a Shared resource, never a workspace-scoped one.
-    const table =
-      resourceType === "mcp"
-        ? mcpTable
-        : resourceType === "skill"
-          ? skillTable
-          : resourceType === "agent"
-            ? agentTable
-            : providerTable;
-    const resource = await db
-      .select({ id: table.id })
-      .from(table)
-      .where(and(eq(table.id, resourceId), eq(table.organizationId, orgId)))
-      .limit(1);
-    if (resource.length === 0) {
+    const resource = await resolveOrgScoped(
+      db,
+      resourceType,
+      resourceId,
+      orgId,
+    );
+    if (!resource) {
       return c.json(
         { error: "Org-scoped resource not found in this organization" },
         404,

--- a/apps/backend/src/routes/mcp.ts
+++ b/apps/backend/src/routes/mcp.ts
@@ -18,13 +18,14 @@ import {
   requireOrgAccess,
   requireWorkspaceAccess,
   requireWorkspaceConfigAccess,
-  workspaceConfigAccess,
+  workspaceCredentialsVisible,
 } from "../middleware/authorization.ts";
 import { redactMcpSecrets } from "../services/credential-redaction.ts";
 import {
   listScoped,
   requireScoped,
   requireWorkspaceMutable,
+  type Scope,
 } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
@@ -69,6 +70,21 @@ export const sanitizeMcpResponse = (record: McpRecord) => {
   };
 };
 
+/**
+ * The read shape of an MCP on the Workspace surface, assembled once for both
+ * read routes: OAuth tokens stripped unconditionally, Operator-entered request
+ * credentials only for a caller who may manage this MCP (ADR-0006), and the
+ * scope the Scoped-resource module resolved it at, which the frontend uses to
+ * mark a Shared row read-only.
+ */
+const mcpReadModel = (
+  { row, scope }: { row: McpRecord; scope: Scope },
+  reveal: boolean,
+) => ({
+  ...redactMcpSecrets(sanitizeMcpResponse(row), { reveal }),
+  scope,
+});
+
 /** Create a new MCP (org-admin, or owner when delegated — ADR-0006) */
 mcp.post(
   "/",
@@ -112,11 +128,8 @@ mcp.get(
     // Request credentials are revealed only to a caller who may manage this MCP
     // (ADR-0006) — the same rule the write routes reject on. The rows still list,
     // because granting an MCP to an Agent does not require self-management.
-    const { allowed } = await workspaceConfigAccess(c, "mcpSelfManagement");
-    const results = scoped.map(({ row, scope }) => ({
-      ...redactMcpSecrets(sanitizeMcpResponse(row), { reveal: allowed }),
-      scope,
-    }));
+    const reveal = await workspaceCredentialsVisible(c, "mcp");
+    const results = scoped.map((found) => mcpReadModel(found, reveal));
 
     return c.json({ results });
   },
@@ -132,16 +145,13 @@ mcp.get(
     const mcpId = c.req.param("mcpId");
     const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
-    const { row, scope } = await requireScoped(db, "mcp", mcpId, {
+    const found = await requireScoped(db, "mcp", mcpId, {
       orgId,
       wsId: workspaceId,
     });
     // See the list route: redacted unless this caller may manage the MCP.
-    const { allowed } = await workspaceConfigAccess(c, "mcpSelfManagement");
-    return c.json({
-      ...redactMcpSecrets(sanitizeMcpResponse(row), { reveal: allowed }),
-      scope,
-    });
+    const reveal = await workspaceCredentialsVisible(c, "mcp");
+    return c.json(mcpReadModel(found, reveal));
   },
 );
 

--- a/apps/backend/src/routes/org-agent.ts
+++ b/apps/backend/src/routes/org-agent.ts
@@ -10,7 +10,11 @@ import { requireOrgAccess } from "../middleware/authorization.ts";
 import { findNonSharedReferences } from "../services/agent-scope-validation.ts";
 import { SUB_AGENT_SELF_ASSIGNMENT_ERROR } from "../services/sub-agent-validation.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
-import { requireSharedDeletable } from "../services/scoped-resource.ts";
+import {
+  listOrgScoped,
+  requireOrgScoped,
+  requireSharedDeletable,
+} from "../services/scoped-resource.ts";
 import { storeAvatar, deleteAvatar } from "../services/avatar.ts";
 import { avatarKeyToUrl } from "../utils/avatar-url.ts";
 import { getOrigin } from "../utils/get-origin.ts";
@@ -36,10 +40,7 @@ function agentWithAvatarUrl(
 orgAgent.get("/", requireAuth, requireOrgAccess(), async (c) => {
   const orgId = c.req.param("orgId")!;
   const baseUrl = getOrigin(c);
-  const results = await db
-    .select()
-    .from(agentTable)
-    .where(eq(agentTable.organizationId, orgId));
+  const results = await listOrgScoped(db, "agent", orgId);
   return c.json({
     results: results.map((r) => agentWithAvatarUrl(r, baseUrl)),
   });
@@ -50,17 +51,8 @@ orgAgent.get("/:agentId", requireAuth, requireOrgAccess(), async (c) => {
   const orgId = c.req.param("orgId")!;
   const agentId = c.req.param("agentId");
   const baseUrl = getOrigin(c);
-  const record = await db
-    .select()
-    .from(agentTable)
-    .where(
-      and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
-    )
-    .limit(1);
-  if (record.length === 0) {
-    throw new NotFoundError("Agent not found");
-  }
-  return c.json(agentWithAvatarUrl(record[0], baseUrl));
+  const record = await requireOrgScoped(db, "agent", agentId, orgId);
+  return c.json(agentWithAvatarUrl(record, baseUrl));
 });
 
 /** Update an org-scoped Agent by ID (admin only) */
@@ -127,16 +119,7 @@ orgAgent.post(
     const agentId = c.req.param("agentId");
     const baseUrl = getOrigin(c);
 
-    const [existing] = await db
-      .select({ avatarKey: agentTable.avatarKey })
-      .from(agentTable)
-      .where(
-        and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
-      )
-      .limit(1);
-    if (!existing) {
-      throw new NotFoundError("Agent not found");
-    }
+    const existing = await requireOrgScoped(db, "agent", agentId, orgId);
 
     const body = await c.req.parseBody();
     const result = await storeAvatar(body["file"], agentId, existing.avatarKey);
@@ -165,16 +148,7 @@ orgAgent.delete(
     const agentId = c.req.param("agentId");
     const baseUrl = getOrigin(c);
 
-    const [existing] = await db
-      .select({ avatarKey: agentTable.avatarKey })
-      .from(agentTable)
-      .where(
-        and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
-      )
-      .limit(1);
-    if (!existing) {
-      throw new NotFoundError("Agent not found");
-    }
+    const existing = await requireOrgScoped(db, "agent", agentId, orgId);
 
     await deleteAvatar(existing.avatarKey);
 

--- a/apps/backend/src/routes/org-mcp.ts
+++ b/apps/backend/src/routes/org-mcp.ts
@@ -14,9 +14,17 @@ import {
 } from "@platypus/schemas";
 import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
-import { requireOrgAccess } from "../middleware/authorization.ts";
+import {
+  orgCredentialsVisible,
+  requireOrgAccess,
+} from "../middleware/authorization.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
-import { requireSharedDeletable } from "../services/scoped-resource.ts";
+import {
+  listOrgScoped,
+  requireOrgScoped,
+  resolveOrgScoped,
+  requireSharedDeletable,
+} from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
 import {
@@ -62,16 +70,13 @@ orgMcp.post(
 /** List org-scoped MCPs */
 orgMcp.get("/", requireAuth, requireOrgAccess(), async (c) => {
   const orgId = c.req.param("orgId")!;
-  const results = await db
-    .select()
-    .from(mcpTable)
-    .where(eq(mcpTable.organizationId, orgId));
+  const results = await listOrgScoped(db, "mcp", orgId);
   // This route admits any Organization member — a Shared MCP has to be listable
   // to be granted. Only an Org Admin sees its request credentials (ADR-0006).
-  const isAdmin = c.get("orgMembership")?.role === "admin";
+  const reveal = orgCredentialsVisible(c);
   return c.json({
     results: results.map((row) =>
-      redactMcpSecrets(sanitizeMcpResponse(row), { reveal: isAdmin }),
+      redactMcpSecrets(sanitizeMcpResponse(row), { reveal }),
     ),
   });
 });
@@ -80,19 +85,10 @@ orgMcp.get("/", requireAuth, requireOrgAccess(), async (c) => {
 orgMcp.get("/:mcpId", requireAuth, requireOrgAccess(), async (c) => {
   const orgId = c.req.param("orgId")!;
   const mcpId = c.req.param("mcpId");
-  const record = await db
-    .select()
-    .from(mcpTable)
-    .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.organizationId, orgId)))
-    .limit(1);
-  if (record.length === 0) {
-    throw new NotFoundError("MCP not found");
-  }
+  const record = await requireOrgScoped(db, "mcp", mcpId, orgId);
   // See the list route: request credentials are Org-Admin-only (ADR-0006).
-  const isAdmin = c.get("orgMembership")?.role === "admin";
-  return c.json(
-    redactMcpSecrets(sanitizeMcpResponse(record[0]), { reveal: isAdmin }),
-  );
+  const reveal = orgCredentialsVisible(c);
+  return c.json(redactMcpSecrets(sanitizeMcpResponse(record), { reveal }));
 });
 
 /** Update an org-scoped MCP by ID (admin only) */
@@ -107,13 +103,9 @@ orgMcp.put(
     const data = c.req.valid("json");
 
     // If URL is changing, clear stored OAuth tokens (they're server-specific)
-    const existing = await db
-      .select()
-      .from(mcpTable)
-      .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.organizationId, orgId)))
-      .limit(1);
+    const existing = await resolveOrgScoped(db, "mcp", mcpId, orgId);
 
-    const urlChanged = existing.length > 0 && existing[0].url !== data.url;
+    const urlChanged = !!existing && existing.url !== data.url;
 
     // A duplicate name surfaces as a Postgres unique violation, mapped to 409
     // by the central onError (ADR-0010).
@@ -184,22 +176,13 @@ orgMcp.post(
       // For OAuth, use authProvider with stored tokens
       if (data.authType === "OAuth" && data.mcpId) {
         const orgId = c.req.param("orgId")!;
-        const mcpRecord = await db
-          .select()
-          .from(mcpTable)
-          .where(
-            and(
-              eq(mcpTable.id, data.mcpId),
-              eq(mcpTable.organizationId, orgId),
-            ),
-          )
-          .limit(1);
+        const mcpRecord = await resolveOrgScoped(db, "mcp", data.mcpId, orgId);
 
-        if (mcpRecord.length === 0) {
+        if (!mcpRecord) {
           return c.json({ success: false, error: "MCP not found" }, 404);
         }
 
-        if (!mcpRecord[0].oauthAccessToken) {
+        if (!mcpRecord.oauthAccessToken) {
           return c.json(
             {
               success: false,
@@ -210,7 +193,7 @@ orgMcp.post(
         }
 
         mcpClient = await createMCPClient({
-          transport: buildMcpTransportConfig(mcpRecord[0]),
+          transport: buildMcpTransportConfig(mcpRecord),
         });
       } else {
         mcpClient = await createMCPClient({
@@ -264,26 +247,22 @@ orgMcp.post(
     const orgId = c.req.param("orgId")!;
     const mcpId = c.req.param("mcpId");
 
-    const mcpRecord = await db
-      .select()
-      .from(mcpTable)
-      .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.organizationId, orgId)))
-      .limit(1);
+    let mcpRecord = await resolveOrgScoped(db, "mcp", mcpId, orgId);
 
-    if (mcpRecord.length === 0) {
+    if (!mcpRecord) {
       return c.json({ error: "MCP not found" }, 404);
     }
 
-    if (mcpRecord[0].authType !== "OAuth") {
+    if (mcpRecord.authType !== "OAuth") {
       return c.json({ error: "MCP auth type is not OAuth" }, 400);
     }
 
-    if (!mcpRecord[0].url) {
+    if (!mcpRecord.url) {
       return c.json({ error: "MCP URL is not configured" }, 400);
     }
-    // Capture the narrowed URL before the `force` block reassigns
-    // `mcpRecord[0]`, which widens the property back to `string | null`.
-    const serverUrl = mcpRecord[0].url;
+    // Capture the narrowed URL before the `force` block reassigns `mcpRecord`,
+    // which widens the property back to `string | null`.
+    const serverUrl = mcpRecord.url;
 
     // `force=true` clears stored tokens before the OAuth flow so mcpAuth always
     // returns REDIRECT (see mcp.ts for the full rationale). DCR/static client
@@ -294,15 +273,12 @@ orgMcp.post(
         .update(mcpTable)
         .set({ ...OAUTH_TOKEN_CLEAR_FIELDS, updatedAt: new Date() })
         .where(eq(mcpTable.id, mcpId));
-      mcpRecord[0] = { ...mcpRecord[0], ...OAUTH_TOKEN_CLEAR_FIELDS };
+      mcpRecord = { ...mcpRecord, ...OAUTH_TOKEN_CLEAR_FIELDS };
     }
 
     try {
       const callbackUrl = buildOAuthCallbackUrl();
-      const provider = new DatabaseOAuthClientProvider(
-        mcpRecord[0],
-        callbackUrl,
-      );
+      const provider = new DatabaseOAuthClientProvider(mcpRecord, callbackUrl);
 
       const result = await mcpAuth(provider, {
         serverUrl,

--- a/apps/backend/src/routes/org-provider.ts
+++ b/apps/backend/src/routes/org-provider.ts
@@ -12,8 +12,15 @@ import {
   deMigrateOrphanedAliases,
 } from "../services/model-alias-migration.ts";
 import { requireAuth } from "../middleware/authentication.ts";
-import { requireOrgAccess } from "../middleware/authorization.ts";
-import { requireSharedDeletable } from "../services/scoped-resource.ts";
+import {
+  orgCredentialsVisible,
+  requireOrgAccess,
+} from "../middleware/authorization.ts";
+import {
+  listOrgScoped,
+  requireOrgScoped,
+  requireSharedDeletable,
+} from "../services/scoped-resource.ts";
 import { redactProviderSecrets } from "../services/credential-redaction.ts";
 import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
@@ -53,17 +60,12 @@ orgProvider.post(
 /** List all organization providers */
 orgProvider.get("/", requireAuth, requireOrgAccess(), async (c) => {
   const orgId = c.req.param("orgId")!;
-  const rows = await db
-    .select()
-    .from(providerTable)
-    .where(eq(providerTable.organizationId, orgId));
+  const rows = await listOrgScoped(db, "provider", orgId);
 
   // This route admits any Organization member — a Shared Provider has to be
   // listable to be selected. Only an Org Admin sees its credentials (ADR-0006).
-  const isAdmin = c.get("orgMembership")?.role === "admin";
-  const results = rows.map((row) =>
-    redactProviderSecrets(row, { reveal: isAdmin }),
-  );
+  const reveal = orgCredentialsVisible(c);
+  const results = rows.map((row) => redactProviderSecrets(row, { reveal }));
 
   return c.json({ results });
 });
@@ -73,24 +75,11 @@ orgProvider.get("/:providerId", requireAuth, requireOrgAccess(), async (c) => {
   const orgId = c.req.param("orgId")!;
   const providerId = c.req.param("providerId");
 
-  const record = await db
-    .select()
-    .from(providerTable)
-    .where(
-      and(
-        eq(providerTable.id, providerId),
-        eq(providerTable.organizationId, orgId),
-      ),
-    )
-    .limit(1);
-
-  if (record.length === 0) {
-    throw new NotFoundError("Provider not found");
-  }
+  const record = await requireOrgScoped(db, "provider", providerId, orgId);
 
   // See the list route: credentials are Org-Admin-only (ADR-0006).
-  const isAdmin = c.get("orgMembership")?.role === "admin";
-  return c.json(redactProviderSecrets(record[0], { reveal: isAdmin }));
+  const reveal = orgCredentialsVisible(c);
+  return c.json(redactProviderSecrets(record, { reveal }));
 });
 
 /** Update an organization provider by ID (admin only) */

--- a/apps/backend/src/routes/org-skill.ts
+++ b/apps/backend/src/routes/org-skill.ts
@@ -8,7 +8,11 @@ import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
-import { requireSharedDeletable } from "../services/scoped-resource.ts";
+import {
+  listOrgScoped,
+  requireOrgScoped,
+  requireSharedDeletable,
+} from "../services/scoped-resource.ts";
 import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
@@ -49,10 +53,7 @@ orgSkill.post(
 /** List org-scoped Skills */
 orgSkill.get("/", requireAuth, requireOrgAccess(), async (c) => {
   const orgId = c.req.param("orgId")!;
-  const results = await db
-    .select()
-    .from(skillTable)
-    .where(eq(skillTable.organizationId, orgId));
+  const results = await listOrgScoped(db, "skill", orgId);
   return c.json({ results });
 });
 
@@ -60,17 +61,8 @@ orgSkill.get("/", requireAuth, requireOrgAccess(), async (c) => {
 orgSkill.get("/:skillId", requireAuth, requireOrgAccess(), async (c) => {
   const orgId = c.req.param("orgId")!;
   const skillId = c.req.param("skillId");
-  const record = await db
-    .select()
-    .from(skillTable)
-    .where(
-      and(eq(skillTable.id, skillId), eq(skillTable.organizationId, orgId)),
-    )
-    .limit(1);
-  if (record.length === 0) {
-    throw new NotFoundError("Skill not found");
-  }
-  return c.json(record[0]);
+  const record = await requireOrgScoped(db, "skill", skillId, orgId);
+  return c.json(record);
 });
 
 /** Update an org-scoped Skill by ID (admin only) */

--- a/apps/backend/src/routes/org-tool.ts
+++ b/apps/backend/src/routes/org-tool.ts
@@ -1,10 +1,9 @@
 import { Hono } from "hono";
 import { getToolSets } from "../tools/index.ts";
 import { db } from "../index.ts";
-import { mcp as mcpTable } from "../db/schema.ts";
-import { eq } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
+import { listOrgScoped } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 
 // Tool sets available to an org-scoped (Shared) Agent: the statically
@@ -31,10 +30,7 @@ orgTool.get("/", requireAuth, requireOrgAccess(), async (c) => {
           })),
   }));
 
-  const mcps = await db
-    .select()
-    .from(mcpTable)
-    .where(eq(mcpTable.organizationId, orgId));
+  const mcps = await listOrgScoped(db, "mcp", orgId);
   const mcpList = mcps.map((mcp) => ({
     id: mcp.id,
     name: mcp.name,

--- a/apps/backend/src/routes/provider.ts
+++ b/apps/backend/src/routes/provider.ts
@@ -16,17 +16,32 @@ import {
   requireOrgAccess,
   requireWorkspaceAccess,
   requireWorkspaceConfigAccess,
-  workspaceConfigAccess,
+  workspaceCredentialsVisible,
 } from "../middleware/authorization.ts";
 import { redactProviderSecrets } from "../services/credential-redaction.ts";
 import {
   listScoped,
   requireScoped,
   requireWorkspaceMutable,
+  type Scope,
 } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 
 const provider = new Hono<{ Variables: Variables }>();
+
+/**
+ * The read shape of a Provider on the Workspace surface, assembled once for both
+ * read routes: stored credentials only for a caller who may manage this Provider
+ * (ADR-0006), and the scope the Scoped-resource module resolved it at, which the
+ * frontend uses to mark a Shared row read-only.
+ */
+const providerReadModel = (
+  { row, scope }: { row: typeof providerTable.$inferSelect; scope: Scope },
+  reveal: boolean,
+) => ({
+  ...redactProviderSecrets(row, { reveal }),
+  scope,
+});
 
 /**
  * Create a workspace-scoped provider. Org-admin by default; a workspace owner
@@ -82,14 +97,8 @@ provider.get(
     // (ADR-0006) — the same rule the write routes reject on. The rows themselves
     // still list, because selecting a Provider on an Agent or Chat does not
     // require self-management.
-    const { allowed } = await workspaceConfigAccess(
-      c,
-      "providerSelfManagement",
-    );
-    const results = scoped.map(({ row, scope }) => ({
-      ...redactProviderSecrets(row, { reveal: allowed }),
-      scope,
-    }));
+    const reveal = await workspaceCredentialsVisible(c, "provider");
+    const results = scoped.map((found) => providerReadModel(found, reveal));
     return c.json({ results });
   },
 );
@@ -110,14 +119,8 @@ provider.get(
       wsId: workspaceId,
     });
     // See the list route: redacted unless this caller may manage the Provider.
-    const { allowed } = await workspaceConfigAccess(
-      c,
-      "providerSelfManagement",
-    );
-    return c.json({
-      ...redactProviderSecrets(found.row, { reveal: allowed }),
-      scope: found.scope,
-    });
+    const reveal = await workspaceCredentialsVisible(c, "provider");
+    return c.json(providerReadModel(found, reveal));
   },
 );
 

--- a/apps/backend/src/routes/tool.test.ts
+++ b/apps/backend/src/routes/tool.test.ts
@@ -56,11 +56,11 @@ describe("Tool Routes", () => {
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
 
-      const mockMcps = [{ id: "mcp-1", name: "MCP 1" }];
       mockDb.where
-        .mockReturnValueOnce(mockDb)
-        .mockReturnValueOnce(mockDb)
-        .mockResolvedValueOnce(mockMcps);
+        .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // requireWorkspaceAccess
+        .mockResolvedValueOnce([{ id: "mcp-1", name: "MCP 1" }]) // workspace MCPs
+        .mockResolvedValueOnce([]); // attached Shared MCPs
 
       const res = await app.request(baseUrl);
       expect(res.status).toBe(200);
@@ -90,6 +90,39 @@ describe("Tool Routes", () => {
         expect.objectContaining({
           id: "mcp-1",
           name: "MCP 1",
+          category: "MCP",
+        }),
+      );
+    });
+
+    it("includes Shared MCPs attached to this workspace", async () => {
+      // The catalog lists what the Workspace may actually use, which is what
+      // `GET /mcps` already lists: its own MCPs plus the Shared ones attached
+      // here (ADR-0007). Listing only workspace-scoped rows hid every attached
+      // Shared MCP from the tool-set picker.
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+
+      mockDb.where
+        .mockReturnValueOnce(mockDb)
+        .mockReturnValueOnce(mockDb)
+        .mockResolvedValueOnce([]) // no workspace-scoped MCPs
+        // attached Shared MCPs arrive from an inner join, keyed by table name.
+        .mockResolvedValueOnce([
+          { mcp: { id: "mcp-shared", name: "Shared MCP" } },
+        ]);
+
+      const res = await app.request(baseUrl);
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(json.results).toContainEqual(
+        expect.objectContaining({
+          id: "mcp-shared",
+          name: "Shared MCP",
           category: "MCP",
         }),
       );

--- a/apps/backend/src/routes/tool.ts
+++ b/apps/backend/src/routes/tool.ts
@@ -2,13 +2,12 @@ import { Hono } from "hono";
 import { getToolSets } from "../tools/index.ts";
 import { CORE_BUILTIN_OWNER, getToolSetPlugin } from "../plugins/registry.ts";
 import { db } from "../index.ts";
-import { mcp as mcpTable } from "../db/schema.ts";
-import { eq } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
   requireWorkspaceAccess,
 } from "../middleware/authorization.ts";
+import { listScoped } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 
 const tool = new Hono<{ Variables: Variables }>();
@@ -20,6 +19,7 @@ tool.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
     // Get static tools. Each set is annotated with the `plugin` that
     // contributed it (ADR-0013 observability); the core-internal `sandbox` set is
@@ -40,14 +40,13 @@ tool.get(
             })),
     }));
 
-    // Get MCPs
-    const mcps = await db
-      .select()
-      .from(mcpTable)
-      .where(eq(mcpTable.workspaceId, workspaceId));
-    const mcpList = mcps.map((mcp) => ({
-      id: mcp.id,
-      name: mcp.name,
+    // The MCPs this Workspace may actually use: its own, plus the Shared
+    // (org-scoped) ones attached to it (ADR-0007) — the same set `GET /mcps`
+    // lists, resolved through the same authority.
+    const mcps = await listScoped(db, "mcp", { orgId, wsId: workspaceId });
+    const mcpList = mcps.map(({ row }) => ({
+      id: row.id,
+      name: row.name,
       category: "MCP",
     }));
 

--- a/apps/backend/src/routes/trigger.test.ts
+++ b/apps/backend/src/routes/trigger.test.ts
@@ -159,6 +159,30 @@ describe("Trigger Routes", () => {
       });
     });
 
+    it("accepts a Shared agent attached to this workspace", async () => {
+      // A Shared Agent runs here where an Attachment makes it visible
+      // (ADR-0007), so a trigger may point at one — the run resolves the Agent
+      // through the same authority.
+      stubAuthLookups();
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "agent-1", organizationId: orgId, workspaceId: null },
+        ])
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attached here
+      const nextRun = new Date("2026-02-01T09:00:00Z");
+      mockValidateCronExpression.mockReturnValueOnce(nextRun);
+      mockDb.returning.mockResolvedValueOnce([
+        { ...cronTrigger, id: "trig-shared", nextRunAt: nextRun },
+      ]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify(createBody),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(201);
+    });
+
     it("rejects creation when the agent is not in the workspace", async () => {
       stubAuthLookups();
       mockDb.limit.mockResolvedValueOnce([]); // agent verify: not found

--- a/apps/backend/src/routes/trigger.ts
+++ b/apps/backend/src/routes/trigger.ts
@@ -7,7 +7,6 @@ import { db } from "../index.ts";
 import {
   trigger as triggerTable,
   triggerRun as triggerRunTable,
-  agent as agentTable,
 } from "../db/schema.ts";
 import { triggerCreateSchema, triggerUpdateSchema } from "@platypus/schemas";
 import { requireAuth } from "../middleware/authentication.ts";
@@ -16,6 +15,7 @@ import {
   requireWorkspaceAccess,
   requireWorkspaceOwner,
 } from "../middleware/authorization.ts";
+import { resolveScoped } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
 import { validateCronExpression } from "../utils/cron.ts";
@@ -78,21 +78,18 @@ trigger.post(
   sValidator("json", triggerCreateSchema),
   async (c) => {
     const data = c.req.valid("json");
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
 
-    // Verify agent exists in workspace
-    const agentRecord = await db
-      .select()
-      .from(agentTable)
-      .where(
-        and(
-          eq(agentTable.id, data.agentId),
-          eq(agentTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
+    // The Agent must be usable here: workspace-scoped, or a Shared one attached
+    // to this Workspace (ADR-0007) — the same set the run resolves when the
+    // trigger fires.
+    const agentRecord = await resolveScoped(db, "agent", data.agentId, {
+      orgId,
+      wsId: workspaceId,
+    });
 
-    if (agentRecord.length === 0) {
+    if (!agentRecord) {
       return c.json({ error: "Agent not found in this workspace" }, 400);
     }
 
@@ -151,6 +148,7 @@ trigger.put(
   sValidator("json", triggerUpdateSchema),
   async (c) => {
     const triggerId = c.req.param("triggerId");
+    const orgId = c.req.param("orgId")!;
     const workspaceId = c.req.param("workspaceId")!;
     const data = c.req.valid("json");
 
@@ -172,18 +170,13 @@ trigger.put(
 
     // If agentId is being changed, verify new agent exists
     if (data.agentId && data.agentId !== existing[0].agentId) {
-      const agentRecord = await db
-        .select()
-        .from(agentTable)
-        .where(
-          and(
-            eq(agentTable.id, data.agentId),
-            eq(agentTable.workspaceId, workspaceId),
-          ),
-        )
-        .limit(1);
+      // See the create route: workspace-scoped, or Shared and attached here.
+      const agentRecord = await resolveScoped(db, "agent", data.agentId, {
+        orgId,
+        wsId: workspaceId,
+      });
 
-      if (agentRecord.length === 0) {
+      if (!agentRecord) {
         return c.json({ error: "Agent not found in this workspace" }, 400);
       }
     }

--- a/apps/backend/src/services/chat-metadata.test.ts
+++ b/apps/backend/src/services/chat-metadata.test.ts
@@ -50,6 +50,15 @@ const provider = {
   providerType: "OpenAI",
   taskModelId: "task-model",
   modelIds: ["task-model"],
+  workspaceId: "ws-1",
+  organizationId: null,
+};
+
+/** The same Provider as a Shared (org-scoped) row. */
+const sharedProvider = {
+  ...provider,
+  workspaceId: null,
+  organizationId: "org-1",
 };
 
 describe("generateChatMetadata", () => {
@@ -175,6 +184,38 @@ describe("generateChatMetadata", () => {
 
     const result = await generateChatMetadata(params);
     expect(result).toBeNull();
+  });
+
+  it("refuses a Shared provider that is not attached to this workspace", async () => {
+    // Titling resolves its Provider through the Scoped-resource authority, so a
+    // Shared Provider reaches this Workspace only where an Attachment does
+    // (ADR-0007) — matching every other resource a Chat turn resolves.
+    stubReads({
+      chat: { id: "chat-1", title: "Untitled", messages: [userMessage] },
+      workspace: { id: "ws-1", taskModelProviderId: null },
+      provider: sharedProvider,
+    });
+    mockDb.limit.mockResolvedValueOnce([]); // attachment check → not attached
+
+    const result = await generateChatMetadata(params);
+    expect(result).toBeNull();
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  it("titles with a Shared provider attached to this workspace", async () => {
+    stubReads({
+      chat: { id: "chat-1", title: "Untitled", messages: [userMessage] },
+      workspace: { id: "ws-1", taskModelProviderId: null },
+      provider: sharedProvider,
+    });
+    mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]); // attached here
+    mockGenerateText.mockResolvedValueOnce({
+      output: { title: "Titled", tags: ["a"] },
+    });
+    mockDb.returning.mockResolvedValueOnce([{ id: "chat-1" }]);
+
+    const result = await generateChatMetadata(params);
+    expect(result).not.toBeNull();
   });
 
   it("returns null when the provider cannot be resolved", async () => {

--- a/apps/backend/src/services/chat-metadata.ts
+++ b/apps/backend/src/services/chat-metadata.ts
@@ -1,13 +1,13 @@
 import { generateText, Output } from "ai";
-import { and, eq, or, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../index.ts";
 import {
   chat as chatTable,
-  provider as providerTable,
   workspace as workspaceTable,
 } from "../db/schema.ts";
 import { openProvider } from "./provider.ts";
+import { resolveScoped } from "./scoped-resource.ts";
 import { pointerSettingModelId } from "./model-capability.ts";
 import { dedupeArray, toKebabCase } from "../utils.ts";
 import { UNTITLED_CHAT_TITLE, type Provider } from "@platypus/schemas";
@@ -87,21 +87,15 @@ export const generateChatMetadata = async (
   // Use the workspace task-model provider if set, otherwise the supplied one.
   const effectiveProviderId = workspace.taskModelProviderId || providerId;
 
-  const providerRows = await db
-    .select()
-    .from(providerTable)
-    .where(
-      and(
-        eq(providerTable.id, effectiveProviderId),
-        or(
-          eq(providerTable.workspaceId, workspaceId),
-          eq(providerTable.organizationId, orgId),
-        ),
-      ),
-    )
-    .limit(1);
-  const provider = providerRows[0] as Provider | undefined;
-  if (!provider) return null;
+  // Resolved through the Scoped-resource authority, as every other resource a
+  // Chat turn reaches is: a Shared Provider titles here only where an Attachment
+  // makes it visible to this Workspace (ADR-0007).
+  const found = await resolveScoped(db, "provider", effectiveProviderId, {
+    orgId,
+    wsId: workspaceId,
+  });
+  if (!found) return null;
+  const provider = found.row as Provider;
 
   // Fetch existing tags from all chats in the workspace so the model can reuse
   // them rather than minting near-duplicate variants.

--- a/apps/backend/src/services/credential-redaction.ts
+++ b/apps/backend/src/services/credential-redaction.ts
@@ -13,6 +13,11 @@
  * to them, so the rows must keep flowing with the secrets removed.
  *
  * `reveal` defaults to `false` on both helpers so a new call site fails closed.
+ *
+ * *Who* may reveal is decided once per surface, not per route:
+ * `workspaceCredentialsVisible` and `orgCredentialsVisible`
+ * (`middleware/authorization.ts`), which are where these helpers' `reveal`
+ * argument comes from.
  */
 
 /** Replaces a redacted secret so a caller can tell "unset" from "not shown". */

--- a/apps/backend/src/services/scoped-resource.test.ts
+++ b/apps/backend/src/services/scoped-resource.test.ts
@@ -2,14 +2,19 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 // test-utils installs the drizzle-orm mock, so it must be imported before the
 // operators this file asserts on — `inArray` is a spy only through that mock.
 import { mockDb, resetMockDb, asDb } from "../test-utils.ts";
-import { inArray } from "drizzle-orm";
+import { inArray, isNull } from "drizzle-orm";
+import { agent as agentTable } from "../db/schema.ts";
 import {
   resolveScoped,
+  resolveScopedByName,
   listScoped,
   listScopedByIds,
   requireScoped,
   requireWorkspaceMutable,
   requireSharedDeletable,
+  resolveOrgScoped,
+  requireOrgScoped,
+  listOrgScoped,
 } from "./scoped-resource.ts";
 import { NotFoundError, LockedError, ConflictError } from "../errors.ts";
 
@@ -79,6 +84,137 @@ describe("ScopedResource read module", () => {
 
       const found = await resolveScoped(asDb(mockDb), "agent", "a1", ctx);
       expect(found).toBeNull();
+    });
+  });
+
+  describe("resolveScopedByName", () => {
+    it("prefers the workspace-scoped row of that name", async () => {
+      const row = { id: "s1", name: "triage", workspaceId: "ws-1" };
+      mockDb.limit.mockResolvedValueOnce([row]);
+
+      const found = await resolveScopedByName(
+        asDb(mockDb),
+        "skill",
+        "triage",
+        ctx,
+      );
+      expect(found).toEqual({ row, scope: "workspace" });
+      // The Shared branch never ran — a Workspace row of the same name wins
+      // outright rather than racing an unordered `LIMIT 1` against it.
+      expect(mockDb.innerJoin).not.toHaveBeenCalled();
+    });
+
+    it("falls back to an attached org-scoped row of that name", async () => {
+      const row = {
+        id: "s2",
+        name: "triage",
+        organizationId: "org-1",
+        workspaceId: null,
+      };
+      mockDb.limit
+        .mockResolvedValueOnce([]) // no workspace-scoped row of this name
+        .mockResolvedValueOnce([row]) // the Shared row
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attached here
+
+      const found = await resolveScopedByName(
+        asDb(mockDb),
+        "skill",
+        "triage",
+        ctx,
+      );
+      expect(found).toEqual({ row, scope: "organization" });
+    });
+
+    it("returns null for an org-scoped row not attached here", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: "s2",
+            name: "triage",
+            organizationId: "org-1",
+            workspaceId: null,
+          },
+        ])
+        .mockResolvedValueOnce([]); // attachment check → not attached
+
+      const found = await resolveScopedByName(
+        asDb(mockDb),
+        "skill",
+        "triage",
+        ctx,
+      );
+      expect(found).toBeNull();
+    });
+
+    it("returns null when no row of that name is visible", async () => {
+      mockDb.limit.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const found = await resolveScopedByName(
+        asDb(mockDb),
+        "skill",
+        "triage",
+        ctx,
+      );
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("resolveOrgScoped", () => {
+    it("returns the Shared row of this organization", async () => {
+      const row = { id: "a1", organizationId: "org-1", workspaceId: null };
+      mockDb.limit.mockResolvedValueOnce([row]);
+
+      const found = await resolveOrgScoped(
+        asDb(mockDb),
+        "agent",
+        "a1",
+        "org-1",
+      );
+      expect(found).toEqual(row);
+      // Only genuinely Shared rows answer on the Organization surface: a row
+      // carrying both scope columns belongs to its Workspace (ADR-0007).
+      expect(isNull).toHaveBeenCalledWith(agentTable.workspaceId);
+    });
+
+    it("returns null when the resource is not Shared in this organization", async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const found = await resolveOrgScoped(
+        asDb(mockDb),
+        "agent",
+        "a1",
+        "org-1",
+      );
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("requireOrgScoped", () => {
+    it("throws NotFoundError when the resource is not Shared here", async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+      await expect(
+        requireOrgScoped(asDb(mockDb), "agent", "a1", "org-1"),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it("returns the row when it is Shared here", async () => {
+      const row = { id: "a1", organizationId: "org-1", workspaceId: null };
+      mockDb.limit.mockResolvedValueOnce([row]);
+      await expect(
+        requireOrgScoped(asDb(mockDb), "agent", "a1", "org-1"),
+      ).resolves.toEqual(row);
+    });
+  });
+
+  describe("listOrgScoped", () => {
+    it("lists this organization's Shared rows", async () => {
+      const rows = [{ id: "a1", organizationId: "org-1", workspaceId: null }];
+      mockDb.where.mockResolvedValueOnce(rows);
+
+      const results = await listOrgScoped(asDb(mockDb), "agent", "org-1");
+      expect(results).toEqual(rows);
+      expect(isNull).toHaveBeenCalledWith(agentTable.workspaceId);
     });
   });
 

--- a/apps/backend/src/services/scoped-resource.ts
+++ b/apps/backend/src/services/scoped-resource.ts
@@ -18,12 +18,20 @@ import { isResourceListedInBlueprint } from "./blueprint-guard.ts";
  * directly; Organization-scoped (Shared) rows are visible only where an
  * **Attachment** exists, and are locked against Workspace-surface mutation.
  *
+ * The Organization surface asks a narrower question — "is this a Shared
+ * resource of this Organization?" — with no Workspace and so no Attachment in
+ * play. `resolveOrgScoped`/`requireOrgScoped`/`listOrgScoped` answer it, and
+ * take a bare `orgId` rather than a {@link ScopeContext} for exactly that
+ * reason.
+ *
  * Collapses the "resolve → null-check → org-scope-403" branch that the
- * dual-scope resource routes each re-implemented. `resolveScoped`/`listScoped`
- * are exception-free for callers that tolerate absence (e.g. the Chat-turn
- * attachment check); `requireScoped`/`requireWorkspaceMutable`/
- * `requireSharedDeletable` throw the typed errors mapped centrally by
- * `app.onError` (ADR-0010).
+ * dual-scope resource routes each re-implemented. `resolveScoped`/
+ * `resolveScopedByName`/`listScoped`/`resolveOrgScoped`/`listOrgScoped` are
+ * exception-free for callers that tolerate absence (e.g. the Chat-turn
+ * attachment check, and the agent-facing Tools, which return an `{ error }`
+ * payload rather than throwing); `requireScoped`/`requireOrgScoped`/
+ * `requireWorkspaceMutable`/`requireSharedDeletable` throw the typed errors
+ * mapped centrally by `app.onError` (ADR-0010).
  */
 
 /** `"workspace"` for a directly-owned row, `"organization"` for a Shared one. */
@@ -94,6 +102,27 @@ export const isSharedRow = (
   orgId: string,
 ): boolean => !!row && row.organizationId === orgId && !row.workspaceId;
 
+/** Whether this Workspace holds an Attachment for the given Shared resource. */
+const isAttached = async (
+  database: Database,
+  type: ScopedResourceType,
+  id: string,
+  wsId: string,
+): Promise<boolean> => {
+  const [attached] = await database
+    .select({ id: attachmentTable.id })
+    .from(attachmentTable)
+    .where(
+      and(
+        eq(attachmentTable.workspaceId, wsId),
+        eq(attachmentTable.resourceType, type),
+        eq(attachmentTable.resourceId, id),
+      ),
+    )
+    .limit(1);
+  return !!attached;
+};
+
 /**
  * Resolves a single resource visible inside this Workspace, or `null` when it
  * is not visible here. A Workspace-scoped row matches directly; an
@@ -133,19 +162,56 @@ export const resolveScoped = async <T extends ScopedResourceType>(
   if (!isSharedRow(row, ctx.orgId)) return null;
 
   // A Shared resource is visible here only through an Attachment (ADR-0007).
-  const [attached] = await database
-    .select({ id: attachmentTable.id })
-    .from(attachmentTable)
+  if (!(await isAttached(database, type, id, ctx.wsId))) return null;
+  return { row, scope: "organization" };
+};
+
+/**
+ * {@link resolveScoped} keyed by name rather than id, for the agent-facing
+ * Tools, which address resources the way a model does — by the name in the
+ * prompt.
+ *
+ * Two queries rather than one, because a Workspace and its Organization may each
+ * hold a resource of the same name: names are unique per scope, not across the
+ * pair. The Workspace-scoped row wins outright, so the Workspace stays able to
+ * define its own version of a Shared resource; a single `or(...)` + `LIMIT 1`
+ * would pick between them in whatever order the planner happened to return.
+ */
+export const resolveScopedByName = async <T extends ScopedResourceType>(
+  database: Database,
+  type: T,
+  name: string,
+  ctx: ScopeContext,
+): Promise<{ row: RowOf[T]; scope: Scope } | null> => {
+  const { table } = REGISTRY[type];
+
+  const workspaceRows = await database
+    .select()
+    .from(table)
+    .where(and(eq(table.workspaceId, ctx.wsId), eq(table.name, name)))
+    .limit(1);
+  const workspaceRow = workspaceRows[0] as RowOf[T] | undefined;
+  if (workspaceRow) return { row: workspaceRow, scope: "workspace" };
+
+  // `isNull(workspaceId)` is what makes the row Shared: the scope columns are
+  // mutually exclusive on write, not by a database constraint, so a row carrying
+  // both must not reach another Workspace through that Workspace's Attachment.
+  const orgRows = await database
+    .select()
+    .from(table)
     .where(
       and(
-        eq(attachmentTable.workspaceId, ctx.wsId),
-        eq(attachmentTable.resourceType, type),
-        eq(attachmentTable.resourceId, id),
+        eq(table.organizationId, ctx.orgId),
+        isNull(table.workspaceId),
+        eq(table.name, name),
       ),
     )
     .limit(1);
-  if (!attached) return null;
-  return { row, scope: "organization" };
+  const orgRow = orgRows[0] as RowOf[T] | undefined;
+  if (!orgRow) return null;
+
+  if (!(await isAttached(database, type, orgRow.id, ctx.wsId))) return null;
+  return { row: orgRow, scope: "organization" };
 };
 
 /**
@@ -230,6 +296,77 @@ export const listScopedByIds = <T extends ScopedResourceType>(
   ids.length === 0 ? Promise.resolve([]) : listScoped(database, type, ctx, ids);
 
 /**
+ * Resolves a **Shared resource** of this Organization — the Organization
+ * surface's counterpart to {@link resolveScoped}, where there is no Workspace
+ * and so no Attachment to gate on. Returns `null` when the id is not a Shared
+ * resource of this Organization. Never throws.
+ *
+ * `isNull(workspaceId)` carries the same defence `listScoped` applies to its
+ * Organization half: the scope columns are mutually exclusive on write, not by a
+ * database constraint, and a row carrying both belongs to its Workspace — it is
+ * not Shared, and does not answer here. The org routes' own `UPDATE`/`DELETE`
+ * clauses still match on `organizationId` alone; no route can write both columns,
+ * so that gap is unreachable rather than closed.
+ */
+export const resolveOrgScoped = async <T extends ScopedResourceType>(
+  database: Database,
+  type: T,
+  id: string,
+  orgId: string,
+): Promise<RowOf[T] | null> => {
+  const { table } = REGISTRY[type];
+
+  const rows = await database
+    .select()
+    .from(table)
+    .where(
+      and(
+        eq(table.id, id),
+        eq(table.organizationId, orgId),
+        isNull(table.workspaceId),
+      ),
+    )
+    .limit(1);
+  return (rows[0] as RowOf[T] | undefined) ?? null;
+};
+
+/**
+ * Like {@link resolveOrgScoped} but throws `NotFoundError` when the resource is
+ * not a Shared resource of this Organization — for the org routes that treat
+ * absence as a 404.
+ */
+export const requireOrgScoped = async <T extends ScopedResourceType>(
+  database: Database,
+  type: T,
+  id: string,
+  orgId: string,
+): Promise<RowOf[T]> => {
+  const row = await resolveOrgScoped(database, type, id, orgId);
+  if (!row) {
+    throw new NotFoundError(`${REGISTRY[type].label} not found`);
+  }
+  return row;
+};
+
+/**
+ * Lists this Organization's Shared resources of a type — what the Organization
+ * surface shows, and the set a Workspace may attach from. Never throws.
+ */
+export const listOrgScoped = async <T extends ScopedResourceType>(
+  database: Database,
+  type: T,
+  orgId: string,
+): Promise<RowOf[T][]> => {
+  const { table } = REGISTRY[type];
+
+  const rows = await database
+    .select()
+    .from(table)
+    .where(and(eq(table.organizationId, orgId), isNull(table.workspaceId)));
+  return rows as RowOf[T][];
+};
+
+/**
  * Like `resolveScoped` but throws `NotFoundError` when the resource is not
  * visible here — for routes that treat absence as a 404.
  */
@@ -247,6 +384,16 @@ export const requireScoped = async <T extends ScopedResourceType>(
 };
 
 /**
+ * How a Workspace-surface mutation refuses a Shared row. Exported so the
+ * agent-facing Tools — which return an `{ error }` payload rather than throwing
+ * — refuse in the same words {@link requireWorkspaceMutable} does.
+ */
+export const workspaceMutationLockedMessage = (
+  type: ScopedResourceType,
+): string =>
+  `This ${REGISTRY[type].label.toLowerCase()} is managed at the organization level`;
+
+/**
  * Resolves a resource for Workspace-surface mutation: throws `NotFoundError`
  * when it is not visible here, then `LockedError` when it is an
  * Organization-scoped (Shared) row — a single source of truth edited only on
@@ -261,9 +408,7 @@ export const requireWorkspaceMutable = async <T extends ScopedResourceType>(
 ): Promise<{ row: RowOf[T]; scope: "workspace" }> => {
   const found = await requireScoped(database, type, id, ctx);
   if (found.scope === "organization") {
-    throw new LockedError(
-      `This ${REGISTRY[type].label.toLowerCase()} is managed at the organization level`,
-    );
+    throw new LockedError(workspaceMutationLockedMessage(type));
   }
   return { row: found.row, scope: "workspace" };
 };

--- a/apps/backend/src/tools/agent-management.test.ts
+++ b/apps/backend/src/tools/agent-management.test.ts
@@ -48,7 +48,24 @@ describe("createAgentManagementTools", () => {
       ).toEqual({ error: "Agent not found" });
     });
 
+    it("refuses to update a Shared agent attached to this workspace", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "a1", organizationId: orgId, workspaceId: null },
+        ])
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attached → visible, not writable
+
+      const result = (await tools.updateAgent.execute!(
+        { agentId: "a1", label: "test", name: "New Name" },
+        ctx,
+      )) as { error?: string };
+
+      expect(result.error).toContain("managed at the organization level");
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
     it("validates sub-agent assignments", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "a1", workspaceId }]);
       vi.mocked(validateSubAgentAssignment).mockResolvedValueOnce({
         valid: false,
         error: "Circular dependency detected",
@@ -75,8 +92,26 @@ describe("createAgentManagementTools", () => {
       ).toEqual({ error: "Agent not found" });
     });
 
+    it("refuses to delete a Shared agent attached to this workspace", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "a1", organizationId: orgId, workspaceId: null },
+        ])
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attached → visible, not deletable
+
+      const result = (await tools.deleteAgent.execute!(
+        { agentId: "a1", label: "Agent 1" },
+        ctx,
+      )) as { error?: string };
+
+      expect(result.error).toContain("managed at the organization level");
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
     it("deletes agent and cleans up avatar", async () => {
-      mockDb.limit.mockResolvedValue([{ avatarKey: "avatars/a1.png" }]);
+      mockDb.limit.mockResolvedValue([
+        { id: "a1", workspaceId, avatarKey: "avatars/a1.png" },
+      ]);
 
       expect(
         await tools.deleteAgent.execute!(
@@ -87,7 +122,9 @@ describe("createAgentManagementTools", () => {
     });
 
     it("deletes agent without avatar", async () => {
-      mockDb.limit.mockResolvedValue([{ avatarKey: null }]);
+      mockDb.limit.mockResolvedValue([
+        { id: "a1", workspaceId, avatarKey: null },
+      ]);
 
       expect(
         await tools.deleteAgent.execute!(

--- a/apps/backend/src/tools/agent-management.ts
+++ b/apps/backend/src/tools/agent-management.ts
@@ -5,6 +5,11 @@ import { db } from "../index.ts";
 import { agent as agentTable } from "../db/schema.ts";
 import { dedupeArray } from "../utils.ts";
 import { validateSubAgentAssignment } from "../services/sub-agent-validation.ts";
+import {
+  resolveScoped,
+  workspaceMutationLockedMessage,
+  type ScopeContext,
+} from "../services/scoped-resource.ts";
 import { getStorage } from "../storage/index.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
 
@@ -25,6 +30,27 @@ export function createAgentManagementTools(
   orgId: string,
   frontendUrl: string | undefined,
 ): Record<string, Tool> {
+  const ctx: ScopeContext = { orgId, wsId: workspaceId };
+
+  /**
+   * Resolves an Agent this Workspace may write to, for the mutating tools. An
+   * attached Shared Agent is visible here but is a single source of truth edited
+   * only on the Organization surface (ADR-0007) — the same rule
+   * `requireWorkspaceMutable` enforces on the routes, in the same words,
+   * returned rather than thrown because a tool answers the model with an
+   * `{ error }` payload.
+   */
+  const resolveWritableAgent = async (
+    agentId: string,
+  ): Promise<{ row: typeof agentTable.$inferSelect } | { error: string }> => {
+    const found = await resolveScoped(db, "agent", agentId, ctx);
+    if (!found) return { error: "Agent not found" };
+    if (found.scope === "organization") {
+      return { error: workspaceMutationLockedMessage("agent") };
+    }
+    return { row: found.row };
+  };
+
   const createAgent = tool({
     description:
       "Create a new agent in the current workspace. Returns the created agent.",
@@ -178,9 +204,14 @@ export function createAgentManagementTools(
         data.subAgentIds = dedupeArray(data.subAgentIds);
       }
 
+      // Before validating the payload: a Shared Agent should be refused as
+      // locked, not answered with a complaint about the edit it will not apply.
+      const writable = await resolveWritableAgent(agentId);
+      if ("error" in writable) return writable;
+
       if (data.subAgentIds) {
         const validation = await validateSubAgentAssignment(
-          { orgId, wsId: workspaceId },
+          ctx,
           agentId,
           data.subAgentIds,
         );
@@ -225,25 +256,15 @@ export function createAgentManagementTools(
       label: z.string().describe("The agent name (for display purposes)"),
     }),
     execute: async ({ agentId }) => {
-      const existing = await db
-        .select({ avatarKey: agentTable.avatarKey })
-        .from(agentTable)
-        .where(
-          and(
-            eq(agentTable.id, agentId),
-            eq(agentTable.workspaceId, workspaceId),
-          ),
-        )
-        .limit(1);
+      // Detaching a Shared Agent is the workspace-side action, and that is an
+      // Attachment concern — never a delete of the Organization's row.
+      const writable = await resolveWritableAgent(agentId);
+      if ("error" in writable) return writable;
 
-      if (existing.length === 0) {
-        return { error: "Agent not found" };
-      }
-
-      if (existing[0]?.avatarKey) {
+      if (writable.row.avatarKey) {
         try {
           const storage = getStorage();
-          await storage.delete(existing[0].avatarKey);
+          await storage.delete(writable.row.avatarKey);
         } catch {
           // Ignore deletion errors
         }

--- a/apps/backend/src/tools/skill-management.test.ts
+++ b/apps/backend/src/tools/skill-management.test.ts
@@ -30,11 +30,16 @@ describe("createSkillManagementTools", () => {
   });
 
   describe("listSkills", () => {
-    it("returns skills in workspace", async () => {
-      const skills = [{ id: "s1", name: "my-skill" }];
-      mockDb.where.mockResolvedValue(skills);
+    it("returns workspace skills and the Shared skills attached here", async () => {
+      mockDb.where
+        .mockResolvedValueOnce([{ id: "s1", name: "my-skill" }])
+        // attached Shared skills arrive from an inner join, keyed by table name.
+        .mockResolvedValueOnce([{ skill: { id: "s2", name: "shared-skill" } }]);
 
-      expect(await tools.listSkills.execute!({}, ctx)).toEqual(skills);
+      expect(await tools.listSkills.execute!({}, ctx)).toEqual([
+        expect.objectContaining({ id: "s1", scope: "workspace" }),
+        expect.objectContaining({ id: "s2", scope: "organization" }),
+      ]);
     });
   });
 
@@ -59,6 +64,19 @@ describe("createSkillManagementTools", () => {
       expect(result).toMatchObject({ name: "my-skill" });
       expect(result.url).toContain("skills/s1");
     });
+
+    it("returns a Shared skill attached to this workspace", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([]) // no workspace-scoped skill of this name
+        .mockResolvedValueOnce([
+          { id: "s2", name: "shared-skill", organizationId: orgId },
+        ])
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attached here
+
+      expect(
+        await tools.getSkill.execute!({ name: "shared-skill" }, ctx),
+      ).toMatchObject({ name: "shared-skill", scope: "organization" });
+    });
   });
 
   describe("upsertSkill", () => {
@@ -76,6 +94,29 @@ describe("createSkillManagementTools", () => {
           ctx,
         ),
       ).toMatchObject({ name: "my-skill" });
+    });
+
+    it("writes a workspace-scoped row, keyed on (workspaceId, name)", async () => {
+      // The conflict target is what keeps the write Workspace-private: reusing
+      // the name of an attached Shared Skill creates this Workspace's own
+      // version rather than editing the Organization's row.
+      mockDb.returning.mockResolvedValue([{ id: "s1", name: "my-skill" }]);
+
+      await tools.upsertSkill.execute!(
+        {
+          name: "my-skill",
+          description: "A skill for testing purposes",
+          body: validBody,
+        },
+        ctx,
+      );
+
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.workspaceId).toBe(workspaceId);
+      const conflict = mockDb.onConflictDoUpdate.mock.calls[0][0] as {
+        target: unknown[];
+      };
+      expect(conflict.target).toHaveLength(2);
     });
 
     describe("description length", () => {
@@ -121,6 +162,23 @@ describe("createSkillManagementTools", () => {
       )) as { error?: string };
 
       expect(result.error).toContain("referenced by one or more agents");
+    });
+
+    it("refuses to delete a Shared skill", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([]) // no workspace-scoped skill of this name
+        .mockResolvedValueOnce([
+          { id: "s2", name: "shared-skill", organizationId: orgId },
+        ])
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attached here
+
+      const result = (await tools.deleteSkill.execute!(
+        { name: "shared-skill" },
+        ctx,
+      )) as { error?: string };
+
+      expect(result.error).toContain("managed at the organization level");
+      expect(mockDb.delete).not.toHaveBeenCalled();
     });
 
     it("deletes skill when no agents reference it", async () => {

--- a/apps/backend/src/tools/skill-management.ts
+++ b/apps/backend/src/tools/skill-management.ts
@@ -5,31 +5,46 @@ import { skillBaseSchema } from "@platypus/schemas";
 import { db } from "../index.ts";
 import { skill as skillTable, agent as agentTable } from "../db/schema.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
+import {
+  listScoped,
+  resolveScopedByName,
+  workspaceMutationLockedMessage,
+  type ScopeContext,
+} from "../services/scoped-resource.ts";
 
 // Field constraints come from the shared schema so the agent-facing tool can
 // never drift from the bounds the HTTP routes and the web form enforce.
 const skillFields = skillBaseSchema.shape;
 
+/**
+ * Reads here resolve at the invoking Workspace's scope — its own Skills plus the
+ * Shared ones attached to it (ADR-0007) — so the model sees the same Skills the
+ * Operator does. Writes stay Workspace-private: a Shared Skill is a single
+ * source of truth edited only on the Organization surface, so `deleteSkill`
+ * refuses one, and `upsertSkill` writes this Workspace's own version instead of
+ * reaching the Organization's row.
+ */
 export function createSkillManagementTools(
   workspaceId: string,
   orgId: string,
   frontendUrl: string | undefined,
 ): Record<string, Tool> {
+  const ctx: ScopeContext = { orgId, wsId: workspaceId };
+
   const listSkills = tool({
-    description: "List all skills in the current workspace.",
+    description:
+      "List the skills available in the current workspace, including shared skills attached to it. A skill with scope 'organization' is shared and cannot be edited or deleted here.",
     inputSchema: z.object({}),
     execute: async () => {
-      const skills = await db
-        .select({
-          id: skillTable.id,
-          name: skillTable.name,
-          description: skillTable.description,
-          createdAt: skillTable.createdAt,
-          updatedAt: skillTable.updatedAt,
-        })
-        .from(skillTable)
-        .where(eq(skillTable.workspaceId, workspaceId));
-      return skills;
+      const scoped = await listScoped(db, "skill", ctx);
+      return scoped.map(({ row, scope }) => ({
+        id: row.id,
+        name: row.name,
+        description: row.description,
+        createdAt: row.createdAt,
+        updatedAt: row.updatedAt,
+        scope,
+      }));
     },
   });
 
@@ -39,18 +54,9 @@ export function createSkillManagementTools(
       name: z.string().describe("The name of the skill to retrieve"),
     }),
     execute: async ({ name }) => {
-      const result = await db
-        .select()
-        .from(skillTable)
-        .where(
-          and(
-            eq(skillTable.workspaceId, workspaceId),
-            eq(skillTable.name, name),
-          ),
-        )
-        .limit(1);
+      const found = await resolveScopedByName(db, "skill", name, ctx);
 
-      if (result.length === 0) {
+      if (!found) {
         return { error: "Skill not found" };
       }
 
@@ -58,16 +64,16 @@ export function createSkillManagementTools(
         frontendUrl,
         orgId,
         workspaceId,
-        `skills/${result[0].id}`,
+        `skills/${found.row.id}`,
       );
 
-      return { ...result[0], ...(url && { url }) };
+      return { ...found.row, scope: found.scope, ...(url && { url }) };
     },
   });
 
   const upsertSkill = tool({
     description:
-      "Create a new skill or update an existing skill by name. If a skill with the given name already exists in this workspace, it will be updated.",
+      "Create a new skill or update an existing skill by name. If a skill with the given name already exists in this workspace, it will be updated. Using the name of a shared skill creates this workspace's own version of it — the organization's skill is left untouched.",
     inputSchema: z.object({
       name: skillFields.name.describe(
         "Kebab-case name of the skill, unique within the workspace",
@@ -78,6 +84,11 @@ export function createSkillManagementTools(
       body: skillFields.body.describe("The Markdown content of the skill"),
     }),
     execute: async ({ name, description, body }) => {
+      // Writes only ever land on a workspace-scoped row: the conflict target is
+      // `(workspaceId, name)`, so upserting the name of an attached Shared Skill
+      // creates this Workspace's own version of it rather than editing the
+      // Organization's. `resolveScopedByName` then prefers that local row, which
+      // is what makes the override take effect.
       const { nanoid } = await import("nanoid");
       const now = new Date();
 
@@ -115,27 +126,24 @@ export function createSkillManagementTools(
 
   const deleteSkill = tool({
     description:
-      "Delete a skill by name. Will fail if the skill is referenced by one or more agents.",
+      "Delete a skill by name. Will fail if the skill is referenced by one or more agents, or if it is a shared skill managed at the organization level.",
     inputSchema: z.object({
       name: z.string().describe("The name of the skill to delete"),
     }),
     execute: async ({ name }) => {
-      const existing = await db
-        .select({ id: skillTable.id })
-        .from(skillTable)
-        .where(
-          and(
-            eq(skillTable.workspaceId, workspaceId),
-            eq(skillTable.name, name),
-          ),
-        )
-        .limit(1);
+      const existing = await resolveScopedByName(db, "skill", name, ctx);
 
-      if (existing.length === 0) {
+      if (!existing) {
         return { error: "Skill not found" };
       }
+      // Visible here, but a single source of truth deleted only on the
+      // Organization surface (ADR-0007) — detaching it is the workspace-side
+      // action, and that is an Attachment concern, not a delete.
+      if (existing.scope === "organization") {
+        return { error: workspaceMutationLockedMessage("skill") };
+      }
 
-      const skillId = existing[0].id;
+      const skillId = existing.row.id;
 
       const referencingAgents = await db
         .select({ id: agentTable.id })

--- a/apps/backend/src/tools/skill.test.ts
+++ b/apps/backend/src/tools/skill.test.ts
@@ -32,13 +32,41 @@ describe("createLoadSkillTool", () => {
   });
 
   it("falls back to an attached org-scoped skill", async () => {
-    const orgSkill = { name: "shared-skill", body: "Shared instructions" };
-    // Workspace query empty, then the attached org-scoped query resolves.
-    mockDb.limit.mockResolvedValueOnce([]).mockResolvedValueOnce([orgSkill]);
+    const orgSkill = {
+      id: "s2",
+      name: "shared-skill",
+      body: "Shared instructions",
+      organizationId: "org-1",
+      workspaceId: null,
+    };
+    mockDb.limit
+      .mockResolvedValueOnce([]) // no workspace-scoped skill of this name
+      .mockResolvedValueOnce([orgSkill]) // the Shared skill
+      .mockResolvedValueOnce([{ id: "att-1" }]); // attached to this workspace
 
-    expect(await loadSkill.execute({ name: "shared-skill" }, ctx)).toEqual(
-      orgSkill,
-    );
+    expect(await loadSkill.execute({ name: "shared-skill" }, ctx)).toEqual({
+      name: "shared-skill",
+      body: "Shared instructions",
+    });
+  });
+
+  it("refuses an org-scoped skill that is not attached here", async () => {
+    mockDb.limit
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: "s2",
+          name: "shared-skill",
+          body: "Shared instructions",
+          organizationId: "org-1",
+          workspaceId: null,
+        },
+      ])
+      .mockResolvedValueOnce([]); // no attachment → not visible here
+
+    expect(await loadSkill.execute({ name: "shared-skill" }, ctx)).toEqual({
+      error: "Skill 'shared-skill' not found",
+    });
   });
 
   it("returns error when skill not found at either scope", async () => {

--- a/apps/backend/src/tools/skill.ts
+++ b/apps/backend/src/tools/skill.ts
@@ -1,11 +1,7 @@
 import { tool } from "ai";
 import { z } from "zod";
 import { db } from "../index.ts";
-import {
-  skill as skillTable,
-  attachment as attachmentTable,
-} from "../db/schema.ts";
-import { and, eq } from "drizzle-orm";
+import { resolveScopedByName } from "../services/scoped-resource.ts";
 
 export const createLoadSkillTool = (orgId: string, workspaceId: string) =>
   tool({
@@ -15,44 +11,17 @@ export const createLoadSkillTool = (orgId: string, workspaceId: string) =>
       name: z.string().describe("The kebab-case name of the skill to load"),
     }),
     execute: async ({ name }: { name: string }) => {
-      // A workspace-scoped Skill in this workspace.
-      const [workspaceSkill] = await db
-        .select()
-        .from(skillTable)
-        .where(
-          and(
-            eq(skillTable.workspaceId, workspaceId),
-            eq(skillTable.name, name),
-          ),
-        )
-        .limit(1);
+      // The Skill of this name visible here: the workspace-scoped one, or the
+      // org-scoped (Shared) one where attached to this workspace (ADR-0007).
+      const found = await resolveScopedByName(db, "skill", name, {
+        orgId,
+        wsId: workspaceId,
+      });
 
-      if (workspaceSkill) {
-        return { name: workspaceSkill.name, body: workspaceSkill.body };
-      }
-
-      // Otherwise an org-scoped (Shared) Skill, resolved only where attached
-      // to the invoking workspace (ADR-0007).
-      const [orgSkill] = await db
-        .select({ name: skillTable.name, body: skillTable.body })
-        .from(skillTable)
-        .innerJoin(
-          attachmentTable,
-          and(
-            eq(attachmentTable.resourceId, skillTable.id),
-            eq(attachmentTable.resourceType, "skill"),
-            eq(attachmentTable.workspaceId, workspaceId),
-          ),
-        )
-        .where(
-          and(eq(skillTable.organizationId, orgId), eq(skillTable.name, name)),
-        )
-        .limit(1);
-
-      if (!orgSkill) {
+      if (!found) {
         return { error: `Skill '${name}' not found` };
       }
 
-      return { name: orgSkill.name, body: orgSkill.body };
+      return { name: found.row.name, body: found.row.body };
     },
   });

--- a/apps/backend/src/tools/trigger.test.ts
+++ b/apps/backend/src/tools/trigger.test.ts
@@ -42,13 +42,35 @@ describe("createTriggerTools", () => {
   });
 
   describe("listAgents", () => {
-    it("returns agents in workspace", async () => {
-      const agents = [{ id: "a1", name: "Agent 1", description: "desc" }];
-      mockDb.orderBy.mockResolvedValue(agents);
+    it("returns workspace agents and the Shared agents attached here", async () => {
+      mockDb.where
+        .mockResolvedValueOnce([
+          {
+            id: "a1",
+            name: "Agent 1",
+            description: "desc",
+            createdAt: new Date("2024-01-01"),
+          },
+        ])
+        // attached Shared agents arrive from an inner join, keyed by table name.
+        .mockResolvedValueOnce([
+          {
+            agent: {
+              id: "a2",
+              name: "Shared Agent",
+              description: "shared",
+              createdAt: new Date("2024-02-01"),
+            },
+          },
+        ]);
 
       expect(await tools.listAgents.execute!({}, ctx)).toEqual({
-        agents,
-        count: 1,
+        // Newest first, across both scopes.
+        agents: [
+          { id: "a2", name: "Shared Agent", description: "shared" },
+          { id: "a1", name: "Agent 1", description: "desc" },
+        ],
+        count: 2,
       });
     });
   });
@@ -109,7 +131,7 @@ describe("createTriggerTools", () => {
         config: { cronExpression: "0 9 * * *", timezone: "UTC" },
       };
       // Agent exists check
-      mockDb.limit.mockResolvedValue([{ id: "a1" }]);
+      mockDb.limit.mockResolvedValue([{ id: "a1", workspaceId }]);
       // Insert returning
       mockDb.returning.mockResolvedValue([trigger]);
 
@@ -131,7 +153,7 @@ describe("createTriggerTools", () => {
     });
 
     it("returns error for invalid cron expression", async () => {
-      mockDb.limit.mockResolvedValue([{ id: "a1" }]);
+      mockDb.limit.mockResolvedValue([{ id: "a1", workspaceId }]);
 
       const result = (await tools.upsertTrigger.execute!(
         {
@@ -156,7 +178,7 @@ describe("createTriggerTools", () => {
         type: "event",
         config: { events: ["card.created"] },
       };
-      mockDb.limit.mockResolvedValue([{ id: "a1" }]);
+      mockDb.limit.mockResolvedValue([{ id: "a1", workspaceId }]);
       mockDb.returning.mockResolvedValue([trigger]);
 
       const result = (await tools.upsertTrigger.execute!(
@@ -175,7 +197,7 @@ describe("createTriggerTools", () => {
     });
 
     it("returns error for event trigger without events", async () => {
-      mockDb.limit.mockResolvedValue([{ id: "a1" }]);
+      mockDb.limit.mockResolvedValue([{ id: "a1", workspaceId }]);
 
       const result = (await tools.upsertTrigger.execute!(
         {
@@ -212,8 +234,32 @@ describe("createTriggerTools", () => {
       expect(result.error).toContain("Agent not found");
     });
 
+    it("accepts a Shared agent attached to this workspace", async () => {
+      const trigger = { id: "t3", name: "Shared", type: "cron" };
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "a2", organizationId: orgId, workspaceId: null },
+        ])
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attached → usable here
+      mockDb.returning.mockResolvedValue([trigger]);
+
+      const result = (await tools.upsertTrigger.execute!(
+        {
+          label: "Shared",
+          name: "Shared",
+          agentId: "a2",
+          instruction: "Run daily",
+          type: "cron",
+          config: { cronExpression: "0 9 * * *" },
+        },
+        ctx,
+      )) as TriggerResult;
+
+      expect(result.success).toBe(true);
+    });
+
     it("returns error for invalid trigger type", async () => {
-      mockDb.limit.mockResolvedValue([{ id: "a1" }]);
+      mockDb.limit.mockResolvedValue([{ id: "a1", workspaceId }]);
 
       const result = (await tools.upsertTrigger.execute!(
         {

--- a/apps/backend/src/tools/trigger.ts
+++ b/apps/backend/src/tools/trigger.ts
@@ -3,29 +3,41 @@ import { z } from "zod";
 import { nanoid } from "nanoid";
 import { and, desc, eq } from "drizzle-orm";
 import { db } from "../index.ts";
-import { trigger as triggerTable, agent as agentTable } from "../db/schema.ts";
+import { trigger as triggerTable } from "../db/schema.ts";
 import { validateCronExpression } from "../utils/cron.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
+import {
+  listScoped,
+  resolveScoped,
+  type ScopeContext,
+} from "../services/scoped-resource.ts";
 
 export function createTriggerTools(
   workspaceId: string,
   orgId: string,
   frontendUrl: string | undefined,
 ): Record<string, Tool> {
+  // A trigger may point at any Agent this Workspace can run — its own, or a
+  // Shared one attached to it (ADR-0007), which is exactly what the Chat turn
+  // resolves when the trigger fires.
+  const ctx: ScopeContext = { orgId, wsId: workspaceId };
+
   const listAgents = tool({
     description:
-      "List all agents available in this workspace. Returns agent IDs, names, and descriptions. Use this to find agent IDs when creating or editing triggers.",
+      "List all agents available in this workspace, including shared agents attached to it. Returns agent IDs, names, and descriptions. Use this to find agent IDs when creating or editing triggers.",
     inputSchema: z.object({}),
     execute: async () => {
-      const agents = await db
-        .select({
-          id: agentTable.id,
-          name: agentTable.name,
-          description: agentTable.description,
-        })
-        .from(agentTable)
-        .where(eq(agentTable.workspaceId, workspaceId))
-        .orderBy(desc(agentTable.createdAt));
+      const scoped = await listScoped(db, "agent", ctx);
+      // Newest first across both scopes — `listScoped` returns the Workspace
+      // rows then the attached Shared ones, so the ordering is applied here.
+      const agents = scoped
+        .map(({ row }) => row)
+        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+        .map((row) => ({
+          id: row.id,
+          name: row.name,
+          description: row.description,
+        }));
 
       return { agents, count: agents.length };
     },
@@ -221,20 +233,16 @@ export function createTriggerTools(
 
         const currentTrigger = existing[0];
 
-        // If agentId is being changed, verify new agent exists
+        // If agentId is being changed, verify the new agent is usable here
         if (fields.agentId && fields.agentId !== currentTrigger.agentId) {
-          const agentRecord = await db
-            .select()
-            .from(agentTable)
-            .where(
-              and(
-                eq(agentTable.id, fields.agentId),
-                eq(agentTable.workspaceId, workspaceId),
-              ),
-            )
-            .limit(1);
+          const agentRecord = await resolveScoped(
+            db,
+            "agent",
+            fields.agentId,
+            ctx,
+          );
 
-          if (agentRecord.length === 0) {
+          if (!agentRecord) {
             return {
               success: false,
               error:
@@ -346,19 +354,10 @@ export function createTriggerTools(
         };
       }
 
-      // Verify agent exists in workspace
-      const agentRecord = await db
-        .select()
-        .from(agentTable)
-        .where(
-          and(
-            eq(agentTable.id, agentId),
-            eq(agentTable.workspaceId, workspaceId),
-          ),
-        )
-        .limit(1);
+      // Verify the agent is usable in this workspace
+      const agentRecord = await resolveScoped(db, "agent", agentId, ctx);
 
-      if (agentRecord.length === 0) {
+      if (!agentRecord) {
         return {
           success: false,
           error:


### PR DESCRIPTION
Closes #480.

`services/scoped-resource.ts` is the single visibility authority for Scoped resources (ADR-0007/ADR-0010), but three gaps in its interface left several sites hand-rolling the rule — two of them wrongly.

## Module widened

- **`resolveOrgScoped` / `requireOrgScoped` / `listOrgScoped`** answer the Organization surface's narrower question ("is this a Shared resource of this Organization?"), taking a bare `orgId` because no Workspace — and so no Attachment — is in play. They apply the same `isNull(workspaceId)` defence `listScoped` already applies to its Organization half.
- **`resolveScopedByName`** resolves by name for the agent-facing Tools. Two queries rather than one: a Workspace and its Organization may each hold a resource of that name, and the Workspace row must win outright rather than race an unordered `LIMIT 1`.
- **`workspaceMutationLockedMessage`** exports the refusal `requireWorkspaceMutable` throws, so the Tools — which answer the model with an `{ error }` payload rather than throwing — refuse in the same words.

## Two behavioural bugs fixed (each with a test that fails on main)

- **Chat titling** resolved its Provider with a raw `or(workspaceId, organizationId)` clause, omitting the Attachment gate and the both-columns-set defence. An org-scoped Provider **not attached** to the Workspace could title its chats — the exact drift class `chat-execution.ts` documents as closed, reached on every terminal Chat turn. Now goes through `resolveScoped`.
- **The Workspace tool-set catalog** (`routes/tool.ts`) listed workspace-scoped MCPs only, hiding every attached Shared MCP from the picker even though `GET /mcps` listed them correctly.

## Migrated onto the authority

The org-route resolve-or-404 blocks for agent, skill, mcp and provider; `tools/skill.ts` (now by name); `tools/skill-management.ts`; `tools/agent-management.ts`; `tools/trigger.ts`; `routes/trigger.ts`.

Reads now see attached Shared resources — an attached Shared Agent is reachable from the trigger paths, and a trigger pointing at one runs, because the run resolves its Agent through the same authority. Mutations do not gain reach: the Tools refuse a Shared row with the locked message, and `upsertSkill` stays Workspace-private, writing this Workspace's own version of a same-named Shared Skill (the conflict target is `(workspaceId, name)`, and name resolution already prefers the local row).

## Credential redaction

One named expression per surface — `workspaceCredentialsVisible(c, type)` and `orgCredentialsVisible(c)` — replacing the inline `orgMembership?.role === "admin"` checks, with a read-model helper per credential-bearing type composing resolve → reveal → redact.

## Acceptance

- **No non-test module outside `services/scoped-resource.ts` builds an `or(workspaceId, organizationId)` visibility clause** — verified by grep; the only remaining occurrence is `services/chat-execution.test-fixtures.ts`.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass (8 packages; backend 114 files / 1670 tests). The 3 frontend lint warnings are pre-existing and untouched.
- No docs impact: visibility now matches what `building-with-platypus` already describes for Shared resources.

## Beyond the issue's list, and why

- `routes/attachment.ts`'s org-resource check, `routes/org-tool.ts`'s MCP list and the two org-agent avatar lookups are the same hand-rolled block as the eight the issue names, so they were migrated with them.
- `listOrgScoped`/`resolveOrgScoped` require `workspaceId IS NULL`, which the org routes' raw clauses did not. The org routes' own `UPDATE`/`DELETE` clauses still match on `organizationId` alone; no route can write both scope columns, so that read/write gap is unreachable rather than closed, and it is documented on `resolveOrgScoped` rather than guarded at eight mutation sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
