### PR TITLE
fix(backend): put the Kanban routes and Tool set behind one module

### DIFF
--- a/apps/backend/src/errors.test.ts
+++ b/apps/backend/src/errors.test.ts
@@ -3,6 +3,7 @@ import {
   NotFoundError,
   LockedError,
   ConflictError,
+  ValidationError,
   isUniqueViolation,
   mapError,
 } from "./errors.ts";
@@ -23,6 +24,13 @@ describe("central error mapping (app.onError)", () => {
   it("maps ConflictError → 409", () => {
     const mapped = mapError(new ConflictError());
     expect(mapped?.status).toBe(409);
+  });
+
+  it("maps ValidationError → 400", () => {
+    expect(mapError(new ValidationError("Invalid label ID"))).toEqual({
+      status: 400,
+      message: "Invalid label ID",
+    });
   });
 
   it("maps a Postgres unique violation (23505) → 409", () => {

--- a/apps/backend/src/errors.ts
+++ b/apps/backend/src/errors.ts
@@ -30,6 +30,21 @@ export class LockedError extends Error {
   }
 }
 
+/**
+ * The request is well-formed but asks for something the domain rejects — a
+ * label the board does not have, an assignee who cannot work in this
+ * Workspace. Raised by domain modules whose rules serve more than one surface
+ * (the Kanban module serves both the HTTP routes and the Agent Tool set), so
+ * the rule and its message live in one place instead of once per caller.
+ * Surface-specific validation still answers inline. → 400
+ */
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ValidationError";
+  }
+}
+
 /** The operation conflicts with existing state (e.g. a duplicate name). → 409 */
 export class ConflictError extends Error {
   constructor(message = "This operation conflicts with an existing resource") {
@@ -76,6 +91,8 @@ export const mapError = (
     return { status: 403, message: error.message };
   if (error instanceof ConflictError)
     return { status: 409, message: error.message };
+  if (error instanceof ValidationError)
+    return { status: 400, message: error.message };
   if (isUniqueViolation(error))
     return { status: 409, message: "A resource with that name already exists" };
   return null;

--- a/apps/backend/src/routes/kanban.test.ts
+++ b/apps/backend/src/routes/kanban.test.ts
@@ -614,8 +614,7 @@ describe("Kanban Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
-
-      mockDb.orderBy.mockResolvedValueOnce([{ maxPos: 1.0 }]);
+      mockDb.limit.mockResolvedValueOnce([{ id: "col-1", boardId: "board-1" }]); // column guard
 
       const mockCard = {
         id: "test-id-123",
@@ -646,8 +645,7 @@ describe("Kanban Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
-      // card update returns empty (card not in this board)
-      mockDb.returning.mockResolvedValueOnce([]);
+      mockDb.limit.mockResolvedValueOnce([]); // card guard — not on this board
 
       const res = await app.request(
         `${baseUrl}/${boardId}/cards/card-from-other-board`,
@@ -668,6 +666,9 @@ describe("Kanban Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "card-1", columnId: "col-1", boardId: "board-1" },
+      ]); // card guard
 
       const mockCard = { id: "card-1", title: "Updated Card" };
       mockDb.returning.mockResolvedValueOnce([mockCard]);
@@ -688,8 +689,7 @@ describe("Kanban Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
-
-      mockDb.returning.mockResolvedValueOnce([]);
+      mockDb.limit.mockResolvedValueOnce([]); // card guard — not found
 
       const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
         method: "PUT",
@@ -711,6 +711,9 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { ownerId: "user-1", organizationId: "org-1" },
         ]); // requireWorkspaceAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]); // card guard
         mockBoardLabels([{ id: "lbl-a" }, { id: "lbl-b" }]);
         mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
 
@@ -732,6 +735,9 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { ownerId: "user-1", organizationId: "org-1" },
         ]); // requireWorkspaceAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]); // card guard
         mockBoardLabels([{ id: "lbl-new" }]);
         mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
 
@@ -761,6 +767,9 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { ownerId: "user-1", organizationId: "org-1" },
         ]); // requireWorkspaceAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]); // card guard
         mockBoardLabels([]);
         mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
 
@@ -784,9 +793,13 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { ownerId: "user-1", organizationId: "org-1" },
         ]); // requireWorkspaceAccess
-        // validateAssignees: org member query (empty) then super admin query (empty)
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]); // card guard
+        // assignee validation: org member query then super admin query
         mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
+        mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
         mockDb.where.mockResolvedValueOnce([]); // org member lookup — not found
         mockDb.where.mockResolvedValueOnce([]); // super admin lookup — not found
 
@@ -813,12 +826,15 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { ownerId: "admin-user", organizationId: "org-1" },
         ]); // requireWorkspaceAccess
-        // validateAssignees queries
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]); // card guard
+        // assignee validation queries
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
+        mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
         mockDb.where.mockResolvedValueOnce([]); // org member lookup — not found
         mockDb.where.mockResolvedValueOnce([{ id: "admin-user" }]); // super admin lookup — found
-        mockDb.where.mockReturnValueOnce(mockDb); // update subquery chain
-        mockDb.where.mockReturnValueOnce(mockDb); // update main where chain
+        mockDb.where.mockReturnValueOnce(mockDb); // card update chain
 
         const mockCard = {
           id: "card-1",
@@ -849,8 +865,12 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { ownerId: "user-1", organizationId: "org-1" },
         ]); // requireWorkspaceAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]); // card guard
         mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
+        mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
         // No user assignees, so the visibility lookup's two queries come first:
         // workspace-scoped agents, then org-scoped ones joined to an attachment.
         mockDb.where.mockResolvedValueOnce([]);
@@ -864,8 +884,7 @@ describe("Kanban Routes", () => {
             attachment: { id: "att-1" },
           },
         ]);
-        mockDb.where.mockReturnValueOnce(mockDb); // update subquery chain
-        mockDb.where.mockReturnValueOnce(mockDb); // update main where chain
+        mockDb.where.mockReturnValueOnce(mockDb); // card update chain
 
         const mockCard = {
           id: "card-1",
@@ -893,8 +912,12 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { ownerId: "user-1", organizationId: "org-1" },
         ]); // requireWorkspaceAccess
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]); // card guard
         mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
+        mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
         mockDb.where.mockResolvedValueOnce([]); // no workspace-scoped match
         mockDb.where.mockResolvedValueOnce([]); // no attached org-scoped match
 
@@ -909,9 +932,10 @@ describe("Kanban Routes", () => {
         expect(res.status).toBe(400);
         const body = (await res.json()) as Record<string, unknown>;
         expect(body.error).toBe("Invalid agent assignee");
-        // Both scopes were consulted: the second query is the Attachment join
-        // that a workspace-only lookup never makes.
-        expect(mockDb.innerJoin).toHaveBeenCalledTimes(1);
+        // Both scopes were consulted: after the card guard's two joins
+        // (card → column → board) comes the Attachment join that a
+        // workspace-only lookup never makes.
+        expect(mockDb.innerJoin).toHaveBeenCalledTimes(3);
       });
 
       it("should allow org member to be assigned", async () => {
@@ -920,13 +944,16 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { ownerId: "user-1", organizationId: "org-1" },
         ]); // requireWorkspaceAccess
-        // validateAssignees queries
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]); // card guard
+        // assignee validation queries
         mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
+        mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
         mockDb.where.mockResolvedValueOnce([{ userId: "user-1" }]); // org member lookup — found
         mockDb.where.mockResolvedValueOnce([]); // super admin lookup — not found
-        mockDb.where.mockReturnValueOnce(mockDb); // update subquery chain
-        mockDb.where.mockReturnValueOnce(mockDb); // update main where chain
+        mockDb.where.mockReturnValueOnce(mockDb); // card update chain
 
         const mockCard = {
           id: "card-1",
@@ -958,6 +985,11 @@ describe("Kanban Routes", () => {
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
 
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "card-1", columnId: "col-1", boardId: "board-1" },
+      ]); // card guard
+      mockDb.limit.mockResolvedValueOnce([{ id: "col-2", boardId: "board-1" }]); // target column guard
+
       const existingCards = [
         { id: "card-2", columnId: "col-2", position: 1.0 },
         { id: "card-3", columnId: "col-2", position: 2.0 },
@@ -965,7 +997,7 @@ describe("Kanban Routes", () => {
       mockDb.orderBy.mockResolvedValueOnce(existingCards);
 
       const updatedCard = { id: "card-1", columnId: "col-2", position: 0.5 };
-      mockDb.limit.mockResolvedValueOnce([updatedCard]);
+      mockDb.returning.mockResolvedValueOnce([updatedCard]);
 
       const res = await app.request(`${baseUrl}/${boardId}/cards/card-1/move`, {
         method: "POST",
@@ -983,6 +1015,11 @@ describe("Kanban Routes", () => {
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
 
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "card-1", columnId: "col-1", boardId: "board-1" },
+      ]); // card guard
+      mockDb.limit.mockResolvedValueOnce([{ id: "col-2", boardId: "board-1" }]); // target column guard
+
       const existingCards = [
         { id: "card-2", columnId: "col-2", position: 1.0 },
         { id: "card-3", columnId: "col-2", position: 2.0 },
@@ -990,7 +1027,7 @@ describe("Kanban Routes", () => {
       mockDb.orderBy.mockResolvedValueOnce(existingCards);
 
       const updatedCard = { id: "card-1", columnId: "col-2", position: 1.5 };
-      mockDb.limit.mockResolvedValueOnce([updatedCard]);
+      mockDb.returning.mockResolvedValueOnce([updatedCard]);
 
       const res = await app.request(`${baseUrl}/${boardId}/cards/card-1/move`, {
         method: "POST",
@@ -1008,6 +1045,11 @@ describe("Kanban Routes", () => {
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
 
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "card-1", columnId: "col-1", boardId: "board-1" },
+      ]); // card guard
+      mockDb.limit.mockResolvedValueOnce([{ id: "col-1", boardId: "board-1" }]); // target column guard
+
       // Cards with very small gap between positions 1 and 2
       const existingCards = [
         { id: "card-2", columnId: "col-1", position: 1.0 },
@@ -1016,7 +1058,7 @@ describe("Kanban Routes", () => {
       mockDb.orderBy.mockResolvedValueOnce(existingCards);
 
       const updatedCard = { id: "card-1", columnId: "col-1", position: 2.0 };
-      mockDb.limit.mockResolvedValueOnce([updatedCard]);
+      mockDb.returning.mockResolvedValueOnce([updatedCard]);
 
       const res = await app.request(`${baseUrl}/${boardId}/cards/card-1/move`, {
         method: "POST",
@@ -1034,6 +1076,11 @@ describe("Kanban Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
+
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "card-1", columnId: "col-1", boardId: "board-1" },
+      ]); // card guard
+      mockDb.limit.mockResolvedValueOnce([{ id: "col-2", boardId: "board-1" }]); // target column guard
 
       const existingCards = [
         { id: "card-2", columnId: "col-2", position: 1.0 },
@@ -1062,7 +1109,7 @@ describe("Kanban Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
-      mockDb.returning.mockResolvedValueOnce([]); // delete returns empty
+      mockDb.limit.mockResolvedValueOnce([]); // card guard — not on this board
 
       const res = await app.request(
         `${baseUrl}/${boardId}/cards/card-from-other-board`,
@@ -1081,8 +1128,9 @@ describe("Kanban Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
-
-      mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "card-1", columnId: "col-1", boardId: "board-1" },
+      ]); // card guard
 
       const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
         method: "DELETE",
@@ -1097,8 +1145,7 @@ describe("Kanban Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
-
-      mockDb.returning.mockResolvedValueOnce([]);
+      mockDb.limit.mockResolvedValueOnce([]); // card guard — not found
 
       const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
         method: "DELETE",

--- a/apps/backend/src/routes/kanban.ts
+++ b/apps/backend/src/routes/kanban.ts
@@ -1,7 +1,7 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { nanoid } from "nanoid";
-import { and, asc, count, desc, eq, max, inArray, not } from "drizzle-orm";
+import { and, asc, count, desc, eq, inArray, not } from "drizzle-orm";
 import { db } from "../index.ts";
 import {
   kanbanBoard as kanbanBoardTable,
@@ -9,10 +9,8 @@ import {
   kanbanCard as kanbanCardTable,
   kanbanCardComment as kanbanCardCommentTable,
   agent as agentTable,
-  organizationMember as organizationMemberTable,
 } from "../db/schema.ts";
 import { user } from "../db/auth-schema.ts";
-import { dispatchEvent } from "../services/event-dispatch.ts";
 import { avatarKeyToUrl } from "../utils/avatar-url.ts";
 import { getOrigin } from "../utils/get-origin.ts";
 import {
@@ -35,113 +33,46 @@ import {
   isSuperAdmin,
 } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
-import { calculateCardPosition } from "../utils/kanban-positioning.ts";
+import { NotFoundError } from "../errors.ts";
 import {
-  filterKnownLabelIds,
-  pruneCardLabelIds,
-} from "../utils/kanban-labels.ts";
-import { listScopedByIds } from "../services/scoped-resource.ts";
+  createCard,
+  createComment,
+  deleteCard,
+  listComments,
+  moveCard,
+  nextColumnPosition,
+  pruneCardLabelsForBoard,
+  removeComment,
+  requireBoard,
+  requireComment,
+  resolveCommentNames,
+  updateCard,
+  updateCommentBody,
+  type KanbanContext,
+  type KanbanScope,
+} from "../services/kanban.ts";
 
 /**
- * Validates that all assignees reference valid org members (users) or Agents
- * visible in this Workspace — its own, plus the Shared Agents attached to it
- * (ADR-0007), which is the set the assignee picker offers and the set that can
- * actually run here. Returns an error message string if invalid, or null if OK.
+ * The human-facing surface over the Kanban module (`services/kanban.ts`): each
+ * handler authorizes the request, calls the module, and returns its result.
+ * The board's rules live in the module and are shared with the Agent Tool set,
+ * and its typed failures are mapped to a status by `app.onError` (ADR-0010).
  */
-async function validateAssignees(
-  assignees: { type: string; id: string }[],
-  orgId: string,
-  workspaceId: string,
-): Promise<string | null> {
-  const userIds = assignees.filter((a) => a.type === "user").map((a) => a.id);
-  const agentIds = assignees.filter((a) => a.type === "agent").map((a) => a.id);
-
-  const [members, superAdmins, agentRecords] = await Promise.all([
-    userIds.length > 0
-      ? db
-          .select({ userId: organizationMemberTable.userId })
-          .from(organizationMemberTable)
-          .where(
-            and(
-              eq(organizationMemberTable.organizationId, orgId),
-              inArray(organizationMemberTable.userId, userIds),
-            ),
-          )
-      : Promise.resolve([]),
-    userIds.length > 0
-      ? db
-          .select({ id: user.id })
-          .from(user)
-          .where(and(eq(user.role, "admin"), inArray(user.id, userIds)))
-      : Promise.resolve([]),
-    listScopedByIds(db, "agent", agentIds, {
-      orgId,
-      wsId: workspaceId,
-    }),
-  ]);
-
-  // Combine org members and super admins (who may not have an org membership record)
-  const validUserIds = new Set([
-    ...members.map((m) => m.userId),
-    ...superAdmins.map((a) => a.id),
-  ]);
-  if (validUserIds.size < userIds.length) return "Invalid user assignee";
-  if (agentRecords.length !== agentIds.length) return "Invalid agent assignee";
-  return null;
-}
-
-// Any query executor — the top-level `db` or a transaction handle.
-type Executor = Parameters<Parameters<typeof db.transaction>[0]>[0];
-
-/**
- * Removes label IDs the board no longer has from every card on that board.
- * Board labels are an array on the board record and cards reference them by ID,
- * so deleting a label would otherwise leave cards holding an ID that resolves
- * to nothing. Only removes IDs — a card never gains a label here.
- */
-async function pruneCardLabelsForBoard(
-  tx: Executor,
-  boardId: string,
-  labels: { id: string }[],
-): Promise<void> {
-  const cards = await tx
-    .select({ id: kanbanCardTable.id, labelIds: kanbanCardTable.labelIds })
-    .from(kanbanCardTable)
-    .where(
-      inArray(
-        kanbanCardTable.columnId,
-        tx
-          .select({ id: kanbanColumnTable.id })
-          .from(kanbanColumnTable)
-          .where(eq(kanbanColumnTable.boardId, boardId)),
-      ),
-    );
-
-  const stale = pruneCardLabelIds(
-    cards,
-    labels.map((l) => l.id),
-  );
-
-  for (const card of stale) {
-    await tx
-      .update(kanbanCardTable)
-      .set({ labelIds: card.labelIds, updatedAt: new Date() })
-      .where(eq(kanbanCardTable.id, card.id));
-  }
-}
-
-/** The board's label IDs, or an empty list if the board has none. */
-async function getBoardLabelIds(boardId: string): Promise<string[]> {
-  const boardRecord = await db
-    .select({ labels: kanbanBoardTable.labels })
-    .from(kanbanBoardTable)
-    .where(eq(kanbanBoardTable.id, boardId))
-    .limit(1);
-
-  return (boardRecord[0]?.labels ?? []).map((l: { id: string }) => l.id);
-}
 
 const kanban = new Hono<{ Variables: Variables }>();
+
+/** Everything the module needs to place this request: which board, in which Workspace. */
+const scopeOf = (c: Context<{ Variables: Variables }>): KanbanScope => ({
+  orgId: c.req.param("orgId")!,
+  workspaceId: c.req.param("workspaceId")!,
+  boardId: c.req.param("boardId"),
+});
+
+/** The scope plus the signed-in user, for the handlers that write. */
+const contextOf = (c: Context<{ Variables: Variables }>): KanbanContext => ({
+  ...scopeOf(c),
+  actor: { userId: c.get("user")!.id },
+});
 
 // --- Board CRUD ---
 
@@ -227,25 +158,7 @@ kanban.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const boardId = c.req.param("boardId");
-    const workspaceId = c.req.param("workspaceId")!;
-
-    const record = await db
-      .select()
-      .from(kanbanBoardTable)
-      .where(
-        and(
-          eq(kanbanBoardTable.id, boardId),
-          eq(kanbanBoardTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
-
-    if (record.length === 0) {
-      return c.json({ error: "Board not found" }, 404);
-    }
-
-    return c.json(record[0]);
+    return c.json(await requireBoard(db, scopeOf(c), c.req.param("boardId")));
   },
 );
 
@@ -283,9 +196,7 @@ kanban.put(
       return updated;
     });
 
-    if (record.length === 0) {
-      return c.json({ error: "Board not found" }, 404);
-    }
+    if (record.length === 0) throw new NotFoundError("Board not found");
 
     return c.json(record[0]);
   },
@@ -312,9 +223,7 @@ kanban.delete(
       )
       .returning();
 
-    if (result.length === 0) {
-      return c.json({ error: "Board not found" }, 404);
-    }
+    if (result.length === 0) throw new NotFoundError("Board not found");
 
     return c.json({ message: "Board deleted" });
   },
@@ -330,22 +239,7 @@ kanban.get(
   requireWorkspaceAccess,
   async (c) => {
     const boardId = c.req.param("boardId");
-    const workspaceId = c.req.param("workspaceId")!;
-
-    const boardRecord = await db
-      .select()
-      .from(kanbanBoardTable)
-      .where(
-        and(
-          eq(kanbanBoardTable.id, boardId),
-          eq(kanbanBoardTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
-
-    if (boardRecord.length === 0) {
-      return c.json({ error: "Board not found" }, 404);
-    }
+    const board = await requireBoard(db, scopeOf(c), boardId);
 
     const columns = await db
       .select()
@@ -494,7 +388,7 @@ kanban.get(
     }));
 
     return c.json({
-      board: boardRecord[0],
+      board,
       columns: columnsWithCards,
     });
   },
@@ -512,24 +406,9 @@ kanban.put(
   sValidator("json", kanbanColumnReorderSchema),
   async (c) => {
     const boardId = c.req.param("boardId");
-    const workspaceId = c.req.param("workspaceId")!;
     const { columnIds } = c.req.valid("json");
 
-    // Verify board belongs to workspace
-    const boardRecord = await db
-      .select()
-      .from(kanbanBoardTable)
-      .where(
-        and(
-          eq(kanbanBoardTable.id, boardId),
-          eq(kanbanBoardTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
-
-    if (boardRecord.length === 0) {
-      return c.json({ error: "Board not found" }, 404);
-    }
+    await requireBoard(db, scopeOf(c), boardId);
 
     // Validate all columnIds belong to this board
     const boardColumns = await db
@@ -575,24 +454,9 @@ kanban.post(
   sValidator("json", kanbanColumnCreateSchema),
   async (c) => {
     const boardId = c.req.param("boardId");
-    const workspaceId = c.req.param("workspaceId")!;
     const data = c.req.valid("json");
 
-    // Verify board belongs to workspace
-    const boardRecord = await db
-      .select()
-      .from(kanbanBoardTable)
-      .where(
-        and(
-          eq(kanbanBoardTable.id, boardId),
-          eq(kanbanBoardTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
-
-    if (boardRecord.length === 0) {
-      return c.json({ error: "Board not found" }, 404);
-    }
+    await requireBoard(db, scopeOf(c), boardId);
 
     // Check for duplicate column name within the board
     const existingColumn = await db
@@ -613,13 +477,7 @@ kanban.post(
       );
     }
 
-    const maxResult = await db
-      .select({ maxPos: max(kanbanColumnTable.position) })
-      .from(kanbanColumnTable)
-      .where(eq(kanbanColumnTable.boardId, boardId));
-
-    const position = (maxResult[0]?.maxPos ?? 0) + 1.0;
-
+    const position = await nextColumnPosition(db, boardId);
     const id = nanoid();
     const now = new Date();
 
@@ -683,9 +541,7 @@ kanban.put(
       )
       .returning();
 
-    if (record.length === 0) {
-      return c.json({ error: "Column not found" }, 404);
-    }
+    if (record.length === 0) throw new NotFoundError("Column not found");
 
     return c.json(record[0]);
   },
@@ -712,9 +568,7 @@ kanban.delete(
       )
       .returning();
 
-    if (result.length === 0) {
-      return c.json({ error: "Column not found" }, 404);
-    }
+    if (result.length === 0) throw new NotFoundError("Column not found");
 
     return c.json({ message: "Column deleted" });
   },
@@ -731,84 +585,12 @@ kanban.post(
   requireWorkspaceOwner,
   sValidator("json", kanbanCardCreateSchema),
   async (c) => {
-    const boardId = c.req.param("boardId");
-    const columnId = c.req.param("columnId");
-    const data = c.req.valid("json");
-    const user = c.get("user")!;
-
-    // Verify column belongs to this board
-    const columnRecord = await db
-      .select()
-      .from(kanbanColumnTable)
-      .where(
-        and(
-          eq(kanbanColumnTable.id, columnId),
-          eq(kanbanColumnTable.boardId, boardId),
-        ),
-      )
-      .limit(1);
-
-    if (columnRecord.length === 0) {
-      return c.json({ error: "Column not found" }, 404);
-    }
-
-    // Validate labelIds if provided
-    if (data.labelIds && data.labelIds.length > 0) {
-      const boardLabelIds = new Set(await getBoardLabelIds(boardId));
-      const allValid = data.labelIds.every((id: string) =>
-        boardLabelIds.has(id),
-      );
-      if (!allValid) {
-        return c.json({ error: "Invalid label ID" }, 400);
-      }
-    }
-
-    // Validate assignees if provided
-    if (data.assignees && data.assignees.length > 0) {
-      const assigneeError = await validateAssignees(
-        data.assignees,
-        c.req.param("orgId")!,
-        c.req.param("workspaceId")!,
-      );
-      if (assigneeError) {
-        return c.json({ error: assigneeError }, 400);
-      }
-    }
-
-    const maxResult = await db
-      .select({ maxPos: max(kanbanCardTable.position) })
-      .from(kanbanCardTable)
-      .where(eq(kanbanCardTable.columnId, columnId));
-
-    const position = (maxResult[0]?.maxPos ?? 0) + 1.0;
-
-    const id = nanoid();
-    const now = new Date();
-
-    const { dueDate: dueDateStr, ...restData } = data;
-    const record = await db
-      .insert(kanbanCardTable)
-      .values({
-        id,
-        ...restData,
-        ...(dueDateStr !== undefined && {
-          dueDate: dueDateStr ? new Date(dueDateStr) : null,
-        }),
-        columnId,
-        position,
-        createdByUserId: user.id,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning();
-
-    const workspaceId = c.req.param("workspaceId")!;
-    dispatchEvent(c.req.param("orgId")!, workspaceId, "card.created", {
-      ...record[0],
-      boardId,
+    const { card } = await createCard(db, contextOf(c), {
+      ...c.req.valid("json"),
+      columnId: c.req.param("columnId"),
     });
 
-    return c.json(record[0], 201);
+    return c.json(card, 201);
   },
 );
 
@@ -821,69 +603,14 @@ kanban.put(
   requireWorkspaceOwner,
   sValidator("json", kanbanCardUpdateSchema),
   async (c) => {
-    const boardId = c.req.param("boardId");
-    const cardId = c.req.param("cardId");
-    const data = c.req.valid("json");
-    const user = c.get("user")!;
+    const { card } = await updateCard(
+      db,
+      contextOf(c),
+      c.req.param("cardId"),
+      c.req.valid("json"),
+    );
 
-    // Drop label IDs the board doesn't have rather than rejecting the update.
-    // A card can be left holding a deleted label's ID, and the dialog gives the
-    // user no way to see or deselect it — so rejecting would wedge the card.
-    // Saving it self-heals the card.
-    let labelIds = data.labelIds;
-    if (labelIds && labelIds.length > 0) {
-      labelIds = filterKnownLabelIds(labelIds, await getBoardLabelIds(boardId));
-    }
-
-    // Validate assignees if provided
-    if (data.assignees && data.assignees.length > 0) {
-      const assigneeError = await validateAssignees(
-        data.assignees,
-        c.req.param("orgId")!,
-        c.req.param("workspaceId")!,
-      );
-      if (assigneeError) {
-        return c.json({ error: assigneeError }, 400);
-      }
-    }
-
-    const { dueDate: dueDateStr, ...restData } = data;
-    const record = await db
-      .update(kanbanCardTable)
-      .set({
-        ...restData,
-        ...(labelIds !== undefined && { labelIds }),
-        ...(dueDateStr !== undefined && {
-          dueDate: dueDateStr ? new Date(dueDateStr) : null,
-        }),
-        lastEditedByUserId: user.id,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(kanbanCardTable.id, cardId),
-          inArray(
-            kanbanCardTable.columnId,
-            db
-              .select({ id: kanbanColumnTable.id })
-              .from(kanbanColumnTable)
-              .where(eq(kanbanColumnTable.boardId, boardId)),
-          ),
-        ),
-      )
-      .returning();
-
-    if (record.length === 0) {
-      return c.json({ error: "Card not found" }, 404);
-    }
-
-    const workspaceId = c.req.param("workspaceId")!;
-    dispatchEvent(c.req.param("orgId")!, workspaceId, "card.updated", {
-      ...record[0],
-      boardId,
-    });
-
-    return c.json(record[0]);
+    return c.json(card);
   },
 );
 
@@ -896,79 +623,12 @@ kanban.post(
   requireWorkspaceOwner,
   sValidator("json", kanbanCardMoveSchema),
   async (c) => {
-    const cardId = c.req.param("cardId");
-    const { columnId, afterCardId } = c.req.valid("json");
-    const user = c.get("user")!;
-
-    // Get cards in target column sorted by position
-    const cardsInColumn = await db
-      .select()
-      .from(kanbanCardTable)
-      .where(eq(kanbanCardTable.columnId, columnId))
-      .orderBy(asc(kanbanCardTable.position));
-
-    // Filter out the card being moved (in case it's in the same column)
-    const otherCards = cardsInColumn.filter((card) => card.id !== cardId);
-
-    let result: ReturnType<typeof calculateCardPosition>;
-    try {
-      result = calculateCardPosition(otherCards, afterCardId);
-    } catch {
-      return c.json({ error: "afterCardId not found in column" }, 400);
-    }
-
-    const { position, needsRebalance, afterIndex } = result;
-
-    if (needsRebalance) {
-      await db.transaction(async (tx) => {
-        const reorderedCards: { id: string; position: number }[] = [
-          ...otherCards,
-        ];
-        reorderedCards.splice(afterIndex + 1, 0, {
-          id: cardId,
-          position: 0,
-        });
-
-        for (let i = 0; i < reorderedCards.length; i++) {
-          await tx
-            .update(kanbanCardTable)
-            .set({
-              columnId,
-              position: (i + 1) * 1.0,
-              updatedAt: new Date(),
-              ...(reorderedCards[i].id === cardId
-                ? { lastEditedByUserId: user.id }
-                : {}),
-            })
-            .where(eq(kanbanCardTable.id, reorderedCards[i].id));
-        }
-      });
-    } else {
-      await db
-        .update(kanbanCardTable)
-        .set({
-          columnId,
-          position,
-          lastEditedByUserId: user.id,
-          updatedAt: new Date(),
-        })
-        .where(eq(kanbanCardTable.id, cardId));
-    }
-
-    const updated = await db
-      .select()
-      .from(kanbanCardTable)
-      .where(eq(kanbanCardTable.id, cardId))
-      .limit(1);
-
-    const workspaceId = c.req.param("workspaceId")!;
-    const boardId = c.req.param("boardId");
-    dispatchEvent(c.req.param("orgId")!, workspaceId, "card.updated", {
-      ...updated[0],
-      boardId,
+    const { card } = await moveCard(db, contextOf(c), {
+      cardId: c.req.param("cardId"),
+      ...c.req.valid("json"),
     });
 
-    return c.json(updated[0]);
+    return c.json(card);
   },
 );
 
@@ -980,79 +640,31 @@ kanban.delete(
   requireWorkspaceAccess,
   requireWorkspaceOwner,
   async (c) => {
-    const boardId = c.req.param("boardId");
-    const cardId = c.req.param("cardId");
-
-    const result = await db
-      .delete(kanbanCardTable)
-      .where(
-        and(
-          eq(kanbanCardTable.id, cardId),
-          inArray(
-            kanbanCardTable.columnId,
-            db
-              .select({ id: kanbanColumnTable.id })
-              .from(kanbanColumnTable)
-              .where(eq(kanbanColumnTable.boardId, boardId)),
-          ),
-        ),
-      )
-      .returning();
-
-    if (result.length === 0) {
-      return c.json({ error: "Card not found" }, 404);
-    }
-
-    const workspaceId = c.req.param("workspaceId")!;
-    dispatchEvent(c.req.param("orgId")!, workspaceId, "card.deleted", {
-      cardId,
-      boardId,
-      columnId: result[0].columnId,
-    });
-
+    await deleteCard(db, contextOf(c), c.req.param("cardId"));
     return c.json({ message: "Card deleted" });
   },
 );
 
 // --- Card Comments ---
 
-async function resolveCommentNames(
-  comments: (typeof kanbanCardCommentTable.$inferSelect)[],
-) {
-  const userIds = new Set<string>();
-  const agentIds = new Set<string>();
-  for (const comment of comments) {
-    if (comment.createdByUserId) userIds.add(comment.createdByUserId);
-    if (comment.createdByAgentId) agentIds.add(comment.createdByAgentId);
+/**
+ * A comment is addressed through its card, so one that belongs to a different
+ * card is not found at this URL even when both are on this board.
+ */
+const requireCommentOnCard = async (
+  c: Context<{ Variables: Variables }>,
+  commentId: string,
+) => {
+  const comment = await requireComment(db, scopeOf(c), commentId);
+  if (comment.cardId !== c.req.param("cardId")) {
+    throw new NotFoundError("Comment not found");
   }
+  return comment;
+};
 
-  const users =
-    userIds.size > 0
-      ? await db
-          .select({ id: user.id, name: user.name })
-          .from(user)
-          .where(inArray(user.id, Array.from(userIds)))
-      : [];
-  const userMap = new Map(users.map((u) => [u.id, u.name]));
-
-  const agents =
-    agentIds.size > 0
-      ? await db
-          .select({ id: agentTable.id, name: agentTable.name })
-          .from(agentTable)
-          .where(inArray(agentTable.id, Array.from(agentIds)))
-      : [];
-  const agentMap = new Map(agents.map((a) => [a.id, a.name]));
-
-  return comments.map((comment) => ({
-    ...comment,
-    createdByName: comment.createdByUserId
-      ? (userMap.get(comment.createdByUserId) ?? null)
-      : comment.createdByAgentId
-        ? (agentMap.get(comment.createdByAgentId) ?? null)
-        : null,
-  }));
-}
+/** Whether this user may edit or delete a comment somebody else wrote. */
+const canModerate = (c: Context<{ Variables: Variables }>) =>
+  isSuperAdmin(c.get("user")) || c.get("orgMembership")?.role === "admin";
 
 /** List comments for a card */
 kanban.get(
@@ -1061,40 +673,9 @@ kanban.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const boardId = c.req.param("boardId");
-    const cardId = c.req.param("cardId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const comments = await listComments(db, scopeOf(c), c.req.param("cardId"));
 
-    const cardRecord = await db
-      .select({ id: kanbanCardTable.id })
-      .from(kanbanCardTable)
-      .innerJoin(
-        kanbanColumnTable,
-        eq(kanbanCardTable.columnId, kanbanColumnTable.id),
-      )
-      .innerJoin(
-        kanbanBoardTable,
-        and(
-          eq(kanbanColumnTable.boardId, kanbanBoardTable.id),
-          eq(kanbanBoardTable.id, boardId),
-          eq(kanbanBoardTable.workspaceId, workspaceId),
-        ),
-      )
-      .where(eq(kanbanCardTable.id, cardId))
-      .limit(1);
-
-    if (cardRecord.length === 0) {
-      return c.json({ error: "Card not found" }, 404);
-    }
-
-    const comments = await db
-      .select()
-      .from(kanbanCardCommentTable)
-      .where(eq(kanbanCardCommentTable.cardId, cardId))
-      .orderBy(asc(kanbanCardCommentTable.createdAt));
-
-    const enriched = await resolveCommentNames(comments);
-    return c.json({ results: enriched });
+    return c.json({ results: await resolveCommentNames(db, comments) });
   },
 );
 
@@ -1106,50 +687,14 @@ kanban.post(
   requireWorkspaceAccess,
   sValidator("json", kanbanCardCommentCreateSchema),
   async (c) => {
-    const boardId = c.req.param("boardId");
-    const cardId = c.req.param("cardId");
-    const workspaceId = c.req.param("workspaceId")!;
-    const data = c.req.valid("json");
-    const currentUser = c.get("user")!;
+    const comment = await createComment(
+      db,
+      contextOf(c),
+      c.req.param("cardId"),
+      c.req.valid("json").body,
+    );
 
-    const cardRecord = await db
-      .select({ id: kanbanCardTable.id })
-      .from(kanbanCardTable)
-      .innerJoin(
-        kanbanColumnTable,
-        eq(kanbanCardTable.columnId, kanbanColumnTable.id),
-      )
-      .innerJoin(
-        kanbanBoardTable,
-        and(
-          eq(kanbanColumnTable.boardId, kanbanBoardTable.id),
-          eq(kanbanBoardTable.id, boardId),
-          eq(kanbanBoardTable.workspaceId, workspaceId),
-        ),
-      )
-      .where(eq(kanbanCardTable.id, cardId))
-      .limit(1);
-
-    if (cardRecord.length === 0) {
-      return c.json({ error: "Card not found" }, 404);
-    }
-
-    const id = nanoid();
-    const now = new Date();
-
-    const inserted = await db
-      .insert(kanbanCardCommentTable)
-      .values({
-        id,
-        cardId,
-        body: data.body,
-        createdByUserId: currentUser.id,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning();
-
-    const [enriched] = await resolveCommentNames(inserted);
+    const [enriched] = await resolveCommentNames(db, [comment]);
     return c.json(enriched, 201);
   },
 );
@@ -1162,47 +707,20 @@ kanban.put(
   requireWorkspaceAccess,
   sValidator("json", kanbanCardCommentUpdateSchema),
   async (c) => {
-    const cardId = c.req.param("cardId");
     const commentId = c.req.param("commentId");
-    const data = c.req.valid("json");
-    const currentUser = c.get("user")!;
-    const orgMembership = c.get("orgMembership");
+    const existing = await requireCommentOnCard(c, commentId);
 
-    // Fetch the comment to check ownership
-    const [existingComment] = await db
-      .select()
-      .from(kanbanCardCommentTable)
-      .where(
-        and(
-          eq(kanbanCardCommentTable.id, commentId),
-          eq(kanbanCardCommentTable.cardId, cardId),
-        ),
-      )
-      .limit(1);
-
-    if (!existingComment) {
-      return c.json({ error: "Comment not found" }, 404);
-    }
-
-    // Check ownership: super admins, org admins can moderate; others must own the comment
-    const canModerate =
-      isSuperAdmin(currentUser) || orgMembership?.role === "admin";
-    if (!canModerate && existingComment.createdByUserId !== currentUser.id) {
+    if (!canModerate(c) && existing.createdByUserId !== c.get("user")!.id) {
       return c.json({ error: "You can only edit your own comments" }, 403);
     }
 
-    const updated = await db
-      .update(kanbanCardCommentTable)
-      .set({ ...data, updatedAt: new Date() })
-      .where(
-        and(
-          eq(kanbanCardCommentTable.id, commentId),
-          eq(kanbanCardCommentTable.cardId, cardId),
-        ),
-      )
-      .returning();
+    const updated = await updateCommentBody(
+      db,
+      existing,
+      c.req.valid("json").body ?? existing.body,
+    );
 
-    const [enriched] = await resolveCommentNames(updated);
+    const [enriched] = await resolveCommentNames(db, [updated]);
     return c.json(enriched);
   },
 );
@@ -1214,43 +732,14 @@ kanban.delete(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const cardId = c.req.param("cardId");
     const commentId = c.req.param("commentId");
-    const currentUser = c.get("user")!;
-    const orgMembership = c.get("orgMembership");
+    const existing = await requireCommentOnCard(c, commentId);
 
-    // Fetch the comment to check ownership
-    const [existingComment] = await db
-      .select()
-      .from(kanbanCardCommentTable)
-      .where(
-        and(
-          eq(kanbanCardCommentTable.id, commentId),
-          eq(kanbanCardCommentTable.cardId, cardId),
-        ),
-      )
-      .limit(1);
-
-    if (!existingComment) {
-      return c.json({ error: "Comment not found" }, 404);
-    }
-
-    // Check ownership: super admins, org admins can moderate; others must own the comment
-    const canModerate =
-      isSuperAdmin(currentUser) || orgMembership?.role === "admin";
-    if (!canModerate && existingComment.createdByUserId !== currentUser.id) {
+    if (!canModerate(c) && existing.createdByUserId !== c.get("user")!.id) {
       return c.json({ error: "You can only delete your own comments" }, 403);
     }
 
-    await db
-      .delete(kanbanCardCommentTable)
-      .where(
-        and(
-          eq(kanbanCardCommentTable.id, commentId),
-          eq(kanbanCardCommentTable.cardId, cardId),
-        ),
-      );
-
+    await removeComment(db, existing);
     return c.json({ success: true });
   },
 );

--- a/apps/backend/src/services/kanban.test.ts
+++ b/apps/backend/src/services/kanban.test.ts
@@ -1,0 +1,326 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { asDb, createMockDb, type MockDb } from "../test-utils.ts";
+
+vi.mock("./event-dispatch.ts", () => ({
+  dispatchEvent: vi.fn(),
+}));
+
+import { NotFoundError, ValidationError } from "../errors.ts";
+import {
+  applyBodyDiff,
+  bulkUpdateCards,
+  keepKnownLabelIds,
+  placeCardInColumn,
+  rebalancedPositions,
+  requireCard,
+  requireKnownLabelIds,
+  requireValidAssignees,
+  type KanbanContext,
+} from "./kanban.ts";
+
+const scope = { orgId: "org-1", workspaceId: "ws-1" };
+const ctx: KanbanContext = { ...scope, actor: { agentId: "agent-1" } };
+
+describe("kanban module", () => {
+  let db: MockDb;
+
+  beforeEach(() => {
+    db = createMockDb();
+  });
+
+  describe("requireCard", () => {
+    it("returns the card with the board it sits on", async () => {
+      db.limit.mockResolvedValue([
+        { id: "card-1", columnId: "col-1", boardId: "board-1" },
+      ]);
+
+      expect(await requireCard(asDb(db), scope, "card-1")).toEqual({
+        id: "card-1",
+        columnId: "col-1",
+        boardId: "board-1",
+      });
+    });
+
+    it("rejects a card that is out of scope", async () => {
+      db.limit.mockResolvedValue([]);
+
+      await expect(requireCard(asDb(db), scope, "card-1")).rejects.toThrow(
+        NotFoundError,
+      );
+    });
+  });
+
+  describe("label rules", () => {
+    const boardHasLabels = (ids: string[]) =>
+      db.limit.mockResolvedValue([{ labels: ids.map((id) => ({ id })) }]);
+
+    it("rejects a create that names a label the board does not have", async () => {
+      boardHasLabels(["lbl-a"]);
+
+      await expect(
+        requireKnownLabelIds(asDb(db), "board-1", ["lbl-a", "lbl-ghost"]),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("accepts a create whose labels are all on the board", async () => {
+      boardHasLabels(["lbl-a", "lbl-b"]);
+
+      await expect(
+        requireKnownLabelIds(asDb(db), "board-1", ["lbl-b"]),
+      ).resolves.toBeUndefined();
+    });
+
+    it("drops unknown labels on an update, keeping the submitted order", async () => {
+      boardHasLabels(["lbl-a", "lbl-b"]);
+
+      expect(
+        await keepKnownLabelIds(asDb(db), "board-1", [
+          "lbl-b",
+          "lbl-ghost",
+          "lbl-a",
+        ]),
+      ).toEqual(["lbl-b", "lbl-a"]);
+    });
+
+    it("asks the board nothing when no labels were submitted", async () => {
+      expect(await keepKnownLabelIds(asDb(db), "board-1", [])).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("assignee rules", () => {
+    it("passes an org member", async () => {
+      db.where.mockResolvedValueOnce([{ userId: "user-1" }]); // org member
+      db.where.mockResolvedValueOnce([]); // super admin
+
+      await expect(
+        requireValidAssignees(
+          asDb(db),
+          [{ type: "user", id: "user-1" }],
+          scope,
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it("passes a super admin, who holds no membership row", async () => {
+      db.where.mockResolvedValueOnce([]); // org member — none
+      db.where.mockResolvedValueOnce([{ id: "admin-1" }]); // super admin
+
+      await expect(
+        requireValidAssignees(
+          asDb(db),
+          [{ type: "user", id: "admin-1" }],
+          scope,
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects a user who is neither", async () => {
+      db.where.mockResolvedValueOnce([]); // org member — none
+      db.where.mockResolvedValueOnce([]); // super admin — none
+
+      await expect(
+        requireValidAssignees(
+          asDb(db),
+          [{ type: "user", id: "outsider" }],
+          scope,
+        ),
+      ).rejects.toThrow("Invalid user assignee");
+    });
+
+    it("passes a Shared agent attached to this workspace", async () => {
+      db.where.mockResolvedValueOnce([]); // no workspace-scoped agent
+      db.where.mockResolvedValueOnce([
+        { agent: { id: "shared-agent" }, attachment: { id: "att-1" } },
+      ]);
+
+      await expect(
+        requireValidAssignees(
+          asDb(db),
+          [{ type: "agent", id: "shared-agent" }],
+          scope,
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects an agent that is not visible here", async () => {
+      db.where.mockResolvedValueOnce([]); // no workspace-scoped agent
+      db.where.mockResolvedValueOnce([]); // no attached org-scoped agent
+
+      await expect(
+        requireValidAssignees(
+          asDb(db),
+          [{ type: "agent", id: "someone-elses-agent" }],
+          scope,
+        ),
+      ).rejects.toThrow("Invalid agent assignee");
+    });
+
+    it("asks nothing when there are no assignees", async () => {
+      await expect(
+        requireValidAssignees(asDb(db), [], scope),
+      ).resolves.toBeUndefined();
+      expect(db.select).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("placeCardInColumn", () => {
+    it("appends past the last card when no anchor is given", async () => {
+      db.where.mockResolvedValue([{ maxPos: 3 }]);
+
+      expect(
+        await placeCardInColumn(asDb(db), {
+          columnId: "col-1",
+          afterCardId: undefined,
+        }),
+      ).toBe(4);
+    });
+
+    it("starts at 1 in an empty column", async () => {
+      db.where.mockResolvedValue([{ maxPos: null }]);
+
+      expect(
+        await placeCardInColumn(asDb(db), {
+          columnId: "col-1",
+          afterCardId: undefined,
+        }),
+      ).toBe(1);
+    });
+
+    it("halves the gap ahead of the first card for a null anchor", async () => {
+      db.orderBy.mockResolvedValue([
+        { id: "card-2", position: 1.0 },
+        { id: "card-3", position: 2.0 },
+      ]);
+
+      expect(
+        await placeCardInColumn(asDb(db), {
+          columnId: "col-1",
+          afterCardId: null,
+        }),
+      ).toBe(0.5);
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it("leaves the moved card out of the ordering it is re-entering", async () => {
+      db.orderBy.mockResolvedValue([
+        { id: "card-1", position: 1.0 },
+        { id: "card-2", position: 2.0 },
+      ]);
+
+      // Only card-2 remains, so landing after it appends rather than halving.
+      expect(
+        await placeCardInColumn(asDb(db), {
+          columnId: "col-1",
+          afterCardId: "card-2",
+          excludeCardId: "card-1",
+        }),
+      ).toBe(3);
+    });
+
+    it("renumbers the column when the gap has collapsed", async () => {
+      db.orderBy.mockResolvedValue([
+        { id: "card-2", position: 1.0 },
+        { id: "card-3", position: 1.0000001 }, // gap < 0.001
+      ]);
+
+      expect(
+        await placeCardInColumn(asDb(db), {
+          columnId: "col-1",
+          afterCardId: "card-2",
+        }),
+      ).toBe(2);
+
+      // The card ahead keeps slot 1, the one behind moves to 3, and the
+      // arriving card takes the 2 they leave between them.
+      expect(db.set.mock.calls.map((call) => call[0])).toEqual([
+        expect.objectContaining({ position: 1 }),
+        expect.objectContaining({ position: 3 }),
+      ]);
+    });
+
+    it("rejects an anchor that is not in the column", async () => {
+      db.orderBy.mockResolvedValue([{ id: "card-2", position: 1.0 }]);
+
+      await expect(
+        placeCardInColumn(asDb(db), {
+          columnId: "col-1",
+          afterCardId: "ghost",
+        }),
+      ).rejects.toThrow("afterCardId not found in column");
+    });
+  });
+
+  describe("rebalancedPositions", () => {
+    it("leaves the slot just after the anchor free", () => {
+      expect(
+        rebalancedPositions([{ id: "a" }, { id: "b" }, { id: "c" }], 1),
+      ).toEqual([
+        { id: "a", position: 1 },
+        { id: "b", position: 2 },
+        { id: "c", position: 4 },
+      ]);
+    });
+  });
+
+  describe("applyBodyDiff", () => {
+    it("applies search-replace pairs in order", () => {
+      expect(
+        applyBodyDiff("foo bar", [
+          { search: "foo", replace: "qux" },
+          { search: "bar", replace: "quux" },
+        ]),
+      ).toBe("qux quux");
+    });
+
+    it("adds content at either boundary", () => {
+      expect(applyBodyDiff("body", { mode: "append", content: "!" })).toBe(
+        "body!",
+      );
+      expect(applyBodyDiff("body", { mode: "prepend", content: "!" })).toBe(
+        "!body",
+      );
+    });
+
+    it("refuses a diff written against a body it does not match", () => {
+      expect(() =>
+        applyBodyDiff("body", [{ search: "missing", replace: "x" }]),
+      ).toThrow(ValidationError);
+    });
+  });
+
+  describe("bulkUpdateCards", () => {
+    it("reports the cards it could not reach and updates the rest", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([]); // card-2 is out of scope
+      db.returning.mockResolvedValue([{ id: "card-1" }]);
+
+      expect(
+        await bulkUpdateCards(asDb(db), ctx, {
+          cardIds: ["card-1", "card-2"],
+          priority: "high",
+        }),
+      ).toEqual([
+        { cardId: "card-1", success: true },
+        { cardId: "card-2", success: false, error: "Card not found" },
+      ]);
+      expect(db.set).toHaveBeenCalledTimes(1);
+    });
+
+    it("refuses the whole batch when the assignee cannot work here", async () => {
+      db.where.mockResolvedValueOnce([]); // org member — none
+      db.where.mockResolvedValueOnce([]); // super admin — none
+
+      await expect(
+        bulkUpdateCards(asDb(db), ctx, {
+          cardIds: ["card-1"],
+          assignees: [{ type: "user", id: "outsider" }],
+        }),
+      ).rejects.toThrow("Invalid user assignee");
+      expect(db.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/services/kanban.ts
+++ b/apps/backend/src/services/kanban.ts
@@ -1,0 +1,1088 @@
+import { and, asc, eq, inArray, max } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import type {
+  KanbanCardAssignee,
+  KanbanCardPriority,
+  WebhookEvent,
+} from "@platypus/schemas";
+import { db } from "../index.ts";
+import {
+  kanbanBoard as kanbanBoardTable,
+  kanbanColumn as kanbanColumnTable,
+  kanbanCard as kanbanCardTable,
+  kanbanCardComment as kanbanCardCommentTable,
+  agent as agentTable,
+  organizationMember as organizationMemberTable,
+} from "../db/schema.ts";
+import { user } from "../db/auth-schema.ts";
+import { NotFoundError, ValidationError } from "../errors.ts";
+import { dispatchEvent } from "./event-dispatch.ts";
+import { listScopedByIds } from "./scoped-resource.ts";
+import { calculateCardPosition } from "../utils/kanban-positioning.ts";
+import {
+  filterKnownLabelIds,
+  pruneCardLabelIds,
+} from "../utils/kanban-labels.ts";
+
+/**
+ * The Kanban board's write model: every rule and mutation the board has, in one
+ * place, behind an interface both surfaces call. The HTTP routes and the Agent
+ * Tool set are adapters over it — they parse and authorize their own input,
+ * call in here, and shape the result (an HTTP envelope, a tool result). The two
+ * used to carry a copy each and had already drifted apart, so an Agent could
+ * write a label the board does not have and an assignee who cannot work here.
+ *
+ * Who is acting is a parameter (`KanbanActor`), which is all that separates a
+ * human edit from an Agent's: the attribution column written, and whether the
+ * dispatched event carries the acting Agent.
+ *
+ * Failures are the typed errors of ADR-0010 — routes let `app.onError` map them
+ * to a status, the Tool adapter maps them to its `{ error }` result.
+ */
+
+/** Who is performing the mutation — one of a Workspace member or an Agent. */
+export type KanbanActor = { userId: string } | { agentId: string };
+
+/**
+ * Where a lookup may reach. `boardId` narrows it to a single board (the HTTP
+ * surface, which addresses cards through their board); left out, any board in
+ * the Workspace matches (the Tool surface, whose Agent works Workspace-wide).
+ * Either way the Workspace is the outer boundary — nothing resolves across it.
+ */
+export type KanbanScope = {
+  orgId: string;
+  workspaceId: string;
+  boardId?: string;
+};
+
+/** A scope plus the actor, for the mutating entry points. */
+export type KanbanContext = KanbanScope & { actor: KanbanActor };
+
+/** A card's identity and where it sits — what the guards resolve. */
+export type CardRef = { id: string; columnId: string; boardId: string };
+
+/** A column's identity and the board it belongs to. */
+export type ColumnRef = { id: string; boardId: string };
+
+/** A comment row, as the guards return it. */
+export type CommentRow = typeof kanbanCardCommentTable.$inferSelect;
+
+/** A card row as stored. */
+export type CardRow = typeof kanbanCardTable.$inferSelect;
+
+/** A board row as stored. */
+export type BoardRow = typeof kanbanBoardTable.$inferSelect;
+
+/**
+ * A written card and the board it is on. The board comes back with it because
+ * a card row does not name its board — only its column — and both surfaces
+ * need it: to announce the change, and to link to it.
+ */
+export type CardResult = { card: CardRow; boardId: string };
+
+type Database = typeof db;
+type Transaction = Parameters<Parameters<Database["transaction"]>[0]>[0];
+
+/** Any query runner — the top-level `db` or a transaction handle. */
+type Executor = Database | Transaction;
+
+/** The fields a card mutation accepts, whichever surface it arrived on. */
+export type CardInput = {
+  title?: string;
+  body?: string | null;
+  /** A partial edit of the body, resolved against what the card holds now. */
+  bodyDiff?: BodyDiff;
+  labelIds?: string[];
+  assignees?: KanbanCardAssignee[];
+  dueDate?: string | null;
+  priority?: KanbanCardPriority;
+};
+
+/**
+ * A partial edit of a card's body: an ordered list of search/replace pairs, or
+ * a single addition at one end. Offered by the Tool surface so an Agent can
+ * amend a long body without resending it.
+ */
+export type BodyDiff =
+  | { search: string; replace: string }[]
+  | { mode: "append" | "prepend"; content: string };
+
+// --- Actor ---
+
+const isAgent = (actor: KanbanActor): actor is { agentId: string } =>
+  "agentId" in actor;
+
+/** The attribution columns for a row this actor is creating. */
+const createdBy = (actor: KanbanActor) =>
+  isAgent(actor)
+    ? { createdByAgentId: actor.agentId }
+    : { createdByUserId: actor.userId };
+
+/** The attribution columns for a row this actor is editing. */
+const lastEditedBy = (actor: KanbanActor) =>
+  isAgent(actor)
+    ? { lastEditedByAgentId: actor.agentId }
+    : { lastEditedByUserId: actor.userId };
+
+/**
+ * Emits a board event. The acting Agent rides along on Agent-originated writes
+ * so an event trigger does not re-fire on its own agent's work (see #267);
+ * human writes carry no actor.
+ */
+const dispatch = (ctx: KanbanContext, event: WebhookEvent, data: unknown) =>
+  dispatchEvent(
+    ctx.orgId,
+    ctx.workspaceId,
+    event,
+    data,
+    isAgent(ctx.actor) ? { actorAgentId: ctx.actor.agentId } : undefined,
+  );
+
+// --- Scope guards ---
+
+/** The board-side condition every guard joins through: Workspace, then board. */
+const withinScope = (scope: KanbanScope) =>
+  and(
+    eq(kanbanBoardTable.workspaceId, scope.workspaceId),
+    scope.boardId ? eq(kanbanBoardTable.id, scope.boardId) : undefined,
+  );
+
+/** The board itself, or `NotFoundError` when it is out of scope. */
+export const requireBoard = async (
+  database: Database,
+  scope: KanbanScope,
+  boardId: string,
+): Promise<BoardRow> => {
+  const rows = await database
+    .select()
+    .from(kanbanBoardTable)
+    .where(and(eq(kanbanBoardTable.id, boardId), withinScope(scope)))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) throw new NotFoundError("Board not found");
+  return row;
+};
+
+/**
+ * The card, with the board it lives on — or `NotFoundError` when it is out of
+ * scope. Resolving the board here is what lets callers dispatch events and
+ * build links without a second lookup.
+ */
+export const requireCard = async (
+  database: Database,
+  scope: KanbanScope,
+  cardId: string,
+): Promise<CardRef> => {
+  const rows = await database
+    .select({
+      id: kanbanCardTable.id,
+      columnId: kanbanCardTable.columnId,
+      boardId: kanbanColumnTable.boardId,
+    })
+    .from(kanbanCardTable)
+    .innerJoin(
+      kanbanColumnTable,
+      eq(kanbanCardTable.columnId, kanbanColumnTable.id),
+    )
+    .innerJoin(
+      kanbanBoardTable,
+      and(
+        eq(kanbanColumnTable.boardId, kanbanBoardTable.id),
+        withinScope(scope),
+      ),
+    )
+    .where(eq(kanbanCardTable.id, cardId))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) throw new NotFoundError("Card not found");
+  return row;
+};
+
+/** The column, with its board — or `NotFoundError` when it is out of scope. */
+const requireColumn = async (
+  database: Database,
+  scope: KanbanScope,
+  columnId: string,
+): Promise<ColumnRef> => {
+  const rows = await database
+    .select({
+      id: kanbanColumnTable.id,
+      boardId: kanbanColumnTable.boardId,
+    })
+    .from(kanbanColumnTable)
+    .innerJoin(
+      kanbanBoardTable,
+      and(
+        eq(kanbanColumnTable.boardId, kanbanBoardTable.id),
+        withinScope(scope),
+      ),
+    )
+    .where(eq(kanbanColumnTable.id, columnId))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) throw new NotFoundError("Column not found");
+  return row;
+};
+
+/**
+ * The comment — or `NotFoundError` when its card is out of scope. Returns the
+ * whole row because every caller needs it: to check who wrote it, or to hand
+ * it back.
+ */
+export const requireComment = async (
+  database: Database,
+  scope: KanbanScope,
+  commentId: string,
+): Promise<CommentRow> => {
+  const rows = await database
+    .select({
+      id: kanbanCardCommentTable.id,
+      cardId: kanbanCardCommentTable.cardId,
+      body: kanbanCardCommentTable.body,
+      createdByUserId: kanbanCardCommentTable.createdByUserId,
+      createdByAgentId: kanbanCardCommentTable.createdByAgentId,
+      createdAt: kanbanCardCommentTable.createdAt,
+      updatedAt: kanbanCardCommentTable.updatedAt,
+    })
+    .from(kanbanCardCommentTable)
+    .innerJoin(
+      kanbanCardTable,
+      eq(kanbanCardCommentTable.cardId, kanbanCardTable.id),
+    )
+    .innerJoin(
+      kanbanColumnTable,
+      eq(kanbanCardTable.columnId, kanbanColumnTable.id),
+    )
+    .innerJoin(
+      kanbanBoardTable,
+      and(
+        eq(kanbanColumnTable.boardId, kanbanBoardTable.id),
+        withinScope(scope),
+      ),
+    )
+    .where(eq(kanbanCardCommentTable.id, commentId))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) throw new NotFoundError("Comment not found");
+  return row;
+};
+
+// --- Labels ---
+
+/** The board's label IDs, or an empty list if the board has none. */
+const boardLabelIds = async (
+  database: Database,
+  boardId: string,
+): Promise<string[]> => {
+  const rows = await database
+    .select({ labels: kanbanBoardTable.labels })
+    .from(kanbanBoardTable)
+    .where(eq(kanbanBoardTable.id, boardId))
+    .limit(1);
+
+  return (rows[0]?.labels ?? []).map((label: { id: string }) => label.id);
+};
+
+/**
+ * Rejects the write when it names a label the board does not have. Used where
+ * the labels are chosen fresh (creating a card): there is nothing to
+ * self-heal, so an unknown ID is a mistake worth surfacing.
+ */
+export const requireKnownLabelIds = async (
+  database: Database,
+  boardId: string,
+  labelIds: string[] | undefined,
+): Promise<void> => {
+  if (!labelIds || labelIds.length === 0) return;
+  const known = new Set(await boardLabelIds(database, boardId));
+  if (!labelIds.every((id) => known.has(id))) {
+    throw new ValidationError("Invalid label ID");
+  }
+};
+
+/**
+ * Drops the label IDs the board no longer has, keeping the rest in the order
+ * submitted. Used where the labels come back from an existing card: it may be
+ * holding a deleted label's ID that the editor never shows, so rejecting would
+ * wedge the card while saving self-heals it.
+ */
+export const keepKnownLabelIds = async (
+  database: Database,
+  boardId: string,
+  labelIds: string[],
+): Promise<string[]> =>
+  labelIds.length === 0
+    ? labelIds
+    : filterKnownLabelIds(labelIds, await boardLabelIds(database, boardId));
+
+/**
+ * Removes label IDs the board no longer has from every card on that board.
+ * Board labels are an array on the board record and cards reference them by ID,
+ * so deleting a label would otherwise leave cards holding an ID that resolves
+ * to nothing. Only removes IDs — a card never gains a label here.
+ */
+export const pruneCardLabelsForBoard = async (
+  executor: Executor,
+  boardId: string,
+  labels: { id: string }[],
+): Promise<void> => {
+  const cards = await executor
+    .select({ id: kanbanCardTable.id, labelIds: kanbanCardTable.labelIds })
+    .from(kanbanCardTable)
+    .where(
+      inArray(
+        kanbanCardTable.columnId,
+        executor
+          .select({ id: kanbanColumnTable.id })
+          .from(kanbanColumnTable)
+          .where(eq(kanbanColumnTable.boardId, boardId)),
+      ),
+    );
+
+  const stale = pruneCardLabelIds(
+    cards,
+    labels.map((label) => label.id),
+  );
+
+  for (const card of stale) {
+    await executor
+      .update(kanbanCardTable)
+      .set({ labelIds: card.labelIds, updatedAt: new Date() })
+      .where(eq(kanbanCardTable.id, card.id));
+  }
+};
+
+// --- Assignees ---
+
+/**
+ * Rejects assignees that cannot own a card here: a user must be a member of
+ * the Organization (or a super admin, who has no membership row), and an Agent
+ * must be visible in this Workspace — its own, plus the Shared Agents attached
+ * to it (ADR-0007). That is the set the assignee picker offers and the set that
+ * can actually run here.
+ */
+export const requireValidAssignees = async (
+  database: Database,
+  assignees: KanbanCardAssignee[] | undefined,
+  scope: Pick<KanbanScope, "orgId" | "workspaceId">,
+): Promise<void> => {
+  if (!assignees || assignees.length === 0) return;
+
+  const userIds = assignees.filter((a) => a.type === "user").map((a) => a.id);
+  const agentIds = assignees.filter((a) => a.type === "agent").map((a) => a.id);
+
+  const [members, superAdmins, agentRecords] = await Promise.all([
+    userIds.length > 0
+      ? database
+          .select({ userId: organizationMemberTable.userId })
+          .from(organizationMemberTable)
+          .where(
+            and(
+              eq(organizationMemberTable.organizationId, scope.orgId),
+              inArray(organizationMemberTable.userId, userIds),
+            ),
+          )
+      : Promise.resolve([]),
+    userIds.length > 0
+      ? database
+          .select({ id: user.id })
+          .from(user)
+          .where(and(eq(user.role, "admin"), inArray(user.id, userIds)))
+      : Promise.resolve([]),
+    listScopedByIds(database, "agent", agentIds, {
+      orgId: scope.orgId,
+      wsId: scope.workspaceId,
+    }),
+  ]);
+
+  // Super admins may hold no org membership record, so the two sets combine.
+  const validUserIds = new Set([
+    ...members.map((m) => m.userId),
+    ...superAdmins.map((a) => a.id),
+  ]);
+  if (validUserIds.size < userIds.length) {
+    throw new ValidationError("Invalid user assignee");
+  }
+  if (agentRecords.length !== agentIds.length) {
+    throw new ValidationError("Invalid agent assignee");
+  }
+};
+
+// --- Positions ---
+
+/** The tables ordered by a `position` float within a parent. */
+type PositionedTable = typeof kanbanCardTable | typeof kanbanColumnTable;
+
+/** One past the highest position in the group — the append-to-end slot. */
+const nextPosition = async (
+  executor: Executor,
+  table: PositionedTable,
+  parent: ReturnType<typeof eq>,
+): Promise<number> => {
+  const rows = await executor
+    .select({ maxPos: max(table.position) })
+    .from(table)
+    .where(parent);
+
+  return (rows[0]?.maxPos ?? 0) + 1.0;
+};
+
+/** The position a card appended to the end of a column would take. */
+const nextCardPosition = (
+  executor: Executor,
+  columnId: string,
+): Promise<number> =>
+  nextPosition(
+    executor,
+    kanbanCardTable,
+    eq(kanbanCardTable.columnId, columnId),
+  );
+
+/** The position a column appended to the end of a board would take. */
+export const nextColumnPosition = (
+  executor: Executor,
+  boardId: string,
+): Promise<number> =>
+  nextPosition(
+    executor,
+    kanbanColumnTable,
+    eq(kanbanColumnTable.boardId, boardId),
+  );
+
+/**
+ * Whole positions for a column's existing cards once one more is inserted just
+ * after `afterIndex` — the renumbering that reopens the gaps after repeated
+ * halving has closed them. The inserted card takes `afterIndex + 2`, the slot
+ * this leaves free.
+ */
+export const rebalancedPositions = (
+  cards: { id: string }[],
+  afterIndex: number,
+): { id: string; position: number }[] =>
+  cards.map((card, index) => ({
+    id: card.id,
+    position: (index <= afterIndex ? index + 1 : index + 2) * 1.0,
+  }));
+
+/**
+ * Where a card lands in a column, rebalancing the column first if the gap it
+ * would take has collapsed. `afterCardId` is the card to sit behind: `null`
+ * puts it at the head, `undefined` at the end.
+ *
+ * The single home for the board's ordering arithmetic — moving a card, copying
+ * one, and appending one all resolve their position through here.
+ */
+export const placeCardInColumn = async (
+  executor: Executor,
+  input: {
+    columnId: string;
+    afterCardId: string | null | undefined;
+    /** The card being moved, left out of the ordering it is re-entering. */
+    excludeCardId?: string;
+  },
+): Promise<number> => {
+  if (input.afterCardId === undefined) {
+    return nextCardPosition(executor, input.columnId);
+  }
+
+  const cardsInColumn = await executor
+    .select({ id: kanbanCardTable.id, position: kanbanCardTable.position })
+    .from(kanbanCardTable)
+    .where(eq(kanbanCardTable.columnId, input.columnId))
+    .orderBy(asc(kanbanCardTable.position));
+
+  const otherCards = cardsInColumn.filter(
+    (card) => card.id !== input.excludeCardId,
+  );
+
+  let result: ReturnType<typeof calculateCardPosition>;
+  try {
+    result = calculateCardPosition(otherCards, input.afterCardId);
+  } catch {
+    throw new ValidationError("afterCardId not found in column");
+  }
+
+  if (!result.needsRebalance) return result.position;
+
+  for (const card of rebalancedPositions(otherCards, result.afterIndex)) {
+    await executor
+      .update(kanbanCardTable)
+      .set({ position: card.position, updatedAt: new Date() })
+      .where(eq(kanbanCardTable.id, card.id));
+  }
+  return (result.afterIndex + 2) * 1.0;
+};
+
+// --- Card body ---
+
+/** The card's body as stored, or an empty string when it has none. */
+const currentBody = async (
+  database: Database,
+  cardId: string,
+): Promise<string> => {
+  const rows = await database
+    .select({ body: kanbanCardTable.body })
+    .from(kanbanCardTable)
+    .where(eq(kanbanCardTable.id, cardId))
+    .limit(1);
+
+  return rows[0]?.body ?? "";
+};
+
+/**
+ * Applies a partial body edit. Search/replace pairs are applied in order and
+ * each must match, so a diff written against a stale body fails loudly rather
+ * than landing half-applied.
+ */
+export const applyBodyDiff = (body: string, diff: BodyDiff): string => {
+  if (!Array.isArray(diff)) {
+    return diff.mode === "append" ? body + diff.content : diff.content + body;
+  }
+
+  let next = body;
+  for (const op of diff) {
+    if (!next.includes(op.search)) {
+      throw new ValidationError(
+        `bodyDiff search string not found: "${op.search}"`,
+      );
+    }
+    next = next.replace(op.search, op.replace);
+  }
+  return next;
+};
+
+// --- Card mutations ---
+
+/** The columns a card write sets, from the fields the caller supplied. */
+const cardValues = (input: CardInput, body: string | null | undefined) => ({
+  ...(input.title !== undefined && { title: input.title }),
+  ...(body !== undefined && { body }),
+  ...(input.labelIds !== undefined && { labelIds: input.labelIds }),
+  ...(input.assignees !== undefined && { assignees: input.assignees }),
+  ...(input.dueDate !== undefined && {
+    dueDate: input.dueDate ? new Date(input.dueDate) : null,
+  }),
+  ...(input.priority !== undefined && { priority: input.priority }),
+});
+
+/**
+ * Creates a card at the end of a column. Labels are checked against the board
+ * and assignees against the Workspace before anything is written.
+ */
+export const createCard = async (
+  database: Database,
+  ctx: KanbanContext,
+  input: CardInput & { columnId: string; title: string },
+): Promise<CardResult> => {
+  const column = await requireColumn(database, ctx, input.columnId);
+  await requireKnownLabelIds(database, column.boardId, input.labelIds);
+  await requireValidAssignees(database, input.assignees, ctx);
+
+  const position = await nextCardPosition(database, input.columnId);
+  const now = new Date();
+
+  const rows = await database
+    .insert(kanbanCardTable)
+    .values({
+      id: nanoid(),
+      columnId: input.columnId,
+      title: input.title,
+      labelIds: input.labelIds ?? [],
+      assignees: input.assignees ?? [],
+      priority: input.priority ?? "none",
+      ...cardValues(input, input.body),
+      position,
+      ...createdBy(ctx.actor),
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  const card = rows[0];
+  dispatch(ctx, "card.created", { ...card, boardId: column.boardId });
+  return { card, boardId: column.boardId };
+};
+
+/**
+ * Updates a card in place. Unknown label IDs are dropped rather than rejected
+ * (the card may be carrying one the board has since deleted); an assignee who
+ * cannot work here is rejected.
+ */
+export const updateCard = async (
+  database: Database,
+  ctx: KanbanContext,
+  cardId: string,
+  input: CardInput,
+): Promise<CardResult> => {
+  const card = await requireCard(database, ctx, cardId);
+
+  const labelIds =
+    input.labelIds === undefined
+      ? undefined
+      : await keepKnownLabelIds(database, card.boardId, input.labelIds);
+  await requireValidAssignees(database, input.assignees, ctx);
+
+  const body =
+    input.bodyDiff === undefined
+      ? input.body
+      : applyBodyDiff(await currentBody(database, cardId), input.bodyDiff);
+
+  const rows = await database
+    .update(kanbanCardTable)
+    .set({
+      ...cardValues(input, body),
+      ...(labelIds !== undefined && { labelIds }),
+      ...lastEditedBy(ctx.actor),
+      updatedAt: new Date(),
+    })
+    .where(eq(kanbanCardTable.id, cardId))
+    .returning();
+
+  const record = rows[0];
+  if (!record) throw new NotFoundError("Card not found");
+
+  dispatch(ctx, "card.updated", { ...record, boardId: card.boardId });
+  return { card: record, boardId: card.boardId };
+};
+
+/**
+ * Moves a card within or between columns. Both the card and the target column
+ * must be in scope, so a move never carries a card off its board on the HTTP
+ * surface or out of the Workspace on the Tool surface.
+ */
+export const moveCard = async (
+  database: Database,
+  ctx: KanbanContext,
+  input: { cardId: string; columnId: string; afterCardId: string | null },
+): Promise<CardResult> => {
+  await requireCard(database, ctx, input.cardId);
+  const column = await requireColumn(database, ctx, input.columnId);
+
+  const record = await database.transaction(async (tx) => {
+    const position = await placeCardInColumn(tx, {
+      columnId: input.columnId,
+      afterCardId: input.afterCardId,
+      excludeCardId: input.cardId,
+    });
+
+    const rows = await tx
+      .update(kanbanCardTable)
+      .set({
+        columnId: input.columnId,
+        position,
+        ...lastEditedBy(ctx.actor),
+        updatedAt: new Date(),
+      })
+      .where(eq(kanbanCardTable.id, input.cardId))
+      .returning();
+
+    return rows[0];
+  });
+
+  dispatch(ctx, "card.updated", { ...record, boardId: column.boardId });
+  return { card: record, boardId: column.boardId };
+};
+
+/**
+ * Copies a card into a column on the same board, optionally with its comments.
+ * The copy is attributed to whoever asked for it, not to the original author.
+ */
+export const copyCard = async (
+  database: Database,
+  ctx: KanbanContext,
+  input: {
+    cardId: string;
+    columnId: string;
+    /** `null`/omitted places the copy at the end of the column. */
+    afterCardId?: string | null;
+    includeComments?: boolean;
+  },
+): Promise<CardResult> => {
+  const source = await requireCard(database, ctx, input.cardId);
+  const target = await requireColumn(database, ctx, input.columnId);
+  if (source.boardId !== target.boardId) {
+    throw new ValidationError("Cross-board copy is not allowed");
+  }
+
+  const sourceRows = await database
+    .select()
+    .from(kanbanCardTable)
+    .where(eq(kanbanCardTable.id, input.cardId))
+    .limit(1);
+  const sourceCard = sourceRows[0];
+
+  const record = await database.transaction(async (tx) => {
+    const position = await placeCardInColumn(tx, {
+      columnId: input.columnId,
+      afterCardId: input.afterCardId ?? undefined,
+    });
+
+    const newId = nanoid();
+    const now = new Date();
+
+    const rows = await tx
+      .insert(kanbanCardTable)
+      .values({
+        id: newId,
+        columnId: input.columnId,
+        title: sourceCard.title,
+        body: sourceCard.body,
+        labelIds: sourceCard.labelIds,
+        assignees: sourceCard.assignees,
+        dueDate: sourceCard.dueDate,
+        priority: sourceCard.priority,
+        position,
+        ...createdBy(ctx.actor),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+
+    if (input.includeComments) {
+      const comments = await tx
+        .select()
+        .from(kanbanCardCommentTable)
+        .where(eq(kanbanCardCommentTable.cardId, input.cardId))
+        .orderBy(asc(kanbanCardCommentTable.createdAt));
+
+      for (const comment of comments) {
+        await tx.insert(kanbanCardCommentTable).values({
+          id: nanoid(),
+          cardId: newId,
+          body: comment.body,
+          ...createdBy(ctx.actor),
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    }
+
+    return rows[0];
+  });
+
+  dispatch(ctx, "card.created", { ...record, boardId: source.boardId });
+  return { card: record, boardId: source.boardId };
+};
+
+/** Removes an already-resolved card and announces where it had been. */
+const removeCard = async (
+  database: Database,
+  ctx: KanbanContext,
+  card: CardRef,
+): Promise<void> => {
+  await database.delete(kanbanCardTable).where(eq(kanbanCardTable.id, card.id));
+
+  dispatch(ctx, "card.deleted", {
+    cardId: card.id,
+    boardId: card.boardId,
+    columnId: card.columnId,
+  });
+};
+
+/** Deletes a card and announces it. Returns where the card had been. */
+export const deleteCard = async (
+  database: Database,
+  ctx: KanbanContext,
+  cardId: string,
+): Promise<CardRef> => {
+  const card = await requireCard(database, ctx, cardId);
+  await removeCard(database, ctx, card);
+  return card;
+};
+
+/**
+ * Deletes several cards. Every card is resolved before any is removed, so a
+ * batch naming one card that is out of scope deletes none of them.
+ */
+export const deleteCards = async (
+  database: Database,
+  ctx: KanbanContext,
+  cardIds: string[],
+): Promise<CardRef[]> => {
+  const cards: CardRef[] = [];
+  for (const cardId of cardIds) {
+    try {
+      cards.push(await requireCard(database, ctx, cardId));
+    } catch (error) {
+      if (!(error instanceof NotFoundError)) throw error;
+      // Names the card that failed — a batch caller cannot tell otherwise.
+      throw new NotFoundError(`Card not found: ${cardId}`);
+    }
+  }
+
+  for (const card of cards) await removeCard(database, ctx, card);
+  return cards;
+};
+
+/** The label edit a bulk update applies: a replacement, or adds and removes. */
+export type BulkLabelEdit = {
+  labelIds?: string[];
+  addLabelIds?: string[];
+  removeLabelIds?: string[];
+};
+
+/** What a bulk update did, per card, in the order the cards were given. */
+export type BulkUpdateOutcome = {
+  cardId: string;
+  success: boolean;
+  error?: string;
+};
+
+/**
+ * Applies one set of values to many cards in a single transaction. Cards that
+ * are out of scope are reported per card rather than failing the batch, but a
+ * bad assignee or an unreachable target column stops the whole call — those
+ * are wrong for every card, not just one.
+ *
+ * Labels follow the update rule rather than the create rule: unknown IDs are
+ * dropped, not rejected. A bulk edit works over cards that already exist, so
+ * the same self-healing that saves a single card applies here — and refusing
+ * thirty cards over one stale ID none of them can show would be worse.
+ *
+ * With `columnId`, the cards are appended to that column in the order given.
+ */
+export const bulkUpdateCards = async (
+  database: Database,
+  ctx: KanbanContext,
+  input: BulkLabelEdit & {
+    cardIds: string[];
+    columnId?: string;
+    assignees?: KanbanCardAssignee[];
+    priority?: KanbanCardPriority;
+    dueDate?: string | null;
+  },
+): Promise<BulkUpdateOutcome[]> => {
+  if (input.columnId) await requireColumn(database, ctx, input.columnId);
+  await requireValidAssignees(database, input.assignees, ctx);
+
+  const outcomes = new Map<string, BulkUpdateOutcome>();
+  const cards: CardRef[] = [];
+  for (const cardId of input.cardIds) {
+    try {
+      cards.push(await requireCard(database, ctx, cardId));
+      outcomes.set(cardId, { cardId, success: true });
+    } catch (error) {
+      // Only an out-of-scope card is reported per card; a failed query fails
+      // the batch rather than reading as thirty missing cards.
+      if (!(error instanceof NotFoundError)) throw error;
+      outcomes.set(cardId, {
+        cardId,
+        success: false,
+        error: "Card not found",
+      });
+    }
+  }
+
+  if (cards.length === 0) return input.cardIds.map((id) => outcomes.get(id)!);
+
+  // Additive and subtractive label edits build on what each card already
+  // holds, so those rows are read before the write.
+  const editsLabels =
+    input.labelIds !== undefined ||
+    input.addLabelIds !== undefined ||
+    input.removeLabelIds !== undefined;
+  const currentLabels = new Map<string, string[]>();
+  if (input.addLabelIds !== undefined || input.removeLabelIds !== undefined) {
+    const rows = await database
+      .select({ id: kanbanCardTable.id, labelIds: kanbanCardTable.labelIds })
+      .from(kanbanCardTable)
+      .where(
+        inArray(
+          kanbanCardTable.id,
+          cards.map((card) => card.id),
+        ),
+      );
+    for (const row of rows) currentLabels.set(row.id, row.labelIds);
+  }
+
+  // The cards may span boards, so each board's labels are fetched once and
+  // reused for every card on it.
+  const knownLabels = new Map<string, string[]>();
+  const labelsOf = async (boardId: string): Promise<string[]> => {
+    const cached = knownLabels.get(boardId);
+    if (cached) return cached;
+    const labels = await boardLabelIds(database, boardId);
+    knownLabels.set(boardId, labels);
+    return labels;
+  };
+
+  const basePosition = input.columnId
+    ? await nextCardPosition(database, input.columnId)
+    : 0;
+
+  const updated = await database.transaction(async (tx) => {
+    const records: { card: CardRef; row: CardRow }[] = [];
+
+    for (const [index, card] of cards.entries()) {
+      const labelIds = editsLabels
+        ? filterKnownLabelIds(
+            resolveBulkLabels(input, currentLabels.get(card.id) ?? []),
+            await labelsOf(card.boardId),
+          )
+        : undefined;
+
+      const rows = await tx
+        .update(kanbanCardTable)
+        .set({
+          ...(input.columnId !== undefined && {
+            columnId: input.columnId,
+            position: basePosition + index,
+          }),
+          ...(labelIds !== undefined && { labelIds }),
+          ...(input.assignees !== undefined && { assignees: input.assignees }),
+          ...(input.priority !== undefined && { priority: input.priority }),
+          ...(input.dueDate !== undefined && {
+            dueDate: input.dueDate ? new Date(input.dueDate) : null,
+          }),
+          ...lastEditedBy(ctx.actor),
+          updatedAt: new Date(),
+        })
+        .where(eq(kanbanCardTable.id, card.id))
+        .returning();
+
+      records.push({ card, row: rows[0] });
+    }
+    return records;
+  });
+
+  for (const { card, row } of updated) {
+    dispatch(ctx, "card.updated", { ...row, boardId: card.boardId });
+  }
+
+  return input.cardIds.map((id) => outcomes.get(id)!);
+};
+
+/** The label list a bulk edit asks for, before it is checked against the board. */
+const resolveBulkLabels = (
+  edit: BulkLabelEdit,
+  current: string[],
+): string[] => {
+  if (edit.labelIds !== undefined) return edit.labelIds;
+  let next = [...new Set([...current, ...(edit.addLabelIds ?? [])])];
+  if (edit.removeLabelIds) {
+    next = next.filter((id) => !edit.removeLabelIds!.includes(id));
+  }
+  return next;
+};
+
+// --- Comments ---
+
+/** A comment with the display name of whoever wrote it, user or Agent. */
+export type CommentWithAuthor = CommentRow & { createdByName: string | null };
+
+/**
+ * Resolves each comment's author to a name. Comments store only an ID, and the
+ * author is a user or an Agent depending on which column is set.
+ */
+export const resolveCommentNames = async (
+  database: Database,
+  comments: CommentRow[],
+): Promise<CommentWithAuthor[]> => {
+  const userIds = new Set<string>();
+  const agentIds = new Set<string>();
+  for (const comment of comments) {
+    if (comment.createdByUserId) userIds.add(comment.createdByUserId);
+    if (comment.createdByAgentId) agentIds.add(comment.createdByAgentId);
+  }
+
+  const users =
+    userIds.size > 0
+      ? await database
+          .select({ id: user.id, name: user.name })
+          .from(user)
+          .where(inArray(user.id, Array.from(userIds)))
+      : [];
+  const userMap = new Map(users.map((u) => [u.id, u.name]));
+
+  const agents =
+    agentIds.size > 0
+      ? await database
+          .select({ id: agentTable.id, name: agentTable.name })
+          .from(agentTable)
+          .where(inArray(agentTable.id, Array.from(agentIds)))
+      : [];
+  const agentMap = new Map(agents.map((a) => [a.id, a.name]));
+
+  return comments.map((comment) => ({
+    ...comment,
+    createdByName: comment.createdByUserId
+      ? (userMap.get(comment.createdByUserId) ?? null)
+      : comment.createdByAgentId
+        ? (agentMap.get(comment.createdByAgentId) ?? null)
+        : null,
+  }));
+};
+
+/** A card's comments, oldest first. */
+export const listComments = async (
+  database: Database,
+  scope: KanbanScope,
+  cardId: string,
+): Promise<CommentRow[]> => {
+  await requireCard(database, scope, cardId);
+
+  return database
+    .select()
+    .from(kanbanCardCommentTable)
+    .where(eq(kanbanCardCommentTable.cardId, cardId))
+    .orderBy(asc(kanbanCardCommentTable.createdAt));
+};
+
+/** Adds a comment to a card, attributed to the actor. */
+export const createComment = async (
+  database: Database,
+  ctx: KanbanContext,
+  cardId: string,
+  body: string,
+): Promise<CommentRow> => {
+  await requireCard(database, ctx, cardId);
+
+  const now = new Date();
+  const rows = await database
+    .insert(kanbanCardCommentTable)
+    .values({
+      id: nanoid(),
+      cardId,
+      body,
+      ...createdBy(ctx.actor),
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  return rows[0];
+};
+
+/**
+ * Rewrites a comment's body. It takes the comment rather than an ID because
+ * only `requireComment` produces one, which keeps the scope check mandatory.
+ * Who may then edit which comment is the surface's own call — the HTTP routes
+ * let a moderator edit anyone's.
+ */
+export const updateCommentBody = async (
+  database: Database,
+  comment: CommentRow,
+  body: string,
+): Promise<CommentRow> => {
+  const rows = await database
+    .update(kanbanCardCommentTable)
+    .set({ body, updatedAt: new Date() })
+    .where(eq(kanbanCardCommentTable.id, comment.id))
+    .returning();
+
+  return rows[0];
+};
+
+/** Deletes a comment the caller has already resolved. */
+export const removeComment = async (
+  database: Database,
+  comment: CommentRow,
+): Promise<void> => {
+  await database
+    .delete(kanbanCardCommentTable)
+    .where(eq(kanbanCardCommentTable.id, comment.id));
+};

--- a/apps/backend/src/tools/kanban.test.ts
+++ b/apps/backend/src/tools/kanban.test.ts
@@ -106,12 +106,13 @@ describe("createKanbanTools", () => {
 
   describe("upsertCard (update) — bodyDiff", () => {
     function setupCardUpdate(existingBody: string, updatedCard: object) {
-      // verifyCard returns a record (limit call #1), body select returns body (limit call #2),
-      // update returning returns updated card, getBoardIdForCard returns boardId (limit call #3)
+      // The card guard resolves the card and its board (limit call #1), then
+      // the diff is applied to the body it holds now (limit call #2).
       mockDb.limit
-        .mockResolvedValueOnce([{ id: "card-1" }]) // verifyCard
-        .mockResolvedValueOnce([{ body: existingBody }]) // SELECT body
-        .mockResolvedValueOnce([{ boardId: "board-1" }]); // getBoardIdForCard
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard
+        .mockResolvedValueOnce([{ body: existingBody }]); // SELECT body
       mockDb.returning.mockResolvedValueOnce([updatedCard]);
     }
 
@@ -133,7 +134,9 @@ describe("createKanbanTools", () => {
 
     it("returns error when search string not found", async () => {
       mockDb.limit
-        .mockResolvedValueOnce([{ id: "card-1" }]) // verifyCard
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard
         .mockResolvedValueOnce([{ body: "Hello world" }]); // SELECT body
 
       expect(
@@ -223,6 +226,151 @@ describe("createKanbanTools", () => {
     });
   });
 
+  // The Tool surface enforces the same label and assignee rules as the HTTP
+  // surface: both go through the Kanban module, so an Agent cannot write a
+  // label the board does not have or an assignee who cannot work here.
+  describe("upsertCard — label and assignee rules", () => {
+    it("rejects an unknown label ID when creating", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([{ id: "col-1", boardId: "board-1" }]) // column guard
+        .mockResolvedValueOnce([{ labels: [{ id: "lbl-a" }] }]); // board labels
+
+      expect(
+        await tools.upsertCard.execute!(
+          {
+            columnId: "col-1",
+            title: "Card",
+            labelIds: ["lbl-a", "lbl-ghost"],
+            label: "test",
+          },
+          ctx,
+        ),
+      ).toEqual({ error: "Invalid label ID" });
+    });
+
+    it("rejects a user assignee who is not an org member when creating", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "col-1", boardId: "board-1" }]); // column guard
+      mockDb.where.mockReturnValueOnce(mockDb); // column guard chain
+      mockDb.where.mockResolvedValueOnce([]); // org member lookup — not found
+      mockDb.where.mockResolvedValueOnce([]); // super admin lookup — not found
+
+      expect(
+        await tools.upsertCard.execute!(
+          {
+            columnId: "col-1",
+            title: "Card",
+            assignees: [{ type: "user", id: "outsider" }],
+            label: "test",
+          },
+          ctx,
+        ),
+      ).toEqual({ error: "Invalid user assignee" });
+    });
+
+    it("rejects an agent that is not visible in this workspace when creating", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "col-1", boardId: "board-1" }]); // column guard
+      mockDb.where.mockReturnValueOnce(mockDb); // column guard chain
+      mockDb.where.mockResolvedValueOnce([]); // no workspace-scoped agent
+      mockDb.where.mockResolvedValueOnce([]); // no attached org-scoped agent
+
+      expect(
+        await tools.upsertCard.execute!(
+          {
+            columnId: "col-1",
+            title: "Card",
+            assignees: [{ type: "agent", id: "someone-elses-agent" }],
+            label: "test",
+          },
+          ctx,
+        ),
+      ).toEqual({ error: "Invalid agent assignee" });
+    });
+
+    it("drops unknown label IDs when updating", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard
+        .mockResolvedValueOnce([{ labels: [{ id: "lbl-a" }] }]); // board labels
+      mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
+
+      await tools.upsertCard.execute!(
+        {
+          cardId: "card-1",
+          labelIds: ["lbl-ghost", "lbl-a"],
+          label: "test",
+        },
+        ctx,
+      );
+
+      expect(mockDb.set).toHaveBeenCalledWith(
+        expect.objectContaining({ labelIds: ["lbl-a"] }),
+      );
+    });
+
+    it("rejects an invalid assignee when updating", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "card-1", columnId: "col-1", boardId: "board-1" },
+      ]); // card guard
+      mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
+      mockDb.where.mockResolvedValueOnce([]); // org member lookup — not found
+      mockDb.where.mockResolvedValueOnce([]); // super admin lookup — not found
+
+      expect(
+        await tools.upsertCard.execute!(
+          {
+            cardId: "card-1",
+            assignees: [{ type: "user", id: "outsider" }],
+            label: "test",
+          },
+          ctx,
+        ),
+      ).toEqual({ error: "Invalid user assignee" });
+    });
+  });
+
+  describe("bulkEditCards — label and assignee rules", () => {
+    // A bulk edit works over cards that already exist, so it follows the
+    // update rule: an unknown label is dropped rather than failing the batch.
+    it("drops unknown label IDs", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard
+        .mockResolvedValueOnce([{ labels: [{ id: "lbl-a" }] }]); // board labels
+      mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
+
+      await tools.bulkEditCards.execute!(
+        {
+          cardIds: ["card-1"],
+          labelIds: ["lbl-ghost", "lbl-a"],
+          label: "test",
+        },
+        ctx,
+      );
+
+      expect(mockDb.set).toHaveBeenCalledWith(
+        expect.objectContaining({ labelIds: ["lbl-a"] }),
+      );
+    });
+
+    it("rejects an invalid assignee", async () => {
+      mockDb.where.mockResolvedValueOnce([]); // org member lookup — not found
+      mockDb.where.mockResolvedValueOnce([]); // super admin lookup — not found
+
+      expect(
+        await tools.bulkEditCards.execute!(
+          {
+            cardIds: ["card-1"],
+            assignees: [{ type: "user", id: "outsider" }],
+            label: "test",
+          },
+          ctx,
+        ),
+      ).toEqual({ error: "Invalid user assignee" });
+    });
+  });
+
   describe("moveCard", () => {
     it("returns error when card not found", async () => {
       mockDb.limit.mockResolvedValue([]);
@@ -257,13 +405,13 @@ describe("createKanbanTools", () => {
       const newCard = { ...sourceCard, id: "new-card-id", columnId: "col-2" };
 
       mockDb.limit
-        .mockResolvedValueOnce([{ id: "card-1" }]) // verifyCard
-        .mockResolvedValueOnce([{ id: "col-2" }]) // verifyColumn
-        .mockResolvedValueOnce([{ boardId: "board-1" }]) // getBoardIdForCard
-        .mockResolvedValueOnce([{ boardId: "board-1" }]) // target column boardId
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard
+        .mockResolvedValueOnce([{ id: "col-2", boardId: "board-1" }]) // column guard
         .mockResolvedValueOnce([sourceCard]); // source card select
       // Skip non-terminal where() calls, then resolve terminal where() for max position
-      for (let i = 0; i < 5; i++) mockDb.where.mockReturnValueOnce(mockDb);
+      for (let i = 0; i < 3; i++) mockDb.where.mockReturnValueOnce(mockDb);
       mockDb.where.mockResolvedValueOnce([{ maxPos: 3 }]);
       mockDb.returning.mockResolvedValueOnce([newCard]);
 
@@ -294,13 +442,13 @@ describe("createKanbanTools", () => {
       ];
 
       mockDb.limit
-        .mockResolvedValueOnce([{ id: "card-1" }]) // verifyCard
-        .mockResolvedValueOnce([{ id: "col-1" }]) // verifyColumn
-        .mockResolvedValueOnce([{ boardId: "board-1" }]) // getBoardIdForCard
-        .mockResolvedValueOnce([{ boardId: "board-1" }]) // target column boardId
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard
+        .mockResolvedValueOnce([{ id: "col-1", boardId: "board-1" }]) // column guard
         .mockResolvedValueOnce([sourceCard]); // source card select
       // Skip non-terminal where() calls, then resolve terminal where() for max position
-      for (let i = 0; i < 5; i++) mockDb.where.mockReturnValueOnce(mockDb);
+      for (let i = 0; i < 3; i++) mockDb.where.mockReturnValueOnce(mockDb);
       mockDb.where.mockResolvedValueOnce([{ maxPos: 1 }]);
       mockDb.returning.mockResolvedValueOnce([newCard]);
       // comments query (orderBy resolves)
@@ -334,8 +482,10 @@ describe("createKanbanTools", () => {
 
     it("returns error when target column not found", async () => {
       mockDb.limit
-        .mockResolvedValueOnce([{ id: "card-1" }]) // verifyCard passes
-        .mockResolvedValueOnce([]); // verifyColumn fails
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard passes
+        .mockResolvedValueOnce([]); // column guard fails
 
       expect(
         await tools.copyCard.execute!(
@@ -347,10 +497,10 @@ describe("createKanbanTools", () => {
 
     it("returns error when cross-board copy is attempted", async () => {
       mockDb.limit
-        .mockResolvedValueOnce([{ id: "card-1" }]) // verifyCard
-        .mockResolvedValueOnce([{ id: "col-2" }]) // verifyColumn
-        .mockResolvedValueOnce([{ boardId: "board-1" }]) // getBoardIdForCard (source)
-        .mockResolvedValueOnce([{ boardId: "board-2" }]); // target column boardId
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard (source)
+        .mockResolvedValueOnce([{ id: "col-2", boardId: "board-2" }]); // column guard (target)
 
       expect(
         await tools.copyCard.execute!(

--- a/apps/backend/src/tools/kanban.ts
+++ b/apps/backend/src/tools/kanban.ts
@@ -1,103 +1,89 @@
 import { tool, type Tool } from "ai";
 import { z } from "zod";
-import { and, asc, eq, inArray, max } from "drizzle-orm";
+import { asc, eq, inArray } from "drizzle-orm";
 import { db } from "../index.ts";
 import {
   kanbanBoard as kanbanBoardTable,
   kanbanColumn as kanbanColumnTable,
   kanbanCard as kanbanCardTable,
-  kanbanCardComment as kanbanCardCommentTable,
-  agent as agentTable,
 } from "../db/schema.ts";
-import { user } from "../db/auth-schema.ts";
-import { calculateCardPosition } from "../utils/kanban-positioning.ts";
+import { NotFoundError, ValidationError } from "../errors.ts";
+import {
+  bulkUpdateCards,
+  copyCard,
+  createCard,
+  createComment,
+  deleteCards,
+  listComments,
+  moveCard,
+  requireBoard,
+  requireCard,
+  removeComment,
+  requireComment,
+  resolveCommentNames,
+  updateCard,
+  updateCommentBody,
+  type KanbanContext,
+} from "../services/kanban.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
-import { dispatchEvent } from "../services/event-dispatch.ts";
 import { createListAgentsTool } from "./agent-discovery.ts";
 
+/**
+ * The Agent-facing surface over the Kanban module (`services/kanban.ts`): each
+ * Tool parses its input, calls the module, and shapes the result. The board's
+ * rules — what a label may be, who may be assigned, where a card lands, what
+ * event fires — belong to the module and are shared with the HTTP routes, so
+ * an Agent cannot write anything a person could not write through the UI.
+ */
 export function createKanbanTools(
   workspaceId: string,
   agentId: string,
   orgId: string,
   frontendUrl: string | undefined,
 ): Record<string, Tool> {
-  /** Returns true only if the card exists AND belongs to a board in this workspace. */
-  async function verifyCard(cardId: string): Promise<boolean> {
-    const result = await db
-      .select({ id: kanbanCardTable.id })
-      .from(kanbanCardTable)
-      .innerJoin(
-        kanbanColumnTable,
-        eq(kanbanCardTable.columnId, kanbanColumnTable.id),
-      )
-      .innerJoin(
-        kanbanBoardTable,
-        and(
-          eq(kanbanColumnTable.boardId, kanbanBoardTable.id),
-          eq(kanbanBoardTable.workspaceId, workspaceId),
-        ),
-      )
-      .where(eq(kanbanCardTable.id, cardId))
-      .limit(1);
-    return result.length > 0;
+  // No board is named: an Agent works across every board in its Workspace.
+  const ctx: KanbanContext = {
+    orgId,
+    workspaceId,
+    actor: { agentId },
+  };
+
+  /**
+   * Turns the module's typed failures into the `{ error }` payload a Tool
+   * result carries — a Tool reports a problem back to the model rather than
+   * throwing it into the run.
+   */
+  async function asToolResult<T>(
+    run: () => Promise<T>,
+  ): Promise<T | ErrorResult> {
+    try {
+      return await run();
+    } catch (error) {
+      if (error instanceof NotFoundError || error instanceof ValidationError) {
+        return { error: error.message };
+      }
+      throw error;
+    }
   }
 
-  /** Returns true only if the column exists AND belongs to a board in this workspace. */
-  async function verifyColumn(columnId: string): Promise<boolean> {
-    const result = await db
-      .select({ id: kanbanColumnTable.id })
-      .from(kanbanColumnTable)
-      .innerJoin(
-        kanbanBoardTable,
-        and(
-          eq(kanbanColumnTable.boardId, kanbanBoardTable.id),
-          eq(kanbanBoardTable.workspaceId, workspaceId),
-        ),
-      )
-      .where(eq(kanbanColumnTable.id, columnId))
-      .limit(1);
-    return result.length > 0;
-  }
+  /** The board's page in the frontend, when one is configured. */
+  const boardUrl = (boardId: string): string | undefined =>
+    buildResourceUrl(frontendUrl, orgId, workspaceId, `boards/${boardId}`);
 
-  /** Returns true only if the comment exists AND belongs to a card on a board in this workspace. */
-  async function verifyComment(commentId: string): Promise<boolean> {
-    const result = await db
-      .select({ id: kanbanCardCommentTable.id })
-      .from(kanbanCardCommentTable)
-      .innerJoin(
-        kanbanCardTable,
-        eq(kanbanCardCommentTable.cardId, kanbanCardTable.id),
-      )
-      .innerJoin(
-        kanbanColumnTable,
-        eq(kanbanCardTable.columnId, kanbanColumnTable.id),
-      )
-      .innerJoin(
-        kanbanBoardTable,
-        and(
-          eq(kanbanColumnTable.boardId, kanbanBoardTable.id),
-          eq(kanbanBoardTable.workspaceId, workspaceId),
-        ),
-      )
-      .where(eq(kanbanCardCommentTable.id, commentId))
-      .limit(1);
-    return result.length > 0;
-  }
+  /** A deep link that opens the card on its board. */
+  const cardUrl = (boardId: string, cardId: string): string | undefined => {
+    const url = boardUrl(boardId);
+    return url && `${url}?cardId=${cardId}`;
+  };
 
-  async function getBoardIdForCard(
-    cardId: string,
-  ): Promise<string | undefined> {
-    const result = await db
-      .select({ boardId: kanbanColumnTable.boardId })
-      .from(kanbanCardTable)
-      .innerJoin(
-        kanbanColumnTable,
-        eq(kanbanCardTable.columnId, kanbanColumnTable.id),
-      )
-      .where(eq(kanbanCardTable.id, cardId))
-      .limit(1);
-    return result[0]?.boardId;
-  }
+  /** A written card as a Tool returns it: the row, plus a link to it. */
+  const withCardUrl = <T extends { id: string }>(result: {
+    card: T;
+    boardId: string;
+  }) => {
+    const url = cardUrl(result.boardId, result.card.id);
+    return { ...result.card, ...(url && { url }) };
+  };
 
   const listAgents = createListAgentsTool({ orgId, wsId: workspaceId });
 
@@ -126,86 +112,68 @@ export function createKanbanTools(
       boardId: z.string().describe("The ID of the board to get state for"),
       label: z.string().describe("The board name (for display purposes)"),
     }),
-    execute: async ({ boardId }) => {
-      const boardRecord = await db
-        .select()
-        .from(kanbanBoardTable)
-        .where(
-          and(
-            eq(kanbanBoardTable.id, boardId),
-            eq(kanbanBoardTable.workspaceId, workspaceId),
-          ),
-        )
-        .limit(1);
+    execute: async ({ boardId }) =>
+      asToolResult(async () => {
+        const board = await requireBoard(db, ctx, boardId);
 
-      if (boardRecord.length === 0) {
-        return { error: "Board not found" };
-      }
+        const columns = await db
+          .select()
+          .from(kanbanColumnTable)
+          .where(eq(kanbanColumnTable.boardId, boardId))
+          .orderBy(asc(kanbanColumnTable.position));
 
-      const columns = await db
-        .select()
-        .from(kanbanColumnTable)
-        .where(eq(kanbanColumnTable.boardId, boardId))
-        .orderBy(asc(kanbanColumnTable.position));
+        const columnIds = columns.map((col) => col.id);
 
-      const columnIds = columns.map((col) => col.id);
+        type CardSummary = {
+          id: string;
+          columnId: string;
+          title: string;
+          position: number;
+          labelIds: string[];
+          assignees: { type: "user" | "agent"; id: string }[];
+          dueDate: Date | null;
+          priority: string;
+        };
 
-      type CardSummary = {
-        id: string;
-        columnId: string;
-        title: string;
-        position: number;
-        labelIds: string[];
-        assignees: { type: "user" | "agent"; id: string }[];
-        dueDate: Date | null;
-        priority: string;
-      };
+        let cards: CardSummary[] = [];
+        if (columnIds.length > 0) {
+          cards = await db
+            .select({
+              id: kanbanCardTable.id,
+              columnId: kanbanCardTable.columnId,
+              title: kanbanCardTable.title,
+              position: kanbanCardTable.position,
+              labelIds: kanbanCardTable.labelIds,
+              assignees: kanbanCardTable.assignees,
+              dueDate: kanbanCardTable.dueDate,
+              priority: kanbanCardTable.priority,
+            })
+            .from(kanbanCardTable)
+            .where(inArray(kanbanCardTable.columnId, columnIds))
+            .orderBy(asc(kanbanCardTable.position));
+        }
 
-      let cards: CardSummary[] = [];
-      if (columnIds.length > 0) {
-        const fullCards = await db
-          .select({
-            id: kanbanCardTable.id,
-            columnId: kanbanCardTable.columnId,
-            title: kanbanCardTable.title,
-            position: kanbanCardTable.position,
-            labelIds: kanbanCardTable.labelIds,
-            assignees: kanbanCardTable.assignees,
-            dueDate: kanbanCardTable.dueDate,
-            priority: kanbanCardTable.priority,
-          })
-          .from(kanbanCardTable)
-          .where(inArray(kanbanCardTable.columnId, columnIds))
-          .orderBy(asc(kanbanCardTable.position));
-        cards = fullCards;
-      }
+        const cardsByColumn = new Map<string, CardSummary[]>();
+        for (const card of cards) {
+          const existing = cardsByColumn.get(card.columnId) ?? [];
+          existing.push(card);
+          cardsByColumn.set(card.columnId, existing);
+        }
 
-      const cardsByColumn = new Map<string, CardSummary[]>();
-      for (const card of cards) {
-        const existing = cardsByColumn.get(card.columnId) ?? [];
-        existing.push(card);
-        cardsByColumn.set(card.columnId, existing);
-      }
+        const columnsWithCards = columns.map((col) => ({
+          ...col,
+          cards: cardsByColumn.get(col.id) ?? [],
+        }));
 
-      const columnsWithCards = columns.map((col) => ({
-        ...col,
-        cards: cardsByColumn.get(col.id) ?? [],
-      }));
+        const url = boardUrl(boardId);
 
-      const url = buildResourceUrl(
-        frontendUrl,
-        orgId,
-        workspaceId,
-        `boards/${boardId}`,
-      );
-
-      return {
-        board: boardRecord[0],
-        columns: columnsWithCards,
-        labels: boardRecord[0].labels,
-        ...(url && { url }),
-      };
-    },
+        return {
+          board,
+          columns: columnsWithCards,
+          labels: board.labels,
+          ...(url && { url }),
+        };
+      }),
   });
 
   const getCard = tool({
@@ -214,29 +182,18 @@ export function createKanbanTools(
       cardId: z.string().describe("The ID of the card to get"),
       label: z.string().describe("The card title (for display purposes)"),
     }),
-    execute: async ({ cardId }) => {
-      if (!(await verifyCard(cardId))) {
-        return { error: "Card not found" };
-      }
+    execute: async ({ cardId }) =>
+      asToolResult(async () => {
+        const ref = await requireCard(db, ctx, cardId);
 
-      const card = await db
-        .select()
-        .from(kanbanCardTable)
-        .where(eq(kanbanCardTable.id, cardId))
-        .limit(1);
+        const cards = await db
+          .select()
+          .from(kanbanCardTable)
+          .where(eq(kanbanCardTable.id, cardId))
+          .limit(1);
 
-      const boardId = await getBoardIdForCard(cardId);
-      const url = boardId
-        ? buildResourceUrl(
-            frontendUrl,
-            orgId,
-            workspaceId,
-            `boards/${boardId}`,
-          ) + `?cardId=${cardId}`
-        : undefined;
-
-      return { ...card[0], ...(url && { url }) };
-    },
+        return withCardUrl({ card: cards[0], boardId: ref.boardId });
+      }),
   });
 
   const upsertCard = tool({
@@ -304,154 +261,27 @@ export function createKanbanTools(
       .refine((v) => !(v.body !== undefined && v.bodyDiff !== undefined), {
         message: "body and bodyDiff are mutually exclusive",
       }),
-    execute: async ({
-      cardId,
-      columnId,
-      title,
-      body,
-      bodyDiff,
-      labelIds,
-      assignees,
-      dueDate,
-      priority,
-    }) => {
-      // Update existing card
-      if (cardId) {
-        if (!(await verifyCard(cardId))) {
-          return { error: "Card not found" };
+    execute: async ({ cardId, columnId, title, label: _label, ...fields }) =>
+      asToolResult(async () => {
+        if (cardId) {
+          return withCardUrl(
+            await updateCard(db, ctx, cardId, { title, ...fields }),
+          );
         }
 
-        const updateData: Record<string, unknown> = {
-          lastEditedByAgentId: agentId,
-          updatedAt: new Date(),
-        };
-        if (title !== undefined) updateData.title = title;
-        if (body !== undefined) updateData.body = body;
-        if (bodyDiff !== undefined) {
-          const existing = await db
-            .select({ body: kanbanCardTable.body })
-            .from(kanbanCardTable)
-            .where(eq(kanbanCardTable.id, cardId))
-            .limit(1);
-          const currentBody = existing[0]?.body ?? "";
-
-          let newBody: string;
-          if (Array.isArray(bodyDiff)) {
-            newBody = currentBody;
-            for (const op of bodyDiff) {
-              if (!newBody.includes(op.search)) {
-                return {
-                  error: `bodyDiff search string not found: "${op.search}"`,
-                };
-              }
-              newBody = newBody.replace(op.search, op.replace);
-            }
-          } else {
-            newBody =
-              bodyDiff.mode === "append"
-                ? currentBody + bodyDiff.content
-                : bodyDiff.content + currentBody;
-          }
-          updateData.body = newBody;
-        }
-        if (labelIds !== undefined) updateData.labelIds = labelIds;
-        if (assignees !== undefined) updateData.assignees = assignees;
-        if (dueDate !== undefined)
-          updateData.dueDate = dueDate ? new Date(dueDate) : null;
-        if (priority !== undefined) updateData.priority = priority;
-
-        const record = await db
-          .update(kanbanCardTable)
-          .set(updateData)
-          .where(eq(kanbanCardTable.id, cardId))
-          .returning();
-
-        if (record.length === 0) {
-          return { error: "Card not found" };
+        if (!columnId || !title) {
+          return {
+            error: "columnId and title are required when creating a new card",
+          };
         }
 
-        const boardId = await getBoardIdForCard(cardId);
-        dispatchEvent(
-          orgId,
-          workspaceId,
-          "card.updated",
-          { ...record[0], boardId },
-          { actorAgentId: agentId },
+        return withCardUrl(
+          await createCard(db, ctx, { ...fields, columnId, title }),
         );
-        const url = boardId
-          ? buildResourceUrl(
-              frontendUrl,
-              orgId,
-              workspaceId,
-              `boards/${boardId}`,
-            ) + `?cardId=${cardId}`
-          : undefined;
-
-        return { ...record[0], ...(url && { url }) };
-      }
-
-      // Create new card
-      if (!columnId || !title) {
-        return {
-          error: "columnId and title are required when creating a new card",
-        };
-      }
-
-      if (!(await verifyColumn(columnId))) {
-        return { error: "Column not found" };
-      }
-
-      const { nanoid } = await import("nanoid");
-
-      const maxResult = await db
-        .select({ maxPos: max(kanbanCardTable.position) })
-        .from(kanbanCardTable)
-        .where(eq(kanbanCardTable.columnId, columnId));
-
-      const position = (maxResult[0]?.maxPos ?? 0) + 1.0;
-      const id = nanoid();
-      const now = new Date();
-
-      const record = await db
-        .insert(kanbanCardTable)
-        .values({
-          id,
-          columnId,
-          title,
-          body: body ?? null,
-          labelIds: labelIds ?? [],
-          assignees: assignees ?? [],
-          dueDate: dueDate ? new Date(dueDate) : null,
-          priority: priority ?? "none",
-          position,
-          createdByAgentId: agentId,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning();
-
-      const boardId = await getBoardIdForCard(id);
-      dispatchEvent(
-        orgId,
-        workspaceId,
-        "card.created",
-        { ...record[0], boardId },
-        { actorAgentId: agentId },
-      );
-      const url = boardId
-        ? buildResourceUrl(
-            frontendUrl,
-            orgId,
-            workspaceId,
-            `boards/${boardId}`,
-          ) + `?cardId=${id}`
-        : undefined;
-
-      return { ...record[0], ...(url && { url }) };
-    },
+      }),
   });
 
-  const moveCard = tool({
+  const moveCardTool = tool({
     description:
       "Move a kanban card to a different position or column. Use afterCardId=null to place at the beginning.",
     inputSchema: z.object({
@@ -465,92 +295,10 @@ export function createKanbanTools(
           "Place after this card ID, or null to place at the beginning",
         ),
     }),
-    execute: async ({ cardId, columnId, afterCardId }) => {
-      if (!(await verifyCard(cardId))) {
-        return { error: "Card not found" };
-      }
-      if (!(await verifyColumn(columnId))) {
-        return { error: "Column not found" };
-      }
-
-      const cardsInColumn = await db
-        .select()
-        .from(kanbanCardTable)
-        .where(eq(kanbanCardTable.columnId, columnId))
-        .orderBy(asc(kanbanCardTable.position));
-
-      const otherCards = cardsInColumn.filter((card) => card.id !== cardId);
-
-      let result: ReturnType<typeof calculateCardPosition>;
-      try {
-        result = calculateCardPosition(otherCards, afterCardId);
-      } catch {
-        return { error: "afterCardId not found in column" };
-      }
-
-      const { position, needsRebalance, afterIndex } = result;
-
-      if (needsRebalance) {
-        await db.transaction(async (tx) => {
-          const reorderedCards: { id: string; position: number }[] = [
-            ...otherCards,
-          ];
-          reorderedCards.splice(afterIndex + 1, 0, {
-            id: cardId,
-            position: 0,
-          });
-
-          for (let i = 0; i < reorderedCards.length; i++) {
-            await tx
-              .update(kanbanCardTable)
-              .set({
-                columnId,
-                position: (i + 1) * 1.0,
-                updatedAt: new Date(),
-                ...(reorderedCards[i].id === cardId
-                  ? { lastEditedByAgentId: agentId }
-                  : {}),
-              })
-              .where(eq(kanbanCardTable.id, reorderedCards[i].id));
-          }
-        });
-      } else {
-        await db
-          .update(kanbanCardTable)
-          .set({
-            columnId,
-            position,
-            lastEditedByAgentId: agentId,
-            updatedAt: new Date(),
-          })
-          .where(eq(kanbanCardTable.id, cardId));
-      }
-
-      const updated = await db
-        .select()
-        .from(kanbanCardTable)
-        .where(eq(kanbanCardTable.id, cardId))
-        .limit(1);
-
-      const boardId = await getBoardIdForCard(cardId);
-      dispatchEvent(
-        orgId,
-        workspaceId,
-        "card.updated",
-        { ...updated[0], boardId },
-        { actorAgentId: agentId },
-      );
-      const url = boardId
-        ? buildResourceUrl(
-            frontendUrl,
-            orgId,
-            workspaceId,
-            `boards/${boardId}`,
-          ) + `?cardId=${cardId}`
-        : undefined;
-
-      return { ...updated[0], ...(url && { url }) };
-    },
+    execute: async ({ cardId, columnId, afterCardId }) =>
+      asToolResult(async () =>
+        withCardUrl(await moveCard(db, ctx, { cardId, columnId, afterCardId })),
+      ),
   });
 
   const deleteCard = tool({
@@ -562,86 +310,23 @@ export function createKanbanTools(
         .describe("One or more card IDs to delete"),
       label: z.string().describe("The card title(s) (for display purposes)"),
     }),
-    execute: async ({ cardIds }) => {
-      for (const cardId of cardIds) {
-        if (!(await verifyCard(cardId))) {
-          return { error: `Card not found: ${cardId}` };
-        }
-      }
-
-      for (const cardId of cardIds) {
-        const boardId = await getBoardIdForCard(cardId);
-        const cardRecord = await db
-          .select({ columnId: kanbanCardTable.columnId })
-          .from(kanbanCardTable)
-          .where(eq(kanbanCardTable.id, cardId))
-          .limit(1);
-        const columnId = cardRecord[0]?.columnId;
-        await db.delete(kanbanCardTable).where(eq(kanbanCardTable.id, cardId));
-        dispatchEvent(
-          orgId,
-          workspaceId,
-          "card.deleted",
-          { cardId, boardId, columnId },
-          { actorAgentId: agentId },
-        );
-      }
-
-      return { success: true };
-    },
+    execute: async ({ cardIds }) =>
+      asToolResult(async () => {
+        await deleteCards(db, ctx, cardIds);
+        return { success: true };
+      }),
   });
 
-  const listComments = tool({
+  const listCommentsTool = tool({
     description: "List all comments on a kanban card, ordered oldest first.",
     inputSchema: z.object({
       cardId: z.string().describe("The ID of the card to list comments for"),
       label: z.string().describe("The card title (for display purposes)"),
     }),
-    execute: async ({ cardId }) => {
-      if (!(await verifyCard(cardId))) {
-        return { error: "Card not found" };
-      }
-
-      const comments = await db
-        .select()
-        .from(kanbanCardCommentTable)
-        .where(eq(kanbanCardCommentTable.cardId, cardId))
-        .orderBy(asc(kanbanCardCommentTable.createdAt));
-
-      const userIds = new Set<string>();
-      const agentIds = new Set<string>();
-      for (const comment of comments) {
-        if (comment.createdByUserId) userIds.add(comment.createdByUserId);
-        if (comment.createdByAgentId) agentIds.add(comment.createdByAgentId);
-      }
-
-      const users =
-        userIds.size > 0
-          ? await db
-              .select({ id: user.id, name: user.name })
-              .from(user)
-              .where(inArray(user.id, Array.from(userIds)))
-          : [];
-      const userMap = new Map(users.map((u) => [u.id, u.name]));
-
-      const agents =
-        agentIds.size > 0
-          ? await db
-              .select({ id: agentTable.id, name: agentTable.name })
-              .from(agentTable)
-              .where(inArray(agentTable.id, Array.from(agentIds)))
-          : [];
-      const agentMap = new Map(agents.map((a) => [a.id, a.name]));
-
-      return comments.map((comment) => ({
-        ...comment,
-        createdByName: comment.createdByUserId
-          ? (userMap.get(comment.createdByUserId) ?? null)
-          : comment.createdByAgentId
-            ? (agentMap.get(comment.createdByAgentId) ?? null)
-            : null,
-      }));
-    },
+    execute: async ({ cardId }) =>
+      asToolResult(async () =>
+        resolveCommentNames(db, await listComments(db, ctx, cardId)),
+      ),
   });
 
   const upsertComment = tool({
@@ -665,49 +350,19 @@ export function createKanbanTools(
         ),
       body: z.string().min(1).describe("The comment text (supports markdown)"),
     }),
-    execute: async ({ commentId, cardId, body }) => {
-      // Update existing comment
-      if (commentId) {
-        if (!(await verifyComment(commentId))) {
-          return { error: "Comment not found" };
+    execute: async ({ commentId, cardId, body }) =>
+      asToolResult(async () => {
+        if (commentId) {
+          const comment = await requireComment(db, ctx, commentId);
+          return updateCommentBody(db, comment, body);
         }
 
-        const record = await db
-          .update(kanbanCardCommentTable)
-          .set({ body, updatedAt: new Date() })
-          .where(eq(kanbanCardCommentTable.id, commentId))
-          .returning();
+        if (!cardId) {
+          return { error: "cardId is required when creating a new comment" };
+        }
 
-        return record[0];
-      }
-
-      // Create new comment
-      if (!cardId) {
-        return { error: "cardId is required when creating a new comment" };
-      }
-
-      if (!(await verifyCard(cardId))) {
-        return { error: "Card not found" };
-      }
-
-      const { nanoid } = await import("nanoid");
-      const id = nanoid();
-      const now = new Date();
-
-      const inserted = await db
-        .insert(kanbanCardCommentTable)
-        .values({
-          id,
-          cardId,
-          body,
-          createdByAgentId: agentId,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning();
-
-      return inserted[0];
-    },
+        return createComment(db, ctx, cardId, body);
+      }),
   });
 
   const deleteComment = tool({
@@ -718,20 +373,15 @@ export function createKanbanTools(
         .string()
         .describe("A short description of the comment (for display purposes)"),
     }),
-    execute: async ({ commentId }) => {
-      if (!(await verifyComment(commentId))) {
-        return { error: "Comment not found" };
-      }
-
-      await db
-        .delete(kanbanCardCommentTable)
-        .where(eq(kanbanCardCommentTable.id, commentId));
-
-      return { success: true };
-    },
+    execute: async ({ commentId }) =>
+      asToolResult(async () => {
+        const comment = await requireComment(db, ctx, commentId);
+        await removeComment(db, comment);
+        return { success: true };
+      }),
   });
 
-  const copyCard = tool({
+  const copyCardTool = tool({
     description:
       "Copy a kanban card to a column on the same board, optionally including comments.",
     inputSchema: z.object({
@@ -753,146 +403,17 @@ export function createKanbanTools(
         .describe("Whether to copy comments from the source card"),
       label: z.string().describe("The card title (for display purposes)"),
     }),
-    execute: async ({ cardId, columnId, afterCardId, includeComments }) => {
-      // 1. Verify the source card exists in this workspace
-      if (!(await verifyCard(cardId))) {
-        return { error: "Card not found" };
-      }
-
-      // 2. Verify the target column exists in this workspace
-      if (!(await verifyColumn(columnId))) {
-        return { error: "Column not found" };
-      }
-
-      // 3. Verify both belong to the same board
-      const sourceBoardId = await getBoardIdForCard(cardId);
-
-      const targetColumnResult = await db
-        .select({ boardId: kanbanColumnTable.boardId })
-        .from(kanbanColumnTable)
-        .where(eq(kanbanColumnTable.id, columnId))
-        .limit(1);
-      const targetBoardId = targetColumnResult[0]?.boardId;
-
-      if (sourceBoardId !== targetBoardId) {
-        return { error: "Cross-board copy is not allowed" };
-      }
-
-      // 4. Fetch source card
-      const sourceCards = await db
-        .select()
-        .from(kanbanCardTable)
-        .where(eq(kanbanCardTable.id, cardId))
-        .limit(1);
-      const sourceCard = sourceCards[0];
-
-      // 5. Calculate position
-      let position: number;
-      if (afterCardId === null || afterCardId === undefined) {
-        // Place at end
-        const maxResult = await db
-          .select({ maxPos: max(kanbanCardTable.position) })
-          .from(kanbanCardTable)
-          .where(eq(kanbanCardTable.columnId, columnId));
-        position = (maxResult[0]?.maxPos ?? 0) + 1.0;
-      } else {
-        const cardsInColumn = await db
-          .select()
-          .from(kanbanCardTable)
-          .where(eq(kanbanCardTable.columnId, columnId))
-          .orderBy(asc(kanbanCardTable.position));
-
-        let result: ReturnType<typeof calculateCardPosition>;
-        try {
-          result = calculateCardPosition(cardsInColumn, afterCardId);
-        } catch {
-          return { error: "afterCardId not found in column" };
-        }
-
-        const { position: calcPos, needsRebalance, afterIndex } = result;
-
-        if (needsRebalance) {
-          // Rebalance existing cards and place new card at the right spot.
-          // Only `.id` is read below, so a minimal {id} shape is enough.
-          const reorderedCards: Array<{ id: string }> = [...cardsInColumn];
-          reorderedCards.splice(afterIndex + 1, 0, { id: "__placeholder__" });
-          for (let i = 0; i < reorderedCards.length; i++) {
-            if (reorderedCards[i].id !== "__placeholder__") {
-              await db
-                .update(kanbanCardTable)
-                .set({ position: (i + 1) * 1.0, updatedAt: new Date() })
-                .where(eq(kanbanCardTable.id, reorderedCards[i].id));
-            }
-          }
-          position = (afterIndex + 2) * 1.0;
-        } else {
-          position = calcPos;
-        }
-      }
-
-      // 6. Insert new card
-      const { nanoid } = await import("nanoid");
-      const newId = nanoid();
-      const now = new Date();
-
-      const record = await db
-        .insert(kanbanCardTable)
-        .values({
-          id: newId,
-          columnId,
-          title: sourceCard.title,
-          body: sourceCard.body,
-          labelIds: sourceCard.labelIds,
-          assignees: sourceCard.assignees,
-          dueDate: sourceCard.dueDate,
-          priority: sourceCard.priority,
-          position,
-          createdByAgentId: agentId,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .returning();
-
-      // 7. Copy comments if requested
-      if (includeComments) {
-        const comments = await db
-          .select()
-          .from(kanbanCardCommentTable)
-          .where(eq(kanbanCardCommentTable.cardId, cardId))
-          .orderBy(asc(kanbanCardCommentTable.createdAt));
-
-        for (const comment of comments) {
-          await db.insert(kanbanCardCommentTable).values({
-            id: nanoid(),
-            cardId: newId,
-            body: comment.body,
-            createdByAgentId: agentId,
-            createdAt: now,
-            updatedAt: now,
-          });
-        }
-      }
-
-      // 8. Dispatch event
-      dispatchEvent(
-        orgId,
-        workspaceId,
-        "card.created",
-        { ...record[0], boardId: sourceBoardId },
-        { actorAgentId: agentId },
-      );
-
-      const url = sourceBoardId
-        ? buildResourceUrl(
-            frontendUrl,
-            orgId,
-            workspaceId,
-            `boards/${sourceBoardId}`,
-          ) + `?cardId=${newId}`
-        : undefined;
-
-      return { ...record[0], ...(url && { url }) };
-    },
+    execute: async ({ cardId, columnId, afterCardId, includeComments }) =>
+      asToolResult(async () =>
+        withCardUrl(
+          await copyCard(db, ctx, {
+            cardId,
+            columnId,
+            afterCardId,
+            includeComments,
+          }),
+        ),
+      ),
   });
 
   const bulkEditCards = tool({
@@ -962,151 +483,20 @@ export function createKanbanTools(
             "labelIds is mutually exclusive with addLabelIds and removeLabelIds",
         },
       ),
-    execute: async ({
-      cardIds,
-      columnId,
-      labelIds,
-      addLabelIds,
-      removeLabelIds,
-      assignees,
-      priority,
-      dueDate,
-    }) => {
-      if (columnId && !(await verifyColumn(columnId))) {
-        return { error: "Column not found" };
-      }
+    execute: async ({ label: _label, ...input }) =>
+      asToolResult(async () => {
+        const results = await bulkUpdateCards(db, ctx, input);
+        const succeeded = results.filter((r) => r.success).length;
 
-      // Verify all cards (best-effort — collect per-card results)
-      const failedResults: { cardId: string; success: false; error: string }[] =
-        [];
-      const validCardIds: string[] = [];
-      for (const cardId of cardIds) {
-        if (await verifyCard(cardId)) {
-          validCardIds.push(cardId);
-        } else {
-          failedResults.push({
-            cardId,
-            success: false,
-            error: "Card not found",
-          });
-        }
-      }
-
-      if (validCardIds.length === 0) {
         return {
-          results: failedResults,
+          results,
           summary: {
-            total: cardIds.length,
-            succeeded: 0,
-            failed: failedResults.length,
+            total: results.length,
+            succeeded,
+            failed: results.length - succeeded,
           },
         };
-      }
-
-      // Fetch current labels when additive/subtractive ops are requested
-      let currentLabelsMap: Map<string, string[]> | undefined;
-      if (addLabelIds !== undefined || removeLabelIds !== undefined) {
-        const currentCards = await db
-          .select({
-            id: kanbanCardTable.id,
-            labelIds: kanbanCardTable.labelIds,
-          })
-          .from(kanbanCardTable)
-          .where(inArray(kanbanCardTable.id, validCardIds));
-        currentLabelsMap = new Map(currentCards.map((c) => [c.id, c.labelIds]));
-      }
-
-      // Determine base position for column moves
-      let basePosition = 0;
-      if (columnId) {
-        const maxResult = await db
-          .select({ maxPos: max(kanbanCardTable.position) })
-          .from(kanbanCardTable)
-          .where(eq(kanbanCardTable.columnId, columnId));
-        basePosition = maxResult[0]?.maxPos ?? 0;
-      }
-
-      // Apply all updates in a single transaction
-      await db.transaction(async (tx) => {
-        for (let i = 0; i < validCardIds.length; i++) {
-          const cardId = validCardIds[i];
-          const updateData: Record<string, unknown> = {
-            lastEditedByAgentId: agentId,
-            updatedAt: new Date(),
-          };
-
-          if (columnId !== undefined) {
-            updateData.columnId = columnId;
-            updateData.position = basePosition + (i + 1) * 1.0;
-          }
-
-          if (labelIds !== undefined) {
-            updateData.labelIds = labelIds;
-          } else if (currentLabelsMap) {
-            const current = currentLabelsMap.get(cardId) ?? [];
-            let next = [...current];
-            if (addLabelIds) {
-              next = [...new Set([...next, ...addLabelIds])];
-            }
-            if (removeLabelIds) {
-              next = next.filter((id) => !removeLabelIds.includes(id));
-            }
-            updateData.labelIds = next;
-          }
-
-          if (assignees !== undefined) updateData.assignees = assignees;
-          if (priority !== undefined) updateData.priority = priority;
-          if (dueDate !== undefined)
-            updateData.dueDate = dueDate ? new Date(dueDate) : null;
-
-          await tx
-            .update(kanbanCardTable)
-            .set(updateData)
-            .where(eq(kanbanCardTable.id, cardId));
-        }
-      });
-
-      // Dispatch events for updated cards
-      for (const cardId of validCardIds) {
-        const boardId = await getBoardIdForCard(cardId);
-        const updated = await db
-          .select()
-          .from(kanbanCardTable)
-          .where(eq(kanbanCardTable.id, cardId))
-          .limit(1);
-        dispatchEvent(
-          orgId,
-          workspaceId,
-          "card.updated",
-          { ...updated[0], boardId },
-          { actorAgentId: agentId },
-        );
-      }
-
-      const succeededResults = validCardIds.map((cardId) => ({
-        cardId,
-        success: true as const,
-      }));
-
-      // Return results in input order
-      const resultMap = new Map<
-        string,
-        { cardId: string; success: boolean; error?: string }
-      >([
-        ...succeededResults.map((r) => [r.cardId, r] as const),
-        ...failedResults.map((r) => [r.cardId, r] as const),
-      ]);
-      const results = cardIds.map((id) => resultMap.get(id)!);
-
-      return {
-        results,
-        summary: {
-          total: cardIds.length,
-          succeeded: validCardIds.length,
-          failed: failedResults.length,
-        },
-      };
-    },
+      }),
   });
 
   return {
@@ -1115,12 +505,15 @@ export function createKanbanTools(
     getBoardState,
     getCard,
     upsertCard,
-    moveCard,
-    copyCard,
+    moveCard: moveCardTool,
+    copyCard: copyCardTool,
     deleteCard,
     bulkEditCards,
-    listComments,
+    listComments: listCommentsTool,
     upsertComment,
     deleteComment,
   };
 }
+
+/** What a Tool returns when the module refuses the write. */
+type ErrorResult = { error: string };

--- a/apps/docs/content/building-with-platypus/boards.mdx
+++ b/apps/docs/content/building-with-platypus/boards.mdx
@@ -79,6 +79,14 @@ set lets an Agent:
   **bulk-edit** many cards at once,
 - **read, add, and edit comments** on a card.
 
+<Callout type="info">
+  An Agent is held to the same rules as a person editing the card: it can only
+  apply labels the board actually has, and can only assign someone who can work
+  in this Workspace — a member of the Organization, or an Agent available here.
+  Ask it for anything else and it is refused, so tell it to read the board's
+  labels first rather than inventing one.
+</Callout>
+
 This is what makes boards a two-way surface: you arrange the work, and an Agent —
 in a Chat or on a schedule via a [Trigger](/building-with-platypus/triggers) — can
 keep it moving. Board activity (cards created, updated, or deleted) can in turn

--- a/docs/adr/0010-typed-errors-with-central-onerror-mapping.md
+++ b/docs/adr/0010-typed-errors-with-central-onerror-mapping.md
@@ -49,3 +49,14 @@ level"`) and name conflicts move into `onError`, so they are defined once.
   as a normal outcome rather than a 404.
 - Authorization is unchanged: middleware still decides actor access and returns its own
   403s inline. The error seam covers resource-state failures, not authorization.
+
+## Amendment — `ValidationError` → 400 (#478)
+
+A fourth class, `ValidationError`, was added when the Kanban board's rules moved into one
+module (`services/kanban.ts`) serving both the HTTP routes and the Agent Tool set. A rule
+with two callers cannot answer with one caller's response shape, so it throws: the route
+lets `onError` map it to 400, and the Tool adapter turns it into its `{ error }` result.
+
+This narrows, but does not reverse, "validation stays inline" above. Validation that
+belongs to a single surface still answers inline; only a rule shared by more than one
+surface earns the seam.


### PR DESCRIPTION
Closes #478.

The board's behaviour was implemented twice — once for the HTTP surface, once for the Agent Tool set — and the copies had drifted. Only the routes validated label IDs against the board and assignees against the Workspace, so an Agent could persist a label the board does not have and an assignee who cannot work there.

Both surfaces now call one module, `services/kanban.ts`, which owns the rules, the ordering arithmetic, the scope guards and the event dispatch. Who is acting is a parameter (`{userId} | {agentId}`), which is all that separates a human edit from an Agent's: the attribution column written, and whether the event carries the acting Agent. The routes and Tools are thin adapters that parse, authorize, and shape the result.

|                       | before | after |
| --------------------- | -----: | ----: |
| `routes/kanban.ts`    |   1258 |   736 |
| `tools/kanban.ts`     |   1126 |   519 |
| `services/kanban.ts`  |      — |  1093 |

The move/rebalance/append logic now exists once. The five copies of the append-to-end idiom, the duplicated `moveCard`, and the third inline copy of append+rebalance inside the card copy are gone.

## Typed errors

The module raises the typed errors of ADR-0010: routes rely on the central `onError` mapping, the Tool adapter turns them into its `{error}` result. This adds a fourth class, `ValidationError` → 400, for rules that serve more than one surface — a rule with two callers cannot answer in one caller's response shape. ADR-0010 carries an amendment saying so.

## Behaviour changes beyond the issue

Two checks fall out of the unified guard, both changing a previously-accepted request from 200 to 404:

- **Moving a card** now verifies the target column is in scope, so a card cannot be moved onto another board or another Workspace's column. The old handler went straight to the position arithmetic with no card lookup and no board check.
- **Updating or deleting a comment** now resolves it through its card's board and Workspace, rather than by `(commentId, cardId)` alone.

Everything else is unchanged: HTTP response shapes, status codes for valid input, and tool input schemas (zero changed schema lines in the tools diff).

## Tests

Seven new Tool-surface tests pin the validation the Tool path was missing; each was confirmed failing against the pre-change code before the module existed. The shared rules are tested through the module's own interface in `services/kanban.test.ts`, not through HTTP. Existing route and Tool tests were updated only where they pinned the divergent behaviour or the internal call shapes.

`pnpm typecheck`, `pnpm lint` and `pnpm test` pass (1684 backend tests).

## Docs

`building-with-platypus/boards.mdx` gains a Callout: an Agent is held to the same rules as a person editing the card. The issue expected no docs impact, but Agent-visible behaviour changed, so CLAUDE.md's rule applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
