### PR TITLE
fix(backend): say why chat titling was skipped

### DIFF
--- a/apps/backend/src/services/chat-metadata.test.ts
+++ b/apps/backend/src/services/chat-metadata.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mockDb, resetMockDb } from "../test-utils.ts";
+import { logger } from "../logger.ts";
 
 const { mockGenerateText, mockLanguageModel } = vi.hoisted(() => ({
   mockGenerateText: vi.fn(),
@@ -228,5 +229,29 @@ describe("generateChatMetadata", () => {
     const result = await generateChatMetadata(params);
     expect(result).toBeNull();
     expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  // Titling is fire-and-forget: the caller swallows the outcome, so without a
+  // log an unresolvable provider is indistinguishable from "titling is broken".
+  it("warns, naming the provider, when the provider cannot be resolved", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(() => logger);
+    stubReads({
+      chat: { id: "chat-1", title: "Untitled", messages: [userMessage] },
+      workspace: { id: "ws-1", taskModelProviderId: "prov-override" },
+      provider: undefined,
+    });
+
+    await generateChatMetadata(params);
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: "chat-1",
+        workspaceId: "ws-1",
+        providerId: "prov-override",
+        fromTaskModelOverride: true,
+      }),
+      expect.stringContaining("not visible in this workspace"),
+    );
+    warn.mockRestore();
   });
 });

--- a/apps/backend/src/services/chat-metadata.ts
+++ b/apps/backend/src/services/chat-metadata.ts
@@ -12,6 +12,7 @@ import { pointerSettingModelId } from "./model-capability.ts";
 import { dedupeArray, toKebabCase } from "../utils.ts";
 import { UNTITLED_CHAT_TITLE, type Provider } from "@platypus/schemas";
 import type { PlatypusUIMessage } from "../types.ts";
+import { logger } from "../logger.ts";
 
 export type GenerateChatMetadataParams = {
   chatId: string;
@@ -94,7 +95,23 @@ export const generateChatMetadata = async (
     orgId,
     wsId: workspaceId,
   });
-  if (!found) return null;
+  if (!found) {
+    // Titling is fire-and-forget, so an unresolvable provider leaves chats
+    // named "Untitled" with nothing else to show for it. Say so: the usual
+    // cause is a task-model override naming an Organization-scoped Provider
+    // that is not attached to this Workspace, which reads as "titling just
+    // stopped" from the outside.
+    logger.warn(
+      {
+        chatId,
+        workspaceId,
+        providerId: effectiveProviderId,
+        fromTaskModelOverride: !!workspace.taskModelProviderId,
+      },
+      "Chat titling skipped: provider is not visible in this workspace",
+    );
+    return null;
+  }
   const provider = found.row as Provider;
 
   // Fetch existing tags from all chats in the workspace so the model can reuse

--- a/apps/docs/content/administering/shared-resources.mdx
+++ b/apps/docs/content/administering/shared-resources.mdx
@@ -60,6 +60,18 @@ To undo either, use **Detach**. On the Organization surface, each card also show
 **Shared with N workspaces**, which is the quickest read on whether you've
 actually handed something out.
 
+An Attachment governs more than what shows up in a list. A Workspace reaches a
+Shared resource only where one exists, background work included: a Trigger can
+run an attached Shared Agent, and a Workspace titles its chats with a Shared
+Provider only if that Provider is attached.
+
+<Callout type="warning">
+  Pointing a Workspace's **Task Model Provider** at a Shared Provider you never
+  attached is the trap. Nothing reports an error — chats simply stay
+  **Untitled**, because the Workspace cannot see the Provider doing the titling.
+  Attach the Provider to that Workspace and titling resumes on the next chat.
+</Callout>
+
 ## What a Workspace Owner sees
 
 An attached Shared resource appears in the Workspace list badged


### PR DESCRIPTION
Follow-up to #484, from the post-merge review of that change.

## Problem

Chat titling resolves its Provider through the Scoped-resource authority, and returns `null` when it cannot see one. Titling is fire-and-forget — the caller swallows the outcome — so that path is silent: chats stay **Untitled** and nothing says why.

#484 narrowed which Providers resolve (an Organization-scoped Provider now needs an Attachment, as ADR-0007 requires everywhere else), which makes the silence easier to hit. A Workspace whose **Task Model Provider** names an unattached Shared Provider stops titling, and looks from the outside like titling is broken.

The behaviour is correct and stays as it is. This only makes it diagnosable.

## Change

- Warn when titling cannot resolve its Provider, carrying the chat, workspace and provider ids plus whether the id came from the Workspace's Task Model Provider override — enough to go straight to the misconfigured field.
- Name the trap in the Shared resources docs: an Attachment governs background work too, and pointing **Task Model Provider** at an unattached Shared Provider silently leaves chats Untitled.

No behaviour change beyond the log.

## Tests

A test pins the warn and its context. `pnpm typecheck`, `pnpm lint`, backend suite (1728) and the docs contract tests (25) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)