### PR TITLE
chore(backend): one contribution-registration pipeline; unify registry semantics

### DIFF
--- a/apps/backend/index.ts
+++ b/apps/backend/index.ts
@@ -65,7 +65,7 @@ const main = async () => {
   // fills — so the boot log is a complete, auditable statement of what runs
   // (ADR-0013 observability). Then hand the result to the registry, the single
   // read-only source behind `GET /plugins` and the catalog annotations.
-  for (const p of loadedPlugins) {
+  for (const p of loadedPlugins.plugins) {
     logger.info(
       {
         plugin: p.name,
@@ -79,7 +79,7 @@ const main = async () => {
     );
   }
   setLoadedPlugins(loadedPlugins);
-  logger.info(`Loaded ${loadedPlugins.length} plugin(s)`);
+  logger.info(`Loaded ${loadedPlugins.plugins.length} plugin(s)`);
 
   serve({
     fetch: app.fetch,

--- a/apps/backend/src/plugins/contribution-pipeline.test.ts
+++ b/apps/backend/src/plugins/contribution-pipeline.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from "vitest";
+import type { PluginConfigContext } from "@platypuschat/plugin-sdk";
+import {
+  registerContributions,
+  type ContributionIdentity,
+  type ExtensionPoint,
+  type RawContribution,
+} from "./contribution-pipeline.ts";
+
+// Every Extension point runs the same seven steps over its slice of a manifest —
+// shape check, id and name checks, namespacing, owner-attributed collision
+// check, attributed registration, bookkeeping. They are tested once here,
+// against a stand-in point, so `loader.test.ts` is left testing what each real
+// point *adds* rather than re-testing this sequence three times.
+
+const PLUGIN: PluginConfigContext = { config: { key: "k" }, credentials: {} };
+
+type Widget = { id: string; label: string; plugin: PluginConfigContext };
+
+// A point with no extras: the pipeline's behaviour with everything optional
+// left out.
+const makePoint = (
+  overrides: Partial<ExtensionPoint<Widget>> = {},
+): {
+  point: ExtensionPoint<Widget>;
+  registered: Array<{ id: string; registration: Widget }>;
+} => {
+  const registered: Array<{ id: string; registration: Widget }> = [];
+  const point: ExtensionPoint<Widget> = {
+    noun: "widget",
+    idField: "id",
+    prepare: (contribution, ctx) => ({
+      id: ctx.id,
+      label: String(contribution.name),
+      plugin: ctx.plugin,
+    }),
+    register: (id, registration) => {
+      registered.push({ id, registration });
+    },
+    ...overrides,
+  };
+  return { point, registered };
+};
+
+const run = (
+  contributions: readonly unknown[],
+  options: {
+    point?: ExtensionPoint<Widget>;
+    pluginName?: string;
+    contributionId?: (id: string) => string;
+    owners?: Map<string, string>;
+  } = {},
+) =>
+  registerContributions({
+    point: options.point ?? makePoint().point,
+    contributions,
+    pluginName: options.pluginName ?? "acme",
+    plugin: PLUGIN,
+    contributionId: options.contributionId ?? ((id) => id),
+    owners: options.owners ?? new Map<string, string>(),
+  });
+
+const widget = (id: string) => ({ id, name: `Widget ${id}` });
+
+describe("registerContributions", () => {
+  it("registers each contribution and returns the ids it registered", () => {
+    const { point, registered } = makePoint();
+    const ids = run([widget("a"), widget("b")], { point });
+
+    expect(ids).toEqual(["a", "b"]);
+    expect(registered.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("registers nothing for an empty contribution list", () => {
+    const { point, registered } = makePoint();
+    expect(run([], { point })).toEqual([]);
+    expect(registered).toEqual([]);
+  });
+
+  it("namespaces the id and trims it first", () => {
+    // `acme. my widget ` must never reach a registry or a persisted column, so
+    // the raw id is trimmed before the plugin prefix is composed onto it.
+    const { point, registered } = makePoint();
+    const ids = run([{ id: "  spaced  ", name: "W" }], {
+      point,
+      contributionId: (id) => `acme.${id}`,
+    });
+
+    expect(ids).toEqual(["acme.spaced"]);
+    expect(registered[0].registration.id).toBe("acme.spaced");
+  });
+
+  it("records each registered id against its owning plugin", () => {
+    const owners = new Map<string, string>();
+    run([widget("a")], { owners, pluginName: "acme" });
+    expect(owners.get("a")).toBe("acme");
+  });
+
+  it("aborts on an id already owned by another plugin, naming both", () => {
+    const owners = new Map([["a", "first"]]);
+    expect(() => run([widget("a")], { owners, pluginName: "second" })).toThrow(
+      'Widget id "a" is contributed by both "first" and "second".',
+    );
+  });
+
+  it("aborts on two contributions in one manifest sharing an id", () => {
+    expect(() => run([widget("a"), widget("a")])).toThrow(
+      'Widget id "a" is contributed by both "acme" and "acme".',
+    );
+  });
+
+  it.each([
+    ["a null entry", null],
+    ["a string entry", "broken"],
+    ["a number entry", 7],
+    ["an array entry", []],
+  ])(
+    "aborts (plugin-named) on %s, naming the index",
+    (_label, contribution) => {
+      expect(() => run([widget("fine"), contribution])).toThrow(
+        'Plugin "acme": every widget contribution must be an object (at index 1).',
+      );
+    },
+  );
+
+  it.each([
+    ["a missing id", { name: "W" }],
+    ["a non-string id", { id: 7, name: "W" }],
+    ["a whitespace-only id", { id: "   ", name: "W" }],
+  ])(
+    "aborts (plugin-named) on %s, naming the index",
+    (_label, contribution) => {
+      // The checks that run before an id is known carry the array index: on a
+      // plugin contributing several entries it is the only thing an Operator can
+      // use to find the offending one.
+      expect(() => run([widget("fine"), contribution])).toThrow(
+        'Plugin "acme": every widget must declare a non-empty "id" (at index 1).',
+      );
+    },
+  );
+
+  it("names the point's own id field in the missing-id error", () => {
+    const { point } = makePoint({
+      noun: "sandbox backend",
+      idField: "backend",
+      prepare: (_c, ctx) => ({ id: ctx.id, label: "", plugin: ctx.plugin }),
+    });
+    expect(() => run([{ name: "W" }], { point })).toThrow(
+      'Plugin "acme": every sandbox backend must declare a non-empty "backend" (at index 0).',
+    );
+  });
+
+  it.each([
+    ["a missing name", { id: "a" }],
+    ["a non-string name", { id: "a", name: 7 }],
+    ["a whitespace-only name", { id: "a", name: "  " }],
+  ])("aborts (plugin-named) on %s, naming the id", (_label, contribution) => {
+    expect(() => run([contribution])).toThrow(
+      'Plugin "acme": widget "a" must declare a non-empty "name".',
+    );
+  });
+
+  it("stops at the first bad entry, leaving the ones ahead of it registered", () => {
+    // Entries validate and register in the same pass, so a good entry ahead of
+    // a bad one is already registered. That is not a leak: the throw aborts
+    // boot, so the half-filled registry never serves a turn.
+    const { point, registered } = makePoint();
+    expect(() => run([widget("fine"), null], { point })).toThrow();
+    expect(registered.map((r) => r.id)).toEqual(["fine"]);
+  });
+
+  it("runs the point's own validator against the un-namespaced contribution", () => {
+    // The validator is handed the id the plugin author wrote, not the
+    // namespaced one, so its messages read with the id they would recognise.
+    const seen: Array<{
+      contribution: RawContribution;
+      identity: ContributionIdentity;
+    }> = [];
+    const { point } = makePoint({
+      validate: (contribution, identity) => {
+        seen.push({ contribution, identity });
+      },
+    });
+    run([{ id: "  a  ", name: "Widget a" }], {
+      point,
+      contributionId: (id) => `acme.${id}`,
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].contribution).toMatchObject({ id: "  a  " });
+    expect(seen[0].identity).toEqual({ pluginName: "acme", rawId: "  a  " });
+  });
+
+  it("lets the point's validator abort the load", () => {
+    const { point, registered } = makePoint({
+      validate: () => {
+        throw new Error('Plugin "acme": widget "a" is missing its widgetry.');
+      },
+    });
+    expect(() => run([widget("a")], { point })).toThrow("missing its widgetry");
+    expect(registered).toEqual([]);
+  });
+
+  it("hands prepare the namespaced id and the plugin's shared config block", () => {
+    const { point, registered } = makePoint();
+    run([widget("a")], { point, contributionId: (id) => `acme.${id}` });
+
+    expect(registered[0].registration).toEqual({
+      id: "acme.a",
+      label: "Widget a",
+      plugin: PLUGIN,
+    });
+    // The same block every contribution of this plugin is bound to — object
+    // identity IS "one credential block per plugin" (ADR-0013).
+    expect(registered[0].registration.plugin).toBe(PLUGIN);
+  });
+
+  it("re-throws a registry collision with plugin attribution", () => {
+    // A registry that rejects the id (an already-registered core built-in, say)
+    // throws without knowing which plugin asked. Attribution is added here.
+    const { point } = makePoint({
+      register: () => {
+        throw new Error("Widget 'a' has already been registered.");
+      },
+    });
+    expect(() => run([widget("a")], { point })).toThrow(
+      'Plugin "acme": failed to register widget "a" (Widget \'a\' has already been registered.).',
+    );
+  });
+
+  it("keeps the registry's own failure as the cause", () => {
+    const cause = new Error("Widget 'a' has already been registered.");
+    const { point } = makePoint({
+      register: () => {
+        throw cause;
+      },
+    });
+    expect(() => run([widget("a")], { point })).toThrow(
+      expect.objectContaining({ cause }),
+    );
+  });
+
+  it("does not record an owner for a contribution the registry refused", () => {
+    const owners = new Map<string, string>();
+    const { point } = makePoint({
+      register: () => {
+        throw new Error("nope");
+      },
+    });
+    expect(() => run([widget("a")], { point, owners })).toThrow();
+    expect(owners.has("a")).toBe(false);
+  });
+});

--- a/apps/backend/src/plugins/contribution-pipeline.ts
+++ b/apps/backend/src/plugins/contribution-pipeline.ts
@@ -1,0 +1,185 @@
+import type { PluginConfigContext } from "@platypuschat/plugin-sdk";
+
+// The one registration sequence every Extension point runs (ADR-0013).
+//
+// Tool sets, Sandbox backends, and Web-search backends differ in what a
+// contribution must contain and in what core registers for it, but not in how
+// one gets from "an entry in a manifest array" to "registered, owned, and
+// reported": check the shape, check the id and name, namespace the id, refuse a
+// collision naming both plugins, register with plugin attribution on failure.
+// That sequence lives here once; a point supplies only what is genuinely its
+// own, and a fourth point is a table entry in `extension-points.ts`, not a
+// fourth copy of this loop.
+
+/**
+ * A contribution as it arrives from a manifest: past the shape check (a
+ * non-null, non-array object), with every field still unknown. TypeScript
+ * protects in-repo plugins; a third-party *JS* package can put any value in
+ * these arrays, which is this module's whole justification.
+ */
+export type RawContribution = Record<string, unknown>;
+
+/** What a point's `validate` is told about the contribution it is checking. */
+export interface ContributionIdentity {
+  /** The contributing plugin's manifest name, for error attribution. */
+  pluginName: string;
+  /**
+   * The id as the plugin author wrote it — checked non-empty, but not yet
+   * trimmed or namespaced, so a message reads with the id they would recognise.
+   */
+  rawId: string;
+}
+
+/** What a point's `prepare` is told about the contribution it is preparing. */
+export interface ContributionContext {
+  /** The contributing plugin's manifest name, for error attribution. */
+  pluginName: string;
+  /** The trimmed, namespaced id this contribution registers under. */
+  id: string;
+  /**
+   * The plugin's boot-resolved deploy-time config/credentials — one shared
+   * block per plugin, bound into every contribution factory.
+   */
+  plugin: PluginConfigContext;
+}
+
+/**
+ * One Extension point's differences from every other. The shared steps are
+ * {@link registerContributions}'s; a point adds the noun its errors read with,
+ * the field it takes its id from, whatever else a valid contribution must
+ * carry, and what core actually registers.
+ */
+export interface ExtensionPoint<TRegistration = unknown> {
+  /** Lower-case noun for error messages — "tool set", "sandbox backend". */
+  noun: string;
+  /** The contribution field holding the id — "id", "backend". */
+  idField: string;
+  /**
+   * Per-point shape checks beyond the shared id/name pair, run before the id is
+   * namespaced (so their messages read with the id the plugin author wrote).
+   * Throws a plugin-named error to abort the load.
+   */
+  validate?(
+    contribution: RawContribution,
+    identity: ContributionIdentity,
+  ): void;
+  /**
+   * Build what core registers: bind the plugin's shared config block into the
+   * contribution's factories, resolve per-point forms, and apply the checks
+   * that only make sense once the namespaced id is known. Throws a plugin-named
+   * error to abort the load.
+   */
+  prepare(
+    contribution: RawContribution,
+    context: ContributionContext,
+  ): TRegistration;
+  /** Hand the prepared registration to core's registry for this point. */
+  register(id: string, registration: TRegistration): void;
+}
+
+export interface RegisterContributionsOptions<TRegistration> {
+  point: ExtensionPoint<TRegistration>;
+  /** This plugin's slice of the manifest for the point — values are unknown. */
+  contributions: readonly unknown[];
+  /** The contributing plugin's manifest name. */
+  pluginName: string;
+  /** The plugin's boot-resolved deploy-time config/credentials. */
+  plugin: PluginConfigContext;
+  /** Applies the origin's id-namespacing rule (core bare, third-party prefixed). */
+  contributionId: (id: string) => string;
+  /**
+   * Point-wide id → owning plugin map, carried across plugins so a collision
+   * can name both sides. Mutated as each contribution registers.
+   */
+  owners: Map<string, string>;
+}
+
+// "tool set" → "Tool set", for the collision message that leads with the noun.
+const sentenceCase = (noun: string): string =>
+  noun.charAt(0).toUpperCase() + noun.slice(1);
+
+/**
+ * Validate and register one plugin's contributions to one Extension point,
+ * returning the ids registered (in manifest order) for the boot log.
+ *
+ * Fail-loud and all-or-nothing (ADR-0013): the first bad contribution throws a
+ * plugin-named error and aborts boot. Entries validate and register in the same
+ * pass, so contributions ahead of a bad one are already registered — not a leak,
+ * since the throw means the half-filled registry never serves a turn.
+ */
+export const registerContributions = <TRegistration>(
+  options: RegisterContributionsOptions<TRegistration>,
+): string[] => {
+  const { point, contributions, pluginName, plugin, contributionId, owners } =
+    options;
+  const registeredIds: string[] = [];
+
+  for (const [index, contribution] of contributions.entries()) {
+    // Identity is checked before it is namespaced: `contributionId(undefined)`
+    // otherwise mints a plausible-looking `"acme.undefined"` and registers it,
+    // so a JS plugin's missing field surfaces as a mystery id in the catalog
+    // rather than a boot error naming the plugin.
+    //
+    // The two checks that run before an id is known carry the array index — on
+    // a plugin contributing several entries it is the only thing an Operator
+    // can use to find the offending one.
+    if (
+      typeof contribution !== "object" ||
+      contribution === null ||
+      Array.isArray(contribution)
+    ) {
+      throw new Error(
+        `Plugin "${pluginName}": every ${point.noun} contribution must be an object (at index ${index}).`,
+      );
+    }
+
+    const raw = contribution as RawContribution;
+    const rawId = raw[point.idField];
+    if (typeof rawId !== "string" || rawId.trim() === "") {
+      throw new Error(
+        `Plugin "${pluginName}": every ${point.noun} must declare a non-empty "${point.idField}" (at index ${index}).`,
+      );
+    }
+    if (typeof raw.name !== "string" || raw.name.trim() === "") {
+      throw new Error(
+        `Plugin "${pluginName}": ${point.noun} "${rawId}" must declare a non-empty "name".`,
+      );
+    }
+
+    point.validate?.(raw, { pluginName, rawId });
+
+    // Trimmed before namespacing: the id is half of a composed
+    // `${manifest.name}.${id}` that gets persisted (into `agent.toolSetIds`,
+    // `sandbox.backend`, `provider.webBackend`), and the other half is held to a
+    // url-safe slug for exactly that reason.
+    const id = contributionId(rawId.trim());
+
+    const existingOwner = owners.get(id);
+    if (existingOwner) {
+      throw new Error(
+        `${sentenceCase(point.noun)} id "${id}" is contributed by both "${existingOwner}" and "${pluginName}".`,
+      );
+    }
+
+    const registration = point.prepare(raw, { pluginName, id, plugin });
+
+    try {
+      point.register(id, registration);
+    } catch (cause) {
+      // A collision with something registered outside the loader (a core
+      // built-in, a legacy static registration) surfaces here — the registry
+      // does not know which plugin asked, so attribution is added.
+      throw new Error(
+        `Plugin "${pluginName}": failed to register ${point.noun} "${id}" (${
+          cause instanceof Error ? cause.message : String(cause)
+        }).`,
+        { cause },
+      );
+    }
+
+    owners.set(id, pluginName);
+    registeredIds.push(id);
+  }
+
+  return registeredIds;
+};

--- a/apps/backend/src/plugins/docker/index.test.ts
+++ b/apps/backend/src/plugins/docker/index.test.ts
@@ -50,7 +50,9 @@ describe("@platypus/docker plugin manifest", () => {
     // loader → registerSandboxBackend → getSandboxBackend.
     expect(getSandboxBackend("docker")).toBeUndefined();
 
-    const loaded = await loadPlugins({ pluginNames: ["@platypus/docker"] });
+    const { plugins: loaded } = await loadPlugins({
+      pluginNames: ["@platypus/docker"],
+    });
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0]).toMatchObject({

--- a/apps/backend/src/plugins/extension-points.ts
+++ b/apps/backend/src/plugins/extension-points.ts
@@ -1,0 +1,216 @@
+import type {
+  SandboxBackendContribution,
+  ToolSetContribution,
+  WebBackendContribution,
+} from "@platypuschat/plugin-sdk";
+import type { SandboxBackendRegistration } from "../sandbox/index.ts";
+import {
+  composeWebBackend,
+  MAX_WEB_TIMEOUT_MS,
+  type WebBackendRegistration,
+} from "../web-backends/index.ts";
+import type { ExtensionPoint } from "./contribution-pipeline.ts";
+
+// What each Extension point adds to the shared registration sequence in
+// `contribution-pipeline.ts`: the noun its errors read with, the field it takes
+// its id from, the shape checks the shared id/name pair does not cover, and how
+// the plugin's deploy-time config block is bound into what core registers.
+//
+// A point is a table entry, not a loop. Adding a fourth (ADR-0013 anticipates
+// them) means one more factory here and one more row in `loader.ts`'s table.
+//
+// Config binding is always a closure or a factory, never an object spread over
+// the contribution: a class-instance contribution loses its prototype and its
+// `this` when spread, and its factories must be called on the author's own
+// object.
+
+/** The Tool-set point (ADR-0013). Registers `{ name, category, description, tools }`. */
+export const toolSetPoint = (
+  register: (id: string, definition: Omit<ToolSetContribution, "id">) => void,
+): ExtensionPoint<Omit<ToolSetContribution, "id">> => ({
+  noun: "tool set",
+  idField: "id",
+  validate: (contribution, { pluginName, rawId }) => {
+    if (
+      typeof contribution.category !== "string" ||
+      contribution.category.trim() === ""
+    ) {
+      throw new Error(
+        `Plugin "${pluginName}": tool set "${rawId}" must declare a non-empty "category".`,
+      );
+    }
+    if (
+      typeof contribution.tools !== "function" &&
+      (typeof contribution.tools !== "object" ||
+        contribution.tools === null ||
+        Array.isArray(contribution.tools))
+    ) {
+      throw new Error(
+        `Plugin "${pluginName}": tool set "${rawId}" must provide a "tools" object or function.`,
+      );
+    }
+  },
+  prepare: (contribution, { plugin }) => {
+    const { name, category, description, tools } =
+      contribution as unknown as ToolSetContribution;
+    // Bind the shared plugin config into the factory so core's registry and its
+    // Chat-turn callers stay ignorant of it: they invoke the stored factory with
+    // only the ToolSetContext, as before. A static-map tool set has no factory
+    // to inject into and is registered untouched.
+    const boundTools =
+      typeof tools === "function"
+        ? (context: Parameters<typeof tools>[0]) => tools(context, plugin)
+        : tools;
+    return { name, category, description, tools: boundTools };
+  },
+  register,
+});
+
+/**
+ * The Sandbox-backend point (ADR-0002/0013). Registers the contribution with its
+ * `configSchema` factory form resolved away and `create` bound to the plugin's
+ * config block.
+ */
+export const sandboxBackendPoint = (
+  register: (registration: SandboxBackendRegistration) => void,
+): ExtensionPoint<SandboxBackendRegistration> => ({
+  noun: "sandbox backend",
+  idField: "backend",
+  validate: (contribution, { pluginName, rawId }) => {
+    // Guaranteed by `SandboxBackendContribution`, and not guaranteed by a
+    // third-party *JS* plugin: a missing `create` used to surface as a TypeError
+    // at chat-turn or teardown time, naming nothing.
+    if (typeof contribution.create !== "function") {
+      throw new Error(
+        `Plugin "${pluginName}": sandbox backend "${rawId}" must provide a "create" function.`,
+      );
+    }
+  },
+  prepare: (raw, { pluginName, id, plugin }) => {
+    const contribution = raw as unknown as SandboxBackendContribution;
+
+    // Resolve a factory-form configSchema against the boot-resolved plugin
+    // config so the three static `configSchema.safeParse` consumers (save route,
+    // teardown, tool resolver) always receive a concrete schema — they never see
+    // plugin config. A plain schema passes through untouched (append-only:
+    // plugin-config-agnostic backends are unaffected).
+    //
+    // The factory is third-party code reading a config block it narrows itself,
+    // so it can throw — a plugin that assumes an Operator supplied
+    // `config.region` raises a bare `Cannot read properties of undefined` naming
+    // nothing. Attributed here for the same reason the shape checks exist: the
+    // schema check below only catches a factory that *returns* a non-schema, not
+    // one that throws on the way there.
+    let configSchema: SandboxBackendRegistration["configSchema"];
+    try {
+      configSchema =
+        typeof contribution.configSchema === "function"
+          ? contribution.configSchema(plugin.config)
+          : contribution.configSchema;
+    } catch (cause) {
+      throw new Error(
+        `Plugin "${pluginName}": sandbox backend "${id}" configSchema factory threw (${
+          cause instanceof Error ? cause.message : String(cause)
+        }).`,
+        { cause },
+      );
+    }
+
+    // Checked after the factory form is resolved away, and duck-typed on
+    // `safeParse` rather than `instanceof z.ZodType`, because that is exactly
+    // what the three static consumers call. Without this, a contribution missing
+    // either schema registers fine and fails at *save* time — a 500 on an
+    // Operator's sandbox form, attributed to nothing.
+    for (const [field, schema] of [
+      ["configSchema", configSchema],
+      ["credentialsSchema", contribution.credentialsSchema],
+    ] as const) {
+      if (
+        typeof schema !== "object" ||
+        schema === null ||
+        typeof (schema as { safeParse?: unknown }).safeParse !== "function"
+      ) {
+        throw new Error(
+          `Plugin "${pluginName}": sandbox backend "${id}" must provide a Zod "${field}".`,
+        );
+      }
+    }
+
+    // Bind the same shared plugin config into create() so core's per-turn
+    // callers (chat resolution, teardown) keep calling create(config,
+    // credentials) with the per-Workspace values only. Third-party backends also
+    // register under the namespaced discriminator, so the `sandbox.backend`
+    // column resolves to the prefixed id (mirroring tool sets).
+    //
+    // Field by field rather than spread over the contribution: `create` must be
+    // called on the author's own object, or a class-instance contribution loses
+    // its prototype and its `this`.
+    return {
+      backend: id,
+      name: contribution.name,
+      configSchema,
+      credentialsSchema: contribution.credentialsSchema,
+      create: (config, credentials) =>
+        contribution.create(config, credentials, plugin),
+    };
+  },
+  register: (_id, registration) => register(registration),
+});
+
+/**
+ * The Web-search-backend point (ADR-0014). Registers core's *composed*
+ * registration — core owns the model-facing Tools — rather than the raw
+ * contribution.
+ */
+export const webBackendPoint = (
+  register: (registration: WebBackendRegistration) => void,
+): ExtensionPoint<WebBackendRegistration> => ({
+  noun: "web backend",
+  idField: "backend",
+  prepare: (raw, { pluginName, id, plugin }) => {
+    const contribution = raw as unknown as WebBackendContribution;
+
+    // A web backend supplies executors only — core builds the Tools — so a
+    // missing factory means the contribution can never serve a turn. The TS type
+    // says so; a third-party JS plugin can still ship it, and boot is where that
+    // is caught (ADR-0014's fail-loud boot posture).
+    if (typeof contribution.createExecutors !== "function") {
+      throw new Error(
+        `Plugin "${pluginName}": web backend "${id}" must provide a "createExecutors" function.`,
+      );
+    }
+
+    // `timeoutMs` is static on the contribution, so an over-ceiling value is
+    // knowable now — refused with attribution rather than silently clamped at
+    // turn time, where an Operator would never see it.
+    if (contribution.timeoutMs !== undefined) {
+      const { timeoutMs } = contribution;
+      if (
+        typeof timeoutMs !== "number" ||
+        !Number.isFinite(timeoutMs) ||
+        timeoutMs <= 0 ||
+        timeoutMs > MAX_WEB_TIMEOUT_MS
+      ) {
+        throw new Error(
+          `Plugin "${pluginName}": web backend "${id}" declares timeoutMs ${String(
+            timeoutMs,
+          )}, which must be a positive number no greater than ${MAX_WEB_TIMEOUT_MS}.`,
+        );
+      }
+    }
+
+    // Core wraps the executors here, binding the same shared plugin config that
+    // every other contribution factory receives. What lands in the registry is
+    // the finished, guarded builder — per-turn callers never see the executors.
+    // The contribution goes in by reference, with the namespaced id alongside it
+    // rather than spread over it, for the same prototype/`this` reason as the
+    // sandbox point above.
+    return composeWebBackend({
+      contribution,
+      backend: id,
+      plugin,
+      pluginName,
+    });
+  },
+  register: (_id, registration) => register(registration),
+});

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -116,7 +116,7 @@ describe("parsePluginList", () => {
 describe("loadPlugins — apiVersion compatibility window (N and N−1)", () => {
   it("accepts a plugin declaring exactly core's apiVersion", async () => {
     const { register, calls } = makeRegister();
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@exact/plugin"],
       builtinPlugins: {},
       importPlugin: () =>
@@ -133,7 +133,7 @@ describe("loadPlugins — apiVersion compatibility window (N and N−1)", () => 
 
   it("accepts a plugin on the previous major (N−1)", async () => {
     const { register, calls } = makeRegister();
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@nminus1/plugin"],
       builtinPlugins: {},
       importPlugin: () =>
@@ -213,7 +213,7 @@ describe("loadPlugins", () => {
         }),
     };
 
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@platypus/tools-basic"],
       builtinPlugins,
       register,
@@ -234,13 +234,52 @@ describe("loadPlugins", () => {
 
   it("registers nothing for an empty list and does not crash", async () => {
     const { register, calls } = makeRegister();
-    const loaded = await loadPlugins({
+    const { plugins: loaded, owners } = await loadPlugins({
       pluginNames: [],
       builtinPlugins: {},
       register,
     });
     expect(loaded).toEqual([]);
     expect(calls).toHaveLength(0);
+    expect(owners.toolSets.size).toBe(0);
+    expect(owners.sandboxBackends.size).toBe(0);
+    expect(owners.webBackends.size).toBe(0);
+  });
+
+  it("returns the id → plugin owner map it built while registering", async () => {
+    // The registry serves catalog annotations from these maps rather than
+    // re-deriving them from each plugin's id arrays (ADR-0013 observability).
+    // One map per Extension point: a Tool set and a backend may share a bare id.
+    const { register } = makeRegister();
+    const { registerSandbox } = makeSandboxRegister();
+    const { registerWeb } = makeWebRegister();
+
+    const { owners } = await loadPlugins({
+      pluginNames: ["@platypus/tools-basic", "@acme/search"],
+      builtinPlugins: {
+        "@platypus/tools-basic": () =>
+          Promise.resolve({
+            plugin: {
+              ...manifest("@platypus/tools-basic", [toolSet("time")]),
+              contributes: {
+                toolSets: [toolSet("time")],
+                sandboxBackends: [sandboxBackend("docker")],
+              },
+            },
+          }),
+      },
+      importPlugin: () =>
+        Promise.resolve({ plugin: webManifest("acme", [webBackend("searx")]) }),
+      register,
+      registerSandbox,
+      registerWeb,
+    });
+
+    expect([...owners.toolSets]).toEqual([["time", "@platypus/tools-basic"]]);
+    expect([...owners.sandboxBackends]).toEqual([
+      ["docker", "@platypus/tools-basic"],
+    ]);
+    expect([...owners.webBackends]).toEqual([["acme.searx", "acme"]]);
   });
 
   it("resolves a third-party plugin via dynamic import", async () => {
@@ -251,7 +290,7 @@ describe("loadPlugins", () => {
       }),
     );
 
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@third/party"],
       builtinPlugins: {},
       importPlugin,
@@ -280,7 +319,7 @@ describe("loadPlugins", () => {
       }),
     );
 
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@platypus/tools-basic", "@third/party"],
       builtinPlugins,
       importPlugin,
@@ -357,37 +396,10 @@ describe("loadPlugins", () => {
     ).rejects.toThrow(/@empty\/plugin.*manifest/s);
   });
 
+  // Contribution shape, id, and name are the shared pipeline's checks, covered
+  // once in `contribution-pipeline.test.ts`. What is left here is what the
+  // Tool-set point itself demands of a contribution.
   it.each([
-    [
-      "a non-object entry",
-      null,
-      /@platypus\/bad.*tool set contribution must be an object/s,
-    ],
-    [
-      "a string entry",
-      "broken",
-      /@platypus\/bad.*tool set contribution must be an object/s,
-    ],
-    [
-      "an array entry",
-      [],
-      /@platypus\/bad.*tool set contribution must be an object/s,
-    ],
-    [
-      "a missing id",
-      { name: "Broken", category: "Test", tools: {} },
-      /@platypus\/bad.*non-empty "id"/s,
-    ],
-    [
-      "a whitespace-only id",
-      { id: "   ", name: "Broken", category: "Test", tools: {} },
-      /@platypus\/bad.*non-empty "id"/s,
-    ],
-    [
-      "a missing name",
-      { id: "broken", category: "Test", tools: {} },
-      /@platypus\/bad.*tool set "broken".*non-empty "name"/s,
-    ],
     [
       "a missing category",
       { id: "broken", name: "Broken", tools: {} },
@@ -436,54 +448,6 @@ describe("loadPlugins", () => {
       expect(calls).toHaveLength(0);
     },
   );
-
-  it("names the array index when a malformed entry has no usable id", async () => {
-    const { register, calls } = makeRegister();
-    await expect(
-      loadPlugins({
-        pluginNames: ["@platypus/bad"],
-        builtinPlugins: {
-          "@platypus/bad": () =>
-            Promise.resolve({
-              plugin: {
-                name: "@platypus/bad",
-                version: "0.1.0",
-                apiVersion: 1,
-                contributes: {
-                  toolSets: [
-                    toolSet("fine"),
-                    null,
-                  ] as unknown as ToolSetContribution[],
-                },
-              },
-            }),
-        },
-        register,
-      }),
-    ).rejects.toThrow(/at index 1/);
-    // Entries validate and register in the same pass, so the good entry ahead of
-    // the bad one is already in the registry. That is not a leak: the throw
-    // aborts boot, so the half-filled registry never serves a turn.
-    expect(calls.map((c) => c.id)).toEqual(["fine"]);
-  });
-
-  it("trims a padded id before namespacing it", async () => {
-    const { register, calls } = makeRegister();
-    const loaded = await loadPlugins({
-      pluginNames: ["@third/party"],
-      builtinPlugins: {},
-      importPlugin: () =>
-        Promise.resolve({
-          plugin: manifest("padded", [
-            { ...toolSet("spaced"), id: "  spaced  " },
-          ]),
-        }),
-      register,
-    });
-    // `acme. my set ` must never reach the registry or `agent.toolSetIds`.
-    expect(calls.map((c) => c.id)).toEqual(["padded.spaced"]);
-    expect(loaded[0].toolSetIds).toEqual(["padded.spaced"]);
-  });
 
   it("aborts (fail-loud) on a duplicate id, naming both owning plugins", async () => {
     const { register } = makeRegister();
@@ -551,7 +515,7 @@ describe("loadPlugins — sandbox backends", () => {
   it("registers a sandbox-backend contribution and reports its id", async () => {
     const { register } = makeRegister();
     const { registerSandbox, calls } = makeSandboxRegister();
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@platypus/docker"],
       builtinPlugins: {
         "@platypus/docker": () =>
@@ -578,57 +542,6 @@ describe("loadPlugins — sandbox backends", () => {
     ]);
   });
 
-  it("aborts (fail-loud) on a duplicate sandbox backend id, naming both plugins", async () => {
-    const { register } = makeRegister();
-    const { registerSandbox } = makeSandboxRegister();
-    // Two core plugins keep bare backend ids, so a shared `docker` collides.
-    const builtinPlugins = {
-      "@a/plugin": () =>
-        Promise.resolve({
-          plugin: sandboxManifest("@a/plugin", [sandboxBackend("docker")]),
-        }),
-      "@b/plugin": () =>
-        Promise.resolve({
-          plugin: sandboxManifest("@b/plugin", [sandboxBackend("docker")]),
-        }),
-    };
-
-    await expect(
-      loadPlugins({
-        pluginNames: ["@a/plugin", "@b/plugin"],
-        builtinPlugins,
-        register,
-        registerSandbox,
-      }),
-    ).rejects.toThrow(/"docker".*"@a\/plugin".*"@b\/plugin"/s);
-  });
-
-  it("re-throws a registry collision with plugin attribution", async () => {
-    const { register } = makeRegister();
-    const registerSandbox = () => {
-      throw new Error("Sandbox backend 'docker' has already been registered.");
-    };
-    // A core plugin keeps its bare `docker` backend id, colliding with a legacy
-    // static registration.
-    await expect(
-      loadPlugins({
-        pluginNames: ["@platypus/collides"],
-        builtinPlugins: {
-          "@platypus/collides": () =>
-            Promise.resolve({
-              plugin: sandboxManifest("@platypus/collides", [
-                sandboxBackend("docker"),
-              ]),
-            }),
-        },
-        register,
-        registerSandbox,
-      }),
-    ).rejects.toThrow(
-      /@platypus\/collides.*"docker".*already been registered/s,
-    );
-  });
-
   it("aborts (fail-loud) when sandboxBackends is not an array", async () => {
     const { register } = makeRegister();
     await expect(
@@ -650,36 +563,13 @@ describe("loadPlugins — sandbox backends", () => {
     ).rejects.toThrow(/@bad\/plugin.*sandboxBackends.*array/s);
   });
 
-  // `sandboxBackends` being an array is checked above; a third-party JS plugin can
-  // still put anything *inside* it. Each of these previously surfaced far from its
-  // cause — an unattributed TypeError at boot, a mystery `"acme.undefined"` in the
-  // catalog, or a 500 on an Operator's sandbox form.
+  // `sandboxBackends` being an array is checked above, and contribution shape,
+  // id, and name are the shared pipeline's checks (covered once in
+  // `contribution-pipeline.test.ts`). What is left here is what the
+  // Sandbox-backend point itself demands — each case previously surfaced far
+  // from its cause: an unattributed TypeError at boot, or a 500 on an Operator's
+  // sandbox form.
   it.each([
-    [
-      "a non-object entry",
-      null,
-      /@platypus\/bad.*sandbox backend contribution must be an object/s,
-    ],
-    [
-      "a missing backend id",
-      {
-        name: "x",
-        configSchema: z.object({}),
-        credentialsSchema: z.object({}),
-        create: () => ({}),
-      },
-      /@platypus\/bad.*non-empty "backend" id/s,
-    ],
-    [
-      "a missing name",
-      {
-        backend: "b",
-        configSchema: z.object({}),
-        credentialsSchema: z.object({}),
-        create: () => ({}),
-      },
-      /@platypus\/bad.*must declare a non-empty "name"/s,
-    ],
     [
       "a missing create",
       {
@@ -842,7 +732,7 @@ describe("loadPlugins — web-search backends", () => {
   it("registers a web-backend contribution and reports its id", async () => {
     const { register } = makeRegister();
     const { registerWeb, calls } = makeWebRegister();
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@platypus/searx"],
       builtinPlugins: {
         "@platypus/searx": () =>
@@ -868,7 +758,7 @@ describe("loadPlugins — web-search backends", () => {
   it("prefixes a third-party web-backend id with the manifest name", async () => {
     const { register } = makeRegister();
     const { registerWeb, calls } = makeWebRegister();
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@acme/platypus-search"],
       builtinPlugins: {},
       importPlugin: () =>
@@ -881,52 +771,6 @@ describe("loadPlugins — web-search backends", () => {
 
     expect(calls.map((c) => c.backend)).toEqual(["acme.web"]);
     expect(loaded[0].webBackendIds).toEqual(["acme.web"]);
-  });
-
-  it("aborts (fail-loud) on a duplicate web backend id, naming both plugins", async () => {
-    const { register } = makeRegister();
-    const { registerWeb } = makeWebRegister();
-    // Two core plugins keep bare backend ids, so a shared `searx` collides.
-    const builtinPlugins = {
-      "@a/plugin": () =>
-        Promise.resolve({
-          plugin: webManifest("@a/plugin", [webBackend("searx")]),
-        }),
-      "@b/plugin": () =>
-        Promise.resolve({
-          plugin: webManifest("@b/plugin", [webBackend("searx")]),
-        }),
-    };
-
-    await expect(
-      loadPlugins({
-        pluginNames: ["@a/plugin", "@b/plugin"],
-        builtinPlugins,
-        register,
-        registerWeb,
-      }),
-    ).rejects.toThrow(/"searx".*"@a\/plugin".*"@b\/plugin"/s);
-  });
-
-  it("re-throws a registry collision with plugin attribution", async () => {
-    const { register } = makeRegister();
-    const registerWeb = () => {
-      throw new Error("Web backend 'searx' has already been registered.");
-    };
-
-    await expect(
-      loadPlugins({
-        pluginNames: ["@platypus/collides"],
-        builtinPlugins: {
-          "@platypus/collides": () =>
-            Promise.resolve({
-              plugin: webManifest("@platypus/collides", [webBackend("searx")]),
-            }),
-        },
-        register,
-        registerWeb,
-      }),
-    ).rejects.toThrow(/@platypus\/collides.*"searx".*already been registered/s);
   });
 
   it("aborts (fail-loud) when webBackends is not an array", async () => {
@@ -950,33 +794,9 @@ describe("loadPlugins — web-search backends", () => {
     ).rejects.toThrow(/@bad\/plugin.*webBackends.*array/s);
   });
 
-  it("aborts (fail-loud, plugin-named) on a non-object web backend entry", async () => {
-    // `webBackends` being an array is checked; a third-party JS plugin can
-    // still put `null` inside it, which would otherwise throw an unattributed
-    // "Cannot read properties of null" reading `.backend` next.
-    const { register } = makeRegister();
-    await expect(
-      loadPlugins({
-        pluginNames: ["@platypus/searx"],
-        builtinPlugins: {
-          "@platypus/searx": () =>
-            Promise.resolve({
-              plugin: {
-                name: "@platypus/searx",
-                version: "0.1.0",
-                apiVersion: 1,
-                contributes: { webBackends: [null] },
-              },
-            }),
-        },
-        register,
-        registerWeb: () => {},
-      }),
-    ).rejects.toThrow(
-      /@platypus\/searx.*web backend contribution must be an object/s,
-    );
-  });
-
+  // Contribution shape, id, and name are the shared pipeline's checks, covered
+  // once in `contribution-pipeline.test.ts`. What is left here is what the
+  // Web-backend point itself demands of a contribution.
   it("aborts (fail-loud) when a contribution has no createExecutors function", async () => {
     const { register } = makeRegister();
     // The TS type requires it; a third-party JS plugin can still omit it, and
@@ -999,51 +819,6 @@ describe("loadPlugins — web-search backends", () => {
         registerWeb: () => {},
       }),
     ).rejects.toThrow(/@platypus\/searx.*"searx".*createExecutors/s);
-  });
-
-  it("aborts (fail-loud) on a contribution with no backend id, before namespacing it", async () => {
-    const { register } = makeRegister();
-    // Namespacing an absent id first would mint `"@platypus/searx.undefined"`
-    // and register it, turning a missing field into a mystery catalog entry.
-    const nameless = {
-      name: "SearXNG",
-      createExecutors: () => ({
-        web_search: () => ({ query: "", results: [] }),
-      }),
-    } as unknown as ReturnType<typeof webBackend>;
-
-    await expect(
-      loadPlugins({
-        pluginNames: ["@platypus/searx"],
-        builtinPlugins: {
-          "@platypus/searx": () =>
-            Promise.resolve({
-              plugin: webManifest("@platypus/searx", [nameless]),
-            }),
-        },
-        register,
-        registerWeb: () => {},
-      }),
-    ).rejects.toThrow(/@platypus\/searx.*non-empty "backend" id/s);
-  });
-
-  it("aborts (fail-loud) on a contribution with a blank display name", async () => {
-    const { register } = makeRegister();
-    await expect(
-      loadPlugins({
-        pluginNames: ["@platypus/searx"],
-        builtinPlugins: {
-          "@platypus/searx": () =>
-            Promise.resolve({
-              plugin: webManifest("@platypus/searx", [
-                { ...webBackend("searx"), name: "   " },
-              ]),
-            }),
-        },
-        register,
-        registerWeb: () => {},
-      }),
-    ).rejects.toThrow(/@platypus\/searx.*"searx".*non-empty "name"/s);
   });
 
   it("refuses an over-ceiling timeoutMs at boot rather than clamping it", async () => {
@@ -1411,7 +1186,7 @@ describe("loadPlugins — example third-party plugin", () => {
     const registered: Record<string, Omit<ToolSetContribution, "id">> = {};
     const sandboxCalls: SandboxBackendContribution[] = [];
 
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["example-cloud-sandbox"],
       builtinPlugins: {},
       importPlugin: () => Promise.resolve({ plugin: examplePlugin }),
@@ -1489,7 +1264,7 @@ describe("loadPlugins — the documented quickstart package", () => {
 
     // No `importPlugin` override: this exercises the default dynamic import, the
     // same path a deployment takes for any installed third-party package.
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@platypus-examples/tool-set"],
       builtinPlugins: {},
       register,
@@ -1526,7 +1301,7 @@ describe("loadPlugins — always-on core set (ADR-0013 amendment)", () => {
         }),
     };
 
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: [],
       alwaysOnPlugins: ["@platypus/tools-basic", "@platypus/tools-platform"],
       builtinPlugins,
@@ -1689,7 +1464,7 @@ describe("loadPlugins — third-party name slug validation (ADR-0013)", () => {
 
   it("accepts a clean slug name and prefixes contribution ids with it", async () => {
     const { register, calls } = makeRegister();
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@acme/platypus-widgets"],
       builtinPlugins: {},
       importPlugin: () =>
@@ -1715,7 +1490,7 @@ describe("loadPlugins — third-party namespacing (ADR-0013)", () => {
       Promise.resolve({ plugin: manifest("example", [toolSet("greeting")]) }),
     );
 
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@platypus/tools-basic", "@example-org/pkg"],
       builtinPlugins,
       importPlugin,
@@ -1732,7 +1507,7 @@ describe("loadPlugins — third-party namespacing (ADR-0013)", () => {
     const { register } = makeRegister();
     const { registerSandbox, calls } = makeSandboxRegister();
 
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@third/infra"],
       builtinPlugins: {},
       importPlugin: () =>
@@ -1759,7 +1534,7 @@ describe("loadPlugins — third-party namespacing (ADR-0013)", () => {
       }),
     );
 
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@platypus/impostor"],
       builtinPlugins: {},
       importPlugin,
@@ -1783,7 +1558,7 @@ describe("loadPlugins — example third-party npm package (end to end)", () => {
   it("loads the installed package via dynamic import and namespaces its id", async () => {
     const { register, calls } = makeRegister();
 
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@platypus-examples/tool-set"],
       builtinPlugins: {},
       register,
@@ -1805,9 +1580,9 @@ describe("loadPlugins — example third-party npm package (end to end)", () => {
 
     // Chat-turn resolution walks the tool-set registry by id (ADR-0013): the
     // example plugin is reachable only under its namespaced id.
-    const set = getToolSet("example.greeting");
+    const set = getToolSet("example.greeting")!;
     expect(set.category).toBe("Examples");
-    expect(() => getToolSet("greeting")).toThrow(/has not been registered/);
+    expect(getToolSet("greeting")).toBeUndefined();
 
     if (typeof set.tools === "function") {
       throw new Error("expected a static tool map");

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -8,16 +8,20 @@ import {
 } from "@platypuschat/plugin-sdk";
 import { ALWAYS_ON_PLUGINS, BUILTIN_PLUGINS } from "./builtin.ts";
 import { registerToolSet } from "../tools/index.ts";
+import { registerSandboxBackend } from "../sandbox/index.ts";
 import {
-  registerSandboxBackend,
-  type SandboxBackendRegistration,
-} from "../sandbox/index.ts";
-import {
-  composeWebBackend,
-  MAX_WEB_TIMEOUT_MS,
   registerWebBackend,
   type WebBackendRegistration,
 } from "../web-backends/index.ts";
+import {
+  registerContributions,
+  type ExtensionPoint,
+} from "./contribution-pipeline.ts";
+import {
+  sandboxBackendPoint,
+  toolSetPoint,
+  webBackendPoint,
+} from "./extension-points.ts";
 
 // Summary of one loaded plugin, for the boot log line and observability.
 export interface LoadedPlugin {
@@ -38,8 +42,39 @@ export interface LoadedPlugin {
   config?: unknown;
 }
 
+/**
+ * Which plugin contributed each registered id, one map per Extension point.
+ * Built while registering — the loader needs it to attribute a collision to both
+ * plugins — and returned so the plugin registry can annotate catalogs without
+ * re-deriving the same maps from the id arrays on {@link LoadedPlugin}.
+ *
+ * One map per point because the registries are separate: a Tool set and a
+ * Sandbox backend may share a bare id.
+ */
+export interface ContributionOwners {
+  toolSets: ReadonlyMap<string, string>;
+  sandboxBackends: ReadonlyMap<string, string>;
+  webBackends: ReadonlyMap<string, string>;
+}
+
+/** Everything one successful load produced, for the boot log and the registry. */
+export interface LoadPluginsResult {
+  plugins: LoadedPlugin[];
+  owners: ContributionOwners;
+}
+
 // A module that exports a plugin manifest. Values are `unknown` until validated.
 type PluginModule = { plugin?: unknown };
+
+// One row of the loader's Extension-point table: where a point's contributions
+// live on a manifest, which `LoadedPlugin` field reports the ids it registered,
+// the point itself, and the owner map it accumulates across plugins.
+interface LoaderExtensionPoint {
+  contributions: (manifest: PlatypusPlugin) => readonly unknown[] | undefined;
+  reportAs: "toolSetIds" | "sandboxBackendIds" | "webBackendIds";
+  point: ExtensionPoint;
+  owners: Map<string, string>;
+}
 
 // Deploy-time config/credentials the Operator supplies for one plugin. Both
 // halves are optional and opaque until validated against the manifest's
@@ -280,7 +315,7 @@ const validateManifest = (name: string, mod: PluginModule): PlatypusPlugin => {
  */
 export async function loadPlugins(
   opts: LoadPluginsOptions = {},
-): Promise<LoadedPlugin[]> {
+): Promise<LoadPluginsResult> {
   const listedNames =
     opts.pluginNames ?? parsePluginList(process.env.PLATYPUS_PLUGINS);
   // The always-on core set is injected on the env-default path (production,
@@ -317,13 +352,38 @@ export async function loadPlugins(
   const pluginConfig =
     opts.pluginConfig ?? parsePluginConfig(process.env.PLATYPUS_PLUGIN_CONFIG);
 
-  // Tracks contribution id -> owning plugin name for owner-attributed collisions.
-  // Tool sets, Sandbox backends, and Web-search backends live in separate
-  // registries, so each keeps its own owner map (a Tool set and a backend may
-  // share a bare id).
-  const owners = new Map<string, string>();
+  // Tracks contribution id -> owning plugin name for owner-attributed
+  // collisions, and is handed to the registry afterwards for catalog annotation.
+  const toolSetOwners = new Map<string, string>();
   const sandboxOwners = new Map<string, string>();
   const webOwners = new Map<string, string>();
+
+  // The Extension-point table. Every point runs the same registration sequence
+  // (`contribution-pipeline.ts`) over its slice of a manifest and differs only
+  // in what it declares here plus its entry in `extension-points.ts`. A fourth
+  // point (ADR-0013 anticipates them) is one more row, not a fourth copy of the
+  // loop.
+  const points: readonly LoaderExtensionPoint[] = [
+    {
+      contributions: (m) => m.contributes.toolSets,
+      reportAs: "toolSetIds",
+      point: toolSetPoint(register),
+      owners: toolSetOwners,
+    },
+    {
+      contributions: (m) => m.contributes.sandboxBackends,
+      reportAs: "sandboxBackendIds",
+      point: sandboxBackendPoint(registerSandbox),
+      owners: sandboxOwners,
+    },
+    {
+      contributions: (m) => m.contributes.webBackends,
+      reportAs: "webBackendIds",
+      point: webBackendPoint(registerWeb),
+      owners: webOwners,
+    },
+  ];
+
   const loaded: LoadedPlugin[] = [];
 
   for (const name of names) {
@@ -376,350 +436,29 @@ export async function loadPlugins(
     const contributionId = (id: string): string =>
       isCore ? id : `${manifest.name}.${id}`;
 
-    const toolSetIds: string[] = [];
-
-    for (const [index, contribution] of (
-      manifest.contributes.toolSets ?? []
-    ).entries()) {
-      // TypeScript protects in-repo plugins, but a third-party JS package can
-      // put any value inside the array. Validate identity before namespacing:
-      // `contributionId(undefined)` otherwise mints a plausible-looking
-      // `"acme.undefined"` Tool set and exposes it through the catalog.
-      //
-      // The two checks that run before an id is known carry the array index —
-      // on a plugin contributing several tool sets it is the only thing an
-      // Operator can use to find the offending entry.
-      if (
-        typeof contribution !== "object" ||
-        contribution === null ||
-        Array.isArray(contribution)
-      ) {
-        throw new Error(
-          `Plugin "${manifest.name}": every tool set contribution must be an object (at index ${index}).`,
-        );
-      }
-      if (
-        typeof contribution.id !== "string" ||
-        contribution.id.trim() === ""
-      ) {
-        throw new Error(
-          `Plugin "${manifest.name}": every tool set must declare a non-empty "id" (at index ${index}).`,
-        );
-      }
-      if (
-        typeof contribution.name !== "string" ||
-        contribution.name.trim() === ""
-      ) {
-        throw new Error(
-          `Plugin "${manifest.name}": tool set "${contribution.id}" must declare a non-empty "name".`,
-        );
-      }
-      if (
-        typeof contribution.category !== "string" ||
-        contribution.category.trim() === ""
-      ) {
-        throw new Error(
-          `Plugin "${manifest.name}": tool set "${contribution.id}" must declare a non-empty "category".`,
-        );
-      }
-      if (
-        typeof contribution.tools !== "function" &&
-        (typeof contribution.tools !== "object" ||
-          contribution.tools === null ||
-          Array.isArray(contribution.tools))
-      ) {
-        throw new Error(
-          `Plugin "${manifest.name}": tool set "${contribution.id}" must provide a "tools" object or function.`,
-        );
-      }
-
-      const { name: tsName, category, description, tools } = contribution;
-      // Trimmed before namespacing: the id is half of a composed
-      // `${manifest.name}.${id}` that gets persisted into `agent.toolSetIds`,
-      // and the other half is held to a url-safe slug above for exactly that
-      // reason. `" my set "` must not reach the registry as `acme. my set `.
-      const effectiveId = contributionId(contribution.id.trim());
-
-      const existingOwner = owners.get(effectiveId);
-      if (existingOwner) {
-        throw new Error(
-          `Tool set id "${effectiveId}" is contributed by both "${existingOwner}" and "${manifest.name}".`,
-        );
-      }
-
-      // Bind the shared plugin config into the factory so core's registry and
-      // its Chat-turn callers stay ignorant of it: they invoke the stored
-      // factory with only the ToolSetContext, as before. A static-map tool set
-      // has no factory to inject into and is registered untouched.
-      const boundTools =
-        typeof tools === "function"
-          ? (ctx: Parameters<typeof tools>[0]) => tools(ctx, pluginCtx)
-          : tools;
-
-      try {
-        register(effectiveId, {
-          name: tsName,
-          category,
-          description,
-          tools: boundTools,
-        });
-      } catch (cause) {
-        // A collision with a Tool set registered outside the loader (a legacy
-        // static registration) surfaces here — re-throw with plugin attribution.
-        throw new Error(
-          `Plugin "${manifest.name}": failed to register tool set "${effectiveId}" (${
-            cause instanceof Error ? cause.message : String(cause)
-          }).`,
-          { cause },
-        );
-      }
-
-      owners.set(effectiveId, manifest.name);
-      toolSetIds.push(effectiveId);
-    }
-
-    const sandboxBackendIds: string[] = [];
-
-    for (const contribution of manifest.contributes.sandboxBackends ?? []) {
-      // Everything below is guaranteed by `SandboxBackendContribution`, and none
-      // of it is guaranteed by a third-party *JS* plugin — which is this loop's
-      // whole justification. Each malformed shape used to surface far from its
-      // cause: `null` as an unattributed `Cannot read properties of null`, a
-      // missing `backend` as a plausible-looking `"acme.undefined"` in the
-      // catalog, a missing `create` or schema as a TypeError at chat-turn or
-      // save time. Boot is where they are caught, named by plugin (ADR-0013).
-      if (typeof contribution !== "object" || contribution === null) {
-        throw new Error(
-          `Plugin "${manifest.name}": every sandbox backend contribution must be an object.`,
-        );
-      }
-      if (
-        typeof contribution.backend !== "string" ||
-        contribution.backend.trim() === ""
-      ) {
-        throw new Error(
-          `Plugin "${manifest.name}": every sandbox backend must declare a non-empty "backend" id.`,
-        );
-      }
-      if (
-        typeof contribution.name !== "string" ||
-        contribution.name.trim() === ""
-      ) {
-        throw new Error(
-          `Plugin "${manifest.name}": sandbox backend "${contribution.backend}" must declare a non-empty "name".`,
-        );
-      }
-      if (typeof contribution.create !== "function") {
-        throw new Error(
-          `Plugin "${manifest.name}": sandbox backend "${contribution.backend}" must provide a "create" function.`,
-        );
-      }
-
-      // Trimmed before namespacing, as in the tool set loop: this id is
-      // persisted into `sandbox.backend` and must not carry stray whitespace.
-      const effectiveBackend = contributionId(contribution.backend.trim());
-
-      const existingOwner = sandboxOwners.get(effectiveBackend);
-      if (existingOwner) {
-        throw new Error(
-          `Sandbox backend id "${effectiveBackend}" is contributed by both "${existingOwner}" and "${manifest.name}".`,
-        );
-      }
-
-      // Resolve a factory-form configSchema against the boot-resolved plugin
-      // config so the three static `configSchema.safeParse` consumers (save
-      // route, teardown, tool resolver) always receive a concrete schema — they
-      // never see plugin config. A plain schema passes through untouched
-      // (append-only: plugin-config-agnostic backends are unaffected).
-      //
-      // The factory is third-party code reading a config block it narrows
-      // itself, so it can throw — a plugin that assumes an Operator supplied
-      // `config.region` raises a bare `Cannot read properties of undefined`
-      // naming nothing. Attributed here for the same reason the shape checks
-      // above exist: the schema check below only catches a factory that
-      // *returns* a non-schema, not one that throws on the way there.
-      let resolvedConfigSchema: SandboxBackendRegistration["configSchema"];
-      try {
-        resolvedConfigSchema =
-          typeof contribution.configSchema === "function"
-            ? contribution.configSchema(pluginCtx.config)
-            : contribution.configSchema;
-      } catch (cause) {
-        throw new Error(
-          `Plugin "${manifest.name}": sandbox backend "${effectiveBackend}" configSchema factory threw (${
-            cause instanceof Error ? cause.message : String(cause)
-          }).`,
-          { cause },
-        );
-      }
-
-      // Checked after the factory form is resolved away, and duck-typed on
-      // `safeParse` rather than `instanceof z.ZodType`, because that is exactly
-      // what the three static consumers call. Without this, a contribution
-      // missing either schema registers fine and fails at *save* time — a 500 on
-      // an Operator's sandbox form, attributed to nothing.
-      for (const [field, schema] of [
-        ["configSchema", resolvedConfigSchema],
-        ["credentialsSchema", contribution.credentialsSchema],
-      ] as const) {
-        if (
-          typeof schema !== "object" ||
-          schema === null ||
-          typeof (schema as { safeParse?: unknown }).safeParse !== "function"
-        ) {
-          throw new Error(
-            `Plugin "${manifest.name}": sandbox backend "${effectiveBackend}" must provide a Zod "${field}".`,
-          );
-        }
-      }
-
-      // Bind the same shared plugin config into create() so core's per-turn
-      // callers (chat resolution, teardown) keep calling create(config,
-      // credentials) with the per-Workspace values only. Third-party backends
-      // also register under the namespaced discriminator, so the
-      // `sandbox.backend` column resolves to the prefixed id (mirroring tool sets).
-      //
-      // Typed as the core registration (concrete configSchema): the factory form
-      // has been resolved away above, so what we register — and what the static
-      // safeParse consumers receive — is always a plain schema.
-      const boundContribution: SandboxBackendRegistration = {
-        ...contribution,
-        backend: effectiveBackend,
-        configSchema: resolvedConfigSchema,
-        create: (config, credentials) =>
-          contribution.create(config, credentials, pluginCtx),
-      };
-
-      try {
-        registerSandbox(boundContribution);
-      } catch (cause) {
-        // A collision with a backend registered outside the loader surfaces
-        // here — re-throw with plugin attribution.
-        throw new Error(
-          `Plugin "${manifest.name}": failed to register sandbox backend "${effectiveBackend}" (${
-            cause instanceof Error ? cause.message : String(cause)
-          }).`,
-          { cause },
-        );
-      }
-
-      sandboxOwners.set(effectiveBackend, manifest.name);
-      sandboxBackendIds.push(effectiveBackend);
-    }
-
-    const webBackendIds: string[] = [];
-
-    for (const contribution of manifest.contributes.webBackends ?? []) {
-      // A third-party JS plugin can put anything in this array — including
-      // `null` — and every other malformed case in this loop gets a
-      // plugin-named boot error, so this one does too rather than throwing an
-      // unattributed `Cannot read properties of null`.
-      if (typeof contribution !== "object" || contribution === null) {
-        throw new Error(
-          `Plugin "${manifest.name}": every web backend contribution must be an object.`,
-        );
-      }
-
-      // Identity is checked before it is namespaced: `contributionId(undefined)`
-      // would otherwise mint a plausible-looking `"acme.undefined"` and register
-      // it, so a JS plugin's missing field would surface as a mystery id in the
-      // catalog rather than a boot error naming the plugin.
-      if (
-        typeof contribution.backend !== "string" ||
-        contribution.backend.trim() === ""
-      ) {
-        throw new Error(
-          `Plugin "${manifest.name}": every web backend must declare a non-empty "backend" id.`,
-        );
-      }
-      if (
-        typeof contribution.name !== "string" ||
-        contribution.name.trim() === ""
-      ) {
-        throw new Error(
-          `Plugin "${manifest.name}": web backend "${contribution.backend}" must declare a non-empty "name".`,
-        );
-      }
-
-      // Trimmed before namespacing, as in the tool set loop.
-      const effectiveBackend = contributionId(contribution.backend.trim());
-
-      const existingOwner = webOwners.get(effectiveBackend);
-      if (existingOwner) {
-        throw new Error(
-          `Web backend id "${effectiveBackend}" is contributed by both "${existingOwner}" and "${manifest.name}".`,
-        );
-      }
-
-      // A web backend supplies executors only — core builds the Tools — so a
-      // missing factory means the contribution can never serve a turn. The TS
-      // type says so; a third-party JS plugin can still ship it, and boot is
-      // where that is caught (ADR-0014's fail-loud boot posture).
-      if (typeof contribution.createExecutors !== "function") {
-        throw new Error(
-          `Plugin "${manifest.name}": web backend "${effectiveBackend}" must provide a "createExecutors" function.`,
-        );
-      }
-
-      // `timeoutMs` is static on the contribution, so an over-ceiling value is
-      // knowable now — refused with attribution rather than silently clamped at
-      // turn time, where an Operator would never see it.
-      if (contribution.timeoutMs !== undefined) {
-        const { timeoutMs } = contribution;
-        if (
-          typeof timeoutMs !== "number" ||
-          !Number.isFinite(timeoutMs) ||
-          timeoutMs <= 0 ||
-          timeoutMs > MAX_WEB_TIMEOUT_MS
-        ) {
-          throw new Error(
-            `Plugin "${manifest.name}": web backend "${effectiveBackend}" declares timeoutMs ${String(
-              timeoutMs,
-            )}, which must be a positive number no greater than ${MAX_WEB_TIMEOUT_MS}.`,
-          );
-        }
-      }
-
-      // Core wraps the executors here, binding the same shared plugin config that
-      // every other contribution factory receives. What lands in the registry is
-      // the finished, guarded builder — per-turn callers never see the executors.
-      //
-      // The contribution goes in by reference, with the namespaced id alongside
-      // it rather than spread over it: `createExecutors` must be called on the
-      // author's own object, or a class-instance contribution loses its
-      // prototype and its `this`. (The sandbox loop achieves the same by
-      // re-wrapping `create` around the original.)
-      const registration = composeWebBackend({
-        contribution,
-        backend: effectiveBackend,
-        plugin: pluginCtx,
+    // Register this plugin's contributions to every Extension point, in table
+    // order, collecting the ids each point took for the boot log.
+    const registeredIds: Record<LoaderExtensionPoint["reportAs"], string[]> = {
+      toolSetIds: [],
+      sandboxBackendIds: [],
+      webBackendIds: [],
+    };
+    for (const entry of points) {
+      registeredIds[entry.reportAs] = registerContributions({
+        point: entry.point,
+        contributions: entry.contributions(manifest) ?? [],
         pluginName: manifest.name,
+        plugin: pluginCtx,
+        contributionId,
+        owners: entry.owners,
       });
-
-      try {
-        registerWeb(registration);
-      } catch (cause) {
-        // A collision with a backend registered outside the loader surfaces
-        // here — re-throw with plugin attribution.
-        throw new Error(
-          `Plugin "${manifest.name}": failed to register web backend "${effectiveBackend}" (${
-            cause instanceof Error ? cause.message : String(cause)
-          }).`,
-          { cause },
-        );
-      }
-
-      webOwners.set(effectiveBackend, manifest.name);
-      webBackendIds.push(effectiveBackend);
     }
 
     loaded.push({
       name: manifest.name,
       version: manifest.version,
       origin,
-      toolSetIds,
-      sandboxBackendIds,
-      webBackendIds,
+      ...registeredIds,
       // Carry the resolved deploy-time config (config only, never credentials)
       // so request handlers can read it via the registry (ADR-0013).
       config: pluginCtx.config,
@@ -740,5 +479,12 @@ export async function loadPlugins(
     }
   }
 
-  return loaded;
+  return {
+    plugins: loaded,
+    owners: {
+      toolSets: toolSetOwners,
+      sandboxBackends: sandboxOwners,
+      webBackends: webOwners,
+    },
+  };
 }

--- a/apps/backend/src/plugins/registry.ts
+++ b/apps/backend/src/plugins/registry.ts
@@ -1,4 +1,8 @@
-import type { LoadedPlugin } from "./loader.ts";
+import type {
+  ContributionOwners,
+  LoadedPlugin,
+  LoadPluginsResult,
+} from "./loader.ts";
 
 // Read-only observability store for the plugins loaded at boot (ADR-0013).
 //
@@ -19,27 +23,30 @@ import type { LoadedPlugin } from "./loader.ts";
  */
 export const CORE_BUILTIN_OWNER = "core (built-in)";
 
+const NO_OWNERS: ContributionOwners = {
+  toolSets: new Map(),
+  sandboxBackends: new Map(),
+  webBackends: new Map(),
+};
+
 let loadedPlugins: readonly LoadedPlugin[] = [];
-let toolSetOwners = new Map<string, string>();
-let sandboxBackendOwners = new Map<string, string>();
-let webBackendOwners = new Map<string, string>();
+let owners: ContributionOwners = NO_OWNERS;
 let pluginConfigs = new Map<string, unknown>();
 
 /**
- * Record the plugins loaded at boot. Called once from the boot sequence after
- * {@link loadPlugins} succeeds; also used by tests to seed the catalog. Rebuilds
- * the id → plugin-name lookups used to annotate existing catalogs.
+ * Record what the boot load produced. Called once from the boot sequence after
+ * {@link loadPlugins} succeeds; also used by tests to seed the catalog.
+ *
+ * The id → plugin-name lookups come straight from the loader, which built them
+ * while registering (it needs them to attribute a collision to both plugins).
+ * Re-deriving them from each plugin's id arrays would be a second, drifting
+ * answer to a question the loader has already answered.
  */
-export const setLoadedPlugins = (plugins: readonly LoadedPlugin[]): void => {
-  loadedPlugins = plugins;
-  toolSetOwners = new Map();
-  sandboxBackendOwners = new Map();
-  webBackendOwners = new Map();
+export const setLoadedPlugins = (result: LoadPluginsResult): void => {
+  loadedPlugins = result.plugins;
+  owners = result.owners;
   pluginConfigs = new Map();
-  for (const p of plugins) {
-    for (const id of p.toolSetIds) toolSetOwners.set(id, p.name);
-    for (const id of p.sandboxBackendIds) sandboxBackendOwners.set(id, p.name);
-    for (const id of p.webBackendIds) webBackendOwners.set(id, p.name);
+  for (const p of result.plugins) {
     if (p.config !== undefined) pluginConfigs.set(p.name, p.config);
   }
 };
@@ -53,15 +60,15 @@ export const getLoadedPlugins = (): readonly LoadedPlugin[] => loadedPlugins;
  * registration rather than a plugin contribution — see `tools/index.ts`).
  */
 export const getToolSetPlugin = (toolSetId: string): string | undefined =>
-  toolSetOwners.get(toolSetId);
+  owners.toolSets.get(toolSetId);
 
 /** The plugin that contributed a Sandbox backend, or `undefined` if none. */
 export const getSandboxBackendPlugin = (backend: string): string | undefined =>
-  sandboxBackendOwners.get(backend);
+  owners.sandboxBackends.get(backend);
 
 /** The plugin that contributed a Web-search backend, or `undefined` if none. */
 export const getWebBackendPlugin = (backend: string): string | undefined =>
-  webBackendOwners.get(backend);
+  owners.webBackends.get(backend);
 
 /**
  * A plugin's boot-resolved, Operator-owned deploy-time **config** (never

--- a/apps/backend/src/plugins/ssh/index.test.ts
+++ b/apps/backend/src/plugins/ssh/index.test.ts
@@ -29,7 +29,9 @@ describe("@platypus/ssh plugin manifest", () => {
     // loader → registerSandboxBackend → getSandboxBackend.
     expect(getSandboxBackend("ssh")).toBeUndefined();
 
-    const loaded = await loadPlugins({ pluginNames: ["@platypus/ssh"] });
+    const { plugins: loaded } = await loadPlugins({
+      pluginNames: ["@platypus/ssh"],
+    });
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0]).toMatchObject({

--- a/apps/backend/src/plugins/tools-platform/index.test.ts
+++ b/apps/backend/src/plugins/tools-platform/index.test.ts
@@ -62,11 +62,12 @@ describe("@platypus/tools-platform — loaded into the core registry", () => {
   it("registers all eight domain tool sets with bare ids", async () => {
     // Module-global registry; vitest isolates modules per file so this doesn't
     // leak. Exercise the real path: loader → registerToolSet → getToolSet.
+    const registeredIds = () => getToolSets().map((s) => s.id);
     for (const id of EXPECTED_IDS) {
-      expect(getToolSets()).not.toHaveProperty(id);
+      expect(registeredIds()).not.toContain(id);
     }
 
-    const loaded = await loadPlugins({
+    const { plugins: loaded } = await loadPlugins({
       pluginNames: ["@platypus/tools-platform"],
     });
 
@@ -78,13 +79,13 @@ describe("@platypus/tools-platform — loaded into the core registry", () => {
     });
 
     for (const id of EXPECTED_IDS) {
-      expect(getToolSets()).toHaveProperty(id);
+      expect(registeredIds()).toContain(id);
     }
   });
 
   it("resolves each tool set's factory to a non-empty tool map at chat-turn time", () => {
     for (const id of EXPECTED_IDS) {
-      const set = getToolSet(id);
+      const set = getToolSet(id)!;
       expect(typeof set.tools).toBe("function");
       const tools =
         typeof set.tools === "function" ? set.tools(ctx) : set.tools;
@@ -93,7 +94,7 @@ describe("@platypus/tools-platform — loaded into the core registry", () => {
   });
 
   it("resolves the read/write agent-management split tools as before", () => {
-    const discovery = getToolSet("agent-discovery");
+    const discovery = getToolSet("agent-discovery")!;
     const discoveryTools =
       typeof discovery.tools === "function"
         ? discovery.tools(ctx)
@@ -102,7 +103,7 @@ describe("@platypus/tools-platform — loaded into the core registry", () => {
       ["getAgent", "listAgents", "listModelProviders", "listToolSets"].sort(),
     );
 
-    const management = getToolSet("agent-management");
+    const management = getToolSet("agent-management")!;
     const managementTools =
       typeof management.tools === "function"
         ? management.tools(ctx)

--- a/apps/backend/src/plugins/web-fetch/index.test.ts
+++ b/apps/backend/src/plugins/web-fetch/index.test.ts
@@ -47,9 +47,11 @@ describe("@platypus/web-fetch plugin manifest", () => {
     // The registry is module-global; vitest isolates modules per file, so this
     // load doesn't leak into other test files. Exercise the real plugin path:
     // loader → registerToolSet → getToolSet.
-    expect(getToolSets()).not.toHaveProperty("web-fetch");
+    expect(getToolSets().map((s) => s.id)).not.toContain("web-fetch");
 
-    const loaded = await loadPlugins({ pluginNames: ["@platypus/web-fetch"] });
+    const { plugins: loaded } = await loadPlugins({
+      pluginNames: ["@platypus/web-fetch"],
+    });
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0]).toMatchObject({
@@ -58,7 +60,7 @@ describe("@platypus/web-fetch plugin manifest", () => {
       toolSetIds: ["web-fetch"],
     });
 
-    const set = getToolSet("web-fetch");
+    const set = getToolSet("web-fetch")!;
     expect(set.name).toBe("Web Fetch");
     expect(set.category).toBe("Web");
     // The loader binds the plugin config into a factory; resolving it (as a Chat

--- a/apps/backend/src/registry/contribution-registry.test.ts
+++ b/apps/backend/src/registry/contribution-registry.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { createContributionRegistry } from "./contribution-registry.ts";
+
+// The three Extension-point registries (Tool sets, Sandbox backends, Web-search
+// backends) are instances of this one factory, so the contract every one of them
+// honours is tested here once. Each registry module keeps a thin suite of its
+// own covering only what it adds — the id it keys on, and the entries it
+// registers at import time.
+
+type Entry = { label: string };
+
+const makeRegistry = () =>
+  createContributionRegistry<Entry>({ noun: "Tool set" });
+
+describe("createContributionRegistry", () => {
+  it("registers an entry and serves it by id", () => {
+    const registry = makeRegistry();
+    registry.register("alpha", { label: "Alpha" });
+    expect(registry.get("alpha")).toEqual({ label: "Alpha" });
+  });
+
+  it("returns the registered entry from register()", () => {
+    const registry = makeRegistry();
+    const entry = { label: "Alpha" };
+    expect(registry.register("alpha", entry)).toBe(entry);
+  });
+
+  it("returns undefined for an id nothing registered", () => {
+    expect(makeRegistry().get("absent")).toBeUndefined();
+  });
+
+  it("answers has() for registered and unregistered ids", () => {
+    const registry = makeRegistry();
+    registry.register("alpha", { label: "Alpha" });
+    expect(registry.has("alpha")).toBe(true);
+    expect(registry.has("absent")).toBe(false);
+  });
+
+  it("does not resolve Object.prototype members as registered entries", () => {
+    // Every one of these ids reaches a lookup from request data — `toolSetId`
+    // from `agent.toolSetIds`, `backend` from a save-route body and from the
+    // `sandbox.backend` / `provider.webBackend` columns. A plain-object store
+    // answered `"toString" in store` with true and handed back
+    // `Object.prototype.toString`: truthy, with no `tools` and no
+    // `configSchema`, so a Chat turn silently resolved no tools and the save
+    // route threw a TypeError instead of reporting an unregistered backend.
+    const registry = makeRegistry();
+    for (const id of [
+      "toString",
+      "constructor",
+      "__proto__",
+      "valueOf",
+      "hasOwnProperty",
+    ]) {
+      expect(registry.get(id)).toBeUndefined();
+      expect(registry.has(id)).toBe(false);
+    }
+  });
+
+  it("stores an entry under an Object.prototype-shaped id without leaking it", () => {
+    const registry = makeRegistry();
+    registry.register("toString", { label: "Odd" });
+    expect(registry.get("toString")).toEqual({ label: "Odd" });
+    expect(registry.get("valueOf")).toBeUndefined();
+  });
+
+  it("rejects a duplicate id, naming the registry's noun", () => {
+    const registry = makeRegistry();
+    registry.register("alpha", { label: "Alpha" });
+    expect(() => registry.register("alpha", { label: "Again" })).toThrow(
+      "Tool set 'alpha' has already been registered.",
+    );
+  });
+
+  it("keeps the first registration when a duplicate is rejected", () => {
+    const registry = makeRegistry();
+    registry.register("alpha", { label: "Alpha" });
+    expect(() => registry.register("alpha", { label: "Again" })).toThrow();
+    expect(registry.get("alpha")).toEqual({ label: "Alpha" });
+  });
+
+  it("lists entries in registration order", () => {
+    const registry = makeRegistry();
+    registry.register("alpha", { label: "Alpha" });
+    registry.register("beta", { label: "Beta" });
+    expect(registry.list().map((e) => e.label)).toEqual(["Alpha", "Beta"]);
+  });
+
+  it("lists nothing before anything registers", () => {
+    expect(makeRegistry().list()).toEqual([]);
+  });
+
+  it("empties on clear() so a test can re-register the same id", () => {
+    const registry = makeRegistry();
+    registry.register("alpha", { label: "Alpha" });
+    registry.clear();
+    expect(registry.get("alpha")).toBeUndefined();
+    expect(registry.list()).toEqual([]);
+    expect(() => registry.register("alpha", { label: "Again" })).not.toThrow();
+  });
+
+  it("keeps instances independent", () => {
+    const one = makeRegistry();
+    const two = makeRegistry();
+    one.register("alpha", { label: "Alpha" });
+    expect(two.get("alpha")).toBeUndefined();
+  });
+});

--- a/apps/backend/src/registry/contribution-registry.ts
+++ b/apps/backend/src/registry/contribution-registry.ts
@@ -1,0 +1,70 @@
+// One boot-populated store, shared by every Extension point (ADR-0013).
+//
+// Tool sets, Sandbox backends, and Web-search backends each keep their own
+// instance, but they answer the same questions — register one entry under an id,
+// serve it back, list what is registered, refuse a duplicate — and used to answer
+// them three slightly different ways: one threw on a miss while the others
+// returned `undefined`, one listed a raw map while the others listed arrays, one
+// had a test reset and the others did not. Callers had to remember which was
+// which, and `getToolSet`'s throw became control flow in the Chat-turn resolver.
+// One factory, one contract.
+
+export interface ContributionRegistry<TEntry> {
+  /**
+   * Store an entry under `id` and return it. Throws when `id` is taken — a
+   * second registration is always a bug (two plugins claiming one id, or a
+   * plugin colliding with a core built-in), and the plugin loader turns this
+   * throw into a boot error naming the plugin.
+   */
+  register(id: string, entry: TEntry): TEntry;
+  /** The entry registered under `id`, or `undefined` when nothing claimed it. */
+  get(id: string): TEntry | undefined;
+  /** Whether anything is registered under `id`. */
+  has(id: string): boolean;
+  /** Every registered entry, in registration order. */
+  list(): readonly TEntry[];
+  /**
+   * Test-only reset. Boot registers once and nothing in production
+   * unregisters, so this exists to let a test re-register the same id rather
+   * than invent a fresh one per case.
+   */
+  clear(): void;
+}
+
+export interface ContributionRegistryOptions {
+  /**
+   * How this registry's entries are named in its errors, sentence-cased —
+   * "Tool set", "Sandbox backend", "Web backend".
+   */
+  noun: string;
+}
+
+/**
+ * Create an empty registry for one Extension point.
+ *
+ * A `Map`, not an object literal: every id reaches these lookups from request
+ * data (`agent.toolSetIds`, a save-route body, the `sandbox.backend` and
+ * `provider.webBackend` columns), and a plain object answers `"toString" in
+ * store` with `true` and hands back `Object.prototype.toString` — an entry the
+ * caller then trips over far from the lookup. A `Map` has no inherited keys, so
+ * an unregistered id is unregistered whatever it is called.
+ */
+export const createContributionRegistry = <TEntry>(
+  options: ContributionRegistryOptions,
+): ContributionRegistry<TEntry> => {
+  const entries = new Map<string, TEntry>();
+
+  return {
+    register(id, entry) {
+      if (entries.has(id)) {
+        throw new Error(`${options.noun} '${id}' has already been registered.`);
+      }
+      entries.set(id, entry);
+      return entry;
+    },
+    get: (id) => entries.get(id),
+    has: (id) => entries.has(id),
+    list: () => [...entries.values()],
+    clear: () => entries.clear(),
+  };
+};

--- a/apps/backend/src/routes/org-tool.ts
+++ b/apps/backend/src/routes/org-tool.ts
@@ -16,8 +16,8 @@ const orgTool = new Hono<{ Variables: Variables }>();
 orgTool.get("/", requireAuth, requireOrgAccess(), async (c) => {
   const orgId = c.req.param("orgId")!;
 
-  const toolSetsList = Object.entries(getToolSets()).map(([id, toolSet]) => ({
-    id,
+  const toolSetsList = getToolSets().map((toolSet) => ({
+    id: toolSet.id,
     name: toolSet.name,
     category: toolSet.category,
     description: toolSet.description,

--- a/apps/backend/src/routes/plugins.test.ts
+++ b/apps/backend/src/routes/plugins.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
+  loadedPluginsFixture,
   mockDb,
   mockNoSession,
   mockSession,
@@ -33,7 +34,7 @@ describe("Plugins Routes", () => {
     resetMockDb();
     vi.clearAllMocks();
     mockDb.where.mockReturnValue(mockDb);
-    setLoadedPlugins(LOADED);
+    setLoadedPlugins(loadedPluginsFixture(LOADED));
   });
 
   const baseUrl = "/organizations/org-1/plugins";

--- a/apps/backend/src/routes/sandbox.test.ts
+++ b/apps/backend/src/routes/sandbox.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { z } from "zod";
-import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
+import {
+  loadedPluginsFixture,
+  mockDb,
+  mockSession,
+  resetMockDb,
+} from "../test-utils.ts";
 import app from "../server.ts";
 import { registerSandboxBackend } from "../sandbox/index.ts";
 import { setLoadedPlugins } from "../plugins/registry.ts";
@@ -59,16 +64,21 @@ describe("Sandbox Routes", () => {
         { ownerId: "user-1", organizationId: "org-1" },
       ]);
       // Attribute the pre-registered backend to a plugin (ADR-0013).
-      setLoadedPlugins([
-        {
-          name: "@platypus/test",
-          version: "1.0.0",
-          origin: "core",
-          toolSetIds: [],
-          sandboxBackendIds: [ANNOTATED_BACKEND],
-          webBackendIds: [],
-        },
-      ]);
+      setLoadedPlugins(
+        loadedPluginsFixture(
+          [
+            {
+              name: "@platypus/test",
+              version: "1.0.0",
+              origin: "core",
+              toolSetIds: [],
+              sandboxBackendIds: [ANNOTATED_BACKEND],
+              webBackendIds: [],
+            },
+          ],
+          { sandboxBackends: new Map([[ANNOTATED_BACKEND, "@platypus/test"]]) },
+        ),
+      );
 
       const res = await app.request(`${baseUrl}/backends`);
       expect(res.status).toBe(200);

--- a/apps/backend/src/routes/tool.test.ts
+++ b/apps/backend/src/routes/tool.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
+import {
+  loadedPluginsFixture,
+  mockDb,
+  mockSession,
+  resetMockDb,
+} from "../test-utils.ts";
 import app from "../server.ts";
 import { setLoadedPlugins } from "../plugins/registry.ts";
 
 vi.mock("../tools/index.ts", () => ({
-  getToolSets: vi.fn().mockReturnValue({
-    math: {
+  getToolSets: vi.fn().mockReturnValue([
+    {
+      id: "math",
       name: "Math",
       category: "Utilities",
       description: "Math tools",
@@ -15,13 +21,14 @@ vi.mock("../tools/index.ts", () => ({
     },
     // A core-internal static set (e.g. `sandbox`) with no owning plugin: it
     // must annotate as core/built-in, not crash.
-    sandbox: {
+    {
+      id: "sandbox",
       name: "Sandbox",
       category: "Sandbox",
       description: "Sandbox tools",
       tools: () => ({}),
     },
-  }),
+  ]),
 }));
 
 describe("Tool Routes", () => {
@@ -32,16 +39,21 @@ describe("Tool Routes", () => {
     // Seed the plugin registry so the Tools listing can annotate the `math`
     // set with its originating plugin (ADR-0013). `sandbox` is intentionally
     // absent — it is a static registration, not a plugin contribution.
-    setLoadedPlugins([
-      {
-        name: "@platypus/tools-basic",
-        version: "1.0.0",
-        origin: "core",
-        toolSetIds: ["math"],
-        sandboxBackendIds: [],
-        webBackendIds: [],
-      },
-    ]);
+    setLoadedPlugins(
+      loadedPluginsFixture(
+        [
+          {
+            name: "@platypus/tools-basic",
+            version: "1.0.0",
+            origin: "core",
+            toolSetIds: ["math"],
+            sandboxBackendIds: [],
+            webBackendIds: [],
+          },
+        ],
+        { toolSets: new Map([["math", "@platypus/tools-basic"]]) },
+      ),
+    );
   });
 
   const orgId = "org-1";

--- a/apps/backend/src/routes/tool.ts
+++ b/apps/backend/src/routes/tool.ts
@@ -25,12 +25,12 @@ tool.get(
     // contributed it (ADR-0013 observability); the core-internal `sandbox` set is
     // a static registration (not a plugin contribution), so it reads as
     // core/built-in rather than a blank owner.
-    const toolSetsList = Object.entries(getToolSets()).map(([id, toolSet]) => ({
-      id,
+    const toolSetsList = getToolSets().map((toolSet) => ({
+      id: toolSet.id,
       name: toolSet.name,
       category: toolSet.category,
       description: toolSet.description,
-      plugin: getToolSetPlugin(id) ?? CORE_BUILTIN_OWNER,
+      plugin: getToolSetPlugin(toolSet.id) ?? CORE_BUILTIN_OWNER,
       tools:
         typeof toolSet.tools === "function"
           ? []

--- a/apps/backend/src/routes/web-backends.test.ts
+++ b/apps/backend/src/routes/web-backends.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
+  loadedPluginsFixture,
   mockDb,
   mockNoSession,
   mockSession,
@@ -21,6 +22,12 @@ const LOADED: LoadedPlugin[] = [
   },
 ];
 
+// The loader hands the registry the owner map it built while registering; this
+// fixture states the one entry the catalog annotation under test reads.
+const LOADED_RESULT = loadedPluginsFixture(LOADED, {
+  webBackends: new Map([["acme-search.searx", "acme-search"]]),
+});
+
 const baseUrl = "/organizations/org-1/web-backends";
 
 describe("Web backend catalog route", () => {
@@ -29,17 +36,17 @@ describe("Web backend catalog route", () => {
     vi.clearAllMocks();
     mockDb.where.mockReturnValue(mockDb);
     clearWebBackends();
-    setLoadedPlugins([]);
+    setLoadedPlugins(loadedPluginsFixture());
   });
 
   afterEach(() => {
     clearWebBackends();
-    setLoadedPlugins([]);
+    setLoadedPlugins(loadedPluginsFixture());
   });
 
   describe("GET /web-backends", () => {
     it("lists a registered backend annotated with the plugin that contributed it", async () => {
-      setLoadedPlugins(LOADED);
+      setLoadedPlugins(LOADED_RESULT);
       registerWebBackend({
         backend: "acme-search.searx",
         name: "SearXNG",

--- a/apps/backend/src/sandbox/index.test.ts
+++ b/apps/backend/src/sandbox/index.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect } from "vitest";
 import { z } from "zod";
 import {
+  clearSandboxBackends,
   registerSandboxBackend,
   getSandboxBackend,
   getSandboxBackends,
@@ -34,45 +35,27 @@ const makeRegistration = (
   create: () => stubBackend,
 });
 
-// The registry is module-level state; we reset by re-importing via vi.resetModules
-// isn't trivial here, so each test uses a unique backend id.
-
+// The store's own contract — miss semantics, duplicate rejection, prototype-key
+// safety, listing, reset — is covered once in
+// `registry/contribution-registry.test.ts`. What is left here is what this
+// instance adds: keying on the registration's own `backend` discriminator.
 describe("sandbox backend registry", () => {
-  it("registers and looks up a backend by id", () => {
+  beforeEach(() => {
+    clearSandboxBackends();
+  });
+
+  it("keys a registration on its own backend id", () => {
     registerSandboxBackend(makeRegistration("test-lookup"));
     const found = getSandboxBackend("test-lookup");
     expect(found?.backend).toBe("test-lookup");
     expect(found?.name).toBe("Test test-lookup");
+    expect(getSandboxBackends().map((r) => r.backend)).toEqual(["test-lookup"]);
   });
 
-  it("returns undefined for an unknown backend", () => {
-    expect(getSandboxBackend("does-not-exist")).toBeUndefined();
-  });
-
-  it("does not resolve Object.prototype members as registered backends", () => {
-    // `backend` reaches this lookup from a request body and from the
-    // `sandbox.backend` column, so a plain-object registry handed back
-    // `Object.prototype.toString` — truthy, no `configSchema` — and the save
-    // route's `registration.configSchema.safeParse(...)` threw a 500 instead of
-    // treating the id as unregistered.
-    expect(getSandboxBackend("toString")).toBeUndefined();
-    expect(getSandboxBackend("constructor")).toBeUndefined();
-    expect(getSandboxBackend("__proto__")).toBeUndefined();
-    expect(getSandboxBackend("hasOwnProperty")).toBeUndefined();
-  });
-
-  it("rejects duplicate registration of the same backend id", () => {
+  it("refuses a second registration under the same backend id", () => {
     registerSandboxBackend(makeRegistration("test-duplicate"));
     expect(() =>
       registerSandboxBackend(makeRegistration("test-duplicate")),
-    ).toThrow(/already been registered/);
-  });
-
-  it("lists all registered backends", () => {
-    registerSandboxBackend(makeRegistration("test-list-a"));
-    registerSandboxBackend(makeRegistration("test-list-b"));
-    const ids = getSandboxBackends().map((r) => r.backend);
-    expect(ids).toContain("test-list-a");
-    expect(ids).toContain("test-list-b");
+    ).toThrow("Sandbox backend 'test-duplicate' has already been registered.");
   });
 });

--- a/apps/backend/src/sandbox/index.ts
+++ b/apps/backend/src/sandbox/index.ts
@@ -1,3 +1,4 @@
+import { createContributionRegistry } from "../registry/contribution-registry.ts";
 import type { SandboxBackendRegistration } from "./types.ts";
 
 // Output bounds, fixed by Platypus and identical across all adapters. Adapters
@@ -17,38 +18,31 @@ export const MAX_SHELL_TIMEOUT_MS = 600_000;
 // is the user-visible root.
 export const SANDBOX_WORKSPACE_ROOT = "/workspace";
 
-// Stored at the erased (default `unknown`) parameterisation: the registry is
+// The Sandbox-backend instance of the shared Extension-point registry. Entries
+// are stored at the erased (default `unknown`) parameterisation: the registry is
 // heterogeneous and lookups hand back this same erased shape.
-//
-// `Object.create(null)`, not `{}`: `backend` reaches this lookup from request
-// bodies (`backend: z.string().min(1)`) and from the `sandbox.backend` column, so
-// a plain object let `getSandboxBackend("toString")` hand back
-// `Object.prototype.toString` — truthy, with no `configSchema` — and the save
-// route's `registration.configSchema.safeParse(...)` then threw a TypeError
-// instead of treating the id as unregistered. A null prototype has nothing to
-// inherit, so an unknown id is `undefined` whatever it is called.
-const SANDBOX_BACKEND_REGISTRY = Object.create(null) as Record<
-  string,
-  SandboxBackendRegistration
->;
+const SANDBOX_BACKENDS = createContributionRegistry<SandboxBackendRegistration>(
+  {
+    noun: "Sandbox backend",
+  },
+);
 
 export const registerSandboxBackend = <TConfig, TCredentials>(
   registration: SandboxBackendRegistration<TConfig, TCredentials>,
 ): void => {
-  if (registration.backend in SANDBOX_BACKEND_REGISTRY) {
-    throw new Error(
-      `Sandbox backend '${registration.backend}' has already been registered.`,
-    );
-  }
-  SANDBOX_BACKEND_REGISTRY[registration.backend] = registration;
+  SANDBOX_BACKENDS.register(registration.backend, registration);
 };
 
+/** The backend registered under `backend`, or `undefined` if none is. */
 export const getSandboxBackend = (
   backend: string,
-): SandboxBackendRegistration | undefined => SANDBOX_BACKEND_REGISTRY[backend];
+): SandboxBackendRegistration | undefined => SANDBOX_BACKENDS.get(backend);
 
+/** Every registered Sandbox backend, in registration order. */
 export const getSandboxBackends =
-  (): ReadonlyArray<SandboxBackendRegistration> =>
-    Object.values(SANDBOX_BACKEND_REGISTRY);
+  (): ReadonlyArray<SandboxBackendRegistration> => SANDBOX_BACKENDS.list();
+
+/** Test-only reset — see {@link createContributionRegistry}. */
+export const clearSandboxBackends = (): void => SANDBOX_BACKENDS.clear();
 
 export * from "./types.ts";

--- a/apps/backend/src/services/agent-scope-validation.ts
+++ b/apps/backend/src/services/agent-scope-validation.ts
@@ -6,7 +6,7 @@ import {
   skill as skillTable,
 } from "../db/schema.ts";
 import { eq, inArray } from "drizzle-orm";
-import { getToolSets } from "../tools/index.ts";
+import { hasToolSet } from "../tools/index.ts";
 import { isSharedRow } from "./scoped-resource.ts";
 
 /**
@@ -115,8 +115,7 @@ export const findNonSharedReferences = async (
   // always allowed; any other id is an MCP-backed tool set and must resolve to
   // an org-scoped MCP.
   const toolSetIds = refs.toolSetIds ?? [];
-  const registry = getToolSets();
-  const mcpIds = toolSetIds.filter((id) => !(id in registry));
+  const mcpIds = toolSetIds.filter((id) => !hasToolSet(id));
   if (mcpIds.length > 0) {
     const rows = await db
       .select({

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -997,10 +997,8 @@ const loadTools = async (
   }
 
   for (const toolSetId of agent.toolSetIds) {
-    let toolSet: ReturnType<typeof getToolSet>;
-    try {
-      toolSet = getToolSet(toolSetId);
-    } catch {
+    const toolSet = getToolSet(toolSetId);
+    if (!toolSet) {
       // Static tool set not found — fall back to MCP lookup.
       const mcp = await queries.getMcp(toolSetId, orgId, workspaceId);
       if (mcp && mcp.url) {

--- a/apps/backend/src/test-utils.ts
+++ b/apps/backend/src/test-utils.ts
@@ -1,5 +1,10 @@
 import { vi, type Mock } from "vitest";
 import type {
+  ContributionOwners,
+  LoadedPlugin,
+  LoadPluginsResult,
+} from "./plugins/loader.ts";
+import type {
   InferToolInput,
   InferToolOutput,
   Tool,
@@ -251,3 +256,22 @@ export const mockSession = (
 export const mockNoSession = () => {
   mockAuth.api.getSession.mockResolvedValue(null);
 };
+
+/**
+ * A {@link setLoadedPlugins} argument for tests. The loader hands the registry
+ * both the loaded plugins and the id → plugin-name maps it built while
+ * registering; a test states only the owner maps for the point it exercises and
+ * gets empty ones for the rest.
+ */
+export const loadedPluginsFixture = (
+  plugins: LoadedPlugin[] = [],
+  owners: Partial<ContributionOwners> = {},
+): LoadPluginsResult => ({
+  plugins,
+  owners: {
+    toolSets: new Map(),
+    sandboxBackends: new Map(),
+    webBackends: new Map(),
+    ...owners,
+  },
+});

--- a/apps/backend/src/tools/agent-discovery.ts
+++ b/apps/backend/src/tools/agent-discovery.ts
@@ -55,14 +55,12 @@ export function createAgentDiscoveryTools(
       "List all available tool sets and MCP servers. Use the returned IDs when assigning toolSetIds to agents.",
     inputSchema: z.object({}),
     execute: async () => {
-      const toolSetsList = Object.entries(getToolSets()).map(
-        ([id, toolSet]) => ({
-          id,
-          name: toolSet.name,
-          category: toolSet.category,
-          description: toolSet.description,
-        }),
-      );
+      const toolSetsList = getToolSets().map((toolSet) => ({
+        id: toolSet.id,
+        name: toolSet.name,
+        category: toolSet.category,
+        description: toolSet.description,
+      }));
 
       const mcps = await listScoped(db, "mcp", ctx);
       const mcpList = mcps.map(({ row }) => ({

--- a/apps/backend/src/tools/index.test.ts
+++ b/apps/backend/src/tools/index.test.ts
@@ -24,15 +24,21 @@ vi.mock("../storage/index.ts", () => ({
 import {
   getToolSets,
   getToolSet,
+  hasToolSet,
   registerToolSet,
   SANDBOX_TOOLSET_ID,
 } from "./index.ts";
 
+// The store's own contract — miss semantics, duplicate rejection, prototype-key
+// safety, listing, reset — is covered once in
+// `registry/contribution-registry.test.ts`. What is left here is what this
+// instance adds: the id it keys on, and what registers at import time.
 describe("Tool Set Registry", () => {
+  const registeredIds = () => getToolSets().map((s) => s.id);
+
   describe("getToolSets", () => {
     it("returns the statically-registered tool sets", () => {
-      const sets = getToolSets();
-      expect(Object.keys(sets).length).toBeGreaterThan(0);
+      expect(registeredIds().length).toBeGreaterThan(0);
     });
 
     it("no longer statically registers the plugin-migrated tool sets", () => {
@@ -40,7 +46,6 @@ describe("Tool Set Registry", () => {
       // loader (ADR-0013): `math-conversions`/`time` → @platypus/tools-basic,
       // `web-fetch` → @platypus/web-fetch, and the Platypus-domain sets →
       // @platypus/tools-platform. None register at import time here anymore.
-      const sets = getToolSets();
       for (const id of [
         "math-conversions",
         "time",
@@ -54,7 +59,7 @@ describe("Tool Set Registry", () => {
         "notifications",
         "memory",
       ]) {
-        expect(sets).not.toHaveProperty(id);
+        expect(registeredIds()).not.toContain(id);
       }
     });
 
@@ -62,42 +67,35 @@ describe("Tool Set Registry", () => {
       // The `sandbox` set is the consumer side of the Sandbox-backend extension
       // point (ADR-0002), not a native Tool set, so it stays a core-internal
       // static registration — the lone one left in tools/index.ts.
-      expect(getToolSets()).toHaveProperty(SANDBOX_TOOLSET_ID);
+      expect(registeredIds()).toContain(SANDBOX_TOOLSET_ID);
     });
   });
 
   describe("getToolSet", () => {
     it("returns the sandbox tool set by id", () => {
-      const set = getToolSet(SANDBOX_TOOLSET_ID);
+      const set = getToolSet(SANDBOX_TOOLSET_ID)!;
       expect(set).toBeDefined();
       expect(set.name).toBe("Sandbox");
       expect(set.category).toBe("Sandbox");
       expect(typeof set.tools).toBe("function");
     });
 
-    it("throws for an unregistered id", () => {
-      expect(() => getToolSet("nonexistent")).toThrow(
-        "Tool set with id 'nonexistent' has not been registered.",
-      );
+    it("returns undefined for an unregistered id", () => {
+      // Chat-turn resolution reads this `undefined` as "not a static tool set,
+      // try MCP", so the miss is a value here rather than an exception.
+      expect(getToolSet("nonexistent")).toBeUndefined();
     });
+  });
 
-    it("throws for Object.prototype members rather than resolving them", () => {
-      // `toolSetId` reaches this lookup from `agent.toolSetIds`, which is
-      // request-body data. A plain-object registry answered `"toString" in
-      // TOOL_SETS_REGISTRY` with true and handed back
-      // `Object.prototype.toString` — a function with no `tools`, so the chat
-      // turn resolved no tools *without* throwing, and the caller's MCP fallback
-      // never ran. Unregistered must mean unregistered whatever the id is called.
-      for (const id of ["toString", "constructor", "__proto__", "valueOf"]) {
-        expect(() => getToolSet(id)).toThrow(
-          `Tool set with id '${id}' has not been registered.`,
-        );
-      }
+  describe("hasToolSet", () => {
+    it("answers for a registered and an unregistered id", () => {
+      expect(hasToolSet(SANDBOX_TOOLSET_ID)).toBe(true);
+      expect(hasToolSet("nonexistent")).toBe(false);
     });
   });
 
   describe("registerToolSet", () => {
-    it("throws when registering a duplicate id", () => {
+    it("keys on the tool-set id, so a duplicate is refused", () => {
       expect(() =>
         registerToolSet(SANDBOX_TOOLSET_ID, {
           name: "Duplicate",
@@ -105,7 +103,7 @@ describe("Tool Set Registry", () => {
           tools: {},
         }),
       ).toThrow(
-        `Tool set with id '${SANDBOX_TOOLSET_ID}' has already been registered.`,
+        `Tool set '${SANDBOX_TOOLSET_ID}' has already been registered.`,
       );
     });
 

--- a/apps/backend/src/tools/index.ts
+++ b/apps/backend/src/tools/index.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../index.ts";
 import { sandbox as sandboxTable } from "../db/schema.ts";
 import { getSandboxBackend } from "../sandbox/index.ts";
+import { createContributionRegistry } from "../registry/contribution-registry.ts";
 import { createSandboxTools } from "../sandbox/tools.ts";
 import { logger } from "../logger.ts";
 
@@ -23,39 +24,26 @@ type ToolSet = {
       ) => Record<string, Tool> | Promise<Record<string, Tool>>);
 };
 
-// `Object.create(null)`, not `{}`, for the same reason as the Sandbox and
-// Web-search backend registries: `toolSetId` reaches `getToolSet` from
-// `agent.toolSetIds`, which is request-body data. With a plain object,
-// `"toString" in TOOL_SETS_REGISTRY` is true, so the lookup handed back
-// `Object.prototype.toString` — a function with no `tools`, which resolved to no
-// tools *without* throwing, so the caller's MCP fallback never ran. A null
-// prototype has nothing to inherit, so an unregistered id throws whatever it is
-// called.
-const TOOL_SETS_REGISTRY = Object.create(null) as {
-  [toolSetId: string]: ToolSet;
-};
+// The Tool-set instance of the shared Extension-point registry — same store,
+// same miss semantics, and same duplicate-id error as the Sandbox and Web-search
+// backend registries.
+const TOOL_SETS = createContributionRegistry<ToolSet>({ noun: "Tool set" });
 
 export const registerToolSet = (
   toolSetId: string,
   toolSet: Omit<ToolSet, "id">,
-): ToolSet => {
-  if (toolSetId in TOOL_SETS_REGISTRY) {
-    throw new Error(
-      `Tool set with id '${toolSetId}' has already been registered.`,
-    );
-  }
-  TOOL_SETS_REGISTRY[toolSetId] = { id: toolSetId, ...toolSet };
-  return TOOL_SETS_REGISTRY[toolSetId];
-};
+): ToolSet => TOOL_SETS.register(toolSetId, { id: toolSetId, ...toolSet });
 
-export const getToolSet = (toolSetId: string): ToolSet => {
-  if (!(toolSetId in TOOL_SETS_REGISTRY)) {
-    throw new Error(`Tool set with id '${toolSetId}' has not been registered.`);
-  }
-  return TOOL_SETS_REGISTRY[toolSetId];
-};
+/** The Tool set registered under `toolSetId`, or `undefined` if none is. */
+export const getToolSet = (toolSetId: string): ToolSet | undefined =>
+  TOOL_SETS.get(toolSetId);
 
-export const getToolSets = (): typeof TOOL_SETS_REGISTRY => TOOL_SETS_REGISTRY;
+/** Whether `toolSetId` names a statically-registered Tool set. */
+export const hasToolSet = (toolSetId: string): boolean =>
+  TOOL_SETS.has(toolSetId);
+
+/** Every registered Tool set, in registration order. Each carries its own id. */
+export const getToolSets = (): readonly ToolSet[] => TOOL_SETS.list();
 
 // Tool set ID constants for referencing registered tool sets by name
 export const MEMORY_TOOLSET_ID = "memory";

--- a/apps/backend/src/web-backends/index.test.ts
+++ b/apps/backend/src/web-backends/index.test.ts
@@ -92,39 +92,25 @@ describe("web-backend registry", () => {
       pluginName: "@acme/searx",
     });
 
-  it("registers a backend and serves it by its discriminator", () => {
+  // The store's own contract — miss semantics, duplicate rejection,
+  // prototype-key safety, listing, reset — is covered once in
+  // `registry/contribution-registry.test.ts`. What is left here is what this
+  // instance adds: keying on the composed registration's own discriminator.
+  it("keys a composed registration on its own discriminator", () => {
     registerWebBackend(registration("searx"));
+    registerWebBackend(registration("brave"));
 
     const found = getWebBackend("searx");
     expect(found?.backend).toBe("searx");
     expect(found?.name).toBe("SearXNG");
     expect(typeof found?.buildTurnTools).toBe("function");
-  });
-
-  it("lists every registered backend", () => {
-    registerWebBackend(registration("searx"));
-    registerWebBackend(registration("brave"));
-
     expect(getWebBackends().map((r) => r.backend)).toEqual(["searx", "brave"]);
   });
 
-  it("returns undefined for an unregistered discriminator", () => {
-    expect(getWebBackend("nope")).toBeUndefined();
-  });
-
-  it("does not resolve Object.prototype members as registered backends", () => {
-    // A plain-object registry would return `Object.prototype.toString` here —
-    // truthy, but with no `buildTurnTools`. PR2 feeds this lookup from a
-    // nullable DB column, so this must stay undefined rather than throw later.
-    expect(getWebBackend("toString")).toBeUndefined();
-    expect(getWebBackend("constructor")).toBeUndefined();
-    expect(getWebBackend("__proto__")).toBeUndefined();
-  });
-
-  it("throws on a duplicate registration", () => {
+  it("refuses a second registration under the same discriminator", () => {
     registerWebBackend(registration("searx"));
     expect(() => registerWebBackend(registration("searx"))).toThrow(
-      /'searx' has already been registered/,
+      "Web backend 'searx' has already been registered.",
     );
   });
 });

--- a/apps/backend/src/web-backends/index.ts
+++ b/apps/backend/src/web-backends/index.ts
@@ -2,6 +2,7 @@ import { tool, type Tool } from "ai";
 import type { PluginConfigContext } from "@platypuschat/plugin-sdk";
 import { isPresentableUrl, WEB_BACKEND_TOOL_MARKER } from "@platypus/schemas";
 import { logger } from "../logger.ts";
+import { createContributionRegistry } from "../registry/contribution-registry.ts";
 import { checkEgress, EGRESS_BLOCKED_MESSAGE } from "../utils/egress-guard.ts";
 import {
   MAX_READ_URL_CONTENT_CHARS,
@@ -66,48 +67,29 @@ const READ_URL_DESCRIPTION =
 // `WEB_BACKEND_TOOL_MARKER`.
 const WEB_BACKEND_TOOL_METADATA = { [WEB_BACKEND_TOOL_MARKER]: true };
 
-// The registry, mirroring `sandbox/index.ts`: a flat map keyed by the
-// discriminator stored in `provider.webBackend`. `Object.create(null)` — not
-// `{}` — so a discriminator that collides with an `Object.prototype` member
-// (`"toString"`, `"constructor"`…) cannot false-hit `in` or shadow a real
-// registration; PR2 feeds this from a nullable DB column, so an unguarded
-// object would let a stale value throw mid-turn instead of degrading cleanly.
-const WEB_BACKEND_REGISTRY = Object.create(null) as Record<
-  string,
-  WebBackendRegistration
->;
+// The Web-search-backend instance of the shared Extension-point registry, keyed
+// by the discriminator stored in `provider.webBackend`.
+const WEB_BACKENDS = createContributionRegistry<WebBackendRegistration>({
+  noun: "Web backend",
+});
 
 export const registerWebBackend = (
   registration: WebBackendRegistration,
 ): void => {
-  if (registration.backend in WEB_BACKEND_REGISTRY) {
-    throw new Error(
-      `Web backend '${registration.backend}' has already been registered.`,
-    );
-  }
-  WEB_BACKEND_REGISTRY[registration.backend] = registration;
+  WEB_BACKENDS.register(registration.backend, registration);
 };
 
+/** The backend registered under `backend`, or `undefined` if none is. */
 export const getWebBackend = (
   backend: string,
-): WebBackendRegistration | undefined => WEB_BACKEND_REGISTRY[backend];
+): WebBackendRegistration | undefined => WEB_BACKENDS.get(backend);
 
+/** Every registered Web-search backend, in registration order. */
 export const getWebBackends = (): ReadonlyArray<WebBackendRegistration> =>
-  Object.values(WEB_BACKEND_REGISTRY);
+  WEB_BACKENDS.list();
 
-/**
- * Test-only reset. Boot registers once; nothing in production unregisters.
- * `sandbox/index.test.ts` has no equivalent — it sidesteps the same
- * module-level-state problem by giving every test a unique backend id instead.
- * This module resets explicitly so most tests can reuse the same discriminator
- * (`"searx"`), which reads closer to a real registration than a fresh id per
- * `it()` would.
- */
-export const clearWebBackends = (): void => {
-  for (const key of Object.keys(WEB_BACKEND_REGISTRY)) {
-    delete WEB_BACKEND_REGISTRY[key];
-  }
-};
+/** Test-only reset — see {@link createContributionRegistry}. */
+export const clearWebBackends = (): void => WEB_BACKENDS.clear();
 
 // Cut a backend-supplied string to a core-owned bound, marking the cut so the
 // model can tell a truncated snippet from a naturally short one.


### PR DESCRIPTION
Closes #481.

## What this does

### 1. One registration pipeline

The per-Extension-point registration loop was copied three times in the loader — tool sets, sandbox backends, web backends, 328 lines and 44% of the file — and had drifted apart. The shared seven steps now live once in `plugins/contribution-pipeline.ts`:

shape check → id → name → per-point validator → namespacing → owner-attributed collision check → attributed registration → bookkeeping.

Each point declares only what is genuinely its own in `plugins/extension-points.ts`, and `loader.ts` drives them from a table. `loader.ts` goes from 744 to 490 lines.

The strictest variant of each drifted step won everywhere:

| Step                         | Before                                                                    | Now                                 |
| ---------------------------- | ------------------------------------------------------------------------- | ----------------------------------- |
| Array index in pre-id errors | tool sets only                                                            | all three points                    |
| Rejects an array entry       | tool sets only                                                            | all three points                    |
| Plugin-config binding        | closure (tool sets), **object spread** (sandbox), delegated compose (web) | closure/factory only — never spread |

The sandbox object spread was the live trap the issue called out: a class-instance contribution loses its prototype and its `this` when spread. It is now built field by field, with `create` closing over the author's own object. Verified lossless against `SandboxBackendRegistration`, which declares exactly those five fields.

Per-point specials stay per-point, as asked: the sandbox `configSchema`-factory resolution and the web static `timeoutMs` ceiling live in their own point's `prepare`, and `composeWebBackend` is untouched.

### Adding a fourth Extension point

A table row plus its own factory — not another copy of the loop. Hypothetically, for `contributes.storageBackends`:

```ts
// extension-points.ts
export const storageBackendPoint = (
  register: (registration: StorageBackendRegistration) => void,
): ExtensionPoint<StorageBackendRegistration> => ({
  noun: "storage backend",
  idField: "backend",
  validate: (contribution, { pluginName, rawId }) => {
    if (typeof contribution.createClient !== "function") throw new Error(...);
  },
  prepare: (raw, { pluginName, id, plugin }) => ({ /* bind plugin config */ }),
  register: (_id, registration) => register(registration),
});

// loader.ts, in `points`
{ contributions: (m) => m.contributes.storageBackends,
  reportAs: "storageBackendIds",
  point: storageBackendPoint(registerStorage),
  owners: storageOwners },
```

The shape/id/name checks, namespacing, collision attribution, attributed registration, and bookkeeping all come from the pipeline unchanged.

### 2. One contribution registry

The three copy-identical registries now share one factory (`registry/contribution-registry.ts`). The miss-semantics table from the issue collapses to a single row:

|           | miss                | list shape | test reset               |
| --------- | ------------------- | ---------- | ------------------------ |
| all three | returns `undefined` | array      | `clear()` on the factory |

`getToolSet`'s throw is gone, so `services/chat-execution.ts` no longer uses `try/catch` as control flow to detect "not a static Tool set, fall back to MCP", and `services/agent-scope-validation.ts` answers the same question the same way via `hasToolSet`. No throwing `require*` variant was added — nothing wanted one.

The store is now a `Map`, which retires the prototype-pollution comment that was repeated three times: a `Map` has no inherited keys, so `"toString"` is unregistered whatever it is called.

### 3. Owner maps come from the loader

`loadPlugins` returns `{ plugins, owners }`. `plugins/registry.ts` stores the maps the loader already built while registering (it needs them to attribute collisions) instead of re-deriving them from each plugin's id arrays. Its public getters are unchanged.

## Error-text changes

Per the issue's constraint, every existing error keeps its information content. Three messages read differently:

- Sandbox and web contributions **gain** the array index in their pre-id errors, as tool sets already had: `every sandbox backend contribution must be an object (at index 1).`
- The missing-id message drops a redundant word: `non-empty "backend"` rather than `non-empty "backend" id`.
- Duplicate registration reads `Tool set 'x' has already been registered.` rather than `Tool set with id 'x' ...`, matching the sandbox and web wording.

No other boot behaviour changes, for currently-valid or currently-invalid plugin sets. Fail-loud and all-or-nothing throughout (ADR-0013); contribution ids, namespacing, always-on handling, and the apiVersion gate are untouched. `LoadPluginsOptions` is unchanged and every collaborator stays injectable; `apps/backend/index.ts` changed only for the return shape.

## Tests

- `plugins/contribution-pipeline.test.ts` (new) — the seven shared steps, tested once against a stand-in point.
- `registry/contribution-registry.test.ts` (new) — the one registry contract, tested once.
- `loader.test.ts` — reorganized: the triplicated shape/id/name, duplicate-id, and registry-collision cases are gone; what remains per point is that point's own validator, plus a new test pinning the returned owner maps.
- The three registry suites keep thin instantiation checks (the id each keys on, what registers at import time).
- Per-plugin manifest tests were touched only mechanically, for the `{ plugins, owners }` return shape and the array-shaped `getToolSets()`.

`pnpm typecheck`, `pnpm lint`, and `pnpm test` (8 packages, 116 backend test files / 1663 tests) pass on this branch rebased onto `main`. The full suite passed on the rewired loader before any loader test was touched, which is the load-bearing evidence that boot behaviour is unchanged.

## Docs

No docs change is due. `apps/backend/src/plugins/**` is in CLAUDE.md's docs table, so `extending/index.mdx` was checked: its claims about boot validation, plugin-named attribution, and trimming ids before namespacing all still hold, and the manifest surface and SDK are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
