### PR TITLE
feat(backend): give plugins a logger on PluginConfigContext

### DIFF
--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import pino from "pino";
 import { z } from "zod";
 import {
   OLDEST_SUPPORTED_API_VERSION,
@@ -14,7 +15,12 @@ import {
   MAX_WEB_TIMEOUT_MS,
   type WebBackendRegistration,
 } from "../web-backends/index.ts";
-import { loadPlugins, parsePluginConfig, parsePluginList } from "./loader.ts";
+import {
+  loadPlugins,
+  parsePluginConfig,
+  parsePluginList,
+  type PluginLoggerParent,
+} from "./loader.ts";
 import { plugin as examplePlugin } from "./example/index.ts";
 import { registerToolSet, getToolSet } from "../tools/index.ts";
 
@@ -63,6 +69,29 @@ const toolSet = (id: string): ToolSetContribution => ({
   category: "Test",
   tools: {},
 });
+
+// Every deploy-time block the loader builds now carries a plugin-bound logger.
+// The assertions below still spell the block out in full — `expect.anything()`
+// widened once here, because it is typed `any` and would be an unsafe
+// assignment at each site. What the logger IS is asserted on its own, further
+// down.
+const A_LOGGER_MATCHER = expect.anything() as unknown;
+
+// Core's own logger, at whatever level an Operator's LOG_LEVEL would have set,
+// writing its parsed JSON into `lines` instead of stdout. Same library and same
+// `child()` seam the loader uses by default, only with somewhere to read the
+// output back from — so what these tests assert is what an Operator would see.
+const captureLogger = (level: string) => {
+  const lines: Array<Record<string, unknown>> = [];
+  const logger = pino(
+    { level },
+    {
+      write: (chunk: string) =>
+        lines.push(JSON.parse(chunk) as Record<string, unknown>),
+    },
+  );
+  return { logger, lines };
+};
 
 // A capturing `registerWeb` for the Web-search-backend extension point. It takes
 // core's composed registration, not the raw contribution.
@@ -906,6 +935,7 @@ describe("loadPlugins — web-search backends", () => {
     expect(createExecutors).toHaveBeenCalledWith(ctx, {
       config: { endpoint: "https://searx.internal" },
       credentials: { apiKey: "sk-test" },
+      logger: A_LOGGER_MATCHER,
     });
   });
 });
@@ -1047,10 +1077,12 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
     expect(seen.toolSet).toEqual({
       config: { region: "eu" },
       credentials: { apiToken: "tok_123" },
+      logger: A_LOGGER_MATCHER,
     });
     expect(seen.sandbox).toEqual({
       config: { region: "eu" },
       credentials: { apiToken: "tok_123" },
+      logger: A_LOGGER_MATCHER,
     });
   });
 
@@ -1175,7 +1207,164 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
       userId: "u",
     });
 
-    expect(seenPlugin).toEqual({ config: undefined, credentials: undefined });
+    expect(seenPlugin).toEqual({
+      config: undefined,
+      credentials: undefined,
+      logger: A_LOGGER_MATCHER,
+    });
+  });
+});
+
+describe("loadPlugins — plugin logger injection", () => {
+  // A plugin contributing to all three Extension points, each factory recording
+  // the block it was handed and writing one line through it.
+  const loggingManifest = (
+    name: string,
+    seen: Record<string, PluginConfigContext | undefined>,
+  ): PlatypusPlugin => ({
+    name,
+    version: "0.1.0",
+    apiVersion: 1,
+    contributes: {
+      toolSets: [
+        {
+          id: "tools",
+          name: "Tools",
+          category: "Test",
+          tools: (_ctx, plugin) => {
+            seen.toolSet = plugin;
+            plugin?.logger?.info({ point: "toolSet" }, "resolving tools");
+            return {};
+          },
+        },
+      ],
+      sandboxBackends: [
+        {
+          backend: "sandbox",
+          name: "Sandbox",
+          configSchema: z.object({}),
+          credentialsSchema: z.object({}),
+          create: (_config, _credentials, plugin) => {
+            seen.sandbox = plugin;
+            plugin?.logger?.info({ point: "sandbox" }, "creating adapter");
+            return {} as unknown as SandboxBackend;
+          },
+        },
+      ],
+      webBackends: [
+        {
+          backend: "web",
+          name: "Web",
+          createExecutors: (_ctx, plugin) => {
+            seen.web = plugin;
+            plugin?.logger?.info({ point: "web" }, "building executors");
+            return { web_search: () => ({ query: "q", results: [] }) };
+          },
+        },
+      ],
+    },
+  });
+
+  // Drive every factory the way core does at turn time, so what is asserted is
+  // what a plugin author's own code would actually receive.
+  const invokeAllFactories = async (opts: {
+    pluginName: string;
+    baseLogger: PluginLoggerParent;
+    seen: Record<string, PluginConfigContext | undefined>;
+  }) => {
+    const registered: Record<string, Omit<ToolSetContribution, "id">> = {};
+    const sandboxCalls: SandboxBackendContribution[] = [];
+    const { registerWeb, calls: webCalls } = makeWebRegister();
+
+    await loadPlugins({
+      pluginNames: [opts.pluginName],
+      builtinPlugins: {},
+      importPlugin: () =>
+        Promise.resolve({
+          plugin: loggingManifest(opts.pluginName, opts.seen),
+        }),
+      register: (id, def) => {
+        registered[id] = def;
+      },
+      registerSandbox: (c) => sandboxCalls.push(c),
+      registerWeb,
+      baseLogger: opts.baseLogger,
+    });
+
+    await (
+      registered[`${opts.pluginName}.tools`].tools as (ctx: unknown) => unknown
+    )({
+      workspaceId: "w",
+      agentId: "a",
+      orgId: "o",
+      frontendUrl: undefined,
+      userId: "u",
+    });
+    sandboxCalls[0].create({}, {});
+    await webCalls[0].buildTurnTools({
+      orgId: "o",
+      workspaceId: "w",
+      userId: "u",
+    });
+  };
+
+  it("reaches all three Extension points as one logger bound to the manifest name", async () => {
+    const { logger, lines } = captureLogger("info");
+    const seen: Record<string, PluginConfigContext | undefined> = {};
+
+    await invokeAllFactories({
+      pluginName: "acme",
+      baseLogger: logger,
+      seen,
+    });
+
+    // One child per plugin, shared by object identity with the rest of the
+    // deploy-time block — no per-Extension-point plumbing.
+    expect(seen.toolSet?.logger).toBeDefined();
+    expect(seen.sandbox?.logger).toBe(seen.toolSet?.logger);
+    expect(seen.web?.logger).toBe(seen.toolSet?.logger);
+
+    // Every line landed in core's stream, attributed to the manifest name.
+    expect(lines).toHaveLength(3);
+    expect(lines.map((l) => l.point)).toEqual(["toolSet", "sandbox", "web"]);
+    for (const line of lines) {
+      expect(line.plugin).toBe("acme");
+      expect(line.msg).toEqual(expect.any(String));
+    }
+  });
+
+  it("suppresses a plugin line the Operator's LOG_LEVEL excludes", async () => {
+    // The plugin logs at `info`; the deployment is set to `warn`. Nothing is
+    // written — the plugin's lines obey LOG_LEVEL like core's own.
+    const { logger, lines } = captureLogger("warn");
+
+    await invokeAllFactories({
+      pluginName: "acme",
+      baseLogger: logger,
+      seen: {},
+    });
+
+    expect(lines).toEqual([]);
+  });
+
+  it("binds each plugin to its own name", async () => {
+    const { logger, lines } = captureLogger("info");
+
+    await invokeAllFactories({
+      pluginName: "acme",
+      baseLogger: logger,
+      seen: {},
+    });
+    await invokeAllFactories({
+      pluginName: "widgets",
+      baseLogger: logger,
+      seen: {},
+    });
+
+    expect([...new Set(lines.map((l) => l.plugin))]).toEqual([
+      "acme",
+      "widgets",
+    ]);
   });
 });
 
@@ -1572,10 +1761,15 @@ describe("loadPlugins — example third-party npm package (end to end)", () => {
   });
 
   it("registers into the real registry so a Chat turn resolves it by the prefixed id", async () => {
+    // The package logs at `debug`, so the stream is set to admit it — the same
+    // thing an Operator does with LOG_LEVEL when they want a plugin's detail.
+    const { logger: baseLogger, lines } = captureLogger("debug");
+
     await loadPlugins({
       pluginNames: ["@platypus-examples/tool-set"],
       builtinPlugins: {},
       register: registerToolSet,
+      baseLogger,
     });
 
     // Chat-turn resolution walks the tool-set registry by id (ADR-0013): the
@@ -1584,13 +1778,54 @@ describe("loadPlugins — example third-party npm package (end to end)", () => {
     expect(set.category).toBe("Examples");
     expect(getToolSet("greeting")).toBeUndefined();
 
-    if (typeof set.tools === "function") {
-      throw new Error("expected a static tool map");
+    if (typeof set.tools !== "function") {
+      throw new Error("expected a tool-set factory");
     }
-    const result = (await set.tools.greet.execute!(
+    const tools = await set.tools({
+      workspaceId: "ws-1",
+      agentId: "agent-1",
+      orgId: "org-1",
+      frontendUrl: undefined,
+      userId: "user-1",
+    });
+    const result = (await tools.greet.execute!(
       { name: "Ada" },
       { toolCallId: "t1", messages: [], context: {} },
     )) as string;
     expect(result).toContain("Ada");
+
+    // The whole third-party logging path, through the real published package:
+    // the line the plugin wrote is in core's stream, attributed to its manifest
+    // name, with the fields it supplied intact.
+    expect(lines).toContainEqual(
+      expect.objectContaining({
+        plugin: "example",
+        workspaceId: "ws-1",
+        agentId: "agent-1",
+        level: 20, // debug
+      }),
+    );
+  });
+
+  it("writes nothing when the Operator's LOG_LEVEL excludes the plugin's level", async () => {
+    const { logger: baseLogger, lines } = captureLogger("info");
+    const { register, calls } = makeRegister();
+
+    await loadPlugins({
+      pluginNames: ["@platypus-examples/tool-set"],
+      builtinPlugins: {},
+      register,
+      baseLogger,
+    });
+
+    await (calls[0].def.tools as (ctx: unknown) => unknown)({
+      workspaceId: "ws-1",
+      agentId: "agent-1",
+      orgId: "org-1",
+      frontendUrl: undefined,
+      userId: "user-1",
+    });
+
+    expect(lines).toEqual([]);
   });
 });

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -3,9 +3,11 @@ import {
   PLUGIN_API_VERSION,
   type PlatypusPlugin,
   type PluginConfigContext,
+  type PluginLogger,
   type SandboxBackendContribution,
   type ToolSetContribution,
 } from "@platypuschat/plugin-sdk";
+import { logger } from "../logger.ts";
 import { ALWAYS_ON_PLUGINS, BUILTIN_PLUGINS } from "./builtin.ts";
 import { registerToolSet } from "../tools/index.ts";
 import { registerSandboxBackend } from "../sandbox/index.ts";
@@ -88,6 +90,17 @@ export interface RawPluginConfig {
 // Parsed from `PLATYPUS_PLUGIN_CONFIG` (see {@link parsePluginConfig}).
 export type PluginConfigMap = Record<string, RawPluginConfig>;
 
+/**
+ * What the loader derives each plugin's logger from — core's own logger, whose
+ * level the Operator sets with `LOG_LEVEL`. Declared structurally, one method
+ * wide, so the seam a test replaces is "make me a child" rather than the whole
+ * logging library, and so nothing here leaks pino's types into the SDK contract
+ * the child is handed to plugins as.
+ */
+export interface PluginLoggerParent {
+  child(bindings: Record<string, unknown>): PluginLogger;
+}
+
 export interface LoadPluginsOptions {
   /** Plugin names to load. Defaults to parsing `PLATYPUS_PLUGINS`. */
   pluginNames?: string[];
@@ -119,6 +132,11 @@ export interface LoadPluginsOptions {
    * parsing `PLATYPUS_PLUGIN_CONFIG` (see {@link parsePluginConfig}).
    */
   pluginConfig?: PluginConfigMap;
+  /**
+   * Parent of the per-plugin child loggers. Defaults to core's own logger, so a
+   * plugin's lines share core's stream, format and `LOG_LEVEL`.
+   */
+  baseLogger?: PluginLoggerParent;
 }
 
 /**
@@ -180,10 +198,16 @@ export const parsePluginConfig = (raw: string | undefined): PluginConfigMap => {
  * validated against the manifest's plugin-level schema when declared (fail-loud,
  * plugin-named); when no schema is declared the raw Operator value passes
  * through untouched (`undefined` when absent — nothing to validate against).
+ *
+ * The plugin's logger joins the same block: a child of core's logger bound to
+ * the manifest name, so a line a plugin writes is attributable to it without the
+ * author having to remember to say so, and is filtered by the Operator's
+ * `LOG_LEVEL` like every other line core emits.
  */
 const resolvePluginConfig = (
   manifest: PlatypusPlugin,
   raw: RawPluginConfig,
+  baseLogger: PluginLoggerParent,
 ): PluginConfigContext => {
   const resolveOne = (
     kind: "config" | "credentials",
@@ -208,6 +232,9 @@ const resolvePluginConfig = (
       manifest.credentialsSchema,
       raw.credentials,
     ),
+    // Same `plugin` binding key core's own boot lines use, so an Operator
+    // filtering on one plugin gets core's lines about it and the plugin's own.
+    logger: baseLogger.child({ plugin: manifest.name }),
   };
 };
 
@@ -351,6 +378,7 @@ export async function loadPlugins(
   const registerWeb = opts.registerWeb ?? registerWebBackend;
   const pluginConfig =
     opts.pluginConfig ?? parsePluginConfig(process.env.PLATYPUS_PLUGIN_CONFIG);
+  const baseLogger = opts.baseLogger ?? logger;
 
   // Tracks contribution id -> owning plugin name for owner-attributed
   // collisions, and is handed to the registry afterwards for catalog annotation.
@@ -422,10 +450,13 @@ export async function loadPlugins(
 
     // Resolve the plugin's deploy-time config/credentials once (fail-loud) and
     // share the single block across every contribution factory below — this
-    // object identity IS the "one credential block per plugin" of ADR-0013.
+    // object identity IS the "one credential block per plugin" of ADR-0013. The
+    // plugin's name-bound logger rides along in the same block, which is why one
+    // addition reaches all three Extension points with no per-point plumbing.
     const pluginCtx = resolvePluginConfig(
       manifest,
       pluginConfig[manifest.name] ?? {},
+      baseLogger,
     );
 
     // Core Contributions keep their flat, bare ids (no data migration — every

--- a/apps/backend/src/plugins/tools-platform/index.test.ts
+++ b/apps/backend/src/plugins/tools-platform/index.test.ts
@@ -7,9 +7,25 @@ import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
 // Postgres. Factories return AI SDK tool maps without touching the db until a
 // tool's `execute` runs, so these stubs are enough.
 vi.mock("../../index.ts", () => ({ db: {} }));
-vi.mock("../../logger.ts", () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-}));
+// `child` is part of the mock because the plugin loader derives each plugin's
+// own logger from this one.
+vi.mock("../../logger.ts", () => {
+  const child = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return {
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(() => child),
+    },
+  };
+});
 vi.mock("../../services/event-dispatch.ts", () => ({ dispatchEvent: vi.fn() }));
 vi.mock("../../services/sub-agent-validation.ts", () => ({
   validateSubAgentAssignment: vi.fn(),

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -39,7 +39,7 @@ the deployment rather than be configured in it.
 ## Start here
 
 **[Your first plugin](/extending/your-first-plugin)** is a runnable quickstart
-off the example package in the repository. It ends with two checkpoints, so you
+off the example package in the repository. It ends with three checkpoints, so you
 find out whether it worked rather than guessing.
 
 Then the page for the Extension point you're filling —
@@ -66,6 +66,14 @@ protect deployments that load JavaScript or a malformed package.
 
 Contribution ids are trimmed before they are namespaced, so surrounding
 whitespace never reaches a stored id.
+
+## Logging
+
+A Plugin does not bring its own logger. Core puts one on the deploy-time block it
+hands every contribution factory, already tagged with your Plugin's name, and the
+Operator's `LOG_LEVEL` decides which of your lines are written — the same control
+they have over core's. [Plugin API &
+config](/extending/plugin-api-and-config#logging) has the shape and the levels.
 
 ## Web-search backends
 

--- a/apps/docs/content/extending/plugin-api-and-config.mdx
+++ b/apps/docs/content/extending/plugin-api-and-config.mdx
@@ -124,6 +124,53 @@ The repository ships a two-contribution plugin under the backend's `plugins`
 directory that demonstrates one credential block reaching both a Sandbox backend
 and a Tool set.
 
+## Logging
+
+The same block carries a `logger`, so your plugin writes into the Operator's own
+log stream rather than shouting into `stdout` on its own terms. Four levels —
+`debug`, `info`, `warn`, `error` — each taking a fields object with an optional
+message, or a message on its own:
+
+```ts
+tools: (ctx, plugin) => {
+  plugin?.logger?.info({ workspaceId: ctx.workspaceId }, "Resolving tool set");
+  return {
+    /* … */
+  };
+},
+```
+
+Three things core does for you, and one thing to get right yourself:
+
+- **Your plugin's name is already on every line.** Core binds the manifest
+  `name` to the logger before handing it over, so an Operator can filter their
+  log pipeline down to your plugin. Don't put the name in your own fields.
+- **[`LOG_LEVEL`](/reference/backend-configuration#core) governs your lines like
+  core's.** A `debug` line writes nothing on a deployment left at the default
+  `info`, and appears the moment the Operator raises the level. Put the detail
+  that only matters while diagnosing at `debug`; keep `warn` and `error` for
+  what an Operator should act on.
+- **The format matches core's.** Structured JSON in production, pretty-printed
+  in development — you get both without configuring either.
+- **Prefer the fields object to an interpolated string.** `{ workspaceId }`
+  stays queryable in the Operator's pipeline; `` `for ${workspaceId}` `` does
+  not.
+
+<Callout type="warning">
+  Reaching for `console.log` instead is the trap. Its output bypasses
+  `LOG_LEVEL`, so it cannot be turned down on a busy deployment; it carries no
+  plugin name, so nobody can tell it is yours; and it is unstructured, so it
+  lands in the Operator's pipeline as an unparseable line between two JSON ones.
+</Callout>
+
+Write `plugin?.logger?.` — both are optional members, which is what lets one
+build of your plugin run on a core new enough to supply the logger and one that
+predates it. Core always supplies it.
+
+Deploy-time scope is all a logger line carries. Workspace, Agent and run ids are
+not bound for you; include the ones you have from your own context, as the
+example above does with `workspaceId`.
+
 ## Where to next
 
 - **[Your first plugin](/extending/your-first-plugin)** — the runnable path.

--- a/apps/docs/content/extending/tool-sets.mdx
+++ b/apps/docs/content/extending/tool-sets.mdx
@@ -76,6 +76,10 @@ the link as optional.
 A factory also receives the plugin's deploy-time config as an appended second
 argument — see
 [Plugin API & config](/extending/plugin-api-and-config#deploy-time-config-and-credentials).
+That same argument carries the [logger](/extending/plugin-api-and-config#logging)
+core binds to your plugin's name, which is a reason to reach for a factory even
+where a static map would otherwise do: a static map is handed nothing, so it has
+nowhere to log from.
 
 ## Ids and namespacing
 

--- a/apps/docs/content/extending/your-first-plugin.mdx
+++ b/apps/docs/content/extending/your-first-plugin.mdx
@@ -11,7 +11,7 @@ The repository ships a runnable third-party plugin:
 [`packages/example-plugin`](https://github.com/willdady/platypus/tree/main/packages/example-plugin),
 published as `@platypus-examples/tool-set`. It contributes one Tool set with one
 tool, and it exists so you can prove the whole path — install, list, load,
-grant, call — before you write anything of your own.
+grant, call, log — before you write anything of your own.
 
 Do this first. Then copy the package and replace its contents.
 
@@ -28,12 +28,16 @@ export const plugin: PlatypusPlugin = {
         id: "greeting", // bare — core prefixes it to `example.greeting`
         name: "Greeting",
         category: "Examples",
-        tools: {
-          greet: tool({
-            description: "Return a friendly greeting for the given name.",
-            inputSchema: z.object({ name: z.string() }),
-            execute: ({ name }) => `Hello, ${name}!`,
-          }),
+        tools: (ctx, plugin) => {
+          // Core's logger, already tagged with `example`
+          plugin?.logger?.debug({ workspaceId: ctx.workspaceId }, "Resolving");
+          return {
+            greet: tool({
+              description: "Return a friendly greeting for the given name.",
+              inputSchema: z.object({ name: z.string() }),
+              execute: ({ name }) => `Hello, ${name}!`,
+            }),
+          };
         },
       },
     ],
@@ -108,6 +112,22 @@ Chat on that Agent and ask it to greet someone by name.
 
 The reply comes back through a `greet` tool call you can expand in the
 transcript. That is the loop closed: your code ran inside a Chat turn.
+
+## Checkpoint 3: it can log
+
+The factory writes one line every time it resolves, at `debug`. The default
+`LOG_LEVEL` is `info`, so you saw nothing during Checkpoint 2. Raise it, restart,
+and send another message:
+
+```bash
+LOG_LEVEL=debug
+docker compose restart backend
+```
+
+`docker compose logs backend` now carries a `Resolving` line tagged
+`"plugin":"example"` — core's own stream, core's format, and the name bound for
+you without your code passing it. Put `LOG_LEVEL` back when you're done; `debug`
+is loud on a busy deployment.
 
 ## When it doesn't work
 

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -151,6 +151,10 @@ empty list unless it says otherwise, and silently runs without web-fetch.
   tools. Two plugins whose Tool set ids collide also abort startup.
 - **New gate-able core plugins in a later release are not auto-enabled** — add
   them to your pinned list to opt in.
+- **A plugin logs into your stream, under your `LOG_LEVEL`.** Lines a plugin
+  writes carry `"plugin":"<name>"` and are formatted and filtered exactly like
+  core's own, so raising `LOG_LEVEL` to `debug` while diagnosing one plugin
+  raises everything else with it.
 
 <Callout type="warning">
   **`compose.sandbox.yaml` replaces `PLATYPUS_PLUGINS` — it does not merge.**

--- a/packages/example-plugin/index.test.ts
+++ b/packages/example-plugin/index.test.ts
@@ -1,6 +1,28 @@
-import { describe, it, expect } from "vitest";
-import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
+import { describe, it, expect, vi } from "vitest";
+import {
+  PLUGIN_API_VERSION,
+  type PluginConfigContext,
+  type ToolSetContext,
+} from "@platypuschat/plugin-sdk";
 import { plugin } from "./index.ts";
+
+const CTX: ToolSetContext = {
+  workspaceId: "ws-1",
+  agentId: "agent-1",
+  orgId: "org-1",
+  frontendUrl: undefined,
+  userId: "user-1",
+};
+
+// Resolve the tool set the way core does at Chat-turn time: the factory, the
+// runtime scope, and the plugin's deploy-time block (optional to consume).
+const resolveTools = async (pluginCtx?: PluginConfigContext) => {
+  const toolSet = plugin.contributes.toolSets?.[0];
+  if (!toolSet || typeof toolSet.tools !== "function") {
+    throw new Error("expected a tool-set factory");
+  }
+  return await toolSet.tools(CTX, pluginCtx);
+};
 
 describe("@platypus-examples/tool-set", () => {
   it("exports a well-formed manifest with a short namespace name", () => {
@@ -21,15 +43,40 @@ describe("@platypus-examples/tool-set", () => {
   });
 
   it("greet returns a greeting for the given name", async () => {
-    const toolSet = plugin.contributes.toolSets?.[0];
-    if (!toolSet || typeof toolSet.tools === "function") {
-      throw new Error("expected a static tool map");
-    }
-    const greet = toolSet.tools.greet;
-    const result = await greet.execute!(
+    const tools = await resolveTools();
+    const result = await tools.greet.execute!(
       { name: "Ada" },
       { toolCallId: "t1", messages: [] },
     );
     expect(result).toContain("Ada");
+  });
+
+  it("logs through the logger core puts on the plugin block", async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await resolveTools({ config: undefined, credentials: undefined, logger });
+
+    // Structured fields, not an interpolated string: they stay queryable in the
+    // Operator's log pipeline. The plugin's name is NOT among them — core binds
+    // that onto the child logger, so an author never repeats it.
+    expect(logger.debug).toHaveBeenCalledWith(
+      { workspaceId: "ws-1", agentId: "agent-1" },
+      expect.any(String),
+    );
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("resolves on a core that supplies no logger (both are optional)", async () => {
+    // The append-only contract in practice: `logger` arrived after this SDK's
+    // first release, so the plugin must still resolve where it is absent.
+    await expect(
+      resolveTools({ config: undefined, credentials: undefined }),
+    ).resolves.toHaveProperty("greet");
+    await expect(resolveTools()).resolves.toHaveProperty("greet");
   });
 });

--- a/packages/example-plugin/index.ts
+++ b/packages/example-plugin/index.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 
 // A minimal, runnable example of a THIRD-PARTY Platypus plugin — the kind an
 // Operator installs as an npm package and lists in `PLATYPUS_PLUGINS`. It exists
-// to prove the third-party path end to end: dynamic `import()` resolution and
-// contribution-id namespacing (ADR-0013).
+// to prove the third-party path end to end: dynamic `import()` resolution,
+// contribution-id namespacing (ADR-0013), and logging through core.
 //
 // The manifest `name` ("example") is the namespace: because this package is NOT
 // in core's built-in allowlist, the loader auto-prefixes every contribution id
@@ -24,14 +24,24 @@ export const plugin: PlatypusPlugin = {
         category: "Examples",
         description:
           "A tiny example tool set contributed by a third-party plugin",
-        tools: {
-          greet: tool({
-            description: "Return a friendly greeting for the given name.",
-            inputSchema: z.object({
-              name: z.string().describe("Who to greet"),
+        // A factory rather than a static map, because only a factory is handed
+        // the deploy-time block — and with it the logger core has already bound
+        // to this manifest's name. Optional-chained the whole way so the same
+        // code runs on a core that predates the field.
+        tools: (ctx, plugin) => {
+          plugin?.logger?.debug(
+            { workspaceId: ctx.workspaceId, agentId: ctx.agentId },
+            "Resolving the greeting tool set for a turn",
+          );
+          return {
+            greet: tool({
+              description: "Return a friendly greeting for the given name.",
+              inputSchema: z.object({
+                name: z.string().describe("Who to greet"),
+              }),
+              execute: ({ name }) => `Hello, ${name}! 👋`,
             }),
-            execute: ({ name }) => `Hello, ${name}! 👋`,
-          }),
+          };
         },
       },
     ],

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -87,6 +87,27 @@ plugin-named error.
 Plugins may also declare deploy-time, Operator-owned `configSchema` /
 `credentialsSchema`, supplied via `PLATYPUS_PLUGIN_CONFIG` and validated at boot.
 
+## Logging
+
+Don't reach for `console.*` or bundle a logger. Core puts a `PluginLogger` on the
+deploy-time block every contribution factory receives, already bound to your
+manifest `name`, so your lines join core's own structured stream at the verbosity
+the Operator set with `LOG_LEVEL`:
+
+```ts
+tools: (ctx, plugin) => {
+  // `debug` / `info` / `warn` / `error`, each taking a fields object with an
+  // optional message, or a message on its own.
+  plugin?.logger?.info({ workspaceId: ctx.workspaceId }, "Resolving tool set");
+  return {/* … */};
+};
+```
+
+Prefer the object form — those fields stay queryable where an interpolated string
+does not. Don't put your plugin's name in them; core binds it for you. And keep
+the optional chaining: `logger` is an appended optional member, so
+`plugin?.logger?.` is what lets the same code run on a core that predates it.
+
 ## Web-search backends
 
 A Web-search backend fills the chat **web-search toggle** for Providers without

--- a/packages/plugin-sdk/index.test.ts
+++ b/packages/plugin-sdk/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { z } from "zod";
 import { tool } from "ai";
 import {
@@ -6,6 +6,7 @@ import {
   PLUGIN_API_VERSION,
   type PlatypusPlugin,
   type PluginConfigContext,
+  type PluginLogger,
   type SandboxBackendContribution,
   type ToolSetContribution,
   type WebBackendContribution,
@@ -120,6 +121,95 @@ describe("@platypuschat/plugin-sdk", () => {
       },
     };
     backend.create({}, {}, shared);
+  });
+
+  it("carries an optional logger on the shared block, callable both ways", () => {
+    const calls: unknown[][] = [];
+    const record =
+      () =>
+      (...args: unknown[]) => {
+        calls.push(args);
+      };
+    const logger: PluginLogger = {
+      debug: record(),
+      info: record(),
+      warn: record(),
+      error: record(),
+    };
+    const shared: PluginConfigContext = {
+      config: {},
+      credentials: {},
+      logger,
+    };
+
+    const toolSet: ToolSetContribution = {
+      id: "scoped",
+      name: "Scoped",
+      category: "Productivity",
+      // The shape an author writes: optional chaining all the way, because the
+      // field is appended and a plugin may run on a core that predates it.
+      tools: (ctx, plugin) => {
+        plugin?.logger?.info({ workspaceId: ctx.workspaceId }, "Resolving");
+        plugin?.logger?.warn("Bare message, no fields");
+        return {};
+      },
+    };
+    (toolSet.tools as (ctx: unknown, plugin: PluginConfigContext) => unknown)(
+      {
+        workspaceId: "w",
+        agentId: "a",
+        orgId: "o",
+        frontendUrl: undefined,
+        userId: "u",
+      },
+      shared,
+    );
+
+    expect(calls).toEqual([
+      [{ workspaceId: "w" }, "Resolving"],
+      ["Bare message, no fields"],
+    ]);
+  });
+
+  it("leaves a logger-less block usable (the field is optional)", () => {
+    // A plugin compiled against this SDK must still work where `logger` is
+    // absent — that is the whole point of appending it as optional.
+    const shared: PluginConfigContext = { config: {}, credentials: {} };
+    const backend: SandboxBackendContribution = {
+      backend: "cloud",
+      name: "Cloud",
+      configSchema: z.object({}),
+      credentialsSchema: z.object({}),
+      create: (_config, _credentials, plugin) => {
+        plugin?.logger?.debug("never written");
+        return {} as never;
+      },
+    };
+    expect(() => backend.create({}, {}, shared)).not.toThrow();
+  });
+
+  it("satisfies PluginLogger with a pino-shaped logger (no adapter)", () => {
+    // Core passes its own logger straight through, so the interface has to be
+    // structurally compatible with the `(obj, msg?)` / `(msg)` pair pino exposes
+    // — including the trailing interpolation args pino accepts and this SDK's
+    // narrower contract does not mention.
+    const pinoish = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trace: vi.fn(),
+      fatal: vi.fn(),
+      child: vi.fn(),
+    } as unknown as {
+      debug: (obj: unknown, msg?: string, ...args: unknown[]) => void;
+      info: (obj: unknown, msg?: string, ...args: unknown[]) => void;
+      warn: (obj: unknown, msg?: string, ...args: unknown[]) => void;
+      error: (obj: unknown, msg?: string, ...args: unknown[]) => void;
+    };
+    const asPluginLogger: PluginLogger = pinoish;
+    asPluginLogger.info({ a: 1 }, "hello");
+    expect(pinoish.info).toHaveBeenCalledWith({ a: 1 }, "hello");
   });
 
   it("accepts a web-backend contribution supplying executors only", async () => {

--- a/packages/plugin-sdk/index.ts
+++ b/packages/plugin-sdk/index.ts
@@ -60,6 +60,33 @@ export interface ToolSetContext {
 }
 
 /**
+ * The logging surface core hands a plugin on {@link PluginConfigContext}. A
+ * plugin writes to core's own stream — structured, tagged with the plugin's
+ * manifest name, and governed by the Operator's `LOG_LEVEL` — instead of
+ * `console.*` or a logging library of its own.
+ *
+ * Each level takes either a message alone or a fields object with an optional
+ * message, mirroring the call shape of the library core logs through. The object
+ * form is the one to prefer: its fields stay queryable in the Operator's log
+ * pipeline where an interpolated string does not.
+ *
+ * Deliberately four levels and no `child`. This is the SDK's own hand-written
+ * contract, not a re-export of core's logger, so the backing library can change
+ * without breaking plugins built against it. More members can arrive later as
+ * optional ones under the append-only policy (see {@link PLUGIN_API_VERSION}).
+ */
+export interface PluginLogger {
+  debug(obj: object, msg?: string): void;
+  debug(msg: string): void;
+  info(obj: object, msg?: string): void;
+  info(msg: string): void;
+  warn(obj: object, msg?: string): void;
+  warn(msg: string): void;
+  error(obj: object, msg?: string): void;
+  error(msg: string): void;
+}
+
+/**
  * Deploy-time, Operator-owned config for one plugin, resolved at boot and
  * injected into **every** one of that plugin's contribution factories (ADR-0013).
  * Keyed by plugin name — the "one config namespace" — and validated at boot
@@ -79,6 +106,16 @@ export interface PluginConfigContext<
 > {
   config: TConfig;
   credentials: TCredentials;
+  /**
+   * A {@link PluginLogger} core binds to this plugin's manifest name, so every
+   * line the plugin writes lands in core's stream already attributed and at the
+   * verbosity the Operator asked for. Reach for it instead of `console.*`.
+   *
+   * Optional, and appended (append-only compatibility, ADR-0013) — write
+   * `plugin?.logger?.info(...)`. Core always supplies it; the optionality is
+   * what keeps a plugin built against an earlier SDK compiling unchanged.
+   */
+  logger?: PluginLogger;
 }
 
 /**

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platypuschat/plugin-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Plugin SDK for Platypus — the manifest type and extension-point surface third-party plugins depend on.",
   "license": "MIT",
   "author": "Will Dady",


### PR DESCRIPTION
Closes #490

A plugin author can now write a log line that comes out of core's own stream — structured, honouring the Operator's `LOG_LEVEL`, and tagged with the plugin's manifest name — without importing a logging library of their own or reaching into core.

## What changed

**SDK** — `PluginLogger` is a hand-written structural interface (four levels, the `(obj, msg?)` / `(msg)` overload pair), plus an optional `logger` on `PluginConfigContext`. Hand-written rather than a re-export so pino stays out of the published type surface and the backing library can be swapped later without breaking plugin authors. Optional and appended, so it is append-only per ADR-0013 — no `apiVersion` bump, no existing plugin disturbed. The SDK gains no runtime dependency.

**Loader** — builds one child logger per plugin, `baseLogger.child({ plugin: manifest.name })`, under the same `plugin` binding key core's own boot lines already use, and folds it into the single shared deploy-time block. That block is what every Extension point already receives, so Tool sets, Sandbox backends and Web backends all get the logger with no per-point plumbing. A `baseLogger` option joins the existing `importPlugin` / `register*` injection seams so the `LOG_LEVEL` behaviour is testable.

**Example plugin** — its tool set is now a factory rather than a static map (a static map is handed nothing, so it has nowhere to log from) and writes one line at `debug`, exercising the third-party path end to end.

**SDK version** — `0.2.0` → `0.3.0`. Hand-versioned; published on release, not on merge.

## Tests

The loader tests drive a real pino logger into a capture buffer, so what they assert is what an Operator would see: one child shared by object identity across all three Extension points, every line carrying `plugin: \"<name>\"`, and nothing written when the level excludes it. The end-to-end pair does the same through the real, dynamically-imported \`@platypus-examples/tool-set\` package.

## Docs

`extending/plugin-api-and-config.mdx` gains a Logging section — the four levels, what core binds for you, how `LOG_LEVEL` governs it, and a Callout naming the `console.log` trap. Also updated: `extending/index.mdx`, `extending/tool-sets.mdx`, a third checkpoint in `extending/your-first-plugin.mdx`, an Operator-facing line in `self-hosting/configuration.mdx`, and the SDK README.

## Two calls worth flagging

**The example logs at `debug`, not `info`.** A reader following the quickstart sees nothing until they raise `LOG_LEVEL` — which is what Checkpoint 3 walks them through. `debug` demonstrates both halves of the acceptance criterion (the line appears; it is suppressed when the level excludes it) and teaches the right habit for plumbing lines. Easy to flip if you'd rather it were visible out of the box.

**No guard against a plugin overriding its own attribution.** pino gives per-call fields precedence over child bindings, so a plugin that logs `{ plugin: \"something-else\" }` wins. The docs say not to; there is no code check.

## Out of scope

Binding per-turn scope (Workspace / Agent / run ids) onto plugin log lines, per the issue — that belongs against the per-turn contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)