### PR TITLE
chore(backend): assemble the credential read model once

### DIFF
--- a/apps/backend/src/routes/mcp.ts
+++ b/apps/backend/src/routes/mcp.ts
@@ -20,12 +20,14 @@ import {
   requireWorkspaceConfigAccess,
   workspaceCredentialsVisible,
 } from "../middleware/authorization.ts";
-import { redactMcpSecrets } from "../services/credential-redaction.ts";
+import {
+  mcpReadModel,
+  sanitizeMcpResponse,
+} from "../services/credential-redaction.ts";
 import {
   listScoped,
   requireScoped,
   requireWorkspaceMutable,
-  type Scope,
 } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
@@ -40,7 +42,6 @@ import {
   oauthFetchFn,
   buildOAuthCallbackUrl,
   buildMcpTransportConfig,
-  type McpRecord,
 } from "../services/mcp-oauth-provider.ts";
 
 /** Fields to null-out when clearing OAuth tokens. */
@@ -52,38 +53,6 @@ export const OAUTH_TOKEN_CLEAR_FIELDS = {
 } as const;
 
 const mcp = new Hono<{ Variables: Variables }>();
-
-/** Strips sensitive OAuth fields and adds computed oauthAuthorized flag */
-export const sanitizeMcpResponse = (record: McpRecord) => {
-  const {
-    oauthAccessToken,
-    oauthRefreshToken,
-    oauthClientSecret,
-    oauthTokenExpiresAt,
-    oauthScope,
-    ...rest
-  } = record;
-  return {
-    ...rest,
-    oauthAuthorized:
-      record.authType === "OAuth" ? !!oauthAccessToken : undefined,
-  };
-};
-
-/**
- * The read shape of an MCP on the Workspace surface, assembled once for both
- * read routes: OAuth tokens stripped unconditionally, Operator-entered request
- * credentials only for a caller who may manage this MCP (ADR-0006), and the
- * scope the Scoped-resource module resolved it at, which the frontend uses to
- * mark a Shared row read-only.
- */
-const mcpReadModel = (
-  { row, scope }: { row: McpRecord; scope: Scope },
-  reveal: boolean,
-) => ({
-  ...redactMcpSecrets(sanitizeMcpResponse(row), { reveal }),
-  scope,
-});
 
 /** Create a new MCP (org-admin, or owner when delegated — ADR-0006) */
 mcp.post(
@@ -129,7 +98,9 @@ mcp.get(
     // (ADR-0006) — the same rule the write routes reject on. The rows still list,
     // because granting an MCP to an Agent does not require self-management.
     const reveal = await workspaceCredentialsVisible(c, "mcp");
-    const results = scoped.map((found) => mcpReadModel(found, reveal));
+    const results = scoped.map(({ row, scope }) =>
+      mcpReadModel(row, { reveal, scope }),
+    );
 
     return c.json({ results });
   },
@@ -151,7 +122,7 @@ mcp.get(
     });
     // See the list route: redacted unless this caller may manage the MCP.
     const reveal = await workspaceCredentialsVisible(c, "mcp");
-    return c.json(mcpReadModel(found, reveal));
+    return c.json(mcpReadModel(found.row, { reveal, scope: found.scope }));
   },
 );
 

--- a/apps/backend/src/routes/org-mcp.ts
+++ b/apps/backend/src/routes/org-mcp.ts
@@ -33,8 +33,11 @@ import {
   buildOAuthCallbackUrl,
   buildMcpTransportConfig,
 } from "../services/mcp-oauth-provider.ts";
-import { OAUTH_TOKEN_CLEAR_FIELDS, sanitizeMcpResponse } from "./mcp.ts";
-import { redactMcpSecrets } from "../services/credential-redaction.ts";
+import { OAUTH_TOKEN_CLEAR_FIELDS } from "./mcp.ts";
+import {
+  mcpReadModel,
+  sanitizeMcpResponse,
+} from "../services/credential-redaction.ts";
 import { NotFoundError } from "../errors.ts";
 
 // Org-scoped MCPs are Shared resources (ADR-0007). They introduce credentials
@@ -75,9 +78,7 @@ orgMcp.get("/", requireAuth, requireOrgAccess(), async (c) => {
   // to be granted. Only an Org Admin sees its request credentials (ADR-0006).
   const reveal = orgCredentialsVisible(c);
   return c.json({
-    results: results.map((row) =>
-      redactMcpSecrets(sanitizeMcpResponse(row), { reveal }),
-    ),
+    results: results.map((row) => mcpReadModel(row, { reveal })),
   });
 });
 
@@ -88,7 +89,7 @@ orgMcp.get("/:mcpId", requireAuth, requireOrgAccess(), async (c) => {
   const record = await requireOrgScoped(db, "mcp", mcpId, orgId);
   // See the list route: request credentials are Org-Admin-only (ADR-0006).
   const reveal = orgCredentialsVisible(c);
-  return c.json(redactMcpSecrets(sanitizeMcpResponse(record), { reveal }));
+  return c.json(mcpReadModel(record, { reveal }));
 });
 
 /** Update an org-scoped MCP by ID (admin only) */

--- a/apps/backend/src/routes/org-provider.ts
+++ b/apps/backend/src/routes/org-provider.ts
@@ -21,7 +21,7 @@ import {
   requireOrgScoped,
   requireSharedDeletable,
 } from "../services/scoped-resource.ts";
-import { redactProviderSecrets } from "../services/credential-redaction.ts";
+import { providerReadModel } from "../services/credential-redaction.ts";
 import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
@@ -65,7 +65,7 @@ orgProvider.get("/", requireAuth, requireOrgAccess(), async (c) => {
   // This route admits any Organization member — a Shared Provider has to be
   // listable to be selected. Only an Org Admin sees its credentials (ADR-0006).
   const reveal = orgCredentialsVisible(c);
-  const results = rows.map((row) => redactProviderSecrets(row, { reveal }));
+  const results = rows.map((row) => providerReadModel(row, { reveal }));
 
   return c.json({ results });
 });
@@ -79,7 +79,7 @@ orgProvider.get("/:providerId", requireAuth, requireOrgAccess(), async (c) => {
 
   // See the list route: credentials are Org-Admin-only (ADR-0006).
   const reveal = orgCredentialsVisible(c);
-  return c.json(redactProviderSecrets(record, { reveal }));
+  return c.json(providerReadModel(record, { reveal }));
 });
 
 /** Update an organization provider by ID (admin only) */

--- a/apps/backend/src/routes/provider.ts
+++ b/apps/backend/src/routes/provider.ts
@@ -18,30 +18,15 @@ import {
   requireWorkspaceConfigAccess,
   workspaceCredentialsVisible,
 } from "../middleware/authorization.ts";
-import { redactProviderSecrets } from "../services/credential-redaction.ts";
+import { providerReadModel } from "../services/credential-redaction.ts";
 import {
   listScoped,
   requireScoped,
   requireWorkspaceMutable,
-  type Scope,
 } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 
 const provider = new Hono<{ Variables: Variables }>();
-
-/**
- * The read shape of a Provider on the Workspace surface, assembled once for both
- * read routes: stored credentials only for a caller who may manage this Provider
- * (ADR-0006), and the scope the Scoped-resource module resolved it at, which the
- * frontend uses to mark a Shared row read-only.
- */
-const providerReadModel = (
-  { row, scope }: { row: typeof providerTable.$inferSelect; scope: Scope },
-  reveal: boolean,
-) => ({
-  ...redactProviderSecrets(row, { reveal }),
-  scope,
-});
 
 /**
  * Create a workspace-scoped provider. Org-admin by default; a workspace owner
@@ -98,7 +83,9 @@ provider.get(
     // still list, because selecting a Provider on an Agent or Chat does not
     // require self-management.
     const reveal = await workspaceCredentialsVisible(c, "provider");
-    const results = scoped.map((found) => providerReadModel(found, reveal));
+    const results = scoped.map(({ row, scope }) =>
+      providerReadModel(row, { reveal, scope }),
+    );
     return c.json({ results });
   },
 );
@@ -120,7 +107,7 @@ provider.get(
     });
     // See the list route: redacted unless this caller may manage the Provider.
     const reveal = await workspaceCredentialsVisible(c, "provider");
-    return c.json(providerReadModel(found, reveal));
+    return c.json(providerReadModel(found.row, { reveal, scope: found.scope }));
   },
 );
 

--- a/apps/backend/src/services/credential-redaction.test.ts
+++ b/apps/backend/src/services/credential-redaction.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from "vitest";
 import {
   redactMcpSecrets,
   redactProviderSecrets,
+  mcpReadModel,
+  providerReadModel,
 } from "./credential-redaction.ts";
+import type { McpRecord } from "./mcp-oauth-provider.ts";
 
 describe("redactProviderSecrets", () => {
   const row = {
@@ -94,5 +97,63 @@ describe("redactMcpSecrets", () => {
       {},
     );
     expect(out).toMatchObject({ bearerTokenSet: { configured: false } });
+  });
+});
+
+describe("read models", () => {
+  // The OAuth strip is unconditional and the credential redaction is not.
+  // Pairing them here is the point of the read model: a route that reached for
+  // redactMcpSecrets alone would answer with the minted tokens still attached.
+  const mcp = {
+    id: "mcp-1",
+    name: "Rovo",
+    authType: "OAuth",
+    bearerToken: "tok-secret",
+    headers: { Authorization: "hdr-secret" },
+    oauthAccessToken: "oauth-access",
+    oauthRefreshToken: "oauth-refresh",
+    oauthClientSecret: "oauth-client",
+    oauthScope: "read",
+    oauthTokenExpiresAt: new Date(0),
+  } as unknown as McpRecord;
+
+  it("strips minted OAuth secrets even when credentials are revealed", () => {
+    const out = mcpReadModel(mcp, { reveal: true });
+    const json = JSON.stringify(out);
+    expect(json).not.toContain("oauth-access");
+    expect(json).not.toContain("oauth-refresh");
+    expect(json).not.toContain("oauth-client");
+    // Operator-entered config still reads back for a caller who may manage it.
+    expect(json).toContain("tok-secret");
+    expect(out).toMatchObject({ oauthAuthorized: true });
+  });
+
+  it("strips both secret classes when credentials are not revealed", () => {
+    const json = JSON.stringify(mcpReadModel(mcp, { reveal: false }));
+    expect(json).not.toContain("oauth-access");
+    expect(json).not.toContain("tok-secret");
+    expect(json).not.toContain("hdr-secret");
+  });
+
+  it("fails closed when reveal is not passed", () => {
+    const json = JSON.stringify(mcpReadModel(mcp));
+    expect(json).not.toContain("tok-secret");
+    expect(
+      JSON.stringify(
+        providerReadModel({ id: "p", apiKey: "sk-secret" } as never),
+      ),
+    ).not.toContain("sk-secret");
+  });
+
+  it("carries the resolved scope only when one is given", () => {
+    expect(mcpReadModel(mcp, { scope: "organization" })).toMatchObject({
+      scope: "organization",
+    });
+    expect(mcpReadModel(mcp)).not.toHaveProperty("scope");
+    expect(
+      providerReadModel({ id: "p", apiKey: "k" } as never, {
+        scope: "workspace",
+      }),
+    ).toMatchObject({ scope: "workspace" });
   });
 });

--- a/apps/backend/src/services/credential-redaction.ts
+++ b/apps/backend/src/services/credential-redaction.ts
@@ -20,6 +20,10 @@
  * argument comes from.
  */
 
+import type { Scope } from "./scoped-resource.ts";
+import type { McpRecord } from "./mcp-oauth-provider.ts";
+import type { provider as providerTable } from "../db/schema.ts";
+
 /** Replaces a redacted secret so a caller can tell "unset" from "not shown". */
 export type SecretPresence = {
   /** True when a value is stored, whatever it is. Never the value itself. */
@@ -94,3 +98,60 @@ export const redactMcpSecrets = <T extends McpSecretFields>(
     headersSet: presence(headers),
   };
 };
+
+/**
+ * Strips the OAuth secrets Platypus mints for an MCP and reports only whether
+ * the server is authorized. Unconditional — unlike {@link redactMcpSecrets},
+ * these are never Operator-entered and belong in no response, so every route
+ * returning an MCP row runs it, writes included.
+ */
+export const sanitizeMcpResponse = (record: McpRecord) => {
+  const {
+    oauthAccessToken,
+    oauthRefreshToken,
+    oauthClientSecret,
+    oauthTokenExpiresAt,
+    oauthScope,
+    ...rest
+  } = record;
+  return {
+    ...rest,
+    oauthAuthorized:
+      record.authType === "OAuth" ? !!oauthAccessToken : undefined,
+  };
+};
+
+/** What a read route adds to a row: who may see secrets, and the resolved scope. */
+type ReadModelOptions = {
+  /** Decided per surface by `workspaceCredentialsVisible`/`orgCredentialsVisible`. */
+  reveal?: boolean;
+  /**
+   * The scope the Scoped-resource module resolved the row at, which the frontend
+   * uses to mark a Shared row read-only. Omitted on the Organization surface,
+   * where every row is Organization-scoped by construction.
+   */
+  scope?: Scope;
+};
+
+const withScope = <T extends object>(model: T, scope?: Scope) =>
+  scope ? { ...model, scope } : model;
+
+/**
+ * The read shape of an MCP, for every route that returns one to a reader.
+ *
+ * The pairing is the point: the OAuth strip is unconditional and the credential
+ * redaction is not, and assembling them per route meant each site had to
+ * remember both. A route that reached for `redactMcpSecrets` alone would answer
+ * with the OAuth tokens still on the row.
+ */
+export const mcpReadModel = (row: McpRecord, opts: ReadModelOptions = {}) =>
+  withScope(
+    redactMcpSecrets(sanitizeMcpResponse(row), { reveal: opts.reveal }),
+    opts.scope,
+  );
+
+/** The read shape of a Provider, for every route that returns one to a reader. */
+export const providerReadModel = (
+  row: typeof providerTable.$inferSelect,
+  opts: ReadModelOptions = {},
+) => withScope(redactProviderSecrets(row, { reveal: opts.reveal }), opts.scope);


### PR DESCRIPTION
Follow-up to #484, from the post-merge review of that change.

## Problem

#484 centralized *who* may reveal a credential (`workspaceCredentialsVisible` / `orgCredentialsVisible`), which is half of what issue #480 asked for. The other half — *"a resolve-with-redaction composition for the credential-bearing types, so the reveal decision is made once"* — did not land: the assembly stayed written at six sites.

Two of them were named read models (`mcpReadModel` in `routes/mcp.ts`, `providerReadModel` in `routes/provider.ts`), structurally identical and added in the same commit; the other four were inline in the org routes.

The MCP half carries a hazard. Two different secret classes are stripped by two different functions:

- `sanitizeMcpResponse` — Platypus-minted OAuth tokens, stripped **unconditionally**
- `redactMcpSecrets` — Operator-entered `bearerToken`/`headers`, stripped **unless the caller may manage the MCP**

Every read site had to remember to run both, in that order. A site reaching for `redactMcpSecrets` alone answers with the OAuth tokens still on the row — and `sanitizeMcpResponse` lived in `routes/mcp.ts`, so `org-mcp.ts` imported one route's helper to get it.

## Change

- Move `sanitizeMcpResponse` into `services/credential-redaction.ts`, next to the redaction it pairs with. It stays exported: four write routes return a row without redaction and still need it.
- Add `mcpReadModel(row, { reveal?, scope? })` and `providerReadModel(row, { reveal?, scope? })` there — the whole read shape, including the optional resolved `scope` the Workspace surface attaches for the frontend and the Organization surface has no use for.
- Point all six sites at them; delete the two local read models. No route calls `redactMcpSecrets` / `redactProviderSecrets` directly any more.

No behavioural change: same fields in, same fields out, `reveal` still defaults to `false` so a new call site fails closed.

## Tests

Four tests on the read models, pinning the pairing that motivated the change: minted OAuth secrets are stripped **even when `reveal` is true**, both classes go when it is false, an omitted `reveal` fails closed, and `scope` appears only when given.

`pnpm typecheck`, `pnpm lint`, backend suite (1731) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)