### PR TITLE
feat(backend): route Sub-Agent runs through the run lifecycle

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,7 +32,7 @@ _Avoid_: parsed text, converted file, OCR (Platypus does not OCR).
 A configurable preset that pins a Provider, model, Instructions, generation parameters, Tools, Skills, and sub-Agents. Selecting an Agent on a Chat turn replaces direct Provider/model selection.
 
 **Sub-Agent**:
-An Agent referenced by a parent Agent and exposed to it as a delegate Tool.
+An Agent referenced by a parent Agent and exposed to it as a delegate Tool. Invoking it starts a run in its own right — bounded by the same per-step and per-run timeouts the parent turn was started under, and cancelled when the parent is — but never a Chat: nothing about a delegated run is persisted.
 
 **Instructions**:
 The free-text behaviour brief a User writes on an Agent — or on a Chat with no Agent. One input to the System prompt rather than the whole of it: it renders as the first fragment and cannot suppress the Platypus-owned fragments that follow.

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -55,6 +55,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@ai-sdk/provider": "^4.0.4",
     "@eslint/js": "^10.0.1",
     "@platypus-examples/tool-set": "workspace:*",
     "@types/dockerode": "^4.0.1",

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -4,7 +4,6 @@ import {
   createUIMessageStreamResponse,
   generateText,
   readUIMessageStream,
-  stepCountIs,
   streamText,
 } from "ai";
 import { formatStreamError, isTruncatedByTokenLimit } from "./stream-error.ts";
@@ -14,18 +13,17 @@ import {
   prepareChatTurn,
   validateTurnAttachments,
   type ChatTurn,
-  type ToolActivityEvent,
 } from "../services/chat-execution.ts";
+import type { ToolActivityEvent } from "../services/tool-activity.ts";
 import { logger } from "../logger.ts";
-import { rejectedToolInputs } from "../rejected-tool-input.ts";
 import { actorUserId, type WorkspaceScope } from "../scope.ts";
 import type { PlatypusUIMessage } from "../types.ts";
+import { runRegistry, type RegisterOptions } from "./run-registry.ts";
 import {
-  runRegistry,
-  TimeoutError,
-  type RegisterOptions,
-  type RunHandle,
-} from "./run-registry.ts";
+  buildModelInvocation,
+  computeStats,
+  startRun,
+} from "./run-lifecycle.ts";
 import {
   createNoProgressDetector,
   NoProgressError,
@@ -37,7 +35,6 @@ import type {
   RunInput,
   RunSink,
   RunStats,
-  RunStatus,
 } from "./types.ts";
 
 export type StreamOptions = {
@@ -62,86 +59,6 @@ export type GenerateResult = {
 };
 
 /**
- * One step's Context occupancy: the input tokens the vendor reported for it,
- * which is the whole conversation as that call sent it (ADR-0018). `undefined`
- * where the step reported none — nothing is estimated, and 0 would read as a
- * measurement of an empty context.
- */
-const stepOccupancy = (usage?: { inputTokens?: number }): number | undefined =>
-  typeof usage?.inputTokens === "number" ? usage.inputTokens : undefined;
-
-/**
- * Folds a single step's tool calls and usage into a running `RunStats`
- * accumulator. Mutates `stats` in place. Used by `onStepFinish` so the
- * sink can observe partial progress without waiting for the final result.
- */
-const accumulateStepStats = (
-  stats: RunStats,
-  step: {
-    toolCalls?: Array<{ toolName: string }>;
-    usage?: { inputTokens?: number; outputTokens?: number };
-  },
-): void => {
-  stats.steps = (stats.steps ?? 0) + 1;
-  const counts = new Map<string, number>(
-    (stats.toolCalls ?? []).map((tc) => [tc.name, tc.count]),
-  );
-  for (const tc of step.toolCalls ?? []) {
-    counts.set(tc.toolName, (counts.get(tc.toolName) ?? 0) + 1);
-  }
-  stats.toolCalls = Array.from(counts, ([name, count]) => ({ name, count }));
-  if (step.usage) {
-    stats.inputTokens =
-      (stats.inputTokens ?? 0) + (step.usage.inputTokens ?? 0);
-    stats.outputTokens =
-      (stats.outputTokens ?? 0) + (step.usage.outputTokens ?? 0);
-  }
-  // REPLACED, not summed, and outside the guard above: the whole conversation
-  // is in every step's input count, so the latest step is the current context
-  // size while the running totals are sums of context sizes (ADR-0018). A step
-  // that reports nothing — no count, or no usage object at all — clears the
-  // figure rather than leaving an earlier, smaller step's standing as if it
-  // were current, which is what a mid-run stats flush would otherwise publish.
-  stats.contextOccupancy = stepOccupancy(step.usage);
-};
-
-/**
- * Computes per-run statistics from an AI SDK result with `steps` and
- * `totalUsage`. Works for both stream and generate paths.
- */
-const computeStats = (result: {
-  steps: Array<{
-    toolCalls: Array<{ toolName: string }>;
-    usage?: { inputTokens?: number };
-  }>;
-  totalUsage: { inputTokens?: number; outputTokens?: number };
-}): RunStats => {
-  const toolCallCounts = new Map<string, number>();
-  for (const step of result.steps) {
-    for (const tc of step.toolCalls) {
-      toolCallCounts.set(
-        tc.toolName,
-        (toolCallCounts.get(tc.toolName) ?? 0) + 1,
-      );
-    }
-  }
-  // The FINAL step only. Scanning back for the most recent step that did report
-  // a count would answer with a smaller, earlier context as though it were the
-  // one the run ended on.
-  const contextOccupancy = stepOccupancy(result.steps.at(-1)?.usage);
-  return {
-    steps: result.steps.length,
-    toolCalls: Array.from(toolCallCounts, ([name, count]) => ({ name, count })),
-    inputTokens: result.totalUsage.inputTokens ?? 0,
-    outputTokens: result.totalUsage.outputTokens ?? 0,
-    // Spread so a run whose Provider reported no usage stores no key at all,
-    // matching the schema's optional field: absent means unknown, and 0 would
-    // read as a measurement of an empty context.
-    ...(contextOccupancy === undefined ? {} : { contextOccupancy }),
-  };
-};
-
-/**
  * Derives the `user` argument expected by `prepareChatTurn` from the run
  * scope. For trigger and sub-agent principals the userId resolves through
  * `actorUserId` to the underlying human owner.
@@ -153,41 +70,13 @@ const userFromScope = (scope: WorkspaceScope): { id: string; name: string } => {
   return { id: actorUserId(scope.principal), name: "Sub-agent" };
 };
 
-/**
- * Builds the activity callback handed to `prepareChatTurn`. Every invocation
- * bumps the run's per-step stall timer. When the wrapper passes a tool
- * boundary event we also emit a structured log line — start events at debug
- * (noisy), end events at info with duration so post-mortem of a stalled run
- * shows exactly which tool was slow.
- */
-const makeActivityHandler =
-  (handle: RunHandle, runId: RunId) =>
-  (event?: ToolActivityEvent): void => {
-    handle.bumpStep();
-    if (!event) return;
-    if (event.phase === "start") {
-      logger.debug({ runId, toolName: event.toolName }, "Tool call started");
-    } else {
-      logger.info(
-        {
-          runId,
-          toolName: event.toolName,
-          durationMs: event.durationMs,
-        },
-        "Tool call finished",
-      );
-    }
-  };
-
 /** Mutable per-run state shared by `setup`, the timeout handler, and the
  *  consumer-shaped entry point. A background timer (the timeout) and the
  *  foreground model call both read/write it, so it lives in one object both
  *  can reach. */
 type RunState = {
   turn?: ChatTurn;
-  stats: RunStats;
   messages: PlatypusUIMessage[];
-  terminated: boolean;
 };
 
 /**
@@ -202,8 +91,9 @@ type RunState = {
  * per-step / per-run timeout timers. Cancellation goes through
  * `agentRunner.cancel(runId)` (e.g. from the chat cancel route).
  *
- * Out of scope (later PRs):
- * - Sub-agent runs as AgentRunner consumers (PR #4)
+ * A delegated (sub-agent) run is not driven from here: the delegate tool owns
+ * its own turn, already resolved by the parent's `prepareChatTurn`. It shares
+ * the lifecycle rather than the entry point — see `runs/run-lifecycle.ts`.
  */
 export class AgentRunner {
   private async prepare(
@@ -211,7 +101,7 @@ export class AgentRunner {
     input: RunInput,
     origin: string | undefined,
     frontendUrl?: string,
-    onActivity?: (event?: ToolActivityEvent) => void,
+    onActivity?: (event: ToolActivityEvent) => void,
   ): Promise<ChatTurn> {
     return prepareChatTurn({
       orgId: scope.orgId,
@@ -223,6 +113,9 @@ export class AgentRunner {
       frontendUrl,
       runMode: scope.principal.kind === "user" ? "interactive" : "headless",
       onActivity,
+      // Sub-agent delegate tools built for this turn register their own runs
+      // as children of this one, so they need to know whose child they are.
+      run: { runId: input.runId, scope },
     });
   }
 
@@ -235,14 +128,14 @@ export class AgentRunner {
   }
 
   /**
-   * Shared run scaffolding: the sink lifecycle (`onStart` → `onResolved`),
-   * the registry + timeout wiring, `prepare`, the per-step callback, and the
-   * once-only `finalize`. Both `stream` and `generate` build on this; only the
-   * model invocation and the consumer-shaped return value differ.
+   * Shared run scaffolding: the sink lifecycle (`onStart` → `onResolved`) laid
+   * over the run lifecycle (registry, timeouts, statistics, once-only
+   * termination). Both `stream` and `generate` build on this; only the model
+   * invocation and the consumer-shaped return value differ.
    *
-   * `finalize` and the timeout handler live here but read `state`, which the
-   * caller keeps writing (the streamed messages) after `setup` returns — so a
-   * timeout firing mid-stream still persists the partial answer.
+   * The terminal callback lives here but reads `state`, which the caller keeps
+   * writing (the streamed messages) after `setup` returns — so a timeout firing
+   * mid-stream still persists the partial answer.
    */
   private async setup(params: {
     scope: WorkspaceScope;
@@ -275,53 +168,41 @@ export class AgentRunner {
     await sink.onStart({ runId: input.runId, messages: input.messages });
 
     const state: RunState = {
-      stats: {},
       messages: input.messages,
-      terminated: false,
     };
 
-    const finalize = async (
-      status: RunStatus,
-      error?: Error,
-    ): Promise<void> => {
-      if (state.terminated) return;
-      state.terminated = true;
-      try {
-        await state.turn?.dispose();
-      } catch (err) {
-        logger.error({ err, runId: input.runId }, "Error disposing turn");
-      }
-      try {
-        await sink.onFinish({
-          runId: input.runId,
-          status,
-          messages: state.messages,
-          stats: state.stats,
-          error,
-        });
-      } catch (err) {
-        logger.error({ err, runId: input.runId }, "Error in onFinish");
-      }
-      runRegistry.unregister(input.runId);
-    };
-
-    const handle: RunHandle = runRegistry.register(input.runId, {
-      ...params.timeouts,
-      onTimeout: (error) => {
-        logger.error(
-          {
+    const run = startRun({
+      runId: input.runId,
+      timeouts: params.timeouts,
+      onTerminate: async ({ status, error, stats }) => {
+        try {
+          await state.turn?.dispose();
+        } catch (err) {
+          logger.error({ err, runId: input.runId }, "Error disposing turn");
+        }
+        try {
+          await sink.onFinish({
             runId: input.runId,
-            kind: error.kind,
-            message: error.message,
-            stats: state.stats,
-          },
-          "Run timed out",
-        );
-        void finalize("failed", error);
+            status,
+            messages: state.messages,
+            stats,
+            error,
+          });
+        } catch (err) {
+          logger.error({ err, runId: input.runId }, "Error in onFinish");
+        }
+      },
+      // Sink decides write cadence (FlushScheduler in ChatSink).
+      onStepProgress: (stats) => {
+        void sink
+          .onProgress({ runId: input.runId, messages: state.messages, stats })
+          .catch((err) =>
+            logger.error({ err, runId: input.runId }, "Error in onProgress"),
+          );
       },
     });
 
-    const onActivity = makeActivityHandler(handle, input.runId);
+    const { handle, finish: finalize, onStep, onActivity } = run;
 
     try {
       state.turn = await this.prepare(
@@ -344,68 +225,6 @@ export class AgentRunner {
     const plan: ResolvedRunPlan = { resolved: state.turn.resolved };
     await sink.onResolved({ runId: input.runId, plan });
 
-    const onStep = (step: {
-      toolCalls?: Array<{ toolName: string }>;
-      usage?: { inputTokens?: number; outputTokens?: number };
-      // Both, deliberately. The unified union collapses any reason the
-      // provider adapter doesn't recognise into `other` — which is how
-      // Bedrock's `malformed_tool_use` becomes indistinguishable from a
-      // dozen other endings. The raw value is the only record of what the
-      // provider actually said (issue #406).
-      finishReason?: string;
-      rawFinishReason?: string;
-      /**
-       * The step's parts, read only for the tool calls that failed. Both the
-       * streaming and the unattended path record a `tool-error` here, so one
-       * callback covers both — `onChunk` would cover only streaming.
-       */
-      content?: unknown;
-    }): void => {
-      handle.bumpStep();
-      accumulateStepStats(state.stats, step);
-      logger.info(
-        {
-          runId: input.runId,
-          step: state.stats.steps,
-          toolCalls: step.toolCalls?.map((tc) => tc.toolName) ?? [],
-          finishReason: step.finishReason,
-          rawFinishReason: step.rawFinishReason,
-          stats: state.stats,
-        },
-        "Step finished",
-      );
-      if (isTruncatedByTokenLimit(step.finishReason)) {
-        logger.warn(
-          {
-            runId: input.runId,
-            step: state.stats.steps,
-            rawFinishReason: step.rawFinishReason,
-          },
-          "Step truncated at the output token limit",
-        );
-      }
-      // What the model actually emitted for a tool call that failed. At `debug`
-      // because tool arguments are model and user data: at the default
-      // `LOG_LEVEL=info` nothing is written, and an Operator diagnosing a
-      // recurrence raises the level (issue #421).
-      for (const rejected of rejectedToolInputs(step.content)) {
-        logger.debug(
-          { runId: input.runId, step: state.stats.steps, ...rejected },
-          "Tool call failed",
-        );
-      }
-      // Sink decides write cadence (FlushScheduler in ChatSink).
-      void sink
-        .onProgress({
-          runId: input.runId,
-          messages: state.messages,
-          stats: state.stats,
-        })
-        .catch((err) =>
-          logger.error({ err, runId: input.runId }, "Error in onProgress"),
-        );
-    };
-
     // Unattended runs gain a second stop condition alongside the step
     // ceiling: when the model makes no progress (same call → same result,
     // K times) the loop halts before issuing yet another wasteful step.
@@ -414,33 +233,17 @@ export class AgentRunner {
       ? createNoProgressDetector()
       : null;
 
-    // Built once and shared by both invocations. Generation params pass
-    // through as-is (including `undefined`): the SDK treats an absent key and
-    // an `undefined` value identically, and the streaming path has always
-    // passed them this way in production.
+    // Built once and shared by both invocations, by the same assembly a
+    // delegated run uses.
     const modelArgs = {
-      model: state.turn.stream.model,
+      ...buildModelInvocation(state.turn.stream, {
+        abortSignal: handle.signal,
+        extraStopConditions: noProgress ? [noProgress.stopCondition] : [],
+      }),
       messages: await convertToModelMessages(state.turn.stream.messages),
-      system: state.turn.stream.system,
-      tools: state.turn.stream.tools,
-      stopWhen: noProgress
-        ? [stepCountIs(state.turn.stream.maxSteps), noProgress.stopCondition]
-        : [stepCountIs(state.turn.stream.maxSteps)],
-      abortSignal: handle.signal,
-      // The Provider's declared ceiling for this model, or undefined when it
-      // declares none — which is what Bedrock needs, since its Converse request
-      // carries no `inferenceConfig.maxTokens` at all unless one is passed
-      // (issue #454).
-      maxOutputTokens: state.turn.stream.maxOutputTokens,
-      temperature: state.turn.stream.temperature,
-      topP: state.turn.stream.topP,
-      topK: state.turn.stream.topK,
-      frequencyPenalty: state.turn.stream.frequencyPenalty,
-      presencePenalty: state.turn.stream.presencePenalty,
-      seed: state.turn.stream.seed,
     };
 
-    return { state, handle, finalize, onStep, modelArgs, noProgress };
+    return { state, run, handle, finalize, onStep, modelArgs, noProgress };
   }
 
   async stream(params: {
@@ -450,7 +253,7 @@ export class AgentRunner {
     options: StreamOptions;
   }): Promise<Response> {
     const { input, options } = params;
-    const { state, handle, finalize, onStep, modelArgs } = await this.setup({
+    const { state, run, finalize, onStep, modelArgs } = await this.setup({
       scope: params.scope,
       input,
       sink: params.sink,
@@ -505,18 +308,8 @@ export class AgentRunner {
         // window to overwrite this, so the sink's terminal write observes it.
         finalMessagesReceived = true;
         state.messages = applyToolDurations(finalMessages, toolDurations);
-        let status: RunStatus = "succeeded";
-        let err: Error | undefined;
-        if (handle.signal.aborted) {
-          const reason: unknown = handle.signal.reason;
-          if (reason instanceof TimeoutError) {
-            status = "failed";
-            err = reason;
-          } else {
-            status = "cancelled";
-          }
-        }
-        await finalize(status, err);
+        const { status, error } = run.statusFromSignal();
+        await finalize(status, error);
       },
     });
 
@@ -567,15 +360,14 @@ export class AgentRunner {
     const options = params.options ?? {};
     // No `origin`: headless callers don't have file URLs to inline.
     // Headless runs are unattended → enable no-progress detection.
-    const { state, handle, finalize, onStep, modelArgs, noProgress } =
-      await this.setup({
-        scope: params.scope,
-        input,
-        sink: params.sink,
-        frontendUrl: options.frontendUrl,
-        timeouts: options.timeouts,
-        unattended: true,
-      });
+    const { run, finalize, onStep, modelArgs, noProgress } = await this.setup({
+      scope: params.scope,
+      input,
+      sink: params.sink,
+      frontendUrl: options.frontendUrl,
+      timeouts: options.timeouts,
+      unattended: true,
+    });
 
     const startTime = Date.now();
     try {
@@ -592,7 +384,7 @@ export class AgentRunner {
       if (isTruncatedByTokenLimit(result.finishReason)) {
         stats.truncatedByTokenLimit = true;
       }
-      state.stats = stats;
+      run.setStats(stats);
 
       // The no-progress stop condition halts the loop cleanly (the SDK
       // resolves normally), so the abort is surfaced here rather than via the
@@ -644,14 +436,13 @@ export class AgentRunner {
         },
         "Run generate failed",
       );
-      let status: RunStatus = "failed";
-      if (
-        handle.signal.aborted &&
-        !(handle.signal.reason instanceof TimeoutError)
-      ) {
-        status = "cancelled";
-      }
-      await finalize(status, err);
+      // A cancelled run is recorded as cancelled; a timed-out one stays a
+      // failure, and so does anything the model call threw on its own.
+      const aborted = run.statusFromSignal();
+      await finalize(
+        aborted.status === "cancelled" ? "cancelled" : "failed",
+        err,
+      );
       throw err;
     }
   }

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -18,12 +18,10 @@ import type { ToolActivityEvent } from "../services/tool-activity.ts";
 import { logger } from "../logger.ts";
 import { actorUserId, type WorkspaceScope } from "../scope.ts";
 import type { PlatypusUIMessage } from "../types.ts";
-import { runRegistry, type RegisterOptions } from "./run-registry.ts";
-import {
-  buildModelInvocation,
-  computeStats,
-  startRun,
-} from "./run-lifecycle.ts";
+import { runRegistry, type RunTimeouts } from "./run-registry.ts";
+import { startRun } from "./run-lifecycle.ts";
+import { buildModelInvocation } from "./run-plan.ts";
+import { computeStats } from "./run-stats.ts";
 import {
   createNoProgressDetector,
   NoProgressError,
@@ -45,12 +43,12 @@ export type StreamOptions = {
    * abort signal is intentionally NOT accepted — Chat runs continue to
    * completion regardless of the client connection (see issue #113).
    */
-  timeouts?: Pick<RegisterOptions, "perStepTimeoutMs" | "perRunTimeoutMs">;
+  timeouts?: RunTimeouts;
 };
 
 export type GenerateOptions = {
   frontendUrl?: string;
-  timeouts?: Pick<RegisterOptions, "perStepTimeoutMs" | "perRunTimeoutMs">;
+  timeouts?: RunTimeouts;
 };
 
 export type GenerateResult = {
@@ -100,8 +98,9 @@ export class AgentRunner {
     scope: WorkspaceScope,
     input: RunInput,
     origin: string | undefined,
-    frontendUrl?: string,
-    onActivity?: (event: ToolActivityEvent) => void,
+    frontendUrl: string | undefined,
+    timeouts: RunTimeouts | undefined,
+    onActivity: (event: ToolActivityEvent) => void,
   ): Promise<ChatTurn> {
     return prepareChatTurn({
       orgId: scope.orgId,
@@ -114,8 +113,9 @@ export class AgentRunner {
       runMode: scope.principal.kind === "user" ? "interactive" : "headless",
       onActivity,
       // Sub-agent delegate tools built for this turn register their own runs
-      // as children of this one, so they need to know whose child they are.
-      run: { runId: input.runId, scope },
+      // as children of this one, so they need to know whose child they are and
+      // what bounds this run was started under.
+      run: { runId: input.runId, scope, timeouts },
     });
   }
 
@@ -143,7 +143,7 @@ export class AgentRunner {
     sink: RunSink;
     origin?: string;
     frontendUrl?: string;
-    timeouts?: Pick<RegisterOptions, "perStepTimeoutMs" | "perRunTimeoutMs">;
+    timeouts?: RunTimeouts;
     /**
      * Unattended (trigger/scheduled) runs enable no-progress detection: a
      * stuck model that re-issues the same call for the same result is aborted
@@ -202,15 +202,14 @@ export class AgentRunner {
       },
     });
 
-    const { handle, finish: finalize, onStep, onActivity } = run;
-
     try {
       state.turn = await this.prepare(
         scope,
         input,
         params.origin,
         params.frontendUrl,
-        onActivity,
+        params.timeouts,
+        run.onActivity,
       );
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
@@ -218,7 +217,7 @@ export class AgentRunner {
         { error, runId: input.runId },
         "Run prepare failed before model invocation",
       );
-      await finalize("failed", err);
+      await run.finish("failed", err);
       throw err;
     }
 
@@ -237,13 +236,13 @@ export class AgentRunner {
     // delegated run uses.
     const modelArgs = {
       ...buildModelInvocation(state.turn.stream, {
-        abortSignal: handle.signal,
-        extraStopConditions: noProgress ? [noProgress.stopCondition] : [],
+        abortSignal: run.handle.signal,
+        extraStopCondition: noProgress?.stopCondition,
       }),
       messages: await convertToModelMessages(state.turn.stream.messages),
     };
 
-    return { state, run, handle, finalize, onStep, modelArgs, noProgress };
+    return { state, run, modelArgs, noProgress };
   }
 
   async stream(params: {
@@ -253,7 +252,7 @@ export class AgentRunner {
     options: StreamOptions;
   }): Promise<Response> {
     const { input, options } = params;
-    const { state, run, finalize, onStep, modelArgs } = await this.setup({
+    const { state, run, modelArgs } = await this.setup({
       scope: params.scope,
       input,
       sink: params.sink,
@@ -281,7 +280,7 @@ export class AgentRunner {
 
     const result = streamText({
       ...modelArgs,
-      onStepFinish: (step) => onStep(step),
+      onStepFinish: (step) => run.onStep(step),
       onToolExecutionEnd: ({ toolCall, toolExecutionMs }) => {
         toolDurations.set(toolCall.toolCallId, toolExecutionMs);
       },
@@ -309,7 +308,7 @@ export class AgentRunner {
         finalMessagesReceived = true;
         state.messages = applyToolDurations(finalMessages, toolDurations);
         const { status, error } = run.statusFromSignal();
-        await finalize(status, error);
+        await run.finish(status, error);
       },
     });
 
@@ -360,7 +359,7 @@ export class AgentRunner {
     const options = params.options ?? {};
     // No `origin`: headless callers don't have file URLs to inline.
     // Headless runs are unattended → enable no-progress detection.
-    const { run, finalize, onStep, modelArgs, noProgress } = await this.setup({
+    const { run, modelArgs, noProgress } = await this.setup({
       scope: params.scope,
       input,
       sink: params.sink,
@@ -373,13 +372,13 @@ export class AgentRunner {
     try {
       const result = await generateText({
         ...modelArgs,
-        onStepFinish: (step) => onStep(step),
+        onStepFinish: (step) => run.onStep(step),
       });
 
       const stats = computeStats(result as Parameters<typeof computeStats>[0]);
       // The terminal finish only, as on the streamed path: a step inside a tool
       // loop can end at the ceiling and the run still recover. Set before
-      // `finalize`, which is what carries `state.stats` to `sink.onFinish` —
+      // `finish`, which is what carries the run's stats to `sink.onFinish` —
       // the sink's record is the only channel an unattended run has.
       if (isTruncatedByTokenLimit(result.finishReason)) {
         stats.truncatedByTokenLimit = true;
@@ -406,7 +405,7 @@ export class AgentRunner {
           },
           "Run aborted: no progress",
         );
-        await finalize("failed", err);
+        await run.finish("failed", err);
         return { text: result.text, stats };
       }
 
@@ -424,7 +423,7 @@ export class AgentRunner {
         "Run generate completed",
       );
 
-      await finalize("succeeded");
+      await run.finish("succeeded");
       return { text: result.text, stats };
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
@@ -439,7 +438,7 @@ export class AgentRunner {
       // A cancelled run is recorded as cancelled; a timed-out one stays a
       // failure, and so does anything the model call threw on its own.
       const aborted = run.statusFromSignal();
-      await finalize(
+      await run.finish(
         aborted.status === "cancelled" ? "cancelled" : "failed",
         err,
       );

--- a/apps/backend/src/runs/run-lifecycle.ts
+++ b/apps/backend/src/runs/run-lifecycle.ts
@@ -1,173 +1,15 @@
-import { stepCountIs, type LanguageModel, type Tool } from "ai";
 import { logger } from "../logger.ts";
 import { rejectedToolInputs } from "../rejected-tool-input.ts";
 import type { ToolActivityEvent } from "../services/tool-activity.ts";
 import { isTruncatedByTokenLimit } from "./stream-error.ts";
-import type { NoProgressDetector } from "./no-progress.ts";
+import { accumulateStepStats, type RunStep } from "./run-stats.ts";
 import {
   runRegistry,
   TimeoutError,
-  type RegisterOptions,
   type RunHandle,
+  type RunTimeouts,
 } from "./run-registry.ts";
 import type { RunId, RunStats, RunStatus } from "./types.ts";
-
-/**
- * The generation half of a resolved turn: everything the model call needs
- * except the conversation itself.
- *
- * Structurally what `ChatTurn["stream"]` carries, minus `messages` — a Chat
- * turn passes UI messages that still need converting, a delegated run passes a
- * single task prompt, and neither of those belongs in the shared assembly.
- */
-export type RunPlan = {
-  model: LanguageModel;
-  tools: Record<string, Tool>;
-  system?: string;
-  maxSteps: number;
-  maxOutputTokens?: number;
-  temperature?: number;
-  topP?: number;
-  topK?: number;
-  frequencyPenalty?: number;
-  presencePenalty?: number;
-  seed?: number;
-};
-
-/**
- * Assembles the model/tools/system/stopWhen/ceiling/sampling arguments shared
- * by every run, whichever entry point drives it.
- *
- * Generation params pass through as-is (including `undefined`): the SDK treats
- * an absent key and an `undefined` value identically, and the streaming path
- * has always passed them this way in production.
- */
-export const buildModelInvocation = (
-  plan: RunPlan,
-  options: {
-    abortSignal: AbortSignal;
-    /**
-     * Stop conditions beyond the step ceiling — currently the no-progress
-     * detector on unattended runs.
-     */
-    extraStopConditions?: NoProgressDetector["stopCondition"][];
-  },
-) => ({
-  model: plan.model,
-  system: plan.system,
-  tools: plan.tools,
-  stopWhen: [
-    stepCountIs(plan.maxSteps),
-    ...(options.extraStopConditions ?? []),
-  ],
-  abortSignal: options.abortSignal,
-  // The Provider's declared ceiling for this model, or undefined when it
-  // declares none — which is what Bedrock needs, since its Converse request
-  // carries no `inferenceConfig.maxTokens` at all unless one is passed
-  // (issue #454).
-  maxOutputTokens: plan.maxOutputTokens,
-  temperature: plan.temperature,
-  topP: plan.topP,
-  topK: plan.topK,
-  frequencyPenalty: plan.frequencyPenalty,
-  presencePenalty: plan.presencePenalty,
-  seed: plan.seed,
-});
-
-/**
- * One step's Context occupancy: the input tokens the vendor reported for it,
- * which is the whole conversation as that call sent it (ADR-0018). `undefined`
- * where the step reported none — nothing is estimated, and 0 would read as a
- * measurement of an empty context.
- */
-export const stepOccupancy = (usage?: {
-  inputTokens?: number;
-}): number | undefined =>
-  typeof usage?.inputTokens === "number" ? usage.inputTokens : undefined;
-
-/** As much of an SDK step result as the run lifecycle reads. */
-export type RunStep = {
-  toolCalls?: Array<{ toolName: string }>;
-  usage?: { inputTokens?: number; outputTokens?: number };
-  // Both reasons, deliberately. The unified union collapses any reason the
-  // provider adapter doesn't recognise into `other` — which is how Bedrock's
-  // `malformed_tool_use` becomes indistinguishable from a dozen other endings.
-  // The raw value is the only record of what the provider actually said
-  // (issue #406).
-  finishReason?: string;
-  rawFinishReason?: string;
-  /**
-   * The step's parts, read only for the tool calls that failed. Both the
-   * streaming and the unattended path record a `tool-error` here, so one
-   * callback covers both — `onChunk` would cover only streaming.
-   */
-  content?: unknown;
-};
-
-/**
- * Folds a single step's tool calls and usage into a running `RunStats`
- * accumulator. Mutates `stats` in place, so a consumer can observe partial
- * progress without waiting for the final result.
- */
-export const accumulateStepStats = (stats: RunStats, step: RunStep): void => {
-  stats.steps = (stats.steps ?? 0) + 1;
-  const counts = new Map<string, number>(
-    (stats.toolCalls ?? []).map((tc) => [tc.name, tc.count]),
-  );
-  for (const tc of step.toolCalls ?? []) {
-    counts.set(tc.toolName, (counts.get(tc.toolName) ?? 0) + 1);
-  }
-  stats.toolCalls = Array.from(counts, ([name, count]) => ({ name, count }));
-  if (step.usage) {
-    stats.inputTokens =
-      (stats.inputTokens ?? 0) + (step.usage.inputTokens ?? 0);
-    stats.outputTokens =
-      (stats.outputTokens ?? 0) + (step.usage.outputTokens ?? 0);
-  }
-  // REPLACED, not summed, and outside the guard above: the whole conversation
-  // is in every step's input count, so the latest step is the current context
-  // size while the running totals are sums of context sizes (ADR-0018). A step
-  // that reports nothing — no count, or no usage object at all — clears the
-  // figure rather than leaving an earlier, smaller step's standing as if it
-  // were current, which is what a mid-run stats flush would otherwise publish.
-  stats.contextOccupancy = stepOccupancy(step.usage);
-};
-
-/**
- * Computes per-run statistics from an AI SDK result with `steps` and
- * `totalUsage`. Works for both stream and generate paths.
- */
-export const computeStats = (result: {
-  steps: Array<{
-    toolCalls: Array<{ toolName: string }>;
-    usage?: { inputTokens?: number };
-  }>;
-  totalUsage: { inputTokens?: number; outputTokens?: number };
-}): RunStats => {
-  const toolCallCounts = new Map<string, number>();
-  for (const step of result.steps) {
-    for (const tc of step.toolCalls) {
-      toolCallCounts.set(
-        tc.toolName,
-        (toolCallCounts.get(tc.toolName) ?? 0) + 1,
-      );
-    }
-  }
-  // The FINAL step only. Scanning back for the most recent step that did report
-  // a count would answer with a smaller, earlier context as though it were the
-  // one the run ended on.
-  const contextOccupancy = stepOccupancy(result.steps.at(-1)?.usage);
-  return {
-    steps: result.steps.length,
-    toolCalls: Array.from(toolCallCounts, ([name, count]) => ({ name, count })),
-    inputTokens: result.totalUsage.inputTokens ?? 0,
-    outputTokens: result.totalUsage.outputTokens ?? 0,
-    // Spread so a run whose Provider reported no usage stores no key at all,
-    // matching the schema's optional field: absent means unknown, and 0 would
-    // read as a measurement of an empty context.
-    ...(contextOccupancy === undefined ? {} : { contextOccupancy }),
-  };
-};
 
 /**
  * A registered run: its abort signal and timers, its accumulating statistics,
@@ -196,11 +38,19 @@ export type RunLifecycle = {
   /** Terminate once, with the outcome. Repeat calls are no-ops. */
   finish: (status: RunStatus, error?: Error) => Promise<void>;
   /**
-   * The status an otherwise-successful ending should be recorded under: a run
-   * whose signal was aborted ended because someone stopped it, and a timeout
-   * is a failure rather than a cancellation.
+   * How this run ended, as far as its abort signal knows: `succeeded` while the
+   * signal is clear, `cancelled` where someone stopped it, and `failed` with the
+   * `TimeoutError` where a timer did. The one place that reading is made, so no
+   * caller re-derives it from `signal.reason`.
    */
   statusFromSignal: () => { status: RunStatus; error?: Error };
+  /**
+   * Why the run was stopped, as a sentence, or `undefined` while it is still
+   * running. A cancellation reaches `statusFromSignal` as a status with no
+   * error — deliberately, since nothing failed — so a caller that has to *say*
+   * what happened asks here instead of unpacking `signal.reason` itself.
+   */
+  abortReason: () => string | undefined;
 };
 
 /**
@@ -215,7 +65,7 @@ export const startRun = (params: {
   runId: RunId;
   /** Fields stamped on every log line this run emits (org, workspace, …). */
   log?: Record<string, unknown>;
-  timeouts?: Pick<RegisterOptions, "perStepTimeoutMs" | "perRunTimeoutMs">;
+  timeouts?: RunTimeouts;
   onTerminate: (ctx: {
     status: RunStatus;
     error?: Error;
@@ -315,6 +165,12 @@ export const startRun = (params: {
       : { status: "cancelled" };
   };
 
+  const abortReason = (): string | undefined => {
+    if (!handle.signal.aborted) return undefined;
+    const reason: unknown = handle.signal.reason;
+    return reason instanceof Error ? reason.message : undefined;
+  };
+
   return {
     handle,
     get stats() {
@@ -327,5 +183,6 @@ export const startRun = (params: {
     onActivity,
     finish,
     statusFromSignal,
+    abortReason,
   };
 };

--- a/apps/backend/src/runs/run-lifecycle.ts
+++ b/apps/backend/src/runs/run-lifecycle.ts
@@ -1,0 +1,331 @@
+import { stepCountIs, type LanguageModel, type Tool } from "ai";
+import { logger } from "../logger.ts";
+import { rejectedToolInputs } from "../rejected-tool-input.ts";
+import type { ToolActivityEvent } from "../services/tool-activity.ts";
+import { isTruncatedByTokenLimit } from "./stream-error.ts";
+import type { NoProgressDetector } from "./no-progress.ts";
+import {
+  runRegistry,
+  TimeoutError,
+  type RegisterOptions,
+  type RunHandle,
+} from "./run-registry.ts";
+import type { RunId, RunStats, RunStatus } from "./types.ts";
+
+/**
+ * The generation half of a resolved turn: everything the model call needs
+ * except the conversation itself.
+ *
+ * Structurally what `ChatTurn["stream"]` carries, minus `messages` — a Chat
+ * turn passes UI messages that still need converting, a delegated run passes a
+ * single task prompt, and neither of those belongs in the shared assembly.
+ */
+export type RunPlan = {
+  model: LanguageModel;
+  tools: Record<string, Tool>;
+  system?: string;
+  maxSteps: number;
+  maxOutputTokens?: number;
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  seed?: number;
+};
+
+/**
+ * Assembles the model/tools/system/stopWhen/ceiling/sampling arguments shared
+ * by every run, whichever entry point drives it.
+ *
+ * Generation params pass through as-is (including `undefined`): the SDK treats
+ * an absent key and an `undefined` value identically, and the streaming path
+ * has always passed them this way in production.
+ */
+export const buildModelInvocation = (
+  plan: RunPlan,
+  options: {
+    abortSignal: AbortSignal;
+    /**
+     * Stop conditions beyond the step ceiling — currently the no-progress
+     * detector on unattended runs.
+     */
+    extraStopConditions?: NoProgressDetector["stopCondition"][];
+  },
+) => ({
+  model: plan.model,
+  system: plan.system,
+  tools: plan.tools,
+  stopWhen: [
+    stepCountIs(plan.maxSteps),
+    ...(options.extraStopConditions ?? []),
+  ],
+  abortSignal: options.abortSignal,
+  // The Provider's declared ceiling for this model, or undefined when it
+  // declares none — which is what Bedrock needs, since its Converse request
+  // carries no `inferenceConfig.maxTokens` at all unless one is passed
+  // (issue #454).
+  maxOutputTokens: plan.maxOutputTokens,
+  temperature: plan.temperature,
+  topP: plan.topP,
+  topK: plan.topK,
+  frequencyPenalty: plan.frequencyPenalty,
+  presencePenalty: plan.presencePenalty,
+  seed: plan.seed,
+});
+
+/**
+ * One step's Context occupancy: the input tokens the vendor reported for it,
+ * which is the whole conversation as that call sent it (ADR-0018). `undefined`
+ * where the step reported none — nothing is estimated, and 0 would read as a
+ * measurement of an empty context.
+ */
+export const stepOccupancy = (usage?: {
+  inputTokens?: number;
+}): number | undefined =>
+  typeof usage?.inputTokens === "number" ? usage.inputTokens : undefined;
+
+/** As much of an SDK step result as the run lifecycle reads. */
+export type RunStep = {
+  toolCalls?: Array<{ toolName: string }>;
+  usage?: { inputTokens?: number; outputTokens?: number };
+  // Both reasons, deliberately. The unified union collapses any reason the
+  // provider adapter doesn't recognise into `other` — which is how Bedrock's
+  // `malformed_tool_use` becomes indistinguishable from a dozen other endings.
+  // The raw value is the only record of what the provider actually said
+  // (issue #406).
+  finishReason?: string;
+  rawFinishReason?: string;
+  /**
+   * The step's parts, read only for the tool calls that failed. Both the
+   * streaming and the unattended path record a `tool-error` here, so one
+   * callback covers both — `onChunk` would cover only streaming.
+   */
+  content?: unknown;
+};
+
+/**
+ * Folds a single step's tool calls and usage into a running `RunStats`
+ * accumulator. Mutates `stats` in place, so a consumer can observe partial
+ * progress without waiting for the final result.
+ */
+export const accumulateStepStats = (stats: RunStats, step: RunStep): void => {
+  stats.steps = (stats.steps ?? 0) + 1;
+  const counts = new Map<string, number>(
+    (stats.toolCalls ?? []).map((tc) => [tc.name, tc.count]),
+  );
+  for (const tc of step.toolCalls ?? []) {
+    counts.set(tc.toolName, (counts.get(tc.toolName) ?? 0) + 1);
+  }
+  stats.toolCalls = Array.from(counts, ([name, count]) => ({ name, count }));
+  if (step.usage) {
+    stats.inputTokens =
+      (stats.inputTokens ?? 0) + (step.usage.inputTokens ?? 0);
+    stats.outputTokens =
+      (stats.outputTokens ?? 0) + (step.usage.outputTokens ?? 0);
+  }
+  // REPLACED, not summed, and outside the guard above: the whole conversation
+  // is in every step's input count, so the latest step is the current context
+  // size while the running totals are sums of context sizes (ADR-0018). A step
+  // that reports nothing — no count, or no usage object at all — clears the
+  // figure rather than leaving an earlier, smaller step's standing as if it
+  // were current, which is what a mid-run stats flush would otherwise publish.
+  stats.contextOccupancy = stepOccupancy(step.usage);
+};
+
+/**
+ * Computes per-run statistics from an AI SDK result with `steps` and
+ * `totalUsage`. Works for both stream and generate paths.
+ */
+export const computeStats = (result: {
+  steps: Array<{
+    toolCalls: Array<{ toolName: string }>;
+    usage?: { inputTokens?: number };
+  }>;
+  totalUsage: { inputTokens?: number; outputTokens?: number };
+}): RunStats => {
+  const toolCallCounts = new Map<string, number>();
+  for (const step of result.steps) {
+    for (const tc of step.toolCalls) {
+      toolCallCounts.set(
+        tc.toolName,
+        (toolCallCounts.get(tc.toolName) ?? 0) + 1,
+      );
+    }
+  }
+  // The FINAL step only. Scanning back for the most recent step that did report
+  // a count would answer with a smaller, earlier context as though it were the
+  // one the run ended on.
+  const contextOccupancy = stepOccupancy(result.steps.at(-1)?.usage);
+  return {
+    steps: result.steps.length,
+    toolCalls: Array.from(toolCallCounts, ([name, count]) => ({ name, count })),
+    inputTokens: result.totalUsage.inputTokens ?? 0,
+    outputTokens: result.totalUsage.outputTokens ?? 0,
+    // Spread so a run whose Provider reported no usage stores no key at all,
+    // matching the schema's optional field: absent means unknown, and 0 would
+    // read as a measurement of an empty context.
+    ...(contextOccupancy === undefined ? {} : { contextOccupancy }),
+  };
+};
+
+/**
+ * A registered run: its abort signal and timers, its accumulating statistics,
+ * the callbacks the SDK invokes, and a once-only termination.
+ *
+ * Every run in the system holds one of these — Chat turns and Trigger runs
+ * through `AgentRunner`, delegated runs through the sub-agent tool. Nothing
+ * else registers with `RunRegistry`, so nothing else can time out, be
+ * cancelled, or go unobserved.
+ */
+export type RunLifecycle = {
+  handle: RunHandle;
+  /** Accumulated as steps finish; read by the terminal callback. */
+  readonly stats: RunStats;
+  /**
+   * Replace the accumulated statistics with the authoritative per-run figures
+   * an SDK result carries (`computeStats`). The accumulator exists so a run
+   * that never reaches its result — cancelled, timed out — still reports
+   * something; where a result does arrive, it wins.
+   */
+  setStats: (next: RunStats) => void;
+  /** `onStepFinish` for `streamText` / `generateText`. */
+  onStep: (step: RunStep) => void;
+  /** Tool-call boundary handler for `wrapToolsWithActivity`. */
+  onActivity: (event: ToolActivityEvent) => void;
+  /** Terminate once, with the outcome. Repeat calls are no-ops. */
+  finish: (status: RunStatus, error?: Error) => Promise<void>;
+  /**
+   * The status an otherwise-successful ending should be recorded under: a run
+   * whose signal was aborted ended because someone stopped it, and a timeout
+   * is a failure rather than a cancellation.
+   */
+  statusFromSignal: () => { status: RunStatus; error?: Error };
+};
+
+/**
+ * Registers a run and wires its timers, statistics and logging.
+ *
+ * The caller supplies `onTerminate`, which runs exactly once whichever way the
+ * run ends — success, failure, cancellation, or a timeout that fires while the
+ * model call is still in flight. Unregistering is handled here so no caller can
+ * leak an entry.
+ */
+export const startRun = (params: {
+  runId: RunId;
+  /** Fields stamped on every log line this run emits (org, workspace, …). */
+  log?: Record<string, unknown>;
+  timeouts?: Pick<RegisterOptions, "perStepTimeoutMs" | "perRunTimeoutMs">;
+  onTerminate: (ctx: {
+    status: RunStatus;
+    error?: Error;
+    stats: RunStats;
+  }) => Promise<void> | void;
+  /** Called after each step is folded into `stats`. */
+  onStepProgress?: (stats: RunStats) => void;
+}): RunLifecycle => {
+  const { runId, onTerminate } = params;
+  const logFields = { runId, ...params.log };
+  let stats: RunStats = {};
+  let terminated = false;
+
+  const finish = async (status: RunStatus, error?: Error): Promise<void> => {
+    if (terminated) return;
+    terminated = true;
+    try {
+      await onTerminate({ status, error, stats });
+    } catch (err) {
+      logger.error({ err, ...logFields }, "Error terminating run");
+    }
+    runRegistry.unregister(runId);
+  };
+
+  const handle = runRegistry.register(runId, {
+    ...params.timeouts,
+    onTimeout: (error) => {
+      logger.error(
+        { ...logFields, kind: error.kind, message: error.message, stats },
+        "Run timed out",
+      );
+      void finish("failed", error);
+    },
+  });
+
+  const onStep = (step: RunStep): void => {
+    handle.bumpStep();
+    accumulateStepStats(stats, step);
+    logger.info(
+      {
+        ...logFields,
+        step: stats.steps,
+        toolCalls: step.toolCalls?.map((tc) => tc.toolName) ?? [],
+        finishReason: step.finishReason,
+        rawFinishReason: step.rawFinishReason,
+        stats,
+      },
+      "Step finished",
+    );
+    if (isTruncatedByTokenLimit(step.finishReason)) {
+      logger.warn(
+        {
+          ...logFields,
+          step: stats.steps,
+          rawFinishReason: step.rawFinishReason,
+        },
+        "Step truncated at the output token limit",
+      );
+    }
+    // What the model actually emitted for a tool call that failed. At `debug`
+    // because tool arguments are model and user data: at the default
+    // `LOG_LEVEL=info` nothing is written, and an Operator diagnosing a
+    // recurrence raises the level (issue #421).
+    for (const rejected of rejectedToolInputs(step.content)) {
+      logger.debug(
+        { ...logFields, step: stats.steps, ...rejected },
+        "Tool call failed",
+      );
+    }
+    params.onStepProgress?.(stats);
+  };
+
+  // Start events hold the per-step stall timer down for the duration of the
+  // call; end events release it and log the measured duration, so a post-mortem
+  // of a stalled run shows exactly which tool was slow.
+  const onActivity = (event: ToolActivityEvent): void => {
+    if (event.phase === "start") {
+      handle.holdStep();
+      logger.debug(
+        { ...logFields, toolName: event.toolName },
+        "Tool call started",
+      );
+      return;
+    }
+    handle.releaseStep();
+    logger.info(
+      { ...logFields, toolName: event.toolName, durationMs: event.durationMs },
+      "Tool call finished",
+    );
+  };
+
+  const statusFromSignal = (): { status: RunStatus; error?: Error } => {
+    if (!handle.signal.aborted) return { status: "succeeded" };
+    const reason: unknown = handle.signal.reason;
+    return reason instanceof TimeoutError
+      ? { status: "failed", error: reason }
+      : { status: "cancelled" };
+  };
+
+  return {
+    handle,
+    get stats() {
+      return stats;
+    },
+    setStats: (next: RunStats) => {
+      stats = next;
+    },
+    onStep,
+    onActivity,
+    finish,
+    statusFromSignal,
+  };
+};

--- a/apps/backend/src/runs/run-plan.ts
+++ b/apps/backend/src/runs/run-plan.ts
@@ -1,0 +1,78 @@
+import { stepCountIs, type LanguageModel, type Tool } from "ai";
+import type { NoProgressDetector } from "./no-progress.ts";
+
+/**
+ * The generation half of a resolved turn: everything the model call needs
+ * except the conversation itself.
+ *
+ * Structurally what `ChatTurn["stream"]` carries, minus `messages` — a Chat
+ * turn passes UI messages that still need converting, a delegated run passes a
+ * single task prompt, and neither of those belongs in the shared assembly.
+ */
+export type RunPlan = {
+  model: LanguageModel;
+  tools: Record<string, Tool>;
+  system?: string;
+  maxSteps: number;
+  maxOutputTokens?: number;
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  seed?: number;
+};
+
+/** The generation settings, minus any the plan never set. */
+const declaredSettings = (plan: RunPlan): Partial<RunPlan> =>
+  Object.fromEntries(
+    (
+      [
+        // The Provider's declared ceiling for this model, absent when it
+        // declares none — which is what Bedrock needs, since its Converse
+        // request carries no `inferenceConfig.maxTokens` at all unless one is
+        // passed (issue #454).
+        "maxOutputTokens",
+        "temperature",
+        "topP",
+        "topK",
+        "frequencyPenalty",
+        "presencePenalty",
+        "seed",
+      ] as const
+    )
+      .filter((key) => plan[key] !== undefined)
+      .map((key) => [key, plan[key]]),
+  );
+
+/**
+ * Assembles the model/tools/system/stopWhen/ceiling/sampling arguments shared
+ * by every run, whichever entry point drives it.
+ *
+ * A parameter the plan never set is left off entirely rather than sent as
+ * `undefined`. The SDK reads the two the same way, so this changes nothing it
+ * receives — it means an assertion about what was sent can be written as "the
+ * key is absent", which is the only form that catches a `null` or a `0` sneaking
+ * in as though it were "unset".
+ */
+export const buildModelInvocation = (
+  plan: RunPlan,
+  options: {
+    abortSignal: AbortSignal;
+    /**
+     * A stop condition beyond the step ceiling. Only unattended runs have one:
+     * the no-progress detector, which halts a model re-issuing the same call
+     * for the same result.
+     */
+    extraStopCondition?: NoProgressDetector["stopCondition"];
+  },
+) => ({
+  model: plan.model,
+  system: plan.system,
+  tools: plan.tools,
+  stopWhen: options.extraStopCondition
+    ? [stepCountIs(plan.maxSteps), options.extraStopCondition]
+    : [stepCountIs(plan.maxSteps)],
+  abortSignal: options.abortSignal,
+  ...declaredSettings(plan),
+});

--- a/apps/backend/src/runs/run-registry.test.ts
+++ b/apps/backend/src/runs/run-registry.test.ts
@@ -95,6 +95,103 @@ describe("RunRegistry", () => {
     expect(handle.signal.aborted).toBe(true);
   });
 
+  describe("activity holds", () => {
+    it("suspends the per-step timer while a tool call is in flight", () => {
+      const onTimeout = vi.fn();
+      const handle = registry.register("hold-1", {
+        perStepTimeoutMs: 1000,
+        perRunTimeoutMs: 1_000_000,
+        onTimeout,
+      });
+
+      handle.holdStep();
+      // Ten times the stall threshold: a tool that is still executing is not a
+      // stalled step, however long it takes.
+      vi.advanceTimersByTime(10_000);
+      expect(onTimeout).not.toHaveBeenCalled();
+      expect(handle.signal.aborted).toBe(false);
+
+      handle.releaseStep();
+      vi.advanceTimersByTime(999);
+      expect(onTimeout).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the timer suspended until the last parallel tool call releases", () => {
+      const onTimeout = vi.fn();
+      registry.register("hold-2", {
+        perStepTimeoutMs: 1000,
+        perRunTimeoutMs: 1_000_000,
+        onTimeout,
+      });
+      const handle = registry.register("hold-2b", {
+        perStepTimeoutMs: 1000,
+        perRunTimeoutMs: 1_000_000,
+        onTimeout,
+      });
+
+      handle.holdStep();
+      handle.holdStep();
+      handle.releaseStep();
+      vi.advanceTimersByTime(5000);
+      expect(handle.signal.aborted).toBe(false);
+
+      handle.releaseStep();
+      vi.advanceTimersByTime(1000);
+      expect(handle.signal.aborted).toBe(true);
+    });
+
+    it("ignores a release with no matching hold rather than re-arming twice", () => {
+      const onTimeout = vi.fn();
+      const handle = registry.register("hold-3", {
+        perStepTimeoutMs: 1000,
+        perRunTimeoutMs: 1_000_000,
+        onTimeout,
+      });
+
+      handle.releaseStep();
+      handle.releaseStep();
+      handle.holdStep();
+
+      vi.advanceTimersByTime(5000);
+      expect(handle.signal.aborted).toBe(false);
+    });
+
+    // The per-RUN ceiling is the backstop: a tool that never returns must not
+    // buy the run unlimited wall-clock just by holding the step timer down.
+    it("does not suspend the per-run timeout", () => {
+      const onTimeout = vi.fn();
+      const handle = registry.register("hold-4", {
+        perStepTimeoutMs: 1_000_000,
+        perRunTimeoutMs: 500,
+        onTimeout,
+      });
+
+      handle.holdStep();
+      vi.advanceTimersByTime(500);
+
+      expect(handle.signal.aborted).toBe(true);
+      expect((onTimeout.mock.calls[0][0] as TimeoutError).kind).toBe("run");
+    });
+
+    it("a hold taken after the run finished never re-arms a timer", () => {
+      const onTimeout = vi.fn();
+      const handle = registry.register("hold-5", {
+        perStepTimeoutMs: 1000,
+        onTimeout,
+      });
+
+      handle.holdStep();
+      registry.unregister("hold-5");
+      handle.releaseStep();
+
+      vi.advanceTimersByTime(5000);
+      expect(onTimeout).not.toHaveBeenCalled();
+    });
+  });
+
   it("cancel before timeout suppresses the timeout callback", () => {
     const onTimeout = vi.fn();
     registry.register("run-7", {

--- a/apps/backend/src/runs/run-registry.ts
+++ b/apps/backend/src/runs/run-registry.ts
@@ -34,6 +34,15 @@ export type RegisterOptions = {
   onTimeout?: (error: TimeoutError) => void;
 };
 
+/**
+ * The two bounds a caller may set per run. Named because four call sites
+ * across three modules pass exactly this pair.
+ */
+export type RunTimeouts = Pick<
+  RegisterOptions,
+  "perStepTimeoutMs" | "perRunTimeoutMs"
+>;
+
 export type RunHandle = {
   runId: RunId;
   signal: AbortSignal;

--- a/apps/backend/src/runs/run-registry.ts
+++ b/apps/backend/src/runs/run-registry.ts
@@ -39,6 +39,18 @@ export type RunHandle = {
   signal: AbortSignal;
   /** Reset the per-step timer (e.g. when a step makes progress). */
   bumpStep(): void;
+  /**
+   * Suspend the per-step stall timer for the duration of a tool call.
+   *
+   * The per-step timeout answers "has the model stopped making progress
+   * between steps?", and a tool that is still executing is not that. Holds
+   * nest, so parallel tool calls are counted; the timer re-arms when the last
+   * one releases. The per-RUN timeout is deliberately untouched, so a tool that
+   * never returns is still bounded.
+   */
+  holdStep(): void;
+  /** Release a hold taken by {@link RunHandle.holdStep}. */
+  releaseStep(): void;
 };
 
 export const DEFAULT_PER_STEP_TIMEOUT_MS = 2 * 60 * 1000;
@@ -51,6 +63,8 @@ type Entry = {
   runTimer?: ReturnType<typeof setTimeout>;
   onTimeout?: (error: TimeoutError) => void;
   finished: boolean;
+  /** Tool calls currently in flight; the step timer is off while this is > 0. */
+  holds: number;
 };
 
 export class RunRegistry {
@@ -73,6 +87,7 @@ export class RunRegistry {
       perStepTimeoutMs,
       onTimeout: options.onTimeout,
       finished: false,
+      holds: 0,
     };
 
     const fireTimeout = (kind: "step" | "run") => {
@@ -95,14 +110,35 @@ export class RunRegistry {
 
     this.entries.set(runId, entry);
 
+    // Re-arm the per-step timer, unless a tool call is holding it down. Every
+    // path that restarts the timer goes through here, so a hold cannot be
+    // undone by a concurrent bump.
+    const armStep = (e: Entry) => {
+      if (e.stepTimer) clearTimeout(e.stepTimer);
+      e.stepTimer = undefined;
+      if (e.holds > 0) return;
+      e.stepTimer = setTimeout(() => fireTimeout("step"), e.perStepTimeoutMs);
+    };
+
     return {
       runId,
       signal: controller.signal,
       bumpStep: () => {
         const e = this.entries.get(runId);
         if (!e || e.finished) return;
-        if (e.stepTimer) clearTimeout(e.stepTimer);
-        e.stepTimer = setTimeout(() => fireTimeout("step"), e.perStepTimeoutMs);
+        armStep(e);
+      },
+      holdStep: () => {
+        const e = this.entries.get(runId);
+        if (!e || e.finished) return;
+        e.holds += 1;
+        armStep(e);
+      },
+      releaseStep: () => {
+        const e = this.entries.get(runId);
+        if (!e || e.finished || e.holds === 0) return;
+        e.holds -= 1;
+        armStep(e);
       },
     };
   }

--- a/apps/backend/src/runs/run-stats.ts
+++ b/apps/backend/src/runs/run-stats.ts
@@ -1,0 +1,104 @@
+import type { RunStats } from "./types.ts";
+
+/**
+ * Per-run statistics, folded from the SDK's step results.
+ *
+ * Pure arithmetic over what the vendor reported — no registry, no timers, no
+ * logging — so the occupancy rules below (ADR-0018) can be read and tested
+ * without a run around them.
+ */
+
+/**
+ * One step's Context occupancy: the input tokens the vendor reported for it,
+ * which is the whole conversation as that call sent it (ADR-0018). `undefined`
+ * where the step reported none — nothing is estimated, and 0 would read as a
+ * measurement of an empty context.
+ */
+export const stepOccupancy = (usage?: {
+  inputTokens?: number;
+}): number | undefined =>
+  typeof usage?.inputTokens === "number" ? usage.inputTokens : undefined;
+
+/** As much of an SDK step result as the run lifecycle reads. */
+export type RunStep = {
+  toolCalls?: Array<{ toolName: string }>;
+  usage?: { inputTokens?: number; outputTokens?: number };
+  // Both reasons, deliberately. The unified union collapses any reason the
+  // provider adapter doesn't recognise into `other` — which is how Bedrock's
+  // `malformed_tool_use` becomes indistinguishable from a dozen other endings.
+  // The raw value is the only record of what the provider actually said
+  // (issue #406).
+  finishReason?: string;
+  rawFinishReason?: string;
+  /**
+   * The step's parts, read only for the tool calls that failed. Both the
+   * streaming and the unattended path record a `tool-error` here, so one
+   * callback covers both — `onChunk` would cover only streaming.
+   */
+  content?: unknown;
+};
+
+/**
+ * Folds a single step's tool calls and usage into a running `RunStats`
+ * accumulator. Mutates `stats` in place, so a consumer can observe partial
+ * progress without waiting for the final result.
+ */
+export const accumulateStepStats = (stats: RunStats, step: RunStep): void => {
+  stats.steps = (stats.steps ?? 0) + 1;
+  const counts = new Map<string, number>(
+    (stats.toolCalls ?? []).map((tc) => [tc.name, tc.count]),
+  );
+  for (const tc of step.toolCalls ?? []) {
+    counts.set(tc.toolName, (counts.get(tc.toolName) ?? 0) + 1);
+  }
+  stats.toolCalls = Array.from(counts, ([name, count]) => ({ name, count }));
+  if (step.usage) {
+    stats.inputTokens =
+      (stats.inputTokens ?? 0) + (step.usage.inputTokens ?? 0);
+    stats.outputTokens =
+      (stats.outputTokens ?? 0) + (step.usage.outputTokens ?? 0);
+  }
+  // REPLACED, not summed, and outside the guard above: the whole conversation
+  // is in every step's input count, so the latest step is the current context
+  // size while the running totals are sums of context sizes (ADR-0018). A step
+  // that reports nothing — no count, or no usage object at all — clears the
+  // figure rather than leaving an earlier, smaller step's standing as if it
+  // were current, which is what a mid-run stats flush would otherwise publish.
+  stats.contextOccupancy = stepOccupancy(step.usage);
+};
+
+/**
+ * Computes per-run statistics from an AI SDK result with `steps` and
+ * `totalUsage`. Works for both stream and generate paths.
+ */
+export const computeStats = (result: {
+  steps: Array<{
+    toolCalls: Array<{ toolName: string }>;
+    usage?: { inputTokens?: number };
+  }>;
+  totalUsage: { inputTokens?: number; outputTokens?: number };
+}): RunStats => {
+  const toolCallCounts = new Map<string, number>();
+  for (const step of result.steps) {
+    for (const tc of step.toolCalls) {
+      toolCallCounts.set(
+        tc.toolName,
+        (toolCallCounts.get(tc.toolName) ?? 0) + 1,
+      );
+    }
+  }
+  // The FINAL step only. Scanning back for the most recent step that did report
+  // a count would answer with a smaller, earlier context as though it were the
+  // one the run ended on.
+  const contextOccupancy = stepOccupancy(result.steps.at(-1)?.usage);
+  return {
+    steps: result.steps.length,
+    toolCalls: Array.from(toolCallCounts, ([name, count]) => ({ name, count })),
+    inputTokens: result.totalUsage.inputTokens ?? 0,
+    outputTokens: result.totalUsage.outputTokens ?? 0,
+    // Spread so a run whose Provider reported no usage stores no key at all,
+    // matching the schema's optional field: absent means unknown, and 0 would
+    // read as a measurement of an empty context.
+    ...(contextOccupancy === undefined ? {} : { contextOccupancy }),
+  };
+};

--- a/apps/backend/src/runs/stream-error.ts
+++ b/apps/backend/src/runs/stream-error.ts
@@ -82,10 +82,12 @@ const describeStringifiedToolInputError = (
  * model — so it has to be short enough to read and specific enough to act on.
  *
  * Pure, and separate from {@link formatStreamError}, so a caller that is not
- * rendering a stream failure — naming the reason a sub-agent could not be built,
- * say — gets the same wording without a spurious "Chat stream error" log line.
+ * rendering a stream failure gets the same wording without a spurious "Chat
+ * stream error" log line. Naming why a sub-agent could not be built is the
+ * other caller: what fails there is a Provider being opened, so the cases this
+ * recognises — a missing API key, a 401, a rate limit — are exactly its causes.
  */
-export const describeStreamError = (error: unknown): string => {
+export const describeSdkError = (error: unknown): string => {
   if (LoadAPIKeyError.isInstance(error)) {
     return "AI provider API key is missing or not configured.";
   }
@@ -136,12 +138,12 @@ export const describeStreamError = (error: unknown): string => {
 };
 
 /**
- * {@link describeStreamError}, plus the log line every stream failure earns.
+ * {@link describeSdkError}, plus the log line every stream failure earns.
  * This is what `toUIMessageStream`'s `onError` is wired to on every run.
  */
 export const formatStreamError = (error: unknown): string => {
   logger.error({ error }, "Chat stream error");
-  return describeStreamError(error);
+  return describeSdkError(error);
 };
 
 /**

--- a/apps/backend/src/runs/stream-error.ts
+++ b/apps/backend/src/runs/stream-error.ts
@@ -80,10 +80,12 @@ const describeStringifiedToolInputError = (
  *
  * The text produced here reaches both the user and, on a failed step, the
  * model — so it has to be short enough to read and specific enough to act on.
+ *
+ * Pure, and separate from {@link formatStreamError}, so a caller that is not
+ * rendering a stream failure — naming the reason a sub-agent could not be built,
+ * say — gets the same wording without a spurious "Chat stream error" log line.
  */
-export const formatStreamError = (error: unknown): string => {
-  logger.error({ error }, "Chat stream error");
-
+export const describeStreamError = (error: unknown): string => {
   if (LoadAPIKeyError.isInstance(error)) {
     return "AI provider API key is missing or not configured.";
   }
@@ -131,6 +133,15 @@ export const formatStreamError = (error: unknown): string => {
   // The reported failure landed here and the runtime type was never captured,
   // which is why nobody could tell what had actually been thrown.
   return `An unexpected error occurred (received ${describeNonError(error)}).`;
+};
+
+/**
+ * {@link describeStreamError}, plus the log line every stream failure earns.
+ * This is what `toUIMessageStream`'s `onError` is wired to on every run.
+ */
+export const formatStreamError = (error: unknown): string => {
+  logger.error({ error }, "Chat stream error");
+  return describeStreamError(error);
 };
 
 /**

--- a/apps/backend/src/runs/sub-agent-lifecycle.test.ts
+++ b/apps/backend/src/runs/sub-agent-lifecycle.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { z } from "zod";
+
+vi.mock("../logger.ts", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { startRun } from "./run-lifecycle.ts";
+import { runRegistry, type RunHandle } from "./run-registry.ts";
+import { wrapToolsWithActivity } from "../services/tool-activity.ts";
+import { createSubAgentTool } from "../tools/sub-agent.ts";
+import { workspaceScope, orgScope, type WorkspaceScope } from "../scope.ts";
+import type { RunStatus } from "./types.ts";
+
+/**
+ * A parent turn and the delegate tool it advertises, composed the way
+ * `prepareChatTurn` composes them.
+ *
+ * Never composed in a test before this: the per-step stall timer lives in
+ * `runs/`, the tool wrapper in `services/`, and the delegate in `tools/`, so
+ * "does a long delegation kill the parent?" had no home to be asked in.
+ */
+const USAGE = {
+  inputTokens: {
+    total: 5,
+    noCache: 5,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: 2, text: 2, reasoning: undefined },
+};
+
+const stream = (
+  parts: LanguageModelV3StreamPart[],
+  unified: "stop" | "tool-calls" = "stop",
+): LanguageModelV3StreamPart[] => [
+  { type: "stream-start", warnings: [] },
+  ...parts,
+  { type: "finish", finishReason: { unified, raw: unified }, usage: USAGE },
+];
+
+const modelOf = (...steps: LanguageModelV3StreamPart[][]) => {
+  let index = 0;
+  return new MockLanguageModelV3({
+    doStream: () => {
+      const parts = steps[Math.min(index, steps.length - 1)];
+      index += 1;
+      return Promise.resolve({
+        stream: simulateReadableStream({ chunks: parts }),
+      });
+    },
+  });
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const parentScope: WorkspaceScope = workspaceScope(
+  orgScope({ principal: { kind: "user", userId: "u1", name: "Ada" } }, "org-1"),
+  "ws-1",
+  true,
+);
+
+/** The parent's stall threshold. Small enough to fire inside a fast test. */
+const PER_STEP_MS = 60;
+/** How long the delegated run takes — several times the parent's threshold. */
+const SUB_AGENT_MS = 250;
+
+describe("a delegated run inside a parent run", () => {
+  let outcomes: Array<{ status: RunStatus; error?: Error }>;
+  let parentHandle: RunHandle;
+
+  const startParent = () => {
+    outcomes = [];
+    const parent = startRun({
+      runId: `parent-${Math.random().toString(36).slice(2)}`,
+      timeouts: { perStepTimeoutMs: PER_STEP_MS, perRunTimeoutMs: 60_000 },
+      onTerminate: ({ status, error }) => {
+        outcomes.push({ status, error });
+      },
+    });
+    parentHandle = parent.handle;
+    return parent;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The acceptance criterion: before this, the only thing keeping the parent
+  // alive across a long delegation was a 30s heartbeat interval started in
+  // `services/` and fed by the sub-agent's own stream yields.
+  it("does not trip the parent's per-step stall timeout", async () => {
+    const parent = startParent();
+
+    const { toolName, tool } = createSubAgentTool({
+      id: "sa-1",
+      name: "Slow Agent",
+      model: modelOf(
+        stream(
+          [
+            { type: "tool-input-start", id: "tc1", toolName: "slowWork" },
+            { type: "tool-input-end", id: "tc1" },
+            {
+              type: "tool-call",
+              toolCallId: "tc1",
+              toolName: "slowWork",
+              input: "{}",
+            },
+          ],
+          "tool-calls",
+        ),
+        stream([
+          { type: "text-start", id: "t1" },
+          { type: "text-delta", id: "t1", delta: "Took a while." },
+          { type: "text-end", id: "t1" },
+        ]),
+      ),
+      tools: {
+        slowWork: {
+          inputSchema: z.object({}),
+          execute: async () => {
+            await sleep(SUB_AGENT_MS);
+            return "done";
+          },
+        },
+      },
+      parentRun: { runId: "parent", scope: parentScope },
+    });
+
+    // Exactly what `prepareChatTurn` hands the model: the delegate wrapped so
+    // its boundaries reach the parent's run lifecycle.
+    const wrapped = wrapToolsWithActivity(
+      { [toolName]: tool },
+      parent.onActivity,
+    );
+
+    const execute = (
+      wrapped[toolName] as unknown as {
+        execute: (a: unknown, o: unknown) => AsyncIterable<unknown>;
+      }
+    ).execute;
+
+    for await (const _ of execute(
+      { task: "Take your time" },
+      { abortSignal: parent.handle.signal },
+    )) {
+      void _;
+    }
+
+    expect(parent.handle.signal.aborted).toBe(false);
+    expect(outcomes).toEqual([]);
+
+    await parent.finish("succeeded");
+    expect(outcomes).toEqual([{ status: "succeeded", error: undefined }]);
+  });
+
+  // Proves the threshold above is real: the same wait with no tool call in
+  // flight does end the parent run.
+  it("still stalls a parent that is idle for the same span", async () => {
+    startParent();
+
+    await sleep(PER_STEP_MS * 2);
+
+    expect(parentHandle.signal.aborted).toBe(true);
+    expect(outcomes.map((o) => o.status)).toEqual(["failed"]);
+    expect(outcomes[0].error?.name).toBe("TimeoutError");
+  });
+
+  it("registers the delegated run for its duration and unregisters it after", async () => {
+    const parent = startParent();
+    const registerSpy = vi.spyOn(runRegistry, "register");
+
+    const { tool } = createSubAgentTool({
+      id: "sa-1",
+      name: "Quick Agent",
+      model: modelOf(
+        stream([
+          { type: "text-start", id: "t1" },
+          { type: "text-delta", id: "t1", delta: "Done." },
+          { type: "text-end", id: "t1" },
+        ]),
+      ),
+      tools: {},
+      parentRun: { runId: "parent", scope: parentScope },
+    });
+
+    const gen = (
+      tool as unknown as {
+        execute: (a: unknown, o: unknown) => AsyncIterable<unknown>;
+      }
+    ).execute({ task: "Be quick" }, { abortSignal: parent.handle.signal });
+
+    let subRunId: string | undefined;
+    for await (const _ of gen) {
+      void _;
+      if (subRunId) continue;
+      subRunId = registerSpy.mock.calls.at(-1)?.[0];
+      // Registered from the first activity update, while the delegation is
+      // still streaming.
+      expect(runRegistry.has(subRunId!)).toBe(true);
+    }
+
+    expect(subRunId).toMatch(/^sub_/);
+    expect(runRegistry.has(subRunId!)).toBe(false);
+
+    registerSpy.mockRestore();
+    await parent.finish("succeeded");
+  });
+});

--- a/apps/backend/src/runs/types.ts
+++ b/apps/backend/src/runs/types.ts
@@ -1,7 +1,23 @@
 import type { PlatypusUIMessage } from "../types.ts";
 import type { ChatTurnRequest, ChatTurn } from "../services/chat-execution.ts";
+import type { WorkspaceScope } from "../scope.ts";
+import type { RunTimeouts } from "./run-registry.ts";
 
 export type RunId = string;
+
+/**
+ * The run a sub-Agent delegation nests inside.
+ *
+ * A delegated run is a run in its own right — registry entry, timers,
+ * statistics — so it has to say whose child it is (`workspaceScopeForSubAgent`
+ * chains the principal), inherit the bounds the parent was started under rather
+ * than the process defaults, and be cancelled when the parent is.
+ */
+export type ParentRunContext = {
+  runId: RunId;
+  scope: WorkspaceScope;
+  timeouts?: RunTimeouts;
+};
 
 export type RunStatus = "running" | "succeeded" | "failed" | "cancelled";
 

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -88,10 +88,10 @@ import {
   validateTurnAttachments,
   NotFoundError,
   ValidationError,
-  createToolHeartbeat,
   resolveSearchMode,
-  wrapToolsWithBump,
+  wrapToolsWithActivity,
   normalizeToolResult,
+  type ToolActivityEvent,
 } from "./chat-execution.ts";
 import {
   clearWebBackends,
@@ -1263,92 +1263,6 @@ describe("chat-execution", () => {
     });
   });
 
-  describe("createToolHeartbeat", () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it("fires bump at the configured cadence while a tool is in flight", () => {
-      const bump = vi.fn();
-      const hb = createToolHeartbeat(bump, 1000);
-
-      hb.onToolStart();
-      // No bump yet — the heartbeat fires on each interval tick, not at start.
-      expect(bump).not.toHaveBeenCalled();
-
-      vi.advanceTimersByTime(1000);
-      expect(bump).toHaveBeenCalledTimes(1);
-
-      vi.advanceTimersByTime(2000);
-      expect(bump).toHaveBeenCalledTimes(3);
-
-      hb.onToolEnd();
-      vi.advanceTimersByTime(5000);
-      // No further bumps after the last tool ends.
-      expect(bump).toHaveBeenCalledTimes(3);
-    });
-
-    it("keeps a single heartbeat running across parallel tool calls", () => {
-      const bump = vi.fn();
-      const hb = createToolHeartbeat(bump, 1000);
-
-      hb.onToolStart();
-      hb.onToolStart();
-      hb.onToolStart();
-      expect(hb.inflight()).toBe(3);
-
-      vi.advanceTimersByTime(3000);
-      // Three ticks — proves only one interval is running, not three.
-      expect(bump).toHaveBeenCalledTimes(3);
-
-      hb.onToolEnd();
-      hb.onToolEnd();
-      // Still one tool in flight, heartbeat continues.
-      vi.advanceTimersByTime(1000);
-      expect(bump).toHaveBeenCalledTimes(4);
-
-      hb.onToolEnd();
-      expect(hb.inflight()).toBe(0);
-      vi.advanceTimersByTime(5000);
-      expect(bump).toHaveBeenCalledTimes(4);
-    });
-
-    it("stop() halts the heartbeat and prevents future onToolStart from restarting it", () => {
-      const bump = vi.fn();
-      const hb = createToolHeartbeat(bump, 1000);
-
-      hb.onToolStart();
-      vi.advanceTimersByTime(1000);
-      expect(bump).toHaveBeenCalledTimes(1);
-
-      hb.stop();
-      vi.advanceTimersByTime(5000);
-      expect(bump).toHaveBeenCalledTimes(1);
-
-      // Defensive: a tool callback firing after dispose must not resurrect
-      // a heartbeat that nothing will clean up.
-      hb.onToolStart();
-      vi.advanceTimersByTime(5000);
-      expect(bump).toHaveBeenCalledTimes(1);
-    });
-
-    it("onToolEnd is safe to over-call (inflight clamped at zero)", () => {
-      const bump = vi.fn();
-      const hb = createToolHeartbeat(bump, 1000);
-
-      hb.onToolEnd();
-      hb.onToolEnd();
-      expect(hb.inflight()).toBe(0);
-
-      vi.advanceTimersByTime(5000);
-      expect(bump).not.toHaveBeenCalled();
-    });
-  });
-
   describe("resolveSearchMode", () => {
     // A provider that can serve search natively, so the tests below isolate one
     // condition at a time.
@@ -1463,18 +1377,16 @@ describe("chat-execution", () => {
     });
   });
 
-  describe("wrapToolsWithBump", () => {
+  describe("wrapToolsWithActivity", () => {
     const noop = () => {};
 
     const wrapSingle = (execute: unknown) => {
-      const wrapped = wrapToolsWithBump(
+      const wrapped = wrapToolsWithActivity(
         {
           t: { execute } as unknown as Parameters<
-            typeof wrapToolsWithBump
+            typeof wrapToolsWithActivity
           >[0]["t"],
         },
-        noop,
-        noop,
         noop,
       );
       return (wrapped.t as { execute: (a: unknown, o: unknown) => unknown })
@@ -1517,24 +1429,53 @@ describe("chat-execution", () => {
       expect(parts[0].date).toBeInstanceOf(Date);
     });
 
-    it("runs the tool lifecycle callbacks around a normalized result", async () => {
-      const onStart = vi.fn();
-      const onEnd = vi.fn();
-      const wrapped = wrapToolsWithBump(
+    it("brackets a normalized result with start and end activity events", async () => {
+      const onActivity = vi.fn<(event: ToolActivityEvent) => void>();
+      const wrapped = wrapToolsWithActivity(
         {
           t: {
             execute: () => Promise.resolve({ createdAt: new Date() }),
-          } as unknown as Parameters<typeof wrapToolsWithBump>[0]["t"],
+          } as unknown as Parameters<typeof wrapToolsWithActivity>[0]["t"],
         },
-        noop,
-        onStart,
-        onEnd,
+        onActivity,
       );
       await (
         wrapped.t as { execute: (a: unknown, o: unknown) => Promise<unknown> }
       ).execute({}, {});
-      expect(onStart).toHaveBeenCalledTimes(1);
-      expect(onEnd).toHaveBeenCalledTimes(1);
+      expect(onActivity.mock.calls.map(([e]) => e.phase)).toEqual([
+        "start",
+        "end",
+      ]);
+      expect(onActivity.mock.calls[1][0].toolName).toBe("t");
+    });
+
+    // The end event is what releases the run's per-step hold, so a generator the
+    // consumer drains has to produce one — otherwise the stall timer stays off
+    // for the rest of the run.
+    it("emits the end event once an async-iterable tool is drained", async () => {
+      const onActivity = vi.fn<(event: ToolActivityEvent) => void>();
+      const wrapped = wrapToolsWithActivity(
+        {
+          t: {
+            execute: async function* () {
+              await Promise.resolve();
+              yield { part: 1 };
+            },
+          } as unknown as Parameters<typeof wrapToolsWithActivity>[0]["t"],
+        },
+        onActivity,
+      );
+      const iterable = (
+        wrapped.t as {
+          execute: (a: unknown, o: unknown) => AsyncIterable<unknown>;
+        }
+      ).execute({}, {});
+      expect(onActivity.mock.calls.map(([e]) => e.phase)).toEqual(["start"]);
+      for await (const _ of iterable) void _;
+      expect(onActivity.mock.calls.map(([e]) => e.phase)).toEqual([
+        "start",
+        "end",
+      ]);
     });
   });
 });

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -56,6 +56,12 @@ import {
 } from "./file-gate.ts";
 import type { PlatypusUIMessage } from "../types.ts";
 import { listScopedByIds, resolveScoped } from "./scoped-resource.ts";
+import {
+  wrapToolsWithActivity,
+  type ToolActivityEvent,
+} from "./tool-activity.ts";
+import type { WorkspaceScope } from "../scope.ts";
+import type { RunId } from "../runs/types.ts";
 
 // --- Errors ---
 
@@ -193,24 +199,19 @@ export type PrepareChatTurnInput = {
    */
   runMode?: "interactive" | "headless";
   /**
-   * Called whenever a tool call begins, completes, or yields activity.
-   * The agent runner uses this to reset the per-step timeout so long-running
-   * tool calls (e.g. MCP web search, sub-agent delegation) don't trip the
-   * stall detector while work is actively in progress. The optional `event`
-   * carries tool-call boundary metadata that the runner logs; sub-agent
-   * yield bumps invoke with no event (timer-only).
+   * Called when a tool call begins and again when it settles. The run
+   * lifecycle logs both and holds its per-step stall timer down in between, so
+   * a long tool call (MCP web search, a delegated sub-agent run) is never read
+   * as a stalled step.
    */
-  onActivity?: (event?: ToolActivityEvent) => void;
-};
-
-/**
- * Per-tool-call lifecycle event surfaced to the agent runner so it can log
- * tool start/end with duration. `durationMs` is only set on `"end"` events.
- */
-export type ToolActivityEvent = {
-  phase: "start" | "end";
-  toolName: string;
-  durationMs?: number;
+  onActivity?: (event: ToolActivityEvent) => void;
+  /**
+   * The run this turn belongs to. Sub-agent delegate tools built here register
+   * their own runs as children of it, so a delegated run is cancellable and
+   * subject to timeouts in its own right. Absent for callers that prepare a
+   * turn outside the run lifecycle (tests, the pre-persist file gate).
+   */
+  run?: { runId: RunId; scope: WorkspaceScope };
 };
 
 // --- Queries seam ---
@@ -524,6 +525,7 @@ export const prepareChatTurn = async (
     frontendUrl,
     runMode = "interactive",
     onActivity,
+    run,
   } = input;
 
   const workspace = await queries.getWorkspace(workspaceId);
@@ -557,7 +559,7 @@ export const prepareChatTurn = async (
   ] = await Promise.all([
     loadTools(queries, agent, workspaceId, orgId, frontendUrl, user.id),
     loadSkills(queries, agent, orgId, workspaceId),
-    loadSubAgents(queries, agent, orgId, workspaceId, frontendUrl, onActivity),
+    loadSubAgents(queries, agent, orgId, workspaceId, frontendUrl, run),
     queries.getUserContexts(user.id, workspaceId),
     queries.getRecentMemories(user.id, workspaceId),
     queries.getSandboxEnvKeys(workspaceId),
@@ -604,15 +606,8 @@ export const prepareChatTurn = async (
     tools.loadSkill = createLoadSkillTool(orgId, workspaceId);
   }
 
-  const heartbeat = onActivity ? createToolHeartbeat(onActivity) : null;
-
-  const wrappedTools = heartbeat
-    ? wrapToolsWithBump(
-        tools,
-        onActivity!,
-        heartbeat.onToolStart,
-        heartbeat.onToolEnd,
-      )
+  const wrappedTools = onActivity
+    ? wrapToolsWithActivity(tools, onActivity)
     : tools;
 
   // Inline file URLs to `data:` bytes when we have an origin, then ALWAYS
@@ -643,7 +638,6 @@ export const prepareChatTurn = async (
   const dispose = async () => {
     if (disposed) return;
     disposed = true;
-    heartbeat?.stop();
     for (const client of allMcpClients) {
       try {
         await client.close();
@@ -745,162 +739,12 @@ export const validateTurnAttachments = async (
 // --- Private helpers ---
 
 /**
- * Default cadence between heartbeat bumps while any tool is in flight. Must
- * be comfortably below the smallest configured per-step timeout (2 min for
- * chat by default) so a slow tool can't outlive the timer between heartbeats.
- */
-export const DEFAULT_TOOL_HEARTBEAT_INTERVAL_MS = 30 * 1000;
-
-/**
- * Tracks how many tool calls are currently executing and fires `bump()` at a
- * fixed cadence while that count is positive. Used by `prepareChatTurn` to
- * keep the run's per-step stall timer alive across a long tool call or a
- * sub-agent whose own tool calls yield no parts for an extended period.
- *
- * Exported for direct testing — production callers should always go through
- * `prepareChatTurn`.
- */
-export const createToolHeartbeat = (
-  bump: () => void,
-  intervalMs: number = DEFAULT_TOOL_HEARTBEAT_INTERVAL_MS,
-): {
-  onToolStart: () => void;
-  onToolEnd: () => void;
-  stop: () => void;
-  /** Visible for tests. Number of tool calls currently being tracked. */
-  inflight: () => number;
-} => {
-  let inflight = 0;
-  let stopped = false;
-  let timer: ReturnType<typeof setInterval> | undefined;
-
-  return {
-    onToolStart: () => {
-      // Defensive: if a tool callback somehow fires after stop() (e.g. an
-      // MCP transport that ignores AbortSignal), don't start a fresh timer
-      // that nothing will clean up.
-      if (stopped) return;
-      inflight += 1;
-      if (inflight === 1) {
-        timer = setInterval(bump, intervalMs);
-      }
-    },
-    onToolEnd: () => {
-      inflight = Math.max(0, inflight - 1);
-      if (inflight === 0 && timer) {
-        clearInterval(timer);
-        timer = undefined;
-      }
-    },
-    stop: () => {
-      stopped = true;
-      if (timer) {
-        clearInterval(timer);
-        timer = undefined;
-      }
-    },
-    inflight: () => inflight,
-  };
-};
-
-/**
- * Wraps each tool's `execute` to:
- * 1. Emit `start` / `end` activity events for structured logging and the
- *    initial per-step timer bump (`runId`, `toolName`, `durationMs`).
- * 2. Call `onToolStart` / `onToolEnd` so the surrounding turn can maintain
- *    an inflight counter and run a heartbeat — the only thing that keeps
- *    the per-step timer alive across a tool call (or sub-agent) that takes
- *    longer than the stall threshold to settle.
- *
- * Sub-agent tools whose `execute` is an async generator are returned by
- * reference; the inflight bookkeeping still happens because they expose
- * an `execute` function and we wrap it the same way. Their inner part
- * yields continue to bump the timer via `onProgress` for visibility, but
- * correctness no longer depends on those yields being frequent enough.
- */
-/**
- * Re-exported so callers and tests that reach the normalizer through this
- * module keep working. It lives in `tool-result.ts` because the sub-agent tool
- * builder needs it too, and this module already imports that one.
- *
- * `wrapToolsWithBump` applies it at the promise-resolved and synchronous return
- * paths, covering every value-returning tool on the parent turn at once. The
- * async-iterable path (sub-agent delegate tools) is intentionally exempt — its
- * yields are streamed UI parts, not the result fed to the model.
+ * Re-exported so callers and tests that reach these through this module keep
+ * working. They live in their own modules because the sub-agent tool builder
+ * needs them too, and this module imports that one.
  */
 export { normalizeToolResult };
-
-export const wrapToolsWithBump = (
-  tools: Record<string, Tool>,
-  onActivity: (event?: ToolActivityEvent) => void,
-  onToolStart: () => void,
-  onToolEnd: () => void,
-): Record<string, Tool> => {
-  const wrapped: Record<string, Tool> = {};
-  for (const [name, t] of Object.entries(tools)) {
-    const execute = (t as { execute?: unknown }).execute;
-    if (typeof execute !== "function") {
-      wrapped[name] = t;
-      continue;
-    }
-    const runExecute = execute as (args: unknown, options: unknown) => unknown;
-    wrapped[name] = {
-      ...t,
-      execute: (args: unknown, options: unknown) => {
-        const startedAt = Date.now();
-        onToolStart();
-        onActivity({ phase: "start", toolName: name });
-        const finish = () => {
-          onToolEnd();
-          onActivity({
-            phase: "end",
-            toolName: name,
-            durationMs: Date.now() - startedAt,
-          });
-        };
-        let result: unknown;
-        try {
-          result = runExecute.call(t, args, options);
-        } catch (err) {
-          finish();
-          throw err;
-        }
-        if (
-          result != null &&
-          typeof (result as { then?: unknown }).then === "function"
-        ) {
-          return (result as Promise<unknown>)
-            .then(normalizeToolResult)
-            .finally(finish);
-        }
-        // Async iterable / generator path (sub-agent tools). Wrap it so the
-        // counter decrements once the consumer drains the iterator.
-        if (
-          result != null &&
-          typeof (result as Record<symbol, unknown>)[Symbol.asyncIterator] ===
-            "function"
-        ) {
-          const inner = result as AsyncIterable<unknown>;
-          return (async function* () {
-            try {
-              for await (const part of inner) {
-                yield part;
-              }
-            } finally {
-              finish();
-            }
-          })();
-        }
-        // Normalize before finish() so the sync path mirrors the promise path:
-        // a throw (e.g. a BigInt in the result) happens before the "end" event.
-        const normalized = normalizeToolResult(result);
-        finish();
-        return normalized;
-      },
-    };
-  }
-  return wrapped;
-};
+export { wrapToolsWithActivity, type ToolActivityEvent };
 
 /**
  * Why a model reference resolved to nothing, said in the caller's terms: a
@@ -1083,7 +927,7 @@ const loadSubAgents = async (
   orgId: string,
   workspaceId: string,
   frontendUrl: string | undefined,
-  onProgress?: () => void,
+  run: { runId: RunId; scope: WorkspaceScope } | undefined,
 ): Promise<{
   subAgents: Array<{ id: string; name: string; description?: string | null }>;
   unavailableSubAgents: SubAgentFailure[];
@@ -1160,7 +1004,7 @@ const loadSubAgents = async (
       subAgentMcpClients.push(...mcpClients);
       return subTools;
     },
-    onProgress,
+    run,
   );
 
   // The system prompt must describe only sub-agents that produced a callable

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -60,8 +60,7 @@ import {
   wrapToolsWithActivity,
   type ToolActivityEvent,
 } from "./tool-activity.ts";
-import type { WorkspaceScope } from "../scope.ts";
-import type { RunId } from "../runs/types.ts";
+import type { ParentRunContext } from "../runs/types.ts";
 
 // --- Errors ---
 
@@ -208,10 +207,10 @@ export type PrepareChatTurnInput = {
   /**
    * The run this turn belongs to. Sub-agent delegate tools built here register
    * their own runs as children of it, so a delegated run is cancellable and
-   * subject to timeouts in its own right. Absent for callers that prepare a
-   * turn outside the run lifecycle (tests, the pre-persist file gate).
+   * subject to the same timeouts in its own right. Absent for callers that
+   * prepare a turn outside the run lifecycle (tests, the pre-persist file gate).
    */
-  run?: { runId: RunId; scope: WorkspaceScope };
+  run?: ParentRunContext;
 };
 
 // --- Queries seam ---
@@ -927,7 +926,7 @@ const loadSubAgents = async (
   orgId: string,
   workspaceId: string,
   frontendUrl: string | undefined,
-  run: { runId: RunId; scope: WorkspaceScope } | undefined,
+  run: ParentRunContext | undefined,
 ): Promise<{
   subAgents: Array<{ id: string; name: string; description?: string | null }>;
   unavailableSubAgents: SubAgentFailure[];

--- a/apps/backend/src/services/tool-activity.ts
+++ b/apps/backend/src/services/tool-activity.ts
@@ -1,0 +1,98 @@
+import type { Tool } from "ai";
+import { normalizeToolResult } from "./tool-result.ts";
+
+/**
+ * Per-tool-call lifecycle event surfaced to the run lifecycle.
+ *
+ * `durationMs` is only set on `"end"` events. The run driver logs both phases
+ * and, more importantly, holds the run's per-step stall timer down between
+ * them: a tool that is still executing is not a stalled step, however long it
+ * takes (`RunHandle.holdStep`).
+ */
+export type ToolActivityEvent = {
+  phase: "start" | "end";
+  toolName: string;
+  durationMs?: number;
+};
+
+/**
+ * Wraps each tool's `execute` so the surrounding run sees a `start` event
+ * before it runs and an `end` event once it settles — on every exit path,
+ * including a synchronous throw and a consumer that drains an async generator.
+ *
+ * The wrapper also normalizes value-returning results (issue #321): AI SDK v7
+ * validates each tool result against a strict JSON-value schema on the next
+ * step, and a raw Drizzle `Date` fails it. The async-iterable path is exempt —
+ * its yields are streamed UI parts, not the value fed to the model.
+ *
+ * Lives outside `chat-execution.ts` because both the parent turn and a
+ * sub-agent's own tool set need it, and the sub-agent tool builder is imported
+ * by `chat-execution.ts`.
+ */
+export const wrapToolsWithActivity = (
+  tools: Record<string, Tool>,
+  onActivity: (event: ToolActivityEvent) => void,
+): Record<string, Tool> => {
+  const wrapped: Record<string, Tool> = {};
+  for (const [name, t] of Object.entries(tools)) {
+    const execute = (t as { execute?: unknown }).execute;
+    if (typeof execute !== "function") {
+      wrapped[name] = t;
+      continue;
+    }
+    const runExecute = execute as (args: unknown, options: unknown) => unknown;
+    wrapped[name] = {
+      ...t,
+      execute: (args: unknown, options: unknown) => {
+        const startedAt = Date.now();
+        onActivity({ phase: "start", toolName: name });
+        const finish = () => {
+          onActivity({
+            phase: "end",
+            toolName: name,
+            durationMs: Date.now() - startedAt,
+          });
+        };
+        let result: unknown;
+        try {
+          result = runExecute.call(t, args, options);
+        } catch (err) {
+          finish();
+          throw err;
+        }
+        if (
+          result != null &&
+          typeof (result as { then?: unknown }).then === "function"
+        ) {
+          return (result as Promise<unknown>)
+            .then(normalizeToolResult)
+            .finally(finish);
+        }
+        // Async iterable / generator path (sub-agent tools). Wrap it so the
+        // "end" event fires once the consumer drains the iterator.
+        if (
+          result != null &&
+          typeof (result as Record<symbol, unknown>)[Symbol.asyncIterator] ===
+            "function"
+        ) {
+          const inner = result as AsyncIterable<unknown>;
+          return (async function* () {
+            try {
+              for await (const part of inner) {
+                yield part;
+              }
+            } finally {
+              finish();
+            }
+          })();
+        }
+        // Normalize before finish() so the sync path mirrors the promise path:
+        // a throw (e.g. a BigInt in the result) happens before the "end" event.
+        const normalized = normalizeToolResult(result);
+        finish();
+        return normalized;
+      },
+    };
+  }
+  return wrapped;
+};

--- a/apps/backend/src/services/tool-result.ts
+++ b/apps/backend/src/services/tool-result.ts
@@ -1,5 +1,3 @@
-import type { Tool } from "ai";
-
 /**
  * Coerce a tool result to plain JSON (issue #321).
  *
@@ -15,59 +13,12 @@ import type { Tool } from "ai";
  * normalizer. A top-level `undefined`/function return (whose `JSON.stringify` is
  * `undefined`) is passed through unchanged instead of crashing `JSON.parse`.
  *
- * Lives in its own module because both the parent turn's tool wrapper and the
- * sub-agent tool builder need it, and those two import each other.
+ * Lives in its own module because the tool-activity wrapper that applies it is
+ * shared between a parent turn and a delegated sub-agent run, and this module
+ * must stay free of both.
  */
 export const normalizeToolResult = (value: unknown): unknown => {
   const json = JSON.stringify(value);
   if (json === undefined) return value;
   return JSON.parse(json);
-};
-
-/**
- * Apply {@link normalizeToolResult} to every tool in a map.
- *
- * The parent turn gets this via `wrapToolsWithBump`, which also does heartbeat
- * bookkeeping. A sub-agent's own tools never pass through that wrapper — they go
- * from `loadTools` straight into its `ToolLoopAgent` — so without this they
- * reach the sub-agent's next step raw, and a Drizzle `Date` fails the same
- * validation one level down. The symptom is unrecognisable as #321 from the
- * outside: the sub-agent dies mid-stream and the parent sees a truncated answer.
- *
- * The async-iterable path is left alone, matching the parent wrapper: those
- * yields are streamed UI parts, not the value fed to the model.
- */
-export const withNormalizedResults = (
-  tools: Record<string, Tool>,
-): Record<string, Tool> => {
-  const wrapped: Record<string, Tool> = {};
-  for (const [name, t] of Object.entries(tools)) {
-    const execute = (t as { execute?: unknown }).execute;
-    if (typeof execute !== "function") {
-      wrapped[name] = t;
-      continue;
-    }
-    const runExecute = execute as (args: unknown, options: unknown) => unknown;
-    wrapped[name] = {
-      ...t,
-      execute: (args: unknown, options: unknown) => {
-        const result = runExecute.call(t, args, options);
-        if (
-          result != null &&
-          typeof (result as { then?: unknown }).then === "function"
-        ) {
-          return (result as Promise<unknown>).then(normalizeToolResult);
-        }
-        if (
-          result != null &&
-          typeof (result as Record<symbol, unknown>)[Symbol.asyncIterator] ===
-            "function"
-        ) {
-          return result;
-        }
-        return normalizeToolResult(result);
-      },
-    };
-  }
-  return wrapped;
 };

--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -9,6 +9,8 @@ import {
   SUB_AGENT_TRUNCATION_NOTE,
 } from "./sub-agent.ts";
 import type { SubAgentActivity } from "./sub-agent.ts";
+import { runRegistry } from "../runs/run-registry.ts";
+import { orgScope, workspaceScope, type WorkspaceScope } from "../scope.ts";
 import { DEFAULT_AGENT_MAX_STEPS } from "@platypus/schemas";
 
 // A delegated run now goes through the same pipeline a Chat turn does —
@@ -90,6 +92,13 @@ const toolCall = (id: string, toolName: string, input: string): StepParts => [
   { type: "tool-input-end", id },
   { type: "tool-call", toolCallId: id, toolName, input },
 ];
+
+/** The scope a parent Chat turn would be running under. */
+const parentScope: WorkspaceScope = workspaceScope(
+  orgScope({ principal: { kind: "user", userId: "u1", name: "Ada" } }, "org-1"),
+  "ws-1",
+  true,
+);
 
 const baseOptions = {
   id: "agent-1",
@@ -537,6 +546,40 @@ describe("createSubAgentTool", () => {
       expect(abortSignal).not.toBe(parent.signal);
     });
 
+    // A Trigger run is started under bounds an Operator configured; work it
+    // delegates has to run under the same ones, not the process defaults.
+    it("registers under the bounds the parent run was started with", async () => {
+      const register = vi.spyOn(runRegistry, "register");
+      await delegate({
+        parentRun: {
+          runId: "parent-1",
+          scope: parentScope,
+          timeouts: { perStepTimeoutMs: 600_000, perRunTimeoutMs: 3_600_000 },
+        },
+      });
+
+      expect(register.mock.calls.at(-1)?.[1]).toMatchObject({
+        perStepTimeoutMs: 600_000,
+        perRunTimeoutMs: 3_600_000,
+      });
+      register.mockRestore();
+    });
+
+    // The generator body doesn't start until the consumer pulls, so a parent
+    // cancelled between dispatch and the first tick would never fire the abort
+    // listener and the delegation would run on regardless.
+    it("does not start work for a parent that was already cancelled", async () => {
+      const parent = new AbortController();
+      parent.abort(new Error("Chat run cancelled"));
+
+      await expect(
+        delegate(
+          { model: modelOf(step(text("t1", "should never be produced"))) },
+          { abortSignal: parent.signal },
+        ),
+      ).rejects.toThrow(/Stopped before finishing/);
+    });
+
     it("stops the delegated run when the parent run is cancelled", async () => {
       const parent = new AbortController();
       const { tool } = createSubAgentTool({
@@ -726,7 +769,7 @@ describe("createSubAgentTool", () => {
       });
     });
 
-    it("sends no value for a parameter that was never set", async () => {
+    it("omits parameters that were never set rather than sending undefined", async () => {
       await delegate({ sampling: { temperature: 0.2 } });
 
       const settings = streamArgs();
@@ -738,7 +781,7 @@ describe("createSubAgentTool", () => {
         "presencePenalty",
         "frequencyPenalty",
       ]) {
-        expect(settings[key]).toBeUndefined();
+        expect(settings).not.toHaveProperty(key);
       }
     });
 
@@ -755,7 +798,7 @@ describe("createSubAgentTool", () => {
     it("sends no ceiling when the sub-agent's model declares none", async () => {
       await delegate({});
 
-      expect(streamArgs().maxOutputTokens).toBeUndefined();
+      expect(streamArgs()).not.toHaveProperty("maxOutputTokens");
     });
 
     it("cannot have sampling override the model, instructions or tools", async () => {
@@ -1017,7 +1060,7 @@ describe("createSubAgentTools", () => {
     await runTool(tools.delegateToTuned);
 
     expect(streamArgs()).toMatchObject({ temperature: 0.3, seed: 7 });
-    expect(streamArgs().topP).toBeUndefined();
+    expect(streamArgs()).not.toHaveProperty("topP");
   });
 
   it("passes each sub-agent's own provider security text into its instructions", async () => {

--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ToolExecutionOptions } from "ai";
+import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import type { Tool, ToolExecutionOptions } from "ai";
+import { z } from "zod";
 import {
   createSubAgentTool,
   createSubAgentTools,
@@ -8,17 +11,128 @@ import {
 import type { SubAgentActivity } from "./sub-agent.ts";
 import { DEFAULT_AGENT_MAX_STEPS } from "@platypus/schemas";
 
-// Helper to consume an async generator and collect all yielded values.
-// Deep-copies each yield since the generator reuses mutable objects.
-async function consumeGenerator<T>(
-  gen: AsyncGenerator<T>,
-): Promise<{ yielded: T[] }> {
-  const yielded: T[] = [];
-  for await (const value of gen) {
-    yielded.push(structuredClone(value));
+// A delegated run now goes through the same pipeline a Chat turn does —
+// `streamText` → `toUIMessageStream` → `readUIMessageStream` — so these tests
+// drive a mock *model* and leave that pipeline real. The spy records what
+// reached `streamText` without replacing it.
+const { streamTextSpy } = vi.hoisted(() => ({ streamTextSpy: vi.fn() }));
+
+vi.mock("ai", async () => {
+  const actual = await vi.importActual<typeof import("ai")>("ai");
+  return {
+    ...actual,
+    streamText: (options: Parameters<typeof actual.streamText>[0]) => {
+      streamTextSpy(options);
+      return actual.streamText(options);
+    },
+  };
+});
+
+vi.mock("../logger.ts", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { logger } from "../logger.ts";
+
+// --- Model harness -----------------------------------------------------------
+
+const USAGE = {
+  inputTokens: {
+    total: 10,
+    noCache: 10,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: 4, text: 4, reasoning: undefined },
+};
+
+type StepParts = LanguageModelV3StreamPart[];
+
+/** Wraps a step's parts in the stream-start / finish envelope every step needs. */
+const step = (
+  parts: StepParts,
+  finish: { unified: "stop" | "length" | "tool-calls"; raw?: string } = {
+    unified: "stop",
+    raw: "stop",
+  },
+): StepParts => [
+  { type: "stream-start", warnings: [] },
+  ...parts,
+  {
+    type: "finish",
+    finishReason: { ...finish, raw: finish.raw },
+    usage: USAGE,
+  },
+];
+
+/** A model that replays one step's parts per `doStream` call, in order. */
+const modelOf = (...steps: StepParts[]) => {
+  let index = 0;
+  return new MockLanguageModelV3({
+    doStream: () => {
+      const parts = steps[Math.min(index, steps.length - 1)];
+      index += 1;
+      return Promise.resolve({
+        stream: simulateReadableStream({ chunks: parts }),
+      });
+    },
+  });
+};
+
+const text = (id: string, ...deltas: string[]): StepParts => [
+  { type: "text-start", id },
+  ...deltas.map((delta) => ({ type: "text-delta" as const, id, delta })),
+  { type: "text-end", id },
+];
+
+const toolCall = (id: string, toolName: string, input: string): StepParts => [
+  { type: "tool-input-start", id, toolName },
+  { type: "tool-input-end", id },
+  { type: "tool-call", toolCallId: id, toolName, input },
+];
+
+const baseOptions = {
+  id: "agent-1",
+  name: "Research Agent",
+  model: modelOf(step([])),
+  tools: {} as Record<string, Tool>,
+};
+
+/** Build the delegate tool, run one delegation, collect every yield. */
+const delegate = async (
+  options: Partial<Parameters<typeof createSubAgentTool>[0]> = {},
+  execOptions: Partial<ToolExecutionOptions<Record<string, unknown>>> = {},
+) => {
+  const { tool } = createSubAgentTool({ ...baseOptions, ...options });
+  const gen = tool.execute({ task: "Do something" }, {
+    ...execOptions,
+  } as ToolExecutionOptions<
+    Record<string, unknown>
+  >) as AsyncGenerator<SubAgentActivity>;
+  const yielded: SubAgentActivity[] = [];
+  for await (const value of gen) yielded.push(structuredClone(value));
+  return { tool, yielded };
+};
+
+/** The arguments the delegated run handed to `streamText`. */
+const streamArgs = (call = 0) =>
+  streamTextSpy.mock.calls[call][0] as {
+    system: string;
+    tools: Record<string, { execute: (a: unknown, o: unknown) => unknown }>;
+    stopWhen: Array<(s: { steps: unknown[] }) => boolean>;
+    abortSignal: AbortSignal;
+  } & Record<string, unknown>;
+
+// The step ceiling arrives as `stopWhen: [stepCountIs(n)]`. `stepCountIs` closes
+// over `n` and offers no introspection, so recover it by probing the condition
+// against incrementally longer (empty) step arrays until it fires.
+const stepCeilingOf = (call = 0): number => {
+  const { stopWhen } = streamArgs(call);
+  for (let n = 0; n <= 64; n += 1) {
+    if (stopWhen[0]({ steps: Array.from({ length: n }) })) return n;
   }
-  return { yielded };
-}
+  throw new Error("no step ceiling found in stopWhen");
+};
 
 // The text the parent model actually reads for a completed delegation.
 // `toModelOutput` is declared as returning any tool-result shape, so the text
@@ -35,87 +149,10 @@ const modelText = (
     }) as { value: string }
   ).value;
 
-// Mock stream events helper — returns a sync iterable; AsyncGenerator consumers
-// accept any iterable, so no async generator is needed here.
-function createMockFullStream(
-  events: Array<{ type: string } & Record<string, unknown>>,
-) {
-  return {
-    [Symbol.asyncIterator](): AsyncIterator<
-      { type: string } & Record<string, unknown>
-    > {
-      let i = 0;
-      return {
-        next() {
-          if (i < events.length) {
-            return Promise.resolve({ value: events[i++], done: false });
-          }
-          return Promise.resolve({
-            value: undefined as unknown as { type: string } & Record<
-              string,
-              unknown
-            >,
-            done: true,
-          });
-        },
-      };
-    },
-  };
-}
-
-const { mockStream, MockToolLoopAgent, agentConstructorSpy } = vi.hoisted(
-  () => {
-    const mockStream = vi.fn();
-    const agentConstructorSpy = vi.fn();
-    class MockToolLoopAgent {
-      instructions: string | undefined;
-      constructor(opts: { instructions?: string }) {
-        agentConstructorSpy(opts);
-        this.instructions = opts?.instructions;
-      }
-      stream = mockStream;
-    }
-    return { mockStream, MockToolLoopAgent, agentConstructorSpy };
-  },
-);
-
-vi.mock("ai", async () => {
-  const actual = await vi.importActual("ai");
-  return {
-    ...actual,
-    ToolLoopAgent: MockToolLoopAgent,
-  };
-});
-
-vi.mock("../logger.ts", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-}));
-
-import { logger } from "../logger.ts";
-
-// A constructed sub-agent carries `stopWhen: [stepCountIs(n)]`, where `n` is
-// the resolved step ceiling. `stepCountIs` closes over `n` and offers no
-// introspection, so recover the ceiling by probing the condition against
-// incrementally longer (empty) step arrays until it fires.
-const stepCeilingOf = (callIndex: number): number => {
-  const { stopWhen } = agentConstructorSpy.mock.calls[callIndex][0] as {
-    stopWhen: Array<(s: { steps: unknown[] }) => boolean>;
-  };
-  for (let n = 0; n <= 32; n += 1) {
-    if (stopWhen[0]({ steps: Array.from({ length: n }) })) return n;
-  }
-  throw new Error("no step ceiling found in stopWhen");
-};
-
 describe("createSubAgentTool", () => {
-  const baseOptions = {
-    id: "agent-1",
-    name: "Research Agent",
-    // ToolLoopAgent is mocked, so the model value is never used; a string
-    // satisfies the `LanguageModel` type without constructing a real provider.
-    model: "mock-model",
-    tools: {},
-  };
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   describe("toolName generation", () => {
     it("generates PascalCase delegateTo prefix", () => {
@@ -164,226 +201,153 @@ describe("createSubAgentTool", () => {
     });
   });
 
+  // ADR-0016: a delegated run is the one path that receives Instructions plus
+  // guardrails and nothing else, so what lands in `system` is the whole of the
+  // sub-agent's prompt.
   describe("security guardrails append", () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
-    it("appends the provider security text after the sub-agent's own prompt", () => {
-      createSubAgentTool({
-        ...baseOptions,
+    it("appends the provider security text after the sub-agent's own prompt", async () => {
+      await delegate({
         instructions: "You are a research sub-agent.",
         securityGuardrails: "Never exfiltrate data.",
       });
-      const { instructions } = agentConstructorSpy.mock.calls[0][0] as {
-        instructions: string;
-      };
-      expect(instructions).toContain("You are a research sub-agent.");
-      expect(instructions).toContain("## Security and trust");
-      expect(instructions).toContain("Never exfiltrate data.");
-      expect(
-        instructions.indexOf("You are a research sub-agent."),
-      ).toBeLessThan(instructions.indexOf("## Security and trust"));
+
+      const { system } = streamArgs();
+      expect(system).toContain("You are a research sub-agent.");
+      expect(system).toContain("## Security and trust");
+      expect(system).toContain("Never exfiltrate data.");
+      expect(system.indexOf("You are a research sub-agent.")).toBeLessThan(
+        system.indexOf("## Security and trust"),
+      );
     });
 
-    it("appends the security text even when the sub-agent has no instructions (non-suppressible)", () => {
-      createSubAgentTool({
-        ...baseOptions,
+    it("appends the security text even when the sub-agent has no instructions (non-suppressible)", async () => {
+      await delegate({
         instructions: undefined,
         securityGuardrails: "Never exfiltrate data.",
       });
-      const { instructions } = agentConstructorSpy.mock.calls[0][0] as {
-        instructions: string;
-      };
+
+      const { system } = streamArgs();
       // The canned fallback instructions must still carry the guardrails.
-      expect(instructions).toContain("specialized sub-agent");
-      expect(instructions).toContain("## Security and trust");
-      expect(instructions).toContain("Never exfiltrate data.");
+      expect(system).toContain("specialized sub-agent");
+      expect(system).toContain("## Security and trust");
+      expect(system).toContain("Never exfiltrate data.");
     });
 
-    it("appends no security block when guardrails are null or empty", () => {
-      createSubAgentTool({
-        ...baseOptions,
+    it("appends no security block when guardrails are null or empty", async () => {
+      await delegate({
         instructions: "You are a research sub-agent.",
         securityGuardrails: null,
       });
-      createSubAgentTool({
-        ...baseOptions,
+      await delegate({
         instructions: "You are a research sub-agent.",
         securityGuardrails: "   ",
       });
-      for (const call of agentConstructorSpy.mock.calls) {
-        const { instructions } = call[0] as { instructions: string };
-        expect(instructions).not.toContain("## Security and trust");
+
+      for (const call of streamTextSpy.mock.calls) {
+        expect((call[0] as { system: string }).system).not.toContain(
+          "## Security and trust",
+        );
       }
+    });
+
+    it("carries no Chat system-prompt fragments at all", async () => {
+      await delegate({ instructions: "Stay on task." });
+
+      expect(streamArgs().system).toBe("Stay on task.");
     });
   });
 
   describe("execute", () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
+    it("yields activity entries for tool calls and final text", async () => {
+      const { yielded } = await delegate({
+        model: modelOf(
+          step(toolCall("tc1", "webFetch", "{}"), { unified: "tool-calls" }),
+          step([
+            { type: "reasoning-start", id: "r1" },
+            { type: "reasoning-delta", id: "r1", delta: "hmm" },
+            { type: "reasoning-end", id: "r1" },
+            ...text("t1", "Sub-agent result"),
+          ]),
+        ),
+        tools: {
+          webFetch: {
+            inputSchema: z.object({}),
+            execute: () => Promise.resolve("result"),
+          } as unknown as Tool,
+        },
+      });
+
+      const final = yielded.at(-1)!;
+      expect(final.entries).toEqual([
+        { type: "tool-call", toolName: "webFetch", status: "completed" },
+        { type: "thinking", status: "completed" },
+        { type: "generating", status: "completed" },
+      ]);
+      expect(final.text).toBe("Sub-agent result");
+
+      // The log the user watches shows the tool call running before its result.
+      expect(yielded[0].entries).toEqual([
+        { type: "tool-call", toolName: "webFetch", status: "running" },
+      ]);
     });
 
-    it("yields activity entries for tool calls and final text", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          { type: "tool-input-start", toolName: "web-fetch", id: "tc1" },
-          {
-            type: "tool-result",
-            toolCallId: "tc1",
-            toolName: "web-fetch",
-            output: "result",
-          },
-          { type: "reasoning-start", id: "r1" },
-          { type: "reasoning-end", id: "r1" },
-          { type: "text-start", id: "t1" },
-          { type: "text-delta", id: "t1", text: "Sub-agent result" },
-          { type: "text-end", id: "t1" },
-        ]),
-        // v7: final-step-only text property is intentionally NOT relied upon.
-        text: Promise.resolve(""),
+    // Text deltas grow the answer but leave the activity log alone, so they must
+    // not produce a yield — that would spam the parent's SSE stream.
+    it("does not yield again for a delta that changes no activity entry", async () => {
+      const { yielded } = await delegate({
+        model: modelOf(step(text("t1", "one ", "two ", "three"))),
       });
 
-      const { tool } = createSubAgentTool(baseOptions);
-      const gen = tool.execute(
-        { task: "Do something" },
-        {} as ToolExecutionOptions<Record<string, unknown>>,
-      ) as AsyncGenerator<SubAgentActivity>;
-
-      const { yielded } = await consumeGenerator(gen);
-
-      // Should have yielded 6 activity updates + 1 final with text. The
-      // text-delta between text-start and text-end carries content but does not
-      // change the activity log, so it produces no extra yield.
-      expect(yielded).toHaveLength(7);
-
-      // First yield: tool-call running
-      expect(yielded[0].entries).toHaveLength(1);
-      expect(yielded[0].entries[0]).toEqual({
-        type: "tool-call",
-        toolName: "web-fetch",
-        status: "running",
-      });
-
-      // Second yield: tool-call completed
-      expect(yielded[1].entries[0].status).toBe("completed");
-
-      // Third yield: thinking running
-      expect(yielded[2].entries).toHaveLength(2);
-      expect(yielded[2].entries[1]).toEqual({
-        type: "thinking",
-        status: "running",
-      });
-
-      // Fourth yield: thinking completed
-      expect(yielded[3].entries[1].status).toBe("completed");
-
-      // Fifth yield: generating running
-      expect(yielded[4].entries).toHaveLength(3);
-      expect(yielded[4].entries[2]).toEqual({
-        type: "generating",
-        status: "running",
-      });
-
-      // Sixth yield: generating completed
-      expect(yielded[5].entries[2].status).toBe("completed");
-
-      // Final yield has text (yielded, not returned, since SDK discards return values)
-      expect(yielded[6].text).toBe("Sub-agent result");
-      expect(yielded[6].entries).toHaveLength(3);
+      // text-start (running) → text-end (completed) → the final value.
+      expect(yielded).toHaveLength(3);
+      expect(yielded.at(-1)!.text).toBe("one two three");
     });
 
     // Regression for #324: AI SDK v6→v7 redefined `result.text` as the FINAL
     // step's text only. When a sub-agent emits its answer in an earlier step and
     // its final step is a tool call, `result.text` is empty and the parent gets
-    // nothing. The fix aggregates text-deltas off the fullStream across ALL
-    // steps, so this reproduces that shape with realistic v7 stream events and
-    // an empty final-step `text` promise.
-    it("aggregates assistant text across steps from the stream, not the final-step text property", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          // Step 1: the model emits its answer, then decides to call a tool.
-          { type: "start-step" },
-          { type: "text-start", id: "t1" },
-          { type: "text-delta", id: "t1", text: "Here are " },
-          { type: "text-delta", id: "t1", text: "the boards." },
-          { type: "text-end", id: "t1" },
-          { type: "tool-input-start", toolName: "listBoards", id: "tc1" },
-          // Step 2: the tool result is the FINAL step — no trailing text.
-          { type: "start-step" },
-          {
-            type: "tool-result",
-            toolCallId: "tc1",
-            toolName: "listBoards",
-            output: [{ id: "b1" }],
-          },
-        ]),
-        // v7 semantics: final-step-only text is empty because the last step is
-        // the tool result. The old code returned this verbatim.
-        text: Promise.resolve(""),
+    // nothing.
+    it("aggregates assistant text across steps, not just the final step's", async () => {
+      const { yielded } = await delegate({
+        model: modelOf(
+          step([...text("t1", "Here are ", "the boards.")], {
+            unified: "tool-calls",
+          }),
+          // Nothing but the tool call in step 1; the final step carries no text.
+          step([]),
+        ),
       });
 
-      const { tool } = createSubAgentTool(baseOptions);
-      const gen = tool.execute(
-        { task: "list all boards" },
-        {} as ToolExecutionOptions<Record<string, unknown>>,
-      ) as AsyncGenerator<SubAgentActivity>;
-
-      const { yielded } = await consumeGenerator(gen);
-      const final = yielded.at(-1)!;
-
-      expect(final.text).toBe("Here are the boards.");
+      expect(yielded.at(-1)!.text).toBe("Here are the boards.");
     });
 
     it("joins multiple distinct text blocks with blank lines", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          { type: "text-start", id: "t1" },
-          { type: "text-delta", id: "t1", text: "First block." },
-          { type: "text-end", id: "t1" },
-          { type: "text-start", id: "t2" },
-          { type: "text-delta", id: "t2", text: "Second block." },
-          { type: "text-end", id: "t2" },
-        ]),
-        text: Promise.resolve(""),
+      const { yielded } = await delegate({
+        model: modelOf(
+          step([...text("t1", "First block."), ...text("t2", "Second block.")]),
+        ),
       });
-
-      const { tool } = createSubAgentTool(baseOptions);
-      const gen = tool.execute(
-        { task: "Do something" },
-        {} as ToolExecutionOptions<Record<string, unknown>>,
-      ) as AsyncGenerator<SubAgentActivity>;
-
-      const { yielded } = await consumeGenerator(gen);
 
       expect(yielded.at(-1)!.text).toBe("First block.\n\nSecond block.");
     });
 
     it("falls back to a summary of the final tool result when the sub-agent produced no assistant text", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          { type: "tool-input-start", toolName: "listBoards", id: "tc1" },
-          {
-            type: "tool-result",
-            toolCallId: "tc1",
-            toolName: "listBoards",
-            output: [{ id: "b1", name: "Board One" }],
-          },
-        ]),
-        text: Promise.resolve(""),
+      const { yielded } = await delegate({
+        model: modelOf(
+          step(toolCall("tc1", "listBoards", "{}"), { unified: "tool-calls" }),
+          step([]),
+        ),
+        tools: {
+          listBoards: {
+            inputSchema: z.object({}),
+            execute: () => Promise.resolve([{ id: "b1", name: "Board One" }]),
+          } as unknown as Tool,
+        },
       });
-
-      const { tool } = createSubAgentTool(baseOptions);
-      const gen = tool.execute(
-        { task: "list all boards" },
-        {} as ToolExecutionOptions<Record<string, unknown>>,
-      ) as AsyncGenerator<SubAgentActivity>;
-
-      const { yielded } = await consumeGenerator(gen);
-      const final = yielded.at(-1)!;
 
       // Not silently empty — carries the tool name and the result payload so the
       // parent can still relay something meaningful.
+      const final = yielded.at(-1)!;
       expect(final.text).toContain("listBoards");
       expect(final.text).toContain("Board One");
     });
@@ -392,72 +356,51 @@ describe("createSubAgentTool", () => {
     // generator returned whatever text had accumulated — usually the model's
     // opening preamble — and the parent read the crash as the answer.
     it("throws when the sub-agent stream reports an error", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          { type: "text-start", id: "t1" },
-          {
-            type: "text-delta",
-            id: "t1",
-            text: "I'll start by inspecting the agent.",
-          },
-          {
-            type: "error",
-            error: new Error(
-              "Model tried to call unavailable tool 'delegateToDashboardAgent'.",
-            ),
-          },
-        ]),
-        text: Promise.resolve(""),
-      });
-
-      const { tool } = createSubAgentTool(baseOptions);
-      const gen = tool.execute(
-        { task: "Check the dashboard" },
-        {} as ToolExecutionOptions<Record<string, unknown>>,
-      ) as AsyncGenerator<SubAgentActivity>;
-
-      await expect(consumeGenerator(gen)).rejects.toThrow(
+      await expect(
+        delegate({
+          model: modelOf(
+            step([
+              ...text("t1", "I'll start by inspecting the agent."),
+              {
+                type: "error",
+                error: new Error(
+                  "Model tried to call unavailable tool 'delegateToDashboardAgent'.",
+                ),
+              },
+            ]),
+          ),
+        }),
+      ).rejects.toThrow(
         /Sub-agent "Research Agent" did not complete: Model tried to call unavailable tool/,
       );
     });
 
     it("includes any partial text in the failure so the work is not lost", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          { type: "text-start", id: "t1" },
-          { type: "text-delta", id: "t1", text: "Found 3 stale cards." },
-          { type: "text-end", id: "t1" },
-          { type: "error", error: "upstream connection reset" },
-        ]),
-        text: Promise.resolve(""),
-      });
-
-      const { tool } = createSubAgentTool(baseOptions);
-      const gen = tool.execute(
-        { task: "Audit the board" },
-        {} as ToolExecutionOptions<Record<string, unknown>>,
-      ) as AsyncGenerator<SubAgentActivity>;
-
-      await expect(consumeGenerator(gen)).rejects.toThrow(
+      await expect(
+        delegate({
+          model: modelOf(
+            step([
+              ...text("t1", "Found 3 stale cards."),
+              { type: "error", error: new Error("upstream connection reset") },
+            ]),
+          ),
+        }),
+      ).rejects.toThrow(
         /Partial output before the failure:\nFound 3 stale cards\./,
       );
     });
 
     it("records the failure in the activity log before throwing", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          { type: "error", error: new Error("boom") },
-        ]),
-        text: Promise.resolve(""),
+      const yielded: SubAgentActivity[] = [];
+      const { tool } = createSubAgentTool({
+        ...baseOptions,
+        model: modelOf(step([{ type: "error", error: new Error("boom") }])),
       });
-
-      const { tool } = createSubAgentTool(baseOptions);
       const gen = tool.execute(
         { task: "Do something" },
         {} as ToolExecutionOptions<Record<string, unknown>>,
       ) as AsyncGenerator<SubAgentActivity>;
 
-      const yielded: SubAgentActivity[] = [];
       await expect(
         (async () => {
           for await (const value of gen) yielded.push(structuredClone(value));
@@ -471,243 +414,23 @@ describe("createSubAgentTool", () => {
       });
     });
 
-    it("throws when the sub-agent stream aborts", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          { type: "abort", reason: "step limit" },
-        ]),
-        text: Promise.resolve(""),
+    it("marks tool-call entry as error when the sub-agent's tool fails", async () => {
+      const { yielded } = await delegate({
+        model: modelOf(
+          step(toolCall("tc1", "webFetch", "{}"), { unified: "tool-calls" }),
+          step([]),
+        ),
+        tools: {
+          webFetch: {
+            inputSchema: z.object({}),
+            execute: () => Promise.reject(new Error("Connection refused")),
+          } as unknown as Tool,
+        },
       });
 
-      const { tool } = createSubAgentTool(baseOptions);
-      const gen = tool.execute(
-        { task: "Do something" },
-        {} as ToolExecutionOptions<Record<string, unknown>>,
-      ) as AsyncGenerator<SubAgentActivity>;
-
-      await expect(consumeGenerator(gen)).rejects.toThrow(
-        /Stopped before finishing: step limit/,
-      );
-    });
-
-    // Issue #442. A token-limit stop is neither an `error` nor an `abort`: the
-    // stream ends normally and the partial answer was returned as if it were
-    // the whole finding. The parent has to be told it is looking at a fragment.
-    describe("truncated at the output token limit", () => {
-      const truncatedStream = () =>
-        createMockFullStream([
-          { type: "text-start", id: "t1" },
-          { type: "text-delta", id: "t1", text: "The three stale cards are" },
-          {
-            type: "finish",
-            finishReason: "length",
-            rawFinishReason: "max_tokens",
-          },
-        ]);
-
-      it("flags the delegation result as truncated", async () => {
-        mockStream.mockResolvedValue({
-          fullStream: truncatedStream(),
-          text: Promise.resolve(""),
-        });
-
-        const { tool } = createSubAgentTool(baseOptions);
-        const { yielded } = await consumeGenerator(
-          tool.execute(
-            { task: "Audit the board" },
-            {} as ToolExecutionOptions<Record<string, unknown>>,
-          ) as AsyncGenerator<SubAgentActivity>,
-        );
-        const final = yielded.at(-1)!;
-
-        expect(final.truncatedByTokenLimit).toBe(true);
-        // Not a failure: the partial answer is real work and still comes back.
-        expect(final.text).toBe("The three stale cards are");
-      });
-
-      it("tells the parent model the answer is partial", async () => {
-        mockStream.mockResolvedValue({
-          fullStream: truncatedStream(),
-          text: Promise.resolve(""),
-        });
-
-        const { tool } = createSubAgentTool(baseOptions);
-        const { yielded } = await consumeGenerator(
-          tool.execute(
-            { task: "Audit the board" },
-            {} as ToolExecutionOptions<Record<string, unknown>>,
-          ) as AsyncGenerator<SubAgentActivity>,
-        );
-
-        const value = modelText(tool, yielded.at(-1)!);
-
-        expect(value).toContain("The three stale cards are");
-        expect(value).toContain(SUB_AGENT_TRUNCATION_NOTE);
-      });
-
-      it("says only that the answer was cut off when there is no text at all", () => {
-        const { tool } = createSubAgentTool(baseOptions);
-
-        expect(
-          modelText(tool, {
-            entries: [],
-            text: "",
-            truncatedByTokenLimit: true,
-          }),
-        ).toBe(SUB_AGENT_TRUNCATION_NOTE);
-      });
-
-      it("records the cutoff in the log", async () => {
-        mockStream.mockResolvedValue({
-          fullStream: truncatedStream(),
-          text: Promise.resolve(""),
-        });
-
-        const { tool } = createSubAgentTool(baseOptions);
-        await consumeGenerator(
-          tool.execute(
-            { task: "Audit the board" },
-            {} as ToolExecutionOptions<Record<string, unknown>>,
-          ) as AsyncGenerator<SubAgentActivity>,
-        );
-
-        expect(vi.mocked(logger.warn).mock.calls[0]?.[0]).toMatchObject({
-          subAgentId: "agent-1",
-          subAgentName: "Research Agent",
-          // The provider's own word for the stop, which the unified reason
-          // would otherwise be the only record of.
-          rawFinishReason: "max_tokens",
-        });
-      });
-
-      it("leaves a cleanly finished delegation unflagged", async () => {
-        mockStream.mockResolvedValue({
-          fullStream: createMockFullStream([
-            { type: "text-start", id: "t1" },
-            { type: "text-delta", id: "t1", text: "All done." },
-            { type: "text-end", id: "t1" },
-            { type: "finish", finishReason: "stop" },
-          ]),
-          text: Promise.resolve(""),
-        });
-
-        const { tool } = createSubAgentTool(baseOptions);
-        const { yielded } = await consumeGenerator(
-          tool.execute(
-            { task: "Audit the board" },
-            {} as ToolExecutionOptions<Record<string, unknown>>,
-          ) as AsyncGenerator<SubAgentActivity>,
-        );
-        const final = yielded.at(-1)!;
-
-        expect(final).not.toHaveProperty("truncatedByTokenLimit");
-        expect(modelText(tool, final)).toBe("All done.");
-      });
-
-      // The same rule the run path applies: a step inside the tool loop can end
-      // at the ceiling and the sub-agent still recover and answer in full.
-      it("ignores a step that ended at the limit mid tool-loop", async () => {
-        mockStream.mockResolvedValue({
-          fullStream: createMockFullStream([
-            { type: "tool-input-start", toolName: "listCards", id: "tc1" },
-            { type: "finish-step", finishReason: "length" },
-            {
-              type: "tool-result",
-              toolCallId: "tc1",
-              toolName: "listCards",
-              output: [{ id: "c1" }],
-            },
-            { type: "text-start", id: "t1" },
-            { type: "text-delta", id: "t1", text: "One card." },
-            { type: "text-end", id: "t1" },
-            { type: "finish", finishReason: "stop" },
-          ]),
-          text: Promise.resolve(""),
-        });
-
-        const { tool } = createSubAgentTool(baseOptions);
-        const { yielded } = await consumeGenerator(
-          tool.execute(
-            { task: "Audit the board" },
-            {} as ToolExecutionOptions<Record<string, unknown>>,
-          ) as AsyncGenerator<SubAgentActivity>,
-        );
-
-        expect(yielded.at(-1)!).not.toHaveProperty("truncatedByTokenLimit");
-      });
-
-      // A cutoff is a fact about the answer, not an activity step, so the log
-      // the user watches must not gain a spurious row (or a spurious yield).
-      it("adds no activity entry and no extra yield for the terminal finish", async () => {
-        mockStream.mockResolvedValue({
-          fullStream: truncatedStream(),
-          text: Promise.resolve(""),
-        });
-
-        const { tool } = createSubAgentTool(baseOptions);
-        const { yielded } = await consumeGenerator(
-          tool.execute(
-            { task: "Audit the board" },
-            {} as ToolExecutionOptions<Record<string, unknown>>,
-          ) as AsyncGenerator<SubAgentActivity>,
-        );
-
-        // text-start yields once; the delta and the finish yield nothing; then
-        // the final value.
-        expect(yielded).toHaveLength(2);
-        expect(yielded.at(-1)!.entries).toHaveLength(1);
-      });
-
-      // A stream that fails after hitting the ceiling is still a failure: the
-      // parent must get a tool error, not a flagged partial answer.
-      it("still throws when the stream also reported a failure", async () => {
-        mockStream.mockResolvedValue({
-          fullStream: createMockFullStream([
-            { type: "finish", finishReason: "length" },
-            { type: "error", error: new Error("upstream reset") },
-          ]),
-          text: Promise.resolve(""),
-        });
-
-        const { tool } = createSubAgentTool(baseOptions);
-
-        await expect(
-          consumeGenerator(
-            tool.execute(
-              { task: "Audit the board" },
-              {} as ToolExecutionOptions<Record<string, unknown>>,
-            ) as AsyncGenerator<SubAgentActivity>,
-          ),
-        ).rejects.toThrow(/upstream reset/);
-      });
-    });
-
-    it("marks tool-call entry as error on tool-error event", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          { type: "tool-input-start", toolName: "web-fetch", id: "tc1" },
-          {
-            type: "tool-error",
-            toolCallId: "tc1",
-            toolName: "web-fetch",
-            error: "Connection refused",
-          },
-        ]),
-        text: Promise.resolve(""),
-      });
-
-      const { tool } = createSubAgentTool(baseOptions);
-      const gen = tool.execute(
-        { task: "Do something" },
-        {} as ToolExecutionOptions<Record<string, unknown>>,
-      ) as AsyncGenerator<SubAgentActivity>;
-
-      const { yielded } = await consumeGenerator(gen);
-
-      // Second yield: tool-call with error status
-      expect(yielded[1].entries[0]).toEqual({
+      expect(yielded.at(-1)!.entries).toContainEqual({
         type: "tool-call",
-        toolName: "web-fetch",
+        toolName: "webFetch",
         status: "error",
         error: "Connection refused",
       });
@@ -715,30 +438,22 @@ describe("createSubAgentTool", () => {
 
     // Issue #421: the activity entry keeps only the error text, so a sub-agent
     // run — the least observable surface there is — recorded nothing about the
-    // arguments the model actually emitted.
+    // arguments the model actually emitted. It now goes through the same
+    // instrumentation the Chat path uses, tagged with the sub-agent.
     it("logs what the model emitted for a rejected tool call", async () => {
       const raw = '{"url":"https://example.com/a-page","selecto';
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          { type: "tool-input-start", toolName: "web-fetch", id: "tc1" },
-          {
-            type: "tool-error",
-            toolCallId: "tc1",
-            toolName: "web-fetch",
-            input: raw,
-            error: "AI_InvalidToolInputError: Invalid input for tool web-fetch",
-          },
-        ]),
-        text: Promise.resolve(""),
+      await delegate({
+        model: modelOf(
+          step(toolCall("tc1", "webFetch", raw), { unified: "tool-calls" }),
+          step([]),
+        ),
+        tools: {
+          webFetch: {
+            inputSchema: z.object({ url: z.string() }),
+            execute: () => Promise.resolve("ok"),
+          } as unknown as Tool,
+        },
       });
-
-      const { tool } = createSubAgentTool(baseOptions);
-      await consumeGenerator(
-        tool.execute(
-          { task: "Do something" },
-          {} as ToolExecutionOptions<Record<string, unknown>>,
-        ) as AsyncGenerator<SubAgentActivity>,
-      );
 
       // The same message the run driver logs, so an Operator greps once and
       // the sub-agent fields say which run it came from.
@@ -749,7 +464,7 @@ describe("createSubAgentTool", () => {
         subAgentId: "agent-1",
         subAgentName: "Research Agent",
         toolCallId: "tc1",
-        toolName: "web-fetch",
+        toolName: "webFetch",
         inputType: "string",
         inputKind: "unparseable",
         inputLength: raw.length,
@@ -758,112 +473,264 @@ describe("createSubAgentTool", () => {
     });
 
     it("says nothing about a sub-agent tool call that succeeded", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          { type: "tool-input-start", toolName: "web-fetch", id: "tc1" },
-          {
-            type: "tool-result",
-            toolCallId: "tc1",
-            toolName: "web-fetch",
-            input: { url: "https://example.com" },
-            output: "page text",
-          },
-        ]),
-        text: Promise.resolve(""),
+      await delegate({
+        model: modelOf(
+          step(toolCall("tc1", "webFetch", '{"url":"https://example.com"}'), {
+            unified: "tool-calls",
+          }),
+          step([]),
+        ),
+        tools: {
+          webFetch: {
+            inputSchema: z.object({ url: z.string() }),
+            execute: () => Promise.resolve("page text"),
+          } as unknown as Tool,
+        },
       });
 
-      const { tool } = createSubAgentTool(baseOptions);
-      await consumeGenerator(
-        tool.execute(
-          { task: "Do something" },
-          {} as ToolExecutionOptions<Record<string, unknown>>,
-        ) as AsyncGenerator<SubAgentActivity>,
-      );
-
-      expect(vi.mocked(logger.debug)).not.toHaveBeenCalled();
-    });
-
-    it("passes abortSignal to agent.stream", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([]),
-        text: Promise.resolve("done"),
-      });
-
-      const { tool } = createSubAgentTool(baseOptions);
-      const abortController = new AbortController();
-      const gen = tool.execute({ task: "Do something" }, {
-        abortSignal: abortController.signal,
-      } as ToolExecutionOptions<
-        Record<string, unknown>
-      >) as AsyncGenerator<SubAgentActivity>;
-
-      await consumeGenerator(gen);
-
-      expect(mockStream).toHaveBeenCalledWith(
-        expect.objectContaining({
-          prompt: "Do something",
-          abortSignal: abortController.signal,
-        }),
-      );
+      expect(
+        vi
+          .mocked(logger.debug)
+          .mock.calls.filter((call) => call[1] === "Tool call failed"),
+      ).toHaveLength(0);
     });
 
     it("accumulates entries across multiple events", async () => {
-      mockStream.mockResolvedValue({
-        fullStream: createMockFullStream([
-          { type: "tool-input-start", toolName: "search", id: "tc1" },
-          { type: "tool-input-start", toolName: "fetch", id: "tc2" },
-        ]),
-        text: Promise.resolve("done"),
+      const { yielded } = await delegate({
+        model: modelOf(
+          step(
+            [
+              ...toolCall("tc1", "search", "{}"),
+              ...toolCall("tc2", "fetch", "{}"),
+            ],
+            { unified: "tool-calls" },
+          ),
+          step([]),
+        ),
+        tools: {
+          search: {
+            inputSchema: z.object({}),
+            execute: () => Promise.resolve("a"),
+          } as unknown as Tool,
+          fetch: {
+            inputSchema: z.object({}),
+            execute: () => Promise.resolve("b"),
+          } as unknown as Tool,
+        },
       });
 
-      const { tool } = createSubAgentTool(baseOptions);
-      const gen = tool.execute(
-        { task: "Do something" },
-        {} as ToolExecutionOptions<Record<string, unknown>>,
-      ) as AsyncGenerator<SubAgentActivity>;
-
-      const { yielded } = await consumeGenerator(gen);
-
-      // First yield should have 1 entry, second should have 2
       expect(yielded[0].entries).toHaveLength(1);
       expect(yielded[1].entries).toHaveLength(2);
     });
   });
 
-  // Regression for #321 recurring one level down. The parent turn normalizes
-  // tool results in `wrapToolsWithBump`, but a sub-agent's own tools go from
-  // `loadTools` straight into its ToolLoopAgent. A raw Drizzle `Date` then
-  // fails the sub-agent's next-step prompt validation and kills its stream.
-  // An Agent must generate with the parameters assigned to it wherever it
-  // runs. Before this, a delegated run passed only model/instructions/tools/
-  // stopWhen, so an Agent's Temperature was inert the moment it was used as a
-  // sub-agent — on every Provider, including ones that honour it.
-  describe("sampling parameters", () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
+  // The delegated run is a run in its own right: it holds its own registry
+  // entry, its own timers, and its own abort signal — and the parent's
+  // cancellation reaches it through the registry.
+  describe("run lifecycle", () => {
+    it("generates with its own abort signal rather than the parent's", async () => {
+      const parent = new AbortController();
+      await delegate({}, { abortSignal: parent.signal });
+
+      const { abortSignal } = streamArgs();
+      expect(abortSignal).toBeInstanceOf(AbortSignal);
+      expect(abortSignal).not.toBe(parent.signal);
     });
 
-    const settingsPassedToAgent = () =>
-      agentConstructorSpy.mock.calls[0][0] as Record<string, unknown>;
-
-    it("passes the sub-agent's own sampling parameters to its agent", () => {
-      createSubAgentTool({
+    it("stops the delegated run when the parent run is cancelled", async () => {
+      const parent = new AbortController();
+      const { tool } = createSubAgentTool({
         ...baseOptions,
-        sampling: { temperature: 0.2, topP: 0.9, seed: 42 },
+        model: modelOf(step(text("t1", "half an answ"))),
+      });
+      const gen = tool.execute({ task: "Do something" }, {
+        abortSignal: parent.signal,
+      } as ToolExecutionOptions<
+        Record<string, unknown>
+      >) as AsyncGenerator<SubAgentActivity>;
+
+      await expect(
+        (async () => {
+          for await (const _ of gen) {
+            void _;
+            parent.abort(new Error("Chat run cancelled"));
+          }
+        })(),
+      ).rejects.toThrow(/Stopped before finishing/);
+    });
+
+    it("records the delegated run's step count and token usage", async () => {
+      await delegate({
+        model: modelOf(
+          step(toolCall("tc1", "noop", "{}"), { unified: "tool-calls" }),
+          step(text("t1", "done")),
+        ),
+        tools: {
+          noop: {
+            inputSchema: z.object({}),
+            execute: () => Promise.resolve("ok"),
+          } as unknown as Tool,
+        },
       });
 
-      expect(settingsPassedToAgent()).toMatchObject({
+      const finished = vi
+        .mocked(logger.info)
+        .mock.calls.find((call) => call[1] === "Sub-agent run finished");
+      expect(finished?.[0]).toMatchObject({
+        subAgentId: "agent-1",
+        status: "succeeded",
+        stats: {
+          steps: 2,
+          inputTokens: 20,
+          outputTokens: 8,
+          contextOccupancy: 10,
+        },
+      });
+    });
+  });
+
+  // Issue #442. A token-limit stop is neither an error nor an abort: the stream
+  // ends normally and the partial answer was returned as if it were the whole
+  // finding. The parent has to be told it is looking at a fragment.
+  describe("truncated at the output token limit", () => {
+    const truncated = () =>
+      modelOf(
+        step(text("t1", "The three stale cards are"), {
+          unified: "length",
+          raw: "max_tokens",
+        }),
+      );
+
+    it("flags the delegation result as truncated", async () => {
+      const { yielded } = await delegate({ model: truncated() });
+      const final = yielded.at(-1)!;
+
+      expect(final.truncatedByTokenLimit).toBe(true);
+      // Not a failure: the partial answer is real work and still comes back.
+      expect(final.text).toBe("The three stale cards are");
+    });
+
+    it("tells the parent model the answer is partial", async () => {
+      const { tool, yielded } = await delegate({ model: truncated() });
+
+      const value = modelText(tool, yielded.at(-1)!);
+      expect(value).toContain("The three stale cards are");
+      expect(value).toContain(SUB_AGENT_TRUNCATION_NOTE);
+    });
+
+    it("says only that the answer was cut off when there is no text at all", () => {
+      const { tool } = createSubAgentTool(baseOptions);
+
+      expect(
+        modelText(tool, {
+          entries: [],
+          text: "",
+          truncatedByTokenLimit: true,
+        }),
+      ).toBe(SUB_AGENT_TRUNCATION_NOTE);
+    });
+
+    it("records the cutoff in the log", async () => {
+      await delegate({ model: truncated() });
+
+      const warned = vi
+        .mocked(logger.warn)
+        .mock.calls.find((call) =>
+          String(call[1]).includes(
+            "answer truncated at the output token limit",
+          ),
+        );
+      expect(warned?.[0]).toMatchObject({
+        subAgentId: "agent-1",
+        subAgentName: "Research Agent",
+        // The provider's own word for the stop, which the unified reason
+        // would otherwise be the only record of.
+        rawFinishReason: "max_tokens",
+      });
+    });
+
+    it("leaves a cleanly finished delegation unflagged", async () => {
+      const { tool, yielded } = await delegate({
+        model: modelOf(step(text("t1", "All done."))),
+      });
+      const final = yielded.at(-1)!;
+
+      expect(final).not.toHaveProperty("truncatedByTokenLimit");
+      expect(modelText(tool, final)).toBe("All done.");
+    });
+
+    // The same rule the run path applies: a step inside the tool loop can end at
+    // the ceiling and the sub-agent still recover and answer in full.
+    it("ignores a step that ended at the limit mid tool-loop", async () => {
+      const { yielded } = await delegate({
+        model: modelOf(
+          step(toolCall("tc1", "listCards", "{}"), {
+            unified: "length",
+            raw: "max_tokens",
+          }),
+          step(text("t1", "One card.")),
+        ),
+        tools: {
+          listCards: {
+            inputSchema: z.object({}),
+            execute: () => Promise.resolve([{ id: "c1" }]),
+          } as unknown as Tool,
+        },
+      });
+
+      expect(yielded.at(-1)!).not.toHaveProperty("truncatedByTokenLimit");
+      expect(yielded.at(-1)!.text).toBe("One card.");
+    });
+
+    // A cutoff is a fact about the answer, not an activity step, so the log the
+    // user watches must not gain a spurious row (or a spurious yield).
+    it("adds no activity entry and no extra yield for the terminal finish", async () => {
+      const { yielded } = await delegate({ model: truncated() });
+
+      // text-start yields once; the delta and the finish yield nothing; then
+      // the final value.
+      expect(yielded).toHaveLength(3);
+      expect(yielded.at(-1)!.entries).toHaveLength(1);
+    });
+
+    // A stream that fails after hitting the ceiling is still a failure: the
+    // parent must get a tool error, not a flagged partial answer.
+    it("still throws when the stream also reported a failure", async () => {
+      await expect(
+        delegate({
+          model: modelOf(
+            step(
+              [
+                ...text("t1", "partial"),
+                { type: "error", error: new Error("upstream reset") },
+              ],
+              { unified: "length", raw: "max_tokens" },
+            ),
+          ),
+        }),
+      ).rejects.toThrow(/upstream reset/);
+    });
+  });
+
+  // An Agent must generate with the parameters assigned to it wherever it runs.
+  // Before this, a delegated run passed only model/instructions/tools/stopWhen,
+  // so an Agent's Temperature was inert the moment it was used as a sub-agent.
+  describe("sampling parameters", () => {
+    it("passes the sub-agent's own sampling parameters to its run", async () => {
+      await delegate({ sampling: { temperature: 0.2, topP: 0.9, seed: 42 } });
+
+      expect(streamArgs()).toMatchObject({
         temperature: 0.2,
         topP: 0.9,
         seed: 42,
       });
     });
 
-    it("omits parameters that were never set rather than sending undefined", () => {
-      createSubAgentTool({ ...baseOptions, sampling: { temperature: 0.2 } });
+    it("sends no value for a parameter that was never set", async () => {
+      await delegate({ sampling: { temperature: 0.2 } });
 
-      const settings = settingsPassedToAgent();
-      expect(settings).toMatchObject({ temperature: 0.2 });
+      const settings = streamArgs();
+      expect(settings.temperature).toBe(0.2);
       for (const key of [
         "topP",
         "topK",
@@ -871,7 +738,7 @@ describe("createSubAgentTool", () => {
         "presencePenalty",
         "frequencyPenalty",
       ]) {
-        expect(settings).not.toHaveProperty(key);
+        expect(settings[key]).toBeUndefined();
       }
     });
 
@@ -879,85 +746,70 @@ describe("createSubAgentTool", () => {
     // OWN Provider model entry, not its Agent row (issue #454). Without it a
     // delegated run truncates one level down, on Bedrock especially, with the
     // Org Admin's declared ceiling applying only to the parent turn.
-    it("passes the sub-agent model's output ceiling to its agent", () => {
-      createSubAgentTool({ ...baseOptions, maxOutputTokens: 64000 });
+    it("passes the sub-agent model's output ceiling to its run", async () => {
+      await delegate({ maxOutputTokens: 64000 });
 
-      expect(settingsPassedToAgent()).toMatchObject({
-        maxOutputTokens: 64000,
-      });
+      expect(streamArgs()).toMatchObject({ maxOutputTokens: 64000 });
     });
 
-    it("sends no ceiling when the sub-agent's model declares none", () => {
-      createSubAgentTool({ ...baseOptions });
+    it("sends no ceiling when the sub-agent's model declares none", async () => {
+      await delegate({});
 
-      expect(settingsPassedToAgent()).not.toHaveProperty("maxOutputTokens");
+      expect(streamArgs().maxOutputTokens).toBeUndefined();
     });
 
-    it("cannot have sampling override the model, instructions or tools", () => {
-      createSubAgentTool({
-        ...baseOptions,
+    it("cannot have sampling override the model, instructions or tools", async () => {
+      await delegate({
         instructions: "Stay on task.",
         sampling: { temperature: 0.2 },
       });
 
-      const settings = settingsPassedToAgent();
-      expect(settings.model).toBe("mock-model");
-      expect(settings.instructions).toContain("Stay on task.");
+      expect(streamArgs().system).toContain("Stay on task.");
     });
   });
 
+  // Regression for #321 recurring one level down. The parent turn normalizes
+  // tool results in its activity wrapper; a sub-agent's own tools used to go
+  // from `loadTools` straight into the delegated run untouched, so a raw
+  // Drizzle `Date` failed the sub-agent's next-step prompt validation.
   describe("sub-agent tool results", () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
-    type ExecutableTool = {
-      execute: (args: unknown, opts: unknown) => unknown;
-    };
-
-    const toolPassedToAgent = (name: string) => {
-      const { tools } = agentConstructorSpy.mock.calls[0][0] as {
-        tools: Record<string, ExecutableTool>;
-      };
-      return tools[name];
-    };
-
     it("normalizes Date values out of an async tool result", async () => {
       const createdAt = new Date("2026-08-06T00:00:00.000Z");
-      createSubAgentTool({
-        ...baseOptions,
+      await delegate({
         tools: {
           listBoards: {
+            inputSchema: z.object({}),
             execute: () => Promise.resolve([{ id: "b1", createdAt }]),
-          } as never,
+          } as unknown as Tool,
         },
       });
 
-      const result = await toolPassedToAgent("listBoards").execute({}, {});
+      const result = await streamArgs().tools.listBoards.execute({}, {});
       expect(result).toEqual([
         { id: "b1", createdAt: createdAt.toISOString() },
       ]);
     });
 
-    it("normalizes a synchronous tool result too", () => {
-      createSubAgentTool({
-        ...baseOptions,
+    it("normalizes a synchronous tool result too", async () => {
+      await delegate({
         tools: {
           now: {
+            inputSchema: z.object({}),
             execute: () => ({ at: new Date("2026-08-06T00:00:00.000Z") }),
-          } as never,
+          } as unknown as Tool,
         },
       });
 
-      expect(toolPassedToAgent("now").execute({}, {})).toEqual({
+      expect(streamArgs().tools.now.execute({}, {})).toEqual({
         at: "2026-08-06T00:00:00.000Z",
       });
     });
 
-    it("leaves a tool without an execute function alone", () => {
-      const bare = { description: "no execute" } as never;
-      createSubAgentTool({ ...baseOptions, tools: { bare } });
-      expect(toolPassedToAgent("bare")).toBe(bare);
+    it("leaves a tool without an execute function alone", async () => {
+      const bare = { description: "no execute" } as unknown as Tool;
+      await delegate({ tools: { bare } });
+
+      expect(streamArgs().tools.bare).toBe(bare);
     });
   });
 
@@ -999,6 +851,22 @@ describe("createSubAgentTools", () => {
     vi.clearAllMocks();
   });
 
+  /** Run the delegate a builder produced, so its run arguments can be read. */
+  const runTool = async (tool: Tool) => {
+    const gen = (
+      tool as unknown as {
+        execute: (a: unknown, o: unknown) => AsyncGenerator<SubAgentActivity>;
+      }
+    ).execute({ task: "Do something" }, {});
+    for await (const _ of gen) void _;
+  };
+
+  const workingModel = () =>
+    vi.fn().mockResolvedValue({
+      model: modelOf(step([])),
+      securityGuardrails: null,
+    });
+
   it("returns empty object when given no sub-agents", async () => {
     const result = await createSubAgentTools([], vi.fn(), vi.fn());
     expect(result).toEqual({ tools: {}, failures: [] });
@@ -1022,9 +890,7 @@ describe("createSubAgentTools", () => {
       },
     ];
 
-    const createModelFn = vi
-      .fn()
-      .mockResolvedValue({ model: {}, securityGuardrails: null });
+    const createModelFn = workingModel();
     const loadToolsFn = vi.fn().mockResolvedValue({});
 
     const result = await createSubAgentTools(
@@ -1043,44 +909,36 @@ describe("createSubAgentTools", () => {
 
   // The ceiling belongs to the sub-agent's own (Provider, model) pair, which
   // only the resolver has, so it rides back with the model it applies to.
-  it("forwards the resolved model's output ceiling to the sub-agent's agent", async () => {
+  it("forwards the resolved model's output ceiling to the sub-agent's run", async () => {
     const createModelFn = vi.fn().mockResolvedValue({
-      model: {},
+      model: modelOf(step([])),
       securityGuardrails: null,
       maxOutputTokens: 32000,
     });
 
-    await createSubAgentTools(
+    const { tools } = await createSubAgentTools(
       [{ id: "sa-1", name: "Research", providerId: "p1", modelId: "m1" }],
       createModelFn,
       vi.fn().mockResolvedValue({}),
     );
+    await runTool(tools.delegateToResearch);
 
-    expect(agentConstructorSpy.mock.calls[0][0]).toMatchObject({
-      maxOutputTokens: 32000,
-    });
+    expect(streamArgs()).toMatchObject({ maxOutputTokens: 32000 });
   });
 
   it("continues when a sub-agent fails to initialize, and reports it as a failure", async () => {
     const subAgents = [
-      {
-        id: "sa-1",
-        name: "Failing",
-        providerId: "p1",
-        modelId: "m1",
-      },
-      {
-        id: "sa-2",
-        name: "Working",
-        providerId: "p1",
-        modelId: "m1",
-      },
+      { id: "sa-1", name: "Failing", providerId: "p1", modelId: "m1" },
+      { id: "sa-2", name: "Working", providerId: "p1", modelId: "m1" },
     ];
 
     const createModelFn = vi
       .fn()
       .mockRejectedValueOnce(new Error("Model not found"))
-      .mockResolvedValueOnce({ model: {}, securityGuardrails: null });
+      .mockResolvedValueOnce({
+        model: modelOf(step([])),
+        securityGuardrails: null,
+      });
     const loadToolsFn = vi.fn().mockResolvedValue({});
 
     const result = await createSubAgentTools(
@@ -1099,108 +957,93 @@ describe("createSubAgentTools", () => {
   });
 
   it("uses default maxSteps when not provided", async () => {
-    const subAgents = [
-      {
-        id: "sa-1",
-        name: "Agent",
-        providerId: "p1",
-        modelId: "m1",
-        maxSteps: null,
-      },
-    ];
-
-    const createModelFn = vi
-      .fn()
-      .mockResolvedValue({ model: {}, securityGuardrails: null });
-    const loadToolsFn = vi.fn().mockResolvedValue({});
-
-    const result = await createSubAgentTools(
-      subAgents,
-      createModelFn,
-      loadToolsFn,
+    const { tools } = await createSubAgentTools(
+      [
+        {
+          id: "sa-1",
+          name: "Agent",
+          providerId: "p1",
+          modelId: "m1",
+          maxSteps: null,
+        },
+      ],
+      workingModel(),
+      vi.fn().mockResolvedValue({}),
     );
+    await runTool(tools.delegateToAgent);
 
-    expect(Object.keys(result.tools)).toHaveLength(1);
-    expect(stepCeilingOf(0)).toBe(DEFAULT_AGENT_MAX_STEPS);
+    expect(stepCeilingOf()).toBe(DEFAULT_AGENT_MAX_STEPS);
   });
 
   // A delegated Agent runs on its own ceiling, not the parent's and not the
   // fallback — the whole point of reading `maxSteps` off the row.
   it("forwards an explicit maxSteps instead of the fallback default", async () => {
-    const subAgents = [
-      {
-        id: "sa-1",
-        name: "Agent",
-        providerId: "p1",
-        modelId: "m1",
-        maxSteps: 3,
-      },
-    ];
+    const { tools } = await createSubAgentTools(
+      [
+        {
+          id: "sa-1",
+          name: "Agent",
+          providerId: "p1",
+          modelId: "m1",
+          maxSteps: 3,
+        },
+      ],
+      workingModel(),
+      vi.fn().mockResolvedValue({}),
+    );
+    await runTool(tools.delegateToAgent);
 
-    const createModelFn = vi
-      .fn()
-      .mockResolvedValue({ model: {}, securityGuardrails: null });
-    const loadToolsFn = vi.fn().mockResolvedValue({});
-
-    await createSubAgentTools(subAgents, createModelFn, loadToolsFn);
-
-    expect(stepCeilingOf(0)).toBe(3);
+    expect(stepCeilingOf()).toBe(3);
   });
 
   it("forwards each sub-agent's stored sampling parameters, treating null as unset", async () => {
-    const subAgents = [
-      {
-        id: "sa-1",
-        name: "Tuned",
-        providerId: "p1",
-        modelId: "m1",
-        temperature: 0.3,
-        seed: 7,
-        // Cleared in the UI writes null, which must mean "use the Provider
-        // default" rather than being sent as an explicit value (#263).
-        topP: null,
-      },
-    ];
+    const { tools } = await createSubAgentTools(
+      [
+        {
+          id: "sa-1",
+          name: "Tuned",
+          providerId: "p1",
+          modelId: "m1",
+          temperature: 0.3,
+          seed: 7,
+          // Cleared in the UI writes null, which must mean "use the Provider
+          // default" rather than being sent as an explicit value (#263).
+          topP: null,
+        },
+      ],
+      workingModel(),
+      vi.fn().mockResolvedValue({}),
+    );
+    await runTool(tools.delegateToTuned);
 
-    const createModelFn = vi
-      .fn()
-      .mockResolvedValue({ model: {}, securityGuardrails: null });
-    const loadToolsFn = vi.fn().mockResolvedValue({});
-
-    await createSubAgentTools(subAgents, createModelFn, loadToolsFn);
-
-    const settings = agentConstructorSpy.mock.calls[0][0] as Record<
-      string,
-      unknown
-    >;
-    expect(settings).toMatchObject({ temperature: 0.3, seed: 7 });
-    expect(settings).not.toHaveProperty("topP");
+    expect(streamArgs()).toMatchObject({ temperature: 0.3, seed: 7 });
+    expect(streamArgs().topP).toBeUndefined();
   });
 
   it("passes each sub-agent's own provider security text into its instructions", async () => {
-    const subAgents = [
-      {
-        id: "sa-1",
-        name: "Guarded",
-        providerId: "p1",
-        modelId: "m1",
-        instructions: "You are guarded.",
-      },
-    ];
-
     const createModelFn = vi.fn().mockResolvedValue({
-      model: {},
+      model: modelOf(step([])),
       securityGuardrails: "Provider-specific rule.",
     });
-    const loadToolsFn = vi.fn().mockResolvedValue({});
 
-    await createSubAgentTools(subAgents, createModelFn, loadToolsFn);
+    const { tools } = await createSubAgentTools(
+      [
+        {
+          id: "sa-1",
+          name: "Guarded",
+          providerId: "p1",
+          modelId: "m1",
+          instructions: "You are guarded.",
+        },
+      ],
+      createModelFn,
+      vi.fn().mockResolvedValue({}),
+    );
+    await runTool(tools.delegateToGuarded);
 
-    const { instructions } = agentConstructorSpy.mock.calls[0][0] as {
-      instructions: string;
-    };
-    expect(instructions).toContain("You are guarded.");
-    expect(instructions).toContain("## Security and trust");
-    expect(instructions).toContain("Provider-specific rule.");
+    const { system } = streamArgs();
+    expect(system).toContain("You are guarded.");
+    expect(system).toContain("## Security and trust");
+    expect(system).toContain("Provider-specific rule.");
   });
 });

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -11,15 +11,13 @@ import {
 import { z } from "zod";
 import { logger } from "../logger.ts";
 import { createMessageMetadata } from "../runs/message-metadata.ts";
-import { buildModelInvocation, startRun } from "../runs/run-lifecycle.ts";
+import { startRun } from "../runs/run-lifecycle.ts";
+import { buildModelInvocation } from "../runs/run-plan.ts";
 import { runRegistry } from "../runs/run-registry.ts";
-import {
-  describeStreamError,
-  formatStreamError,
-} from "../runs/stream-error.ts";
-import type { RunId } from "../runs/types.ts";
+import { describeSdkError, formatStreamError } from "../runs/stream-error.ts";
+import type { ParentRunContext } from "../runs/types.ts";
 import { renderSecurityGuardrails } from "../security-prompt.ts";
-import { workspaceScopeForSubAgent, type WorkspaceScope } from "../scope.ts";
+import { actorUserId, workspaceScopeForSubAgent } from "../scope.ts";
 import { wrapToolsWithActivity } from "../services/tool-activity.ts";
 import {
   resolveSamplingSettings,
@@ -172,13 +170,6 @@ const finalToolResult = (
 };
 
 /**
- * The run a delegate tool nests inside: the parent's id and scope. A delegated
- * run registers as a run in its own right, so it needs to say whose child it is
- * (`workspaceScopeForSubAgent`) and to be cancelled when the parent is.
- */
-export type ParentRunContext = { runId: RunId; scope: WorkspaceScope };
-
-/**
  * Options for creating a sub-agent tool.
  */
 interface SubAgentToolOptions {
@@ -293,6 +284,9 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
         // called twice in one turn, and two registry entries under one id is a
         // hard error.
         const runId = `sub_${randomUUID()}`;
+        // Chained rather than reused: the principal records that this run is a
+        // child of `parentRun.runId`, and `actorUserId` still walks back up it
+        // to the human the whole tree is executing for.
         const scope = parentRun
           ? workspaceScopeForSubAgent(parentRun.scope, parentRun.runId)
           : undefined;
@@ -304,12 +298,18 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
 
         const run = startRun({
           runId,
+          // Inherited, not defaulted: a Trigger run is started under bounds an
+          // Operator configured (`TRIGGER_PER_RUN_TIMEOUT_MS` and friends), and
+          // work it delegates has to run under the same ones or a long
+          // delegation is cut short by a limit nobody chose.
+          timeouts: parentRun?.timeouts,
           log: {
             subAgentId: id,
             subAgentName: name,
             parentRunId: parentRun?.runId,
             orgId: scope?.orgId,
             workspaceId: scope?.workspaceId,
+            actorUserId: scope ? actorUserId(scope.principal) : undefined,
           },
           onTerminate: ({ status, error, stats }) => {
             logger.info(
@@ -334,6 +334,11 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
         parentSignal?.addEventListener("abort", cancelWithParent, {
           once: true,
         });
+        // A generator body does not start until the consumer pulls, so the
+        // parent can already have been cancelled by the time we get here — in
+        // which case the listener will never fire and the delegation would run
+        // on regardless.
+        if (parentSignal?.aborted) cancelWithParent();
 
         // Everything below runs inside the registered run, so every exit —
         // including the consumer abandoning this generator mid-stream — reaches
@@ -385,7 +390,7 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
             for await (const message of readUIMessageStream<PlatypusUIMessage>({
               stream: uiStream,
               onError: (error) => {
-                streamFailure ??= describeStreamError(error);
+                streamFailure ??= describeSdkError(error);
               },
             })) {
               latest = message;
@@ -399,14 +404,13 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
             // An abort ends the stream normally, so the signal is the only record
             // that the run was stopped rather than finished.
             if (!streamFailure && run.handle.signal.aborted) {
-              const reason: unknown = run.handle.signal.reason;
-              streamFailure =
-                reason instanceof Error
-                  ? `Stopped before finishing: ${reason.message}`
-                  : "Stopped before finishing.";
+              const reason = run.abortReason();
+              streamFailure = reason
+                ? `Stopped before finishing: ${reason}`
+                : "Stopped before finishing.";
             }
           } catch (error) {
-            streamFailure ??= describeStreamError(error);
+            streamFailure ??= describeSdkError(error);
           }
 
           const aggregatedText = assistantText(latest);
@@ -592,7 +596,7 @@ export const createSubAgentTools = async (
       failures.push({
         id: subAgent.id,
         name: subAgent.name,
-        reason: describeStreamError(error),
+        reason: describeSdkError(error),
       });
     }
   }

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -1,21 +1,32 @@
+import { randomUUID } from "node:crypto";
 import {
-  stepCountIs,
+  getToolOrDynamicToolName,
+  isToolUIPart,
+  readUIMessageStream,
+  streamText,
   tool,
-  ToolLoopAgent,
   type LanguageModel,
   type Tool,
 } from "ai";
 import { z } from "zod";
 import { logger } from "../logger.ts";
-import { describeToolInput } from "../rejected-tool-input.ts";
-import { isTruncatedByTokenLimit } from "../runs/stream-error.ts";
+import { createMessageMetadata } from "../runs/message-metadata.ts";
+import { buildModelInvocation, startRun } from "../runs/run-lifecycle.ts";
+import { runRegistry } from "../runs/run-registry.ts";
+import {
+  describeStreamError,
+  formatStreamError,
+} from "../runs/stream-error.ts";
+import type { RunId } from "../runs/types.ts";
 import { renderSecurityGuardrails } from "../security-prompt.ts";
-import { withNormalizedResults } from "../services/tool-result.ts";
+import { workspaceScopeForSubAgent, type WorkspaceScope } from "../scope.ts";
+import { wrapToolsWithActivity } from "../services/tool-activity.ts";
 import {
   resolveSamplingSettings,
   type SamplingSettings,
   type SamplingSource,
 } from "../services/sampling-settings.ts";
+import type { PlatypusUIMessage } from "../types.ts";
 import { DEFAULT_AGENT_MAX_STEPS } from "@platypus/schemas";
 
 /**
@@ -71,21 +82,6 @@ type ToolResultSummary = { toolName?: string; output: unknown };
  * than silently empty. Returns "" when there is no tool result to summarize —
  * `toModelOutput` then supplies its own generic fallback.
  */
-/**
- * Renders an unknown thrown/streamed value as a one-line message. `String(...)`
- * alone turns a plain object into "[object Object]", which is exactly the kind
- * of uninformative error this module exists to stop producing.
- */
-const describeError = (error: unknown): string => {
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
-  try {
-    return JSON.stringify(error) ?? String(error);
-  } catch {
-    return String(error);
-  }
-};
-
 const summarizeToolResult = (
   toolResult: ToolResultSummary | undefined,
 ): string => {
@@ -95,6 +91,92 @@ const summarizeToolResult = (
   const label = toolName ? `${toolName} result` : "Tool result";
   return `${label}: ${rendered}`;
 };
+
+/**
+ * Projects the delegate's in-progress assistant message onto the activity log
+ * the parent's UI renders.
+ *
+ * A projection rather than an event log kept in parallel: the run path already
+ * folds every stream part into a `UIMessage`, and reading the entries back off
+ * it is what lets a delegated run share that one stream consumer instead of
+ * carrying a second switch over the SDK's part types.
+ */
+const activityEntries = (
+  message: PlatypusUIMessage,
+): SubAgentActivityEntry[] => {
+  const entries: SubAgentActivityEntry[] = [];
+  for (const part of message.parts) {
+    if (part.type === "text") {
+      entries.push({
+        type: "generating",
+        status: part.state === "done" ? "completed" : "running",
+      });
+    } else if (part.type === "reasoning") {
+      entries.push({
+        type: "thinking",
+        status: part.state === "done" ? "completed" : "running",
+      });
+    } else if (isToolUIPart(part)) {
+      const toolName = getToolOrDynamicToolName(part);
+      if (part.state === "output-error") {
+        entries.push({
+          type: "tool-call",
+          toolName,
+          status: "error",
+          error: part.errorText,
+        });
+      } else {
+        entries.push({
+          type: "tool-call",
+          toolName,
+          status: part.state === "output-available" ? "completed" : "running",
+        });
+      }
+    }
+  }
+  return entries;
+};
+
+/**
+ * Every text block the delegate produced, across all of its steps.
+ *
+ * Read off the accumulated message rather than `result.text`, which in AI SDK
+ * v7 carries ONLY the final step's text — so a sub-agent whose answer landed in
+ * an earlier step, or whose final step is a tool call, came back empty (#324).
+ */
+const assistantText = (message: PlatypusUIMessage | undefined): string => {
+  const blocks: string[] = [];
+  for (const part of message?.parts ?? []) {
+    if (part.type !== "text") continue;
+    const text = part.text.trim();
+    if (text) blocks.push(text);
+  }
+  return blocks.join("\n\n");
+};
+
+/** The delegate's last completed tool call, for the no-text fallback. */
+const finalToolResult = (
+  message: PlatypusUIMessage | undefined,
+): ToolResultSummary | undefined => {
+  const parts = message?.parts ?? [];
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    const part = parts[i];
+    if (isToolUIPart(part) && part.state === "output-available") {
+      return {
+        toolName: getToolOrDynamicToolName(part),
+        output: part.output,
+      };
+    }
+  }
+  return undefined;
+};
+
+/**
+ * The run a delegate tool nests inside: the parent's id and scope. A delegated
+ * run registers as a run in its own right, so it needs to say whose child it is
+ * (`workspaceScopeForSubAgent`) and to be cancelled when the parent is.
+ */
+export type ParentRunContext = { runId: RunId; scope: WorkspaceScope };
 
 /**
  * Options for creating a sub-agent tool.
@@ -111,7 +193,7 @@ interface SubAgentToolOptions {
    * Free-text security directives from THIS sub-agent's resolved provider,
    * appended (non-suppressibly) to its instructions. Null/empty → nothing
    * appended. Sub-agents never call renderSystemPrompt, so this is the only
-   * path guardrails reach them.
+   * path guardrails reach them (ADR-0016).
    */
   securityGuardrails?: string | null;
   /**
@@ -128,13 +210,16 @@ interface SubAgentToolOptions {
    * nothing at all.
    */
   maxOutputTokens?: number;
-  /** Called on each activity update from the sub-agent. Used to reset the parent run's per-step timeout. */
-  onProgress?: () => void;
+  /** The parent run this delegate is invoked from, when there is one. */
+  parentRun?: ParentRunContext;
 }
 
 /**
- * Creates a server-side tool that executes a sub-agent using ToolLoopAgent.stream().
- * The sub-agent streams an activity log back to the parent, keeping the SSE
+ * Creates a server-side tool that runs a sub-agent as a run in its own right.
+ *
+ * Each invocation registers with `RunRegistry` — so it carries per-step and
+ * per-run timeouts, is cancelled when the parent run is, and accumulates
+ * `RunStats` — and streams an activity log back to the parent, keeping the SSE
  * connection alive and giving users real-time visibility into sub-agent work.
  *
  * @param options Sub-agent configuration including model, tools, and prompts
@@ -152,7 +237,7 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
     securityGuardrails,
     sampling,
     maxOutputTokens,
-    onProgress,
+    parentRun,
   } = options;
 
   const toolName = subAgentToolName({ name });
@@ -170,20 +255,19 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
     ? `${baseInstructions}\n\n${securityBlock}`
     : baseInstructions;
 
-  const agent = new ToolLoopAgent({
-    ...sampling,
+  // A Sub-Agent invocation receives Instructions plus guardrails and nothing
+  // else — no workspace context, no memories, no user identity (ADR-0016). The
+  // exception is expressed here, in what is handed to the shared assembly,
+  // rather than as a mode inside the system-prompt renderer.
+  const plan = {
+    model,
+    system: composedInstructions,
+    maxSteps,
     // Spread rather than assigned, so an undeclared ceiling leaves the key off
     // entirely instead of sending `maxOutputTokens: undefined`.
     ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
-    model,
-    instructions: composedInstructions,
-    // The sub-agent's own tools never pass through the parent turn's
-    // `wrapToolsWithBump`, so #321 recurs one level down: a raw Drizzle `Date`
-    // in a tool result fails the sub-agent's next-step prompt validation and
-    // kills its stream mid-run.
-    tools: withNormalizedResults(tools),
-    stopWhen: [stepCountIs(maxSteps)],
-  });
+    ...sampling,
+  };
 
   return {
     toolName,
@@ -203,186 +287,193 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
       // `toModelOutput`, which sees every yield as a possible tool output.
       execute: async function* (
         { task },
-        { abortSignal },
+        { abortSignal: parentSignal },
       ): AsyncGenerator<SubAgentActivity> {
-        const result = await agent.stream({ prompt: task, abortSignal });
-        const entries: SubAgentActivityEntry[] = [];
+        // Unique per invocation, not per sub-agent: the same delegate can be
+        // called twice in one turn, and two registry entries under one id is a
+        // hard error.
+        const runId = `sub_${randomUUID()}`;
+        const scope = parentRun
+          ? workspaceScopeForSubAgent(parentRun.scope, parentRun.runId)
+          : undefined;
 
-        // Accumulate the sub-agent's assistant text off the stream, keyed by
-        // text-block id. In AI SDK v7 `result.text` carries ONLY the final
-        // step's text, so a sub-agent whose answer landed in an earlier step —
-        // or whose final step is a tool call — comes back empty (#324). Reading
-        // text-deltas from the fullStream captures every step's output in order.
-        const textBlocks = new Map<string, string>();
-        // Last tool result, used to synthesize a meaningful fallback when the
-        // sub-agent produced no assistant text at all.
-        let lastToolResult: ToolResultSummary | undefined;
-        // Set when the sub-agent's own stream reports a failure. The stream
-        // ENDS NORMALLY after an error part, so without this the generator
-        // would return whatever text had accumulated — typically the model's
-        // opening preamble — and the parent would read a crash as an answer.
-        let streamFailure: string | undefined;
-        // Set when the delegate ran out of output budget. Unlike the two above
-        // this is not a failure — the text is real work — but the stream ends
-        // normally either way, so without reading the finish reason a fragment
-        // is indistinguishable from a finished answer (#442).
-        let truncatedByTokenLimit = false;
-        // What the provider itself called the ending. The unified reason
-        // collapses anything the adapter doesn't recognise, so this is the only
-        // record of the actual stop signal (#406), and a delegated run has no
-        // other observable surface at all.
+        // The provider's own word for the ending. The unified reason collapses
+        // anything the adapter doesn't recognise, so this is the only record of
+        // the actual stop signal (#406).
         let rawFinishReason: string | undefined;
 
-        const completeLastRunning = (type: SubAgentActivityEntry["type"]) => {
-          const entry = entries.findLast(
-            (e) => e.type === type && e.status === "running",
-          );
-          if (entry) entry.status = "completed";
-        };
+        const run = startRun({
+          runId,
+          log: {
+            subAgentId: id,
+            subAgentName: name,
+            parentRunId: parentRun?.runId,
+            orgId: scope?.orgId,
+            workspaceId: scope?.workspaceId,
+          },
+          onTerminate: ({ status, error, stats }) => {
+            logger.info(
+              {
+                runId,
+                subAgentId: id,
+                subAgentName: name,
+                parentRunId: parentRun?.runId,
+                status,
+                error: error?.message,
+                stats,
+              },
+              "Sub-agent run finished",
+            );
+          },
+        });
 
-        for await (const part of result.fullStream) {
-          let changed = true;
+        // Cancelling the parent cancels its delegates. Routed through the
+        // registry rather than a linked signal so the delegated run is recorded
+        // as cancelled rather than silently disappearing.
+        const cancelWithParent = () => runRegistry.cancel(runId);
+        parentSignal?.addEventListener("abort", cancelWithParent, {
+          once: true,
+        });
 
-          switch (part.type) {
-            case "tool-input-start":
-              entries.push({
-                type: "tool-call",
-                toolName: part.toolName,
-                status: "running",
-              });
-              break;
-            case "tool-result":
-              completeLastRunning("tool-call");
-              lastToolResult = {
-                toolName: part.toolName,
-                output: part.output,
-              };
-              break;
-            case "tool-error": {
-              const entry = entries.findLast(
-                (e) => e.type === "tool-call" && e.status === "running",
-              );
-              if (entry) {
-                entry.status = "error";
-                entry.error = String(part.error);
-              }
-              // The activity entry keeps only the error text, so without this
-              // the arguments the sub-agent emitted are gone. A sub-agent run
-              // is the least observable surface there is, which is where the
-              // record is worth the most (issue #421). `debug`, because tool
-              // arguments are model and user data.
-              logger.debug(
+        // Everything below runs inside the registered run, so every exit —
+        // including the consumer abandoning this generator mid-stream — reaches
+        // the terminal callback and unregisters. `finish` is once-only, so the
+        // explicit outcomes below win over the fallback in the `finally`.
+        try {
+          // Set when the sub-agent's own stream reports a failure. The stream
+          // ENDS NORMALLY after an error, so without this the generator would
+          // return whatever text had accumulated — typically the model's opening
+          // preamble — and the parent would read a crash as an answer.
+          let streamFailure: string | undefined;
+          let latest: PlatypusUIMessage | undefined;
+          let entries: SubAgentActivityEntry[] = [];
+
+          try {
+            const result = streamText({
+              ...buildModelInvocation(
                 {
-                  subAgentId: id,
-                  subAgentName: name,
-                  ...describeToolInput(part),
+                  ...plan,
+                  // Wrapped per invocation: the wrapper holds THIS run's per-step
+                  // stall timer down for the duration of each tool call, and
+                  // normalizes results so a raw Drizzle `Date` can't fail the
+                  // sub-agent's next-step prompt validation (#321 one level down).
+                  tools: wrapToolsWithActivity(tools, run.onActivity),
                 },
-                "Tool call failed",
-              );
-              break;
+                { abortSignal: run.handle.signal },
+              ),
+              prompt: task,
+              onStepFinish: (step) => {
+                rawFinishReason = step.rawFinishReason;
+                run.onStep(step);
+              },
+            });
+
+            // The same consumption the run path uses: stream parts folded into a
+            // `UIMessage` by the SDK, errors rendered by `stream-error.ts`, and
+            // the output-ceiling cutoff carried on message metadata.
+            const uiStream = result.toUIMessageStream<PlatypusUIMessage>({
+              messageMetadata: createMessageMetadata(undefined),
+              onError: (error) => formatStreamError(error),
+            });
+
+            // Serialized entries of the last yield. Text deltas and growing tool
+            // inputs change the message on nearly every chunk but leave the
+            // activity log alone, and yielding for those would spam the parent's
+            // SSE stream.
+            let lastYielded = "";
+
+            for await (const message of readUIMessageStream<PlatypusUIMessage>({
+              stream: uiStream,
+              onError: (error) => {
+                streamFailure ??= describeStreamError(error);
+              },
+            })) {
+              latest = message;
+              entries = activityEntries(message);
+              const rendered = JSON.stringify(entries);
+              if (rendered === lastYielded) continue;
+              lastYielded = rendered;
+              yield { entries } satisfies SubAgentActivity;
             }
-            case "reasoning-start":
-              entries.push({ type: "thinking", status: "running" });
-              break;
-            case "reasoning-end":
-              completeLastRunning("thinking");
-              break;
-            case "text-start":
-              textBlocks.set(part.id, "");
-              entries.push({ type: "generating", status: "running" });
-              break;
-            case "text-delta":
-              textBlocks.set(
-                part.id,
-                (textBlocks.get(part.id) ?? "") + part.text,
-              );
-              // Deltas grow the answer but don't change the activity log, so
-              // they must not trigger a yield (would spam the SSE stream).
-              changed = false;
-              break;
-            case "text-end":
-              completeLastRunning("generating");
-              break;
-            case "error":
-              streamFailure = describeError(part.error);
-              entries.push({
-                type: "failed",
-                status: "error",
-                error: streamFailure,
-              });
-              break;
-            // The terminal finish only, as on the run path: a step inside the
-            // tool loop can end at the ceiling and the sub-agent still recover
-            // and answer in full. A cutoff is a fact about the answer rather
-            // than a step of the work, so it adds no activity entry — hence no
-            // yield either.
-            case "finish":
-              truncatedByTokenLimit = isTruncatedByTokenLimit(
-                part.finishReason,
-              );
-              rawFinishReason = part.rawFinishReason;
-              changed = false;
-              break;
-            case "abort":
-              streamFailure = part.reason
-                ? `Stopped before finishing: ${part.reason}`
-                : "Stopped before finishing.";
-              entries.push({
-                type: "failed",
-                status: "error",
-                error: streamFailure,
-              });
-              break;
-            default:
-              changed = false;
+
+            // An abort ends the stream normally, so the signal is the only record
+            // that the run was stopped rather than finished.
+            if (!streamFailure && run.handle.signal.aborted) {
+              const reason: unknown = run.handle.signal.reason;
+              streamFailure =
+                reason instanceof Error
+                  ? `Stopped before finishing: ${reason.message}`
+                  : "Stopped before finishing.";
+            }
+          } catch (error) {
+            streamFailure ??= describeStreamError(error);
           }
 
-          if (changed) {
-            onProgress?.();
-            yield { entries } satisfies SubAgentActivity;
+          const aggregatedText = assistantText(latest);
+          const truncatedByTokenLimit =
+            latest?.metadata?.truncatedByTokenLimit === true;
+
+          // Throw rather than return: a failed delegation must reach the parent
+          // as a tool error, not as a short answer it might summarize and pass
+          // off to the user as the sub-agent's finding. Any partial text rides
+          // along in the message so the work isn't lost.
+          if (streamFailure) {
+            // A delegation stopped because someone cancelled the parent is a
+            // normal outcome, not a fault of this sub-agent — record and log it
+            // as the cancellation it is.
+            const { status, error } = run.statusFromSignal();
+            const cancelled = status === "cancelled";
+            await run.finish(
+              cancelled ? "cancelled" : "failed",
+              error ?? new Error(streamFailure),
+            );
+            logger[cancelled ? "warn" : "error"](
+              { runId, subAgentName: name, error: streamFailure },
+              `Sub-agent "${name}" did not finish`,
+            );
+            // The failure is a step of the work as the parent's UI reads it, so
+            // it lands in the log the user is watching before the throw.
+            yield {
+              entries: [
+                ...entries,
+                { type: "failed", status: "error", error: streamFailure },
+              ],
+            } satisfies SubAgentActivity;
+            throw new Error(
+              `Sub-agent "${name}" did not complete: ${streamFailure}` +
+                (aggregatedText
+                  ? `\n\nPartial output before the failure:\n${aggregatedText}`
+                  : ""),
+            );
           }
+
+          if (truncatedByTokenLimit) {
+            run.setStats({ ...run.stats, truncatedByTokenLimit: true });
+            logger.warn(
+              { runId, subAgentId: id, subAgentName: name, rawFinishReason },
+              `Sub-agent "${name}" answer truncated at the output token limit`,
+            );
+          }
+
+          await run.finish("succeeded");
+
+          const text =
+            aggregatedText || summarizeToolResult(finalToolResult(latest));
+
+          // Yield (not return) the final value with text — the SDK's executeTool
+          // uses for-await-of which discards generator return values.
+          yield {
+            entries,
+            text,
+            // Omitted rather than `false` when the answer is whole, so the flag's
+            // presence is the whole of its meaning wherever it is read.
+            ...(truncatedByTokenLimit ? { truncatedByTokenLimit: true } : {}),
+          } satisfies SubAgentActivity;
+        } finally {
+          parentSignal?.removeEventListener("abort", cancelWithParent);
+          // Reached without an outcome only when nobody consumed the result.
+          await run.finish("cancelled");
         }
-
-        const aggregatedText = Array.from(textBlocks.values())
-          .map((t) => t.trim())
-          .filter(Boolean)
-          .join("\n\n");
-
-        // Throw rather than return: a failed delegation must reach the parent
-        // as a tool error, not as a short answer it might summarize and pass
-        // off to the user as the sub-agent's finding. Any partial text rides
-        // along in the message so the work isn't lost.
-        if (streamFailure) {
-          logger.error(
-            { subAgentName: name, error: streamFailure },
-            `Sub-agent "${name}" stream failed`,
-          );
-          throw new Error(
-            `Sub-agent "${name}" did not complete: ${streamFailure}` +
-              (aggregatedText
-                ? `\n\nPartial output before the failure:\n${aggregatedText}`
-                : ""),
-          );
-        }
-
-        const text = aggregatedText || summarizeToolResult(lastToolResult);
-
-        if (truncatedByTokenLimit) {
-          logger.warn(
-            { subAgentId: id, subAgentName: name, rawFinishReason },
-            `Sub-agent "${name}" answer truncated at the output token limit`,
-          );
-        }
-
-        // Yield (not return) the final value with text — the SDK's executeTool
-        // uses for-await-of which discards generator return values.
-        yield {
-          entries,
-          text,
-          // Omitted rather than `false` when the answer is whole, so the flag's
-          // presence is the whole of its meaning wherever it is read.
-          ...(truncatedByTokenLimit ? { truncatedByTokenLimit: true } : {}),
-        } satisfies SubAgentActivity;
       },
       toModelOutput: ({ output }) => {
         const value = output?.text ?? "Task completed.";
@@ -422,6 +513,7 @@ export type SubAgentFailure = { id: string; name?: string; reason: string };
  * @param subAgents List of sub-agent configurations from the database
  * @param createModelFn Factory function to create a model instance for a sub-agent
  * @param loadToolsFn Async function to load tools for a sub-agent
+ * @param parentRun The run these delegates will nest inside, when there is one
  * @returns The callable tools keyed by tool name, plus the sub-agents that failed
  */
 export const createSubAgentTools = async (
@@ -454,7 +546,7 @@ export const createSubAgentTools = async (
     subAgentId: string,
     toolSetIds: string[],
   ) => Promise<Record<string, Tool>>,
-  onProgress?: () => void,
+  parentRun?: ParentRunContext,
 ): Promise<{
   tools: Record<string, Tool>;
   failures: SubAgentFailure[];
@@ -487,7 +579,7 @@ export const createSubAgentTools = async (
         securityGuardrails,
         sampling: resolveSamplingSettings(subAgent),
         maxOutputTokens,
-        onProgress,
+        parentRun,
       });
 
       tools[toolName] = tool;
@@ -500,7 +592,7 @@ export const createSubAgentTools = async (
       failures.push({
         id: subAgent.id,
         name: subAgent.name,
-        reason: describeError(error),
+        reason: describeStreamError(error),
       });
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@ai-sdk/provider':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.8.0(jiti@2.7.0))


### PR DESCRIPTION
Closes #479.

A Sub-Agent run never entered `apps/backend/src/runs/`. `tools/sub-agent.ts` built its own `ToolLoopAgent` and re-implemented a weaker copy of what Chat turns and Trigger runs get from `AgentRunner`: no `RunRegistry` entry, so no per-step or per-run timeout and nothing to cancel; a hand-rolled 102-line switch over twelve stream part types; its own `describeError`; its own truncation plumbing; and no statistics at all.

## Which shape, and why

The issue offered two. This is **shape 2** — extract the lifecycle half of `AgentRunner` into modules both it and the delegate Tool consume.

Shape 1 (`agentRunner.generate` with a null `RunSink`) was rejected on two invariants the issue lists: `generate` uses `generateText`, which would have removed the streamed `SubAgentActivity` events the frontend consumes; and it renders the full fragment set through `prepareChatTurn`, which ADR-0016 forbids for a delegation.

## What moved

| Module | Holds |
| --- | --- |
| `runs/run-lifecycle.ts` | `startRun` — registry entry, timeouts, step instrumentation, once-only termination, `statusFromSignal` / `abortReason` |
| `runs/run-plan.ts` | the model / tools / system / stopWhen / ceiling / sampling assembly |
| `runs/run-stats.ts` | the Context-occupancy arithmetic (ADR-0018) |
| `services/tool-activity.ts` | `wrapToolsWithActivity` (was `wrapToolsWithBump` in `chat-execution.ts`) |

A delegation is now a run in its own right: registered for its duration, bounded by per-step and per-run timeouts, cancelled when the parent is, and reporting `RunStats` (steps, token usage, Context occupancy). It streams through the same `streamText` → `toUIMessageStream` → `readUIMessageStream` path a Chat turn uses, renders failures through `stream-error.ts`, and carries the output-ceiling cutoff on the shared message metadata.

## The heartbeat, and what replaced it

`createToolHeartbeat` existed only so a long delegation wouldn't trip the **parent** run's per-step stall timeout — a `runs/` concern implemented in `services/` and driven from `tools/` through an `onProgress` callback threaded five modules deep. It fired every 30s to fake progress that wasn't happening.

It's deleted, along with the `onProgress` chain. In its place, `RunHandle.holdStep()` / `releaseStep()` suspend the per-step timer while any tool call is in flight — the per-step timeout asks "has the model stopped making progress between steps?", and a tool that is still executing is not that. Same effective behaviour, in the module that owns the timer. The per-RUN ceiling is deliberately untouched, so a tool that never returns is still bounded.

## Preserved contracts

Unchanged, and pinned by tests: the streamed `SubAgentActivity` event shapes, the delegate tool's result text relayed across steps, the `toModelOutput` truncation note, scoped resolution at the invoking Workspace, `maxSteps` default resolution, sampling via `services/sampling-settings.ts`, the ADR-0016 minimal prompt (Instructions + guardrails, nothing else), and disposal of Sub-Agent MCP clients on the parent turn.

The activity log is now *projected* off the accumulated `UIMessage` rather than kept in parallel — which incidentally fixes a latent bug: `completeLastRunning` marked the last *running* tool-call entry complete, so two parallel tool calls could resolve against the wrong entry.

## New tests

- A delegate tool call whose Sub-Agent takes ~4× the parent's stall threshold does not kill the parent run — composed from `run-registry` + `tool-activity` + `sub-agent`, which had never been assembled in a test. Paired with a negative control proving the threshold is real.
- The delegated run is registered while streaming and unregistered after.
- Registration under the parent's configured bounds; a parent already cancelled before the first tick.
- `sub-agent.test.ts` now drives a `MockLanguageModelV3` and leaves `streamText` / `toUIMessageStream` / `readUIMessageStream` real, so the assertions are about what reached the model and what came back — not about a mocked wrapper.

## Two review findings fixed in the second commit

- A delegation registered with the process defaults, so a Trigger run configured for `TRIGGER_PER_RUN_TIMEOUT_MS` (60 min) handed its delegated work a 10-minute ceiling nobody chose. `ParentRunContext` now carries the parent's bounds.
- A generator body doesn't run until the consumer pulls, so a parent cancelled between tool dispatch and the first tick never fired the abort listener and the delegation ran on regardless.

## Known deviation

`userFromScope`'s `subAgent` branch is still unreachable. `workspaceScopeForSubAgent` is now live — its chained principal drives the delegated run's logged actor and parent-run id — but reaching that branch means routing delegations through `prepareChatTurn`, which would need a minimal-prompt mode there and would re-resolve the model and tools the parent already resolved. Not in the acceptance criteria; flagging it rather than leaving it implicit.

## Docs

No user-facing docs change: the delegate's observable contracts are unchanged, and nothing in `apps/docs` documents run timeouts. `CONTEXT.md`'s **Sub-Agent** entry gains one line, since a delegation is now bounded and cancellable in its own right.

## Gate

`pnpm typecheck`, `pnpm lint`, `pnpm test` (1662 backend, 197 frontend, 122 schemas, 25 docs-contract) all pass, rebased onto `origin/main` at b588c78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
