### PR TITLE
chore(backend): extract a SandboxTransport seam under Docker and SSH

### DIFF
--- a/apps/backend/src/plugins/docker/backend.test.ts
+++ b/apps/backend/src/plugins/docker/backend.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { PassThrough } from "node:stream";
 
 // ---------------------------------------------------------------------------
+// This suite covers the Docker *transport* only: container/volume lifecycle,
+// the tar builder, idempotent teardown, and that dockerode is driven with the
+// argv it was handed. The five-tool contract those primitives sit under —
+// line counting, truncation flags, the timeout clamp, the unique-`oldString`
+// rule, the find(1) argv and its output parser — belongs to
+// `createPosixSandbox` and is tested once in `src/sandbox/posix.test.ts`.
+// Duplicating any of it here would just give the same rule two homes.
+//
+// The tests still drive the composed backend (`createDockerSandboxBackend`)
+// rather than the transport in isolation, because what reaches dockerode is
+// only interesting once core has resolved the path and built the argv.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
 // Mock dockerode. The default export is a class; calling `new Docker()` must
 // return our fake docker handle. We pull state out of `mockState` so tests can
 // configure per-call behaviour.
@@ -256,15 +270,17 @@ vi.mock("../../logger.ts", () => ({
 
 // Import AFTER vi.mock so the adapter binds to our mocked dockerode.
 import {
-  DockerSandboxBackend,
+  createDockerSandboxBackend,
   buildSingleFileTar,
   dockerSandboxConfigSchema,
 } from "./backend.ts";
 import { logger } from "../../logger.ts";
 import {
+  MAX_READ_BYTES,
   MAX_SHELL_OUTPUT_BYTES,
   SANDBOX_WORKSPACE_ROOT,
 } from "../../sandbox/index.ts";
+import { buildFindArgs } from "../../sandbox/posix.ts";
 import type { SandboxContext } from "../../sandbox/types.ts";
 
 const ctx: SandboxContext = {
@@ -342,13 +358,13 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("DockerSandboxBackend — provisioning", () => {
+describe("DockerSandboxTransport — provisioning", () => {
   it("provisions a new container when none exists", async () => {
     setupFreshProvision();
     // Plus an exec for the actual tool call.
     queueExec({ stdout: "hi", exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await backend.shellExec(ctx, { command: "echo hi" });
 
     expect(mockState.pullCalls).toEqual(["debian:stable-slim"]);
@@ -366,7 +382,7 @@ describe("DockerSandboxBackend — provisioning", () => {
     setupFreshProvision();
     queueExec({ exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await backend.shellExec(ctx, { command: "true" });
 
     const opts = mockState.createContainerCalls[0];
@@ -398,7 +414,7 @@ describe("DockerSandboxBackend — provisioning", () => {
     );
     queueExec({ stdout: "ok", exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await backend.shellExec(ctx, { command: "true" });
 
     expect(mockState.createContainerCalls).toHaveLength(0);
@@ -414,7 +430,7 @@ describe("DockerSandboxBackend — provisioning", () => {
     );
     queueExec({ exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await backend.shellExec(ctx, { command: "true" });
 
     expect(mockState.existingContainer.start).toHaveBeenCalledTimes(1);
@@ -427,7 +443,7 @@ describe("DockerSandboxBackend — provisioning", () => {
     queueExec({ exitCode: 0 });
     queueExec({ exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await Promise.all([
       backend.shellExec(ctx, { command: "a" }),
       backend.shellExec(ctx, { command: "b" }),
@@ -437,12 +453,12 @@ describe("DockerSandboxBackend — provisioning", () => {
   });
 });
 
-describe("DockerSandboxBackend — argv safety", () => {
+describe("DockerSandboxTransport — argv safety", () => {
   it("fsRead passes shell-metachar path as literal argv", async () => {
     setupFreshProvision();
     queueExec({ stdout: "data", exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     const malicious = `foo";rm -rf /`;
     await backend.fsRead(ctx, { path: malicious });
 
@@ -451,43 +467,38 @@ describe("DockerSandboxBackend — argv safety", () => {
     expect(last.Cmd).toEqual(["cat", "--", `/workspace/${malicious}`]);
   });
 
-  it("fsList simple glob uses -name", async () => {
+  it("fsRead bounds the cat output at the cap core asked for", async () => {
+    // `cat` will happily emit a gigabyte; the stdout cap is what keeps a huge
+    // file from being buffered whole. Whether a filled buffer counts as
+    // truncated is core's rule, tested in sandbox/posix.test.ts.
     setupFreshProvision();
-    queueExec({ stdout: "", exitCode: 0 });
+    queueExec({ stdout: "a".repeat(MAX_READ_BYTES + 5_000), exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({}, {});
-    await backend.fsList(ctx, { glob: "*.ts" });
+    const backend = createDockerSandboxBackend({}, {});
+    const res = await backend.fsRead(ctx, { path: "big.txt" });
 
-    const last = mockState.execCalls.at(-1) as { Cmd: string[] };
-    const idx = last.Cmd.indexOf("-name");
-    expect(idx).toBeGreaterThan(-1);
-    expect(last.Cmd[idx + 1]).toBe("*.ts");
+    expect(res.content).toHaveLength(MAX_READ_BYTES);
   });
 
-  it("fsList glob with slash uses -path */<glob>", async () => {
-    setupFreshProvision();
+  it("fsList hands core's find argv to dockerode unmodified", async () => {
+    // Pre-warm with a running container so the find exec is the only one and
+    // execCalls[0] is unambiguous.
+    mockState.existingContainer = makeFakeContainer();
+    mockState.containerInspects.push(() =>
+      Promise.resolve({ State: { Running: true } }),
+    );
     queueExec({ stdout: "", exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({}, {});
-    await backend.fsList(ctx, { glob: "src/*.ts" });
-
-    const last = mockState.execCalls.at(-1) as { Cmd: string[] };
-    const idx = last.Cmd.indexOf("-path");
-    expect(idx).toBeGreaterThan(-1);
-    expect(last.Cmd[idx + 1]).toBe("*/src/*.ts");
-  });
-
-  it("fsList glob with ** collapses ** to * for find", async () => {
-    setupFreshProvision();
-    queueExec({ stdout: "", exitCode: 0 });
-
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await backend.fsList(ctx, { glob: "**/*.ts" });
 
-    const last = mockState.execCalls.at(-1) as { Cmd: string[] };
-    const idx = last.Cmd.indexOf("-path");
-    expect(idx).toBeGreaterThan(-1);
-    expect(last.Cmd[idx + 1]).toBe("*/*/*.ts");
+    // What the glob rules *are* is core's business (posix.test.ts). What this
+    // asserts is that the transport adds no shell and re-quotes nothing: the
+    // argv core built arrives at the daemon element for element.
+    const call = mockState.execCalls[0] as { Cmd: string[] };
+    expect(call.Cmd).toEqual(
+      buildFindArgs(SANDBOX_WORKSPACE_ROOT, { glob: "**/*.ts" }),
+    );
   });
 
   it("fsWrite create-mode probes with [test, -e, <path>] and throws if exists", async () => {
@@ -495,7 +506,7 @@ describe("DockerSandboxBackend — argv safety", () => {
     // probe — file exists (exit 0).
     queueExec({ exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await expect(
       backend.fsWrite(ctx, {
         path: "foo",
@@ -516,7 +527,7 @@ describe("DockerSandboxBackend — argv safety", () => {
       Promise.resolve({ State: { Running: true } }),
     );
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await backend.fsWrite(ctx, {
       path: "foo.txt",
       content: "hello",
@@ -529,7 +540,7 @@ describe("DockerSandboxBackend — argv safety", () => {
   });
 });
 
-describe("DockerSandboxBackend — tar builder", () => {
+describe("DockerSandboxTransport — tar builder", () => {
   it("buildSingleFileTar produces a parseable ustar archive", () => {
     const content = Buffer.from("hello world", "utf8");
     const tar = buildSingleFileTar("a/b.txt", content);
@@ -559,13 +570,13 @@ describe("DockerSandboxBackend — tar builder", () => {
   });
 });
 
-describe("DockerSandboxBackend — destroy() idempotence", () => {
+describe("DockerSandboxTransport — destroy() idempotence", () => {
   it("swallows 404 on stop and proceeds to remove + volume remove", async () => {
     mockState.existingContainer = makeFakeContainer();
     mockState.containerStop = () =>
       Promise.reject(makeStatusError("no such container", 404));
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await expect(backend.destroy(ctx)).resolves.toBeUndefined();
     expect(logger.warn).not.toHaveBeenCalled();
   });
@@ -575,7 +586,7 @@ describe("DockerSandboxBackend — destroy() idempotence", () => {
     mockState.containerStop = () =>
       Promise.reject(makeStatusError("already stopped", 304));
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await expect(backend.destroy(ctx)).resolves.toBeUndefined();
     expect(logger.warn).not.toHaveBeenCalled();
   });
@@ -587,7 +598,7 @@ describe("DockerSandboxBackend — destroy() idempotence", () => {
     mockState.volumeRemove = () =>
       Promise.reject(makeStatusError("not found", 404));
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await expect(backend.destroy(ctx)).resolves.toBeUndefined();
     expect(logger.warn).not.toHaveBeenCalled();
   });
@@ -607,7 +618,7 @@ describe("DockerSandboxBackend — destroy() idempotence", () => {
       return Promise.resolve(undefined);
     };
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     await backend.destroy(ctx);
 
     expect(logger.warn).toHaveBeenCalledTimes(1);
@@ -616,13 +627,13 @@ describe("DockerSandboxBackend — destroy() idempotence", () => {
   });
 });
 
-describe("DockerSandboxBackend — shellExec output handling", () => {
+describe("DockerSandboxTransport — shellExec output handling", () => {
   it("times out: returns exitCode 124 and destroys the stream", async () => {
     setupFreshProvision();
     // Long-running exec — close after 200ms; timeout will be 20ms.
     queueExec({ closeDelayMs: 200, exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     const res = await backend.shellExec(ctx, {
       command: "sleep 5",
       timeoutMs: 20,
@@ -636,7 +647,7 @@ describe("DockerSandboxBackend — shellExec output handling", () => {
     const huge = "a".repeat(MAX_SHELL_OUTPUT_BYTES + 5_000);
     queueExec({ stdout: huge, exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {});
     const res = await backend.shellExec(ctx, { command: "yes" });
 
     expect(res.stdout.length).toBe(MAX_SHELL_OUTPUT_BYTES);
@@ -644,42 +655,12 @@ describe("DockerSandboxBackend — shellExec output handling", () => {
   });
 });
 
-describe("DockerSandboxBackend — fsEdit error cases", () => {
-  it("throws when oldString is missing from file", async () => {
-    setupFreshProvision();
-    queueExec({ stdout: "the original content here", exitCode: 0 });
-
-    const backend = new DockerSandboxBackend({}, {});
-    await expect(
-      backend.fsEdit(ctx, {
-        path: "file.txt",
-        oldString: "does-not-appear",
-        newString: "x",
-      }),
-    ).rejects.toThrow(/oldString not found/);
-  });
-
-  it("throws when oldString is not unique", async () => {
-    setupFreshProvision();
-    queueExec({ stdout: "abc abc", exitCode: 0 });
-
-    const backend = new DockerSandboxBackend({}, {});
-    await expect(
-      backend.fsEdit(ctx, {
-        path: "file.txt",
-        oldString: "abc",
-        newString: "x",
-      }),
-    ).rejects.toThrow(/not unique/);
-  });
-});
-
-describe("DockerSandboxBackend — host reachability (ADR-0005)", () => {
+describe("DockerSandboxTransport — host reachability (ADR-0005)", () => {
   it("applies configured extraHosts to HostConfig.ExtraHosts", async () => {
     setupFreshProvision();
     queueExec({ exitCode: 0 });
 
-    const backend = new DockerSandboxBackend(
+    const backend = createDockerSandboxBackend(
       { extraHosts: ["host.docker.internal:host-gateway"] },
       {},
     );
@@ -694,7 +675,7 @@ describe("DockerSandboxBackend — host reachability (ADR-0005)", () => {
     setupFreshProvision();
     queueExec({ exitCode: 0 });
 
-    const backend = new DockerSandboxBackend(
+    const backend = createDockerSandboxBackend(
       { networks: ["primary", "secondary", "tertiary"] },
       {},
     );
@@ -717,7 +698,7 @@ describe("DockerSandboxBackend — host reachability (ADR-0005)", () => {
     setupFreshProvision();
     queueExec({ exitCode: 0 });
 
-    const backend = new DockerSandboxBackend({ networks: ["only"] }, {});
+    const backend = createDockerSandboxBackend({ networks: ["only"] }, {});
     await backend.shellExec(ctx, { command: "true" });
 
     expect(mockState.createContainerCalls[0].HostConfig?.NetworkMode).toBe(

--- a/apps/backend/src/plugins/docker/backend.ts
+++ b/apps/backend/src/plugins/docker/backend.ts
@@ -4,28 +4,18 @@ import { PassThrough } from "node:stream";
 import { z } from "zod";
 import { logger } from "../../logger.ts";
 import {
-  DEFAULT_SHELL_TIMEOUT_MS,
-  MAX_LIST_ENTRIES,
-  MAX_READ_BYTES,
   MAX_SHELL_OUTPUT_BYTES,
-  MAX_SHELL_TIMEOUT_MS,
   SANDBOX_WORKSPACE_ROOT,
 } from "../../sandbox/index.ts";
-import type {
-  FsEditInput,
-  FsEditOutput,
-  FsListEntry,
-  FsListInput,
-  FsListOutput,
-  FsReadInput,
-  FsReadOutput,
-  FsWriteInput,
-  FsWriteOutput,
-  SandboxBackend,
-  SandboxContext,
-  ShellExecInput,
-  ShellExecOutput,
-} from "../../sandbox/types.ts";
+import { createPosixSandbox } from "../../sandbox/posix.ts";
+import {
+  createCappedSink,
+  SandboxPathExistsError,
+  type SandboxExecOptions,
+  type SandboxExecResult,
+  type SandboxTransport,
+} from "../../sandbox/transport.ts";
+import type { SandboxBackend, SandboxContext } from "../../sandbox/types.ts";
 
 const IMAGE = "debian:stable-slim";
 const LABEL_SANDBOX = "platypus.sandbox";
@@ -193,38 +183,18 @@ export function buildSingleFileTar(name: string, content: Buffer): Buffer {
   return Buffer.concat([header, contentBlock, trailer]);
 }
 
-// Resolve a workspace-relative path to an absolute path inside the container.
-// The schema already enforces the path is relative.
-function absPath(relative: string | undefined): string {
-  if (!relative) return SANDBOX_WORKSPACE_ROOT;
-  return `${SANDBOX_WORKSPACE_ROOT}/${relative}`;
-}
-
-// Split the result of a tar `putArchive` target / `fsWrite` path into the
-// parent directory (passed as `path` to putArchive) and the file name (used
-// as the tar entry).
-function splitParent(relative: string): { parent: string; name: string } {
-  const cleaned = relative.replace(/^\/+/, "");
-  const idx = cleaned.lastIndexOf("/");
-  if (idx === -1) {
-    return { parent: SANDBOX_WORKSPACE_ROOT, name: cleaned };
-  }
+// Split an absolute in-container path into the directory `putArchive` extracts
+// into and the file name that becomes the tar entry.
+function splitParent(absPath: string): { parent: string; name: string } {
+  const idx = absPath.lastIndexOf("/");
   return {
-    parent: `${SANDBOX_WORKSPACE_ROOT}/${cleaned.slice(0, idx)}`,
-    name: cleaned.slice(idx + 1),
+    parent: idx <= 0 ? "/" : absPath.slice(0, idx),
+    name: absPath.slice(idx + 1),
   };
 }
 
-type ExecResult = {
-  stdout: Buffer;
-  stderr: Buffer;
-  exitCode: number;
-  durationMs: number;
-  timedOut: boolean;
-};
-
-// Run a single command inside the container, demuxing stdout/stderr. Optional
-// stdout byte cap; on cap-hit we stop accumulating but continue draining.
+// Run a single command inside the container, demuxing stdout/stderr into
+// byte-capped sinks that keep draining once full (see createCappedSink).
 async function runExec(
   container: Container,
   cmd: string[],
@@ -235,7 +205,7 @@ async function runExec(
     stdoutCap?: number;
     stderrCap?: number;
   } = {},
-): Promise<ExecResult> {
+): Promise<SandboxExecResult> {
   const started = Date.now();
   const exec: Exec = await container.exec({
     Cmd: cmd,
@@ -249,31 +219,17 @@ async function runExec(
 
   const stream = await exec.start({ hijack: true, stdin: false });
 
-  const stdoutCap = opts.stdoutCap ?? Number.POSITIVE_INFINITY;
-  const stderrCap = opts.stderrCap ?? Number.POSITIVE_INFINITY;
-  const stdoutChunks: Buffer[] = [];
-  const stderrChunks: Buffer[] = [];
-  let stdoutBytes = 0;
-  let stderrBytes = 0;
+  const stdoutSink = createCappedSink(
+    opts.stdoutCap ?? Number.POSITIVE_INFINITY,
+  );
+  const stderrSink = createCappedSink(
+    opts.stderrCap ?? Number.POSITIVE_INFINITY,
+  );
 
   const stdoutPass = new PassThrough();
   const stderrPass = new PassThrough();
-  stdoutPass.on("data", (c: Buffer) => {
-    if (stdoutBytes < stdoutCap) {
-      const room = stdoutCap - stdoutBytes;
-      const take = c.length <= room ? c : c.subarray(0, room);
-      stdoutChunks.push(take);
-      stdoutBytes += take.length;
-    }
-  });
-  stderrPass.on("data", (c: Buffer) => {
-    if (stderrBytes < stderrCap) {
-      const room = stderrCap - stderrBytes;
-      const take = c.length <= room ? c : c.subarray(0, room);
-      stderrChunks.push(take);
-      stderrBytes += take.length;
-    }
-  });
+  stdoutPass.on("data", (c: Buffer) => stdoutSink.push(c));
+  stderrPass.on("data", (c: Buffer) => stderrSink.push(c));
 
   // dockerode-attached demuxer
   (
@@ -326,15 +282,20 @@ async function runExec(
   }
 
   return {
-    stdout: Buffer.concat(stdoutChunks),
-    stderr: Buffer.concat(stderrChunks),
+    stdout: stdoutSink.collect(),
+    stderr: stderrSink.collect(),
     exitCode,
     durationMs: Date.now() - started,
-    timedOut,
   };
 }
 
-export class DockerSandboxBackend implements SandboxBackend {
+/**
+ * The Docker half of the Sandbox: dockerode `exec` for commands, `putArchive`
+ * for writes, and container/volume lifecycle (ADR-0003). The five model-facing
+ * tools are built on top of this by {@link createPosixSandbox} — nothing here
+ * parses find(1), counts lines, or decides what `truncated` means.
+ */
+export class DockerSandboxTransport implements SandboxTransport {
   private docker: Docker;
   private inflight: Map<string, Promise<Container>>;
   private networks: string[];
@@ -450,235 +411,90 @@ export class DockerSandboxBackend implements SandboxBackend {
     });
   }
 
-  async shellExec(
-    ctx: SandboxContext,
-    input: ShellExecInput,
-  ): Promise<ShellExecOutput> {
-    const container = await this.ensureContainer(ctx);
-    const timeoutMs = Math.min(
-      input.timeoutMs ?? DEFAULT_SHELL_TIMEOUT_MS,
-      MAX_SHELL_TIMEOUT_MS,
-    );
-    const workingDir = input.cwd
-      ? `${SANDBOX_WORKSPACE_ROOT}/${input.cwd}`
-      : SANDBOX_WORKSPACE_ROOT;
-
-    const res = await runExec(container, ["/bin/sh", "-c", input.command], {
-      workingDir,
-      env: input.env,
-      timeoutMs,
-      stdoutCap: MAX_SHELL_OUTPUT_BYTES,
-      stderrCap: MAX_SHELL_OUTPUT_BYTES,
-    });
-
-    const stdout = res.stdout.toString("utf8");
-    const stderr = res.stderr.toString("utf8");
-    // truncated if we hit the cap on either stream (we cannot distinguish
-    // "exactly at cap" from "exceeded cap" here, but the buffer length being
-    // === cap is a strong signal and consistent with the contract).
-    const truncated =
-      res.stdout.length >= MAX_SHELL_OUTPUT_BYTES ||
-      res.stderr.length >= MAX_SHELL_OUTPUT_BYTES;
-
-    return {
-      stdout,
-      stderr,
-      exitCode: res.exitCode,
-      truncated,
-      durationMs: res.durationMs,
-    };
+  // The workspace root is a fixed mount point inside a container we control, so
+  // this is a constant — but it is still the call that guarantees the container
+  // is up, which is why core makes it first in every tool.
+  async rootDir(ctx: SandboxContext): Promise<string> {
+    await this.ensureContainer(ctx);
+    return SANDBOX_WORKSPACE_ROOT;
   }
 
-  async fsRead(ctx: SandboxContext, input: FsReadInput): Promise<FsReadOutput> {
+  // argv goes straight to the daemon: there is no shell between us and the
+  // process, so nothing needs quoting and no model-supplied value can be
+  // reinterpreted as syntax on the way.
+  async exec(
+    ctx: SandboxContext,
+    argv: string[],
+    opts: SandboxExecOptions,
+  ): Promise<SandboxExecResult> {
     const container = await this.ensureContainer(ctx);
-    const target = absPath(input.path);
+    return runExec(container, argv, {
+      workingDir: opts.cwd,
+      env: opts.env,
+      timeoutMs: opts.timeoutMs,
+      stdoutCap: opts.stdoutCap,
+      stderrCap: opts.stderrCap,
+    });
+  }
 
-    // Use argv form (no shell) so paths can't be interpreted as shell syntax.
-    const cmd = input.lineRange
-      ? [
-          "sed",
-          "-n",
-          `${input.lineRange[0]},${input.lineRange[1]}p`,
-          "--",
-          target,
-        ]
-      : ["cat", "--", target];
-
-    const res = await runExec(container, cmd, {
+  // `cat` in argv form. Docker has no file-read API, and the alternative —
+  // `getArchive` — would mean unpacking a tar to read one file. The cap is
+  // applied to the stream as it arrives, so a huge file costs no more than it.
+  async readFile(
+    ctx: SandboxContext,
+    absPath: string,
+    cap: number,
+  ): Promise<Buffer> {
+    const container = await this.ensureContainer(ctx);
+    const res = await runExec(container, ["cat", "--", absPath], {
       workingDir: SANDBOX_WORKSPACE_ROOT,
-      stdoutCap: MAX_READ_BYTES,
+      stdoutCap: cap,
       stderrCap: MAX_SHELL_OUTPUT_BYTES,
     });
 
     if (res.exitCode !== 0) {
-      const msg = res.stderr.toString("utf8").trim() || "fs.read failed";
-      throw new Error(`fs.read: ${msg}`);
+      // The reason only: core names the tool that asked.
+      throw new Error(res.stderr.toString("utf8").trim() || "read failed");
     }
 
-    // Reject non-UTF-8 by decoding with the strict TextDecoder.
-    let content: string;
-    try {
-      content = new TextDecoder("utf-8", { fatal: true }).decode(res.stdout);
-    } catch {
-      throw new Error(`fs.read: file is not valid UTF-8 (${input.path})`);
-    }
-
-    const truncated = res.stdout.length >= MAX_READ_BYTES;
-    // lineCount: count newlines + 1 if there's any trailing content without a
-    // newline. Empty content → 0 lines.
-    let lineCount = 0;
-    if (content.length > 0) {
-      lineCount = content.split("\n").length;
-      if (content.endsWith("\n")) lineCount -= 1;
-    }
-
-    return { content, lineCount, truncated };
+    return res.stdout;
   }
 
-  async fsWrite(
+  // Writes go in as a single-entry tar through `putArchive`, which takes the
+  // path literally — there is no shell to quote against and no `sh -c echo >`
+  // redirection to get wrong.
+  async writeFile(
     ctx: SandboxContext,
-    input: FsWriteInput,
-  ): Promise<FsWriteOutput> {
+    absPath: string,
+    bytes: Buffer,
+    mode: "create" | "overwrite",
+  ): Promise<void> {
     const container = await this.ensureContainer(ctx);
-    const target = absPath(input.path);
 
-    if (input.mode === "create") {
-      // argv form — path can't escape into shell syntax.
-      const probe = await runExec(container, ["test", "-e", target], {
+    // `putArchive` overwrites unconditionally, so create-mode needs its own
+    // probe. Not atomic — a file appearing between the probe and the extract
+    // wins — but Docker offers nothing better, and a Sandbox is single-user.
+    if (mode === "create") {
+      const probe = await runExec(container, ["test", "-e", absPath], {
         workingDir: SANDBOX_WORKSPACE_ROOT,
       });
       if (probe.exitCode === 0) {
-        throw new Error(
-          `fs.write: path already exists (mode=create): ${input.path}`,
-        );
+        throw new SandboxPathExistsError(absPath);
       }
     }
 
-    // Ensure the parent directory exists before extracting the tar.
-    const { parent, name } = splitParent(input.path);
+    const { parent, name } = splitParent(absPath);
+    // The root is the volume mount and always exists; anything deeper may not.
     if (parent !== SANDBOX_WORKSPACE_ROOT) {
       const mk = await runExec(container, ["mkdir", "-p", parent]);
       if (mk.exitCode !== 0) {
-        throw new Error(
-          `fs.write: failed to create parent directory: ${parent}`,
-        );
+        throw new Error(`failed to create parent directory: ${parent}`);
       }
     }
 
-    const contentBuf = Buffer.from(input.content, "utf8");
-    const tar = buildSingleFileTar(name, contentBuf);
-    await container.putArchive(tar, { path: parent });
-
-    return { bytesWritten: contentBuf.length };
-  }
-
-  async fsEdit(ctx: SandboxContext, input: FsEditInput): Promise<FsEditOutput> {
-    const container = await this.ensureContainer(ctx);
-    const target = absPath(input.path);
-
-    // argv form — path is never shell-interpreted.
-    const readRes = await runExec(container, ["cat", "--", target], {
-      workingDir: SANDBOX_WORKSPACE_ROOT,
-      stdoutCap: MAX_READ_BYTES,
+    await container.putArchive(buildSingleFileTar(name, bytes), {
+      path: parent,
     });
-    if (readRes.exitCode !== 0) {
-      const msg = readRes.stderr.toString("utf8").trim() || "fs.edit failed";
-      throw new Error(`fs.edit: ${msg}`);
-    }
-
-    let original: string;
-    try {
-      original = new TextDecoder("utf-8", { fatal: true }).decode(
-        readRes.stdout,
-      );
-    } catch {
-      throw new Error(`fs.edit: file is not valid UTF-8 (${input.path})`);
-    }
-
-    const first = original.indexOf(input.oldString);
-    if (first === -1) {
-      throw new Error(`fs.edit: oldString not found in ${input.path}`);
-    }
-    const second = original.indexOf(input.oldString, first + 1);
-    if (second !== -1) {
-      throw new Error(`fs.edit: oldString is not unique in ${input.path}`);
-    }
-
-    const updated =
-      original.slice(0, first) +
-      input.newString +
-      original.slice(first + input.oldString.length);
-
-    const { parent, name } = splitParent(input.path);
-    const tar = buildSingleFileTar(name, Buffer.from(updated, "utf8"));
-    await container.putArchive(tar, { path: parent });
-
-    return { replacements: 1 };
-  }
-
-  async fsList(ctx: SandboxContext, input: FsListInput): Promise<FsListOutput> {
-    const container = await this.ensureContainer(ctx);
-    const target = absPath(input.path);
-    // Argv form throughout — no shell, no path/glob interpolation.
-    // Truncation is done in Node instead of `| head`.
-    const args: string[] = ["find", target];
-    if (!input.recursive) args.push("-maxdepth", "1");
-    args.push("-mindepth", "1");
-    if (input.glob) {
-      // -name handles a simple file-name glob; -path handles patterns that
-      // include slashes or **. `**` collapses to `*` for find(1) — a lossy
-      // but pragmatic translation; document the limitation in tool description.
-      if (input.glob.includes("/") || input.glob.includes("**")) {
-        args.push("-path", `*/${input.glob.replace(/\*\*/g, "*")}`);
-      } else {
-        args.push("-name", input.glob);
-      }
-    }
-    args.push("-printf", "%y\\t%s\\t%P\\n");
-
-    const res = await runExec(container, args, {
-      workingDir: SANDBOX_WORKSPACE_ROOT,
-      stdoutCap: 4 * 1024 * 1024,
-      stderrCap: MAX_SHELL_OUTPUT_BYTES,
-    });
-
-    if (res.exitCode !== 0 && res.stdout.length === 0) {
-      const msg = res.stderr.toString("utf8").trim() || "fs.list failed";
-      throw new Error(`fs.list: ${msg}`);
-    }
-
-    const lines = res.stdout
-      .toString("utf8")
-      .split("\n")
-      .filter((l) => l.length > 0);
-
-    const entries: FsListEntry[] = [];
-    let truncated = false;
-    for (const line of lines) {
-      const tab1 = line.indexOf("\t");
-      const tab2 = line.indexOf("\t", tab1 + 1);
-      if (tab1 === -1 || tab2 === -1) continue;
-      const typeChar = line.slice(0, tab1);
-      const sizeStr = line.slice(tab1 + 1, tab2);
-      const path = line.slice(tab2 + 1);
-      let type: "file" | "dir";
-      if (typeChar === "f") type = "file";
-      else if (typeChar === "d") type = "dir";
-      else continue; // ignore symlinks / sockets / devices in v1
-      const size = Number.parseInt(sizeStr, 10);
-      entries.push({
-        path,
-        type,
-        ...(Number.isFinite(size) ? { size } : {}),
-      });
-      if (entries.length >= MAX_LIST_ENTRIES) {
-        // If find emitted more entries beyond what we kept, mark truncated.
-        truncated = entries.length < lines.length;
-        break;
-      }
-    }
-
-    return { entries, truncated };
   }
 
   async destroy(ctx: SandboxContext): Promise<void> {
@@ -726,3 +542,14 @@ export class DockerSandboxBackend implements SandboxBackend {
     }
   }
 }
+
+/**
+ * The Docker Sandbox backend: this plugin's transport under core's fixed
+ * five-tool core. What the model sees comes from {@link createPosixSandbox}, so
+ * this adapter cannot drift from the SSH one on anything but the transport.
+ */
+export const createDockerSandboxBackend = (
+  config: Partial<DockerSandboxConfig>,
+  credentials: DockerSandboxCredentials,
+): SandboxBackend =>
+  createPosixSandbox(new DockerSandboxTransport(config, credentials));

--- a/apps/backend/src/plugins/docker/index.ts
+++ b/apps/backend/src/plugins/docker/index.ts
@@ -4,7 +4,7 @@ import type {
 } from "@platypuschat/plugin-sdk";
 import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
 import {
-  DockerSandboxBackend,
+  createDockerSandboxBackend,
   dockerPluginConfigSchema,
   dockerSandboxConfigSchema,
   dockerSandboxCredentialsSchema,
@@ -30,7 +30,7 @@ const dockerBackend: SandboxBackendContribution<
   configSchema: dockerSandboxConfigSchema,
   credentialsSchema: dockerSandboxCredentialsSchema,
   create: (config, credentials) =>
-    new DockerSandboxBackend(config, credentials),
+    createDockerSandboxBackend(config, credentials),
 };
 
 export const plugin: PlatypusPlugin = {

--- a/apps/backend/src/plugins/ssh/backend.test.ts
+++ b/apps/backend/src/plugins/ssh/backend.test.ts
@@ -282,16 +282,12 @@ vi.mock("../../logger.ts", () => ({
 
 // Import AFTER vi.mock so the adapter binds to the mocked ssh2 + logger.
 import {
-  SshSandboxBackend,
+  createSshSandboxBackend,
   sshSandboxConfigSchema,
   sshSandboxCredentialsSchema,
 } from "./backend.ts";
 import { logger } from "../../logger.ts";
-import {
-  MAX_LIST_ENTRIES,
-  MAX_READ_BYTES,
-  MAX_SHELL_OUTPUT_BYTES,
-} from "../../sandbox/index.ts";
+import { MAX_READ_BYTES, MAX_SHELL_OUTPUT_BYTES } from "../../sandbox/index.ts";
 import type { SandboxContext } from "../../sandbox/types.ts";
 
 const ctx: SandboxContext = {
@@ -378,10 +374,10 @@ describe("sshSandboxConfigSchema / credentialsSchema", () => {
   });
 });
 
-describe("SshSandboxBackend — connect", () => {
+describe("SshSandboxTransport — connect", () => {
   it("connects with public-key auth and creates the default workspace root", async () => {
     queueExec({ stdout: "hi", exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await backend.shellExec(ctx, { command: "echo hi" });
 
     expect(mockState.connectConfigs).toHaveLength(1);
@@ -401,7 +397,7 @@ describe("SshSandboxBackend — connect", () => {
 
   it("passes the passphrase through when provided", async () => {
     queueExec({ exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, {
+    const backend = createSshSandboxBackend(CONFIG, {
       privateKey: "K",
       passphrase: "secret",
     });
@@ -411,7 +407,7 @@ describe("SshSandboxBackend — connect", () => {
 
   it("warns loudly about MITM when no hostKey is pinned", async () => {
     queueExec({ exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await backend.shellExec(ctx, { command: "true" });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ host: "ssh.example.com" }),
@@ -421,7 +417,7 @@ describe("SshSandboxBackend — connect", () => {
 
   it("uses a custom rootDir when configured", async () => {
     queueExec({ exitCode: 0 });
-    const backend = new SshSandboxBackend(
+    const backend = createSshSandboxBackend(
       { ...CONFIG, rootDir: "/srv/agent" },
       CREDENTIALS,
     );
@@ -431,7 +427,7 @@ describe("SshSandboxBackend — connect", () => {
 
   it("rejects when the SSH connection errors", async () => {
     mockState.connectShouldFail = new Error("auth failed");
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
       /auth failed/,
     );
@@ -439,18 +435,18 @@ describe("SshSandboxBackend — connect", () => {
 
   it("throws when the workspace root cannot be created", async () => {
     mockState.rootCreateFails = true;
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
       /failed to create workspace root/,
     );
   });
 });
 
-describe("SshSandboxBackend — host-key verification", () => {
+describe("SshSandboxTransport — host-key verification", () => {
   it("connects when the pinned hostKey matches the presented host key", async () => {
     queueExec({ exitCode: 0 });
     mockState.presentedHostKey = Buffer.from(HOST_KEY_B64, "base64");
-    const backend = new SshSandboxBackend(
+    const backend = createSshSandboxBackend(
       // A full `ssh-keyscan`-style line: the parser picks the base64 blob token.
       { ...CONFIG, hostKey: `ssh-ed25519 ${HOST_KEY_B64}` },
       CREDENTIALS,
@@ -468,7 +464,7 @@ describe("SshSandboxBackend — host-key verification", () => {
   it("rejects the connection with a clear error when the pin mismatches", async () => {
     // A bare base64 blob (single token) is also accepted as a pin.
     mockState.presentedHostKey = Buffer.from(HOST_KEY_B64, "base64");
-    const backend = new SshSandboxBackend(
+    const backend = createSshSandboxBackend(
       { ...CONFIG, hostKey: WRONG_HOST_KEY_B64 },
       CREDENTIALS,
     );
@@ -481,7 +477,7 @@ describe("SshSandboxBackend — host-key verification", () => {
 
   it("connects without a hostVerifier and warns exactly once when no hostKey is pinned", async () => {
     queueExec({ exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await backend.shellExec(ctx, { command: "true" });
 
     expect(mockState.connectConfigs[0].hostVerifier).toBeUndefined();
@@ -493,7 +489,7 @@ describe("SshSandboxBackend — host-key verification", () => {
   });
 
   it("throws a clear error when the pinned hostKey cannot be parsed", async () => {
-    const backend = new SshSandboxBackend(
+    const backend = createSshSandboxBackend(
       { ...CONFIG, hostKey: "# not a key" },
       CREDENTIALS,
     );
@@ -505,14 +501,18 @@ describe("SshSandboxBackend — host-key verification", () => {
   });
 });
 
-describe("SshSandboxBackend — shellExec", () => {
+describe("SshSandboxTransport — shellExec", () => {
   it("prefixes cd <rootDir> and returns stdout/stderr/exitCode/durationMs", async () => {
     queueExec({ stdout: "out", stderr: "err", exitCode: 3 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     const res = await backend.shellExec(ctx, { command: "run" });
 
+    // Core hands the transport an argv (`/bin/sh -c <command>`); a login shell
+    // sits in between, so every element is single-quoted before being joined.
     const cmd = mockState.execCommands[1];
-    expect(cmd).toBe("cd '/home/platypus/platypus-workspace' && run");
+    expect(cmd).toBe(
+      "cd '/home/platypus/platypus-workspace' && '/bin/sh' '-c' 'run'",
+    );
     expect(res.stdout).toBe("out");
     expect(res.stderr).toBe("err");
     expect(res.exitCode).toBe(3);
@@ -522,16 +522,16 @@ describe("SshSandboxBackend — shellExec", () => {
 
   it("resolves cwd relative to the rootDir", async () => {
     queueExec({ exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await backend.shellExec(ctx, { command: "ls", cwd: "sub/dir" });
     expect(mockState.execCommands[1]).toBe(
-      "cd '/home/platypus/platypus-workspace/sub/dir' && ls",
+      "cd '/home/platypus/platypus-workspace/sub/dir' && '/bin/sh' '-c' 'ls'",
     );
   });
 
   it("applies env via export statements (not the ssh2 env option)", async () => {
     queueExec({ exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await backend.shellExec(ctx, {
       command: "printenv",
       env: { FOO: "bar", TOKEN: "a b'c" },
@@ -546,7 +546,7 @@ describe("SshSandboxBackend — shellExec", () => {
 
   it("drops env keys that are not valid POSIX identifiers", async () => {
     queueExec({ exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await backend.shellExec(ctx, {
       command: "run",
       // A malformed key (model-supplied env is not schema-key-validated) must
@@ -558,10 +558,12 @@ describe("SshSandboxBackend — shellExec", () => {
     expect(cmd).not.toContain("rm -rf");
   });
 
-  it("caps stdout at MAX_SHELL_OUTPUT_BYTES and flags truncated", async () => {
+  it("stops buffering the ssh2 stream once the caller's stdout cap is reached", async () => {
+    // The cap is enforced while the channel is streaming, not afterwards: the
+    // fake emits more than the cap in one chunk and only the cap is retained.
     const huge = "a".repeat(MAX_SHELL_OUTPUT_BYTES + 5_000);
     queueExec({ stdout: huge, exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     const res = await backend.shellExec(ctx, { command: "yes" });
     expect(res.stdout.length).toBe(MAX_SHELL_OUTPUT_BYTES);
     expect(res.truncated).toBe(true);
@@ -570,7 +572,7 @@ describe("SshSandboxBackend — shellExec", () => {
   it("returns exit code 124 when a command exceeds its timeout", async () => {
     // Channel closes after 200ms; timeout is 20ms, so the adapter closes first.
     queueExec({ closeDelayMs: 200, exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     const res = await backend.shellExec(ctx, {
       command: "sleep 5",
       timeoutMs: 20,
@@ -579,11 +581,11 @@ describe("SshSandboxBackend — shellExec", () => {
   });
 });
 
-describe("SshSandboxBackend — connection lifecycle", () => {
+describe("SshSandboxTransport — connection lifecycle", () => {
   it("reuses a single connection across tool calls within a turn", async () => {
     queueExec({ exitCode: 0 });
     queueExec({ exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await backend.shellExec(ctx, { command: "a" });
     await backend.shellExec(ctx, { command: "b" });
 
@@ -595,7 +597,7 @@ describe("SshSandboxBackend — connection lifecycle", () => {
   it("concurrent first-callers share one connect (inflight promise)", async () => {
     queueExec({ exitCode: 0 });
     queueExec({ exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await Promise.all([
       backend.shellExec(ctx, { command: "a" }),
       backend.shellExec(ctx, { command: "b" }),
@@ -607,7 +609,7 @@ describe("SshSandboxBackend — connection lifecycle", () => {
     vi.useFakeTimers();
     try {
       queueExec({ exitCode: 0 });
-      const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+      const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
       await backend.shellExec(ctx, { command: "true" });
       expect(mockState.ended).toBe(0);
 
@@ -625,10 +627,10 @@ describe("SshSandboxBackend — connection lifecycle", () => {
   });
 });
 
-describe("SshSandboxBackend — destroy() is a no-op", () => {
+describe("SshSandboxTransport — destroy() is a no-op", () => {
   it("disconnects without running any remote mutation command", async () => {
     queueExec({ exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await backend.shellExec(ctx, { command: "true" });
     const execCountBefore = mockState.execCommands.length;
 
@@ -640,7 +642,7 @@ describe("SshSandboxBackend — destroy() is a no-op", () => {
   });
 
   it("is safe to call when never connected", async () => {
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await expect(backend.destroy(ctx)).resolves.toBeUndefined();
     expect(mockState.connectConfigs).toHaveLength(0);
     expect(mockState.ended).toBe(0);
@@ -660,23 +662,10 @@ function seedFile(rel: string, content: string | Buffer) {
   );
 }
 
-describe("SshSandboxBackend — fs.write (SFTP)", () => {
-  it("create mode writes a new file and returns bytesWritten", async () => {
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsWrite(ctx, {
-      path: "notes.txt",
-      content: "hello",
-      mode: "create",
-    });
-    expect(res.bytesWritten).toBe(5);
-    expect(mockState.files.get(abs("notes.txt"))?.toString("utf8")).toBe(
-      "hello",
-    );
-  });
-
+describe("SshSandboxTransport — fs.write (SFTP)", () => {
   it("create mode fails cleanly when the target already exists", async () => {
     seedFile("exists.txt", "old");
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await expect(
       backend.fsWrite(ctx, {
         path: "exists.txt",
@@ -690,20 +679,8 @@ describe("SshSandboxBackend — fs.write (SFTP)", () => {
     );
   });
 
-  it("overwrite mode replaces an existing file", async () => {
-    seedFile("f.txt", "original content here");
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsWrite(ctx, {
-      path: "f.txt",
-      content: "new",
-      mode: "overwrite",
-    });
-    expect(res.bytesWritten).toBe(3);
-    expect(mockState.files.get(abs("f.txt"))?.toString("utf8")).toBe("new");
-  });
-
   it("auto-creates parent directories (mkdir -p) before writing", async () => {
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await backend.fsWrite(ctx, {
       path: "a/b/c/deep.txt",
       content: "x",
@@ -718,7 +695,7 @@ describe("SshSandboxBackend — fs.write (SFTP)", () => {
   });
 
   it("writes paths literally over SFTP (no shell quoting/injection)", async () => {
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     const weird = `foo";rm -rf /.txt`;
     await backend.fsWrite(ctx, {
       path: weird,
@@ -731,127 +708,32 @@ describe("SshSandboxBackend — fs.write (SFTP)", () => {
       true,
     );
   });
-
-  it("writes zero-length content", async () => {
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsWrite(ctx, {
-      path: "empty.txt",
-      content: "",
-      mode: "create",
-    });
-    expect(res.bytesWritten).toBe(0);
-    expect(mockState.files.get(abs("empty.txt"))?.length).toBe(0);
-  });
 });
 
-describe("SshSandboxBackend — fs.read (SFTP)", () => {
-  it("reads content with correct lineCount and truncated=false", async () => {
-    seedFile("f.txt", "line1\nline2\nline3\n");
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsRead(ctx, { path: "f.txt" });
-    expect(res.content).toBe("line1\nline2\nline3\n");
-    expect(res.lineCount).toBe(3);
-    expect(res.truncated).toBe(false);
-  });
-
-  it("counts a trailing partial line", async () => {
-    seedFile("f.txt", "a\nb\nc");
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsRead(ctx, { path: "f.txt" });
-    expect(res.lineCount).toBe(3);
-  });
-
-  it("an empty file reads as zero lines", async () => {
-    seedFile("empty.txt", "");
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsRead(ctx, { path: "empty.txt" });
-    expect(res.content).toBe("");
-    expect(res.lineCount).toBe(0);
-    expect(res.truncated).toBe(false);
-  });
-
-  it("caps at MAX_READ_BYTES and flags truncated", async () => {
+describe("SshSandboxTransport — fs.read (SFTP)", () => {
+  it("reads no more than the cap however large the file is", async () => {
+    // The transport fstat()s first and asks for min(size, cap), so an oversized
+    // file costs the cap and no more. What that means for `truncated` is core's
+    // call, not this adapter's — see sandbox/posix.test.ts.
     seedFile("big.txt", "a".repeat(MAX_READ_BYTES + 5_000));
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     const res = await backend.fsRead(ctx, { path: "big.txt" });
     expect(res.content.length).toBe(MAX_READ_BYTES);
-    expect(res.truncated).toBe(true);
   });
 
-  it("rejects a non-UTF-8 file with a clear error", async () => {
-    // 0xff is never valid in UTF-8.
-    seedFile("bin.dat", Buffer.from([0x66, 0x6f, 0xff, 0x6f]));
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    await expect(backend.fsRead(ctx, { path: "bin.dat" })).rejects.toThrow(
-      /not valid UTF-8/,
-    );
-  });
-
-  it("honours lineRange, slicing the requested window", async () => {
-    seedFile("f.txt", "one\ntwo\nthree\nfour\nfive\n");
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsRead(ctx, {
-      path: "f.txt",
-      lineRange: [2, 4],
-    });
-    expect(res.content).toBe("two\nthree\nfour\n");
-    expect(res.lineCount).toBe(3);
+  it("reads a file smaller than the cap whole", async () => {
+    // min(size, cap) must not over-request either: asking for `cap` bytes of a
+    // short file is what a naive read would do, and SFTP would pad the buffer.
+    seedFile("small.txt", "abc");
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const res = await backend.fsRead(ctx, { path: "small.txt" });
+    expect(res.content).toBe("abc");
   });
 });
 
-describe("SshSandboxBackend — fs.edit (SFTP)", () => {
-  it("replaces exactly one occurrence and writes it back", async () => {
-    seedFile("f.txt", "the quick brown fox");
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsEdit(ctx, {
-      path: "f.txt",
-      oldString: "quick",
-      newString: "slow",
-    });
-    expect(res).toEqual({ replacements: 1 });
-    expect(mockState.files.get(abs("f.txt"))?.toString("utf8")).toBe(
-      "the slow brown fox",
-    );
-  });
-
-  it("throws when oldString is absent", async () => {
-    seedFile("f.txt", "nothing to see here");
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    await expect(
-      backend.fsEdit(ctx, {
-        path: "f.txt",
-        oldString: "missing",
-        newString: "x",
-      }),
-    ).rejects.toThrow(/oldString not found/);
-  });
-
-  it("throws when oldString is not unique", async () => {
-    seedFile("f.txt", "abc abc");
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    await expect(
-      backend.fsEdit(ctx, {
-        path: "f.txt",
-        oldString: "abc",
-        newString: "x",
-      }),
-    ).rejects.toThrow(/not unique/);
-    // Unchanged on failure.
-    expect(mockState.files.get(abs("f.txt"))?.toString("utf8")).toBe("abc abc");
-  });
-
-  it("rejects a non-UTF-8 file", async () => {
-    seedFile("bin.dat", Buffer.from([0xff, 0xfe]));
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    await expect(
-      backend.fsEdit(ctx, { path: "bin.dat", oldString: "a", newString: "b" }),
-    ).rejects.toThrow(/not valid UTF-8/);
-  });
-});
-
-describe("SshSandboxBackend — SFTP session lifecycle", () => {
+describe("SshSandboxTransport — SFTP session lifecycle", () => {
   it("opens the SFTP subsystem once and reuses it across fs calls in a turn", async () => {
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await backend.fsWrite(ctx, { path: "a.txt", content: "1", mode: "create" });
     await backend.fsRead(ctx, { path: "a.txt" });
     await backend.fsEdit(ctx, {
@@ -866,187 +748,51 @@ describe("SshSandboxBackend — SFTP session lifecycle", () => {
 
   it("propagates an SFTP subsystem open failure", async () => {
     mockState.sftpShouldFail = new Error("sftp channel refused");
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await expect(backend.fsRead(ctx, { path: "a.txt" })).rejects.toThrow(
       /sftp channel refused/,
     );
   });
 });
 
-// Build a `find -printf '%y\t%s\t%P\n'` line for the mocked exec output.
-function findLine(type: "f" | "d" | "l", size: number, path: string): string {
-  return `${type}\t${size}\t${path}`;
-}
-
-// The find command is the second exec (execCommands[0] is the connect-time root
+// The find command is the last exec (execCommands[0] is the connect-time root
 // resolution). Grab it for command-shape assertions.
 const lastFindCommand = () =>
   mockState.execCommands[mockState.execCommands.length - 1];
 
-describe("SshSandboxBackend — fs.list (exec find)", () => {
-  it("lists a flat directory non-recursively with type and size", async () => {
-    queueExec({
-      stdout:
-        [
-          findLine("f", 12, "a.txt"),
-          findLine("d", 4096, "sub"),
-          findLine("f", 0, "empty.txt"),
-        ].join("\n") + "\n",
-      exitCode: 0,
-    });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsList(ctx, {});
+// find(1)'s own `\t`/`\n` escapes, as they appear inside the single-quoted
+// -printf argument on the wire (the shell must pass them through untouched).
+const PRINTF_ARG = String.raw`'-printf' '%y\t%s\t%P\n'`;
 
-    expect(res.truncated).toBe(false);
-    expect(res.entries).toEqual([
-      { path: "a.txt", type: "file", size: 12 },
-      { path: "sub", type: "dir", size: 4096 },
-      { path: "empty.txt", type: "file", size: 0 },
-    ]);
-
-    // Non-recursive → -maxdepth 1; roots at the resolved workspace root.
-    const cmd = lastFindCommand();
-    expect(cmd).toBe(
-      `find '${ROOT}' -maxdepth 1 -mindepth 1 -printf '%y\\t%s\\t%P\\n'`,
-    );
-  });
-
-  it("lists recursively (no -maxdepth) under a subpath", async () => {
-    queueExec({
-      stdout:
-        [findLine("f", 3, "x"), findLine("f", 3, "d/y")].join("\n") + "\n",
-      exitCode: 0,
-    });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsList(ctx, { path: "src", recursive: true });
-
-    expect(res.entries.map((e) => e.path)).toEqual(["x", "d/y"]);
-    const cmd = lastFindCommand();
-    expect(cmd).toBe(
-      `find '${ROOT}/src' -mindepth 1 -printf '%y\\t%s\\t%P\\n'`,
-    );
-    expect(cmd).not.toContain("-maxdepth");
-  });
-
-  it("ignores symlinks / sockets / devices (only file and dir)", async () => {
-    queueExec({
-      stdout:
-        [
-          findLine("f", 1, "real.txt"),
-          findLine("l", 7, "link"),
-          "s\t0\tsock",
-        ].join("\n") + "\n",
-      exitCode: 0,
-    });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsList(ctx, {});
-    expect(res.entries).toEqual([{ path: "real.txt", type: "file", size: 1 }]);
-  });
-
-  it("translates a bare glob to -name (single-quoted, no shell expansion)", async () => {
-    queueExec({ stdout: findLine("f", 5, "a.ts") + "\n", exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    await backend.fsList(ctx, { glob: "*.ts" });
-    const cmd = lastFindCommand();
-    expect(cmd).toContain("-name '*.ts'");
-    expect(cmd).not.toContain("-path");
-  });
-
-  it("translates a slashed glob to -path", async () => {
-    queueExec({ stdout: findLine("f", 5, "src/a.ts") + "\n", exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    await backend.fsList(ctx, { glob: "src/*.ts", recursive: true });
-    expect(lastFindCommand()).toContain("-path '*/src/*.ts'");
-  });
-
-  it("collapses ** to * for -path (documented lossy translation)", async () => {
+describe("SshSandboxTransport — fs.list (exec find)", () => {
+  it("quotes every element of the find argv core handed it", async () => {
     queueExec({ stdout: "", exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    await backend.fsList(ctx, { glob: "**/*.ts", recursive: true });
-    expect(lastFindCommand()).toContain("-path '*/*/*.ts'");
-  });
-
-  it("truncates to MAX_LIST_ENTRIES and flags truncated", async () => {
-    const lines: string[] = [];
-    for (let i = 0; i < MAX_LIST_ENTRIES + 1; i++) {
-      lines.push(findLine("f", 1, `f${i}.txt`));
-    }
-    queueExec({ stdout: lines.join("\n") + "\n", exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsList(ctx, { recursive: true });
-    expect(res.entries).toHaveLength(MAX_LIST_ENTRIES);
-    expect(res.truncated).toBe(true);
-  });
-
-  it("does not flag truncated at exactly MAX_LIST_ENTRIES entries", async () => {
-    const lines: string[] = [];
-    for (let i = 0; i < MAX_LIST_ENTRIES; i++) {
-      lines.push(findLine("f", 1, `f${i}.txt`));
-    }
-    queueExec({ stdout: lines.join("\n") + "\n", exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsList(ctx, { recursive: true });
-    expect(res.entries).toHaveLength(MAX_LIST_ENTRIES);
-    expect(res.truncated).toBe(false);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    await backend.fsList(ctx, {});
+    // Core passes cwd=rootDir, so the `cd` prefix precedes find as well; the
+    // argv itself (find, its target, its flags) is core's — this only asserts
+    // that none of it reaches the login shell unquoted.
+    expect(lastFindCommand()).toBe(
+      `cd '${ROOT}' && 'find' '${ROOT}' '-maxdepth' '1' '-mindepth' '1' ${PRINTF_ARG}`,
+    );
   });
 
   it("single-quotes the list path so shell metacharacters cannot break out", async () => {
     queueExec({ stdout: "", exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     // A metachar-laden path (schema rejects absolute/`..`, but quote defensively).
     await backend.fsList(ctx, { path: `foo; rm -rf ~` });
-    const cmd = lastFindCommand();
     // The whole path is inside one single-quoted argument.
-    expect(cmd).toBe(
-      `find '${ROOT}/foo; rm -rf ~' -maxdepth 1 -mindepth 1 -printf '%y\\t%s\\t%P\\n'`,
+    expect(lastFindCommand()).toBe(
+      `cd '${ROOT}' && 'find' '${ROOT}/foo; rm -rf ~' '-maxdepth' '1' '-mindepth' '1' ${PRINTF_ARG}`,
     );
   });
 
   it("escapes an embedded single quote in the path", async () => {
     queueExec({ stdout: "", exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
     await backend.fsList(ctx, { path: `it's` });
     // classic '\'' escape idiom, matching shQuote.
-    expect(lastFindCommand()).toContain(`find '${ROOT}/it'\\''s'`);
-  });
-
-  it("returns an empty list for an empty directory", async () => {
-    queueExec({ stdout: "", exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsList(ctx, {});
-    expect(res.entries).toEqual([]);
-    expect(res.truncated).toBe(false);
-  });
-
-  it("emits partial results when find exits non-zero but printed rows", async () => {
-    queueExec({
-      stdout: findLine("f", 1, "readable.txt") + "\n",
-      stderr: "find: 'sub': Permission denied",
-      exitCode: 1,
-    });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsList(ctx, { recursive: true });
-    expect(res.entries).toEqual([
-      { path: "readable.txt", type: "file", size: 1 },
-    ]);
-  });
-
-  it("throws when find fails with no output", async () => {
-    queueExec({
-      stdout: "",
-      stderr: "find: '/nope': No such file or directory",
-      exitCode: 1,
-    });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    await expect(backend.fsList(ctx, { path: "nope" })).rejects.toThrow(
-      /No such file or directory/,
-    );
-  });
-
-  it("omits size for a file with an unparseable size field", async () => {
-    queueExec({ stdout: "f\t?\tweird.txt\n", exitCode: 0 });
-    const backend = new SshSandboxBackend(CONFIG, CREDENTIALS);
-    const res = await backend.fsList(ctx, {});
-    expect(res.entries).toEqual([{ path: "weird.txt", type: "file" }]);
+    expect(lastFindCommand()).toContain(`'find' '${ROOT}/it'\\''s'`);
   });
 });

--- a/apps/backend/src/plugins/ssh/backend.ts
+++ b/apps/backend/src/plugins/ssh/backend.ts
@@ -9,37 +9,30 @@ import { z } from "zod";
 import { logger } from "../../logger.ts";
 import {
   DEFAULT_SHELL_TIMEOUT_MS,
-  MAX_LIST_ENTRIES,
-  MAX_READ_BYTES,
   MAX_SHELL_OUTPUT_BYTES,
-  MAX_SHELL_TIMEOUT_MS,
 } from "../../sandbox/index.ts";
-import type {
-  FsEditInput,
-  FsEditOutput,
-  FsListEntry,
-  FsListInput,
-  FsListOutput,
-  FsReadInput,
-  FsReadOutput,
-  FsWriteInput,
-  FsWriteOutput,
-  SandboxBackend,
-  SandboxContext,
-  ShellExecInput,
-  ShellExecOutput,
-} from "../../sandbox/types.ts";
+import { createPosixSandbox } from "../../sandbox/posix.ts";
+import {
+  createCappedSink,
+  SandboxPathExistsError,
+  type SandboxExecOptions,
+  type SandboxExecResult,
+  type SandboxTransport,
+} from "../../sandbox/transport.ts";
+import type { SandboxBackend, SandboxContext } from "../../sandbox/types.ts";
 
 // The SSH reference Sandbox adapter (ADR-0012). Attaches to a pre-existing,
-// operator-owned host over SSH (public-key auth only) and runs the fixed tool
-// core against it. `shell.exec` runs over the `exec` channel; `fs.read`,
-// `fs.write`, and `fs.edit` run over the SFTP subsystem (the faithful analogue
-// of Docker's `putArchive` writes — literal paths, no shell-injection surface,
-// native `wx`=create / `w`=overwrite). `fs.list` runs over `exec` as a single
-// `find -printf` recursive listing (ADR-0012 rejected a client-side SFTP walk),
-// making it the sole shell-injection surface in `fs.*` — every model-supplied
-// value it interpolates is single-quoted. The adapter never provisions or
-// destroys the machine.
+// operator-owned host over SSH (public-key auth only) and supplies the
+// transport core builds the fixed tool core on.
+//
+// Commands run over the `exec` channel and files over the SFTP subsystem — the
+// faithful analogue of Docker's `putArchive` writes: literal paths, no
+// shell-injection surface, native `wx`=create / `w`=overwrite. `exec` is the
+// one place a shell is involved, because a login shell always is; every argv
+// element and every interpolated value is single-quoted there, which is what
+// lets core hand this transport an unescaped argv like any other.
+//
+// The adapter never provisions or destroys the machine.
 
 const DEFAULT_SSH_PORT = 22;
 // rootDir default (ADR-0012): resolved to `$HOME/platypus-workspace` on the host
@@ -96,14 +89,6 @@ type Connection = {
   sftp: SFTPWrapper | null;
 };
 
-type ExecResult = {
-  stdout: Buffer;
-  stderr: Buffer;
-  exitCode: number;
-  durationMs: number;
-  timedOut: boolean;
-};
-
 // Single-quote a value for safe interpolation into a `/bin/sh` command line.
 // Wraps in single quotes and escapes embedded single quotes with the classic
 // `'\''` idiom. Used for the operator-supplied rootDir and for model-supplied
@@ -129,38 +114,6 @@ function buildEnvPrefix(env: Record<string, string> | undefined): string {
     .filter(([k]) => ENV_KEY_PATTERN.test(k))
     .map(([k, v]) => `export ${k}=${shQuote(v)}; `)
     .join("");
-}
-
-// Cap for `fs.list` find(1) output. Larger than MAX_SHELL_OUTPUT_BYTES because a
-// recursive listing of up to MAX_LIST_ENTRIES rows can exceed the shell-output
-// cap; matches the Docker adapter's 4 MiB list buffer. Node-side truncation to
-// MAX_LIST_ENTRIES is the authoritative bound (this only guards memory).
-const FS_LIST_OUTPUT_CAP = 4 * 1024 * 1024;
-
-// Resolve a workspace-root-relative path to an absolute path on the host. The
-// schema already enforces the path is relative; SFTP takes the result literally,
-// so there is no shell quoting and no injection surface (ADR-0012).
-function absPath(rootDir: string, relative: string): string {
-  return `${rootDir}/${relative.replace(/^\/+/, "")}`;
-}
-
-// Count lines the same way the Docker adapter does: newline count, less one for a
-// trailing newline. Empty content is zero lines.
-function countLines(content: string): number {
-  if (content.length === 0) return 0;
-  let lineCount = content.split("\n").length;
-  if (content.endsWith("\n")) lineCount -= 1;
-  return lineCount;
-}
-
-// Decode a Buffer as strict UTF-8, rejecting non-UTF-8 bytes (matching the
-// Docker adapter, which decodes with `new TextDecoder("utf-8", { fatal: true })`).
-function decodeUtf8Strict(buf: Buffer, tool: string, path: string): string {
-  try {
-    return new TextDecoder("utf-8", { fatal: true }).decode(buf);
-  } catch {
-    throw new Error(`${tool}: file is not valid UTF-8 (${path})`);
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -282,7 +235,13 @@ function parseHostKeyPin(pin: string): Buffer {
   return decoded;
 }
 
-export class SshSandboxBackend implements SandboxBackend {
+/**
+ * The SSH half of the Sandbox: ssh2 `exec` for commands, SFTP for files, and a
+ * self-managed connection with an idle reaper (ADR-0012). The five model-facing
+ * tools are built on top of this by {@link createPosixSandbox} — nothing here
+ * parses find(1), counts lines, or decides what `truncated` means.
+ */
+export class SshSandboxTransport implements SandboxTransport {
   private config: SshSandboxConfig;
   private credentials: SshSandboxCredentials;
   // Single reused connection and its in-flight promise (mirrors the Docker
@@ -449,18 +408,18 @@ export class SshSandboxBackend implements SandboxBackend {
     }
   }
 
-  // Run a single command over `exec`, capping stdout/stderr at `outputCap`
-  // (default MAX_SHELL_OUTPUT_BYTES; fs.list raises it) and enforcing a timeout.
-  // On timeout the channel is closed and exit code 124 is reported (a remote
-  // command may keep running as an orphan — the host is not ours to reap;
-  // ADR-0012).
+  // Run a single command over `exec`, capping each stream independently and
+  // enforcing a timeout. On timeout the channel is closed and exit code 124 is
+  // reported (a remote command may keep running as an orphan — the host is not
+  // ours to reap; ADR-0012).
   private runExec(
     client: Client,
     command: string,
     timeoutMs: number,
-    outputCap: number = MAX_SHELL_OUTPUT_BYTES,
-  ): Promise<ExecResult> {
-    return new Promise<ExecResult>((resolve, reject) => {
+    stdoutCap: number = MAX_SHELL_OUTPUT_BYTES,
+    stderrCap: number = MAX_SHELL_OUTPUT_BYTES,
+  ): Promise<SandboxExecResult> {
+    return new Promise<SandboxExecResult>((resolve, reject) => {
       const started = Date.now();
       client.exec(command, (err: Error | undefined, stream: ClientChannel) => {
         if (err) {
@@ -468,10 +427,8 @@ export class SshSandboxBackend implements SandboxBackend {
           return;
         }
 
-        const stdoutChunks: Buffer[] = [];
-        const stderrChunks: Buffer[] = [];
-        let stdoutBytes = 0;
-        let stderrBytes = 0;
+        const stdoutSink = createCappedSink(stdoutCap);
+        const stderrSink = createCappedSink(stderrCap);
         let exitCode = 0;
         let timedOut = false;
         let settled = false;
@@ -486,24 +443,8 @@ export class SshSandboxBackend implements SandboxBackend {
         }, timeoutMs);
         timer.unref?.();
 
-        const capture = (
-          chunk: Buffer,
-          chunks: Buffer[],
-          bytes: number,
-        ): number => {
-          if (bytes >= outputCap) return bytes;
-          const room = outputCap - bytes;
-          const take = chunk.length <= room ? chunk : chunk.subarray(0, room);
-          chunks.push(take);
-          return bytes + take.length;
-        };
-
-        stream.on("data", (chunk: Buffer) => {
-          stdoutBytes = capture(chunk, stdoutChunks, stdoutBytes);
-        });
-        stream.stderr.on("data", (chunk: Buffer) => {
-          stderrBytes = capture(chunk, stderrChunks, stderrBytes);
-        });
+        stream.on("data", (chunk: Buffer) => stdoutSink.push(chunk));
+        stream.stderr.on("data", (chunk: Buffer) => stderrSink.push(chunk));
         // The exit code arrives on `exit`; `close` fires afterwards and is when
         // we settle. A signal-killed process reports a null code.
         stream.on("exit", (code: number | null) => {
@@ -514,11 +455,10 @@ export class SshSandboxBackend implements SandboxBackend {
           if (settled) return;
           settled = true;
           resolve({
-            stdout: Buffer.concat(stdoutChunks),
-            stderr: Buffer.concat(stderrChunks),
+            stdout: stdoutSink.collect(),
+            stderr: stderrSink.collect(),
             exitCode: timedOut ? 124 : exitCode,
             durationMs: Date.now() - started,
-            timedOut,
           });
         });
         stream.on("error", (streamErr: Error) => {
@@ -531,38 +471,94 @@ export class SshSandboxBackend implements SandboxBackend {
     });
   }
 
-  async shellExec(
-    _ctx: SandboxContext,
-    input: ShellExecInput,
-  ): Promise<ShellExecOutput> {
+  // The workspace root, resolved once per connection against the host's `$HOME`
+  // and created if missing. Also the lazy-connect hook: core calls this first in
+  // every tool, so the connection opens on first use and is reused for the turn.
+  async rootDir(_ctx: SandboxContext): Promise<string> {
     const conn = await this.ensureConnection();
-    const timeoutMs = Math.min(
-      input.timeoutMs ?? DEFAULT_SHELL_TIMEOUT_MS,
-      MAX_SHELL_TIMEOUT_MS,
+    return conn.rootDir;
+  }
+
+  // A login shell always sits between us and the process, so every argv element
+  // is single-quoted before being joined — that shell must not get a say in what
+  // the words are. `cwd` becomes a `cd` prefix (there is no native working
+  // directory over SSH) and the env goes in as `export` statements rather than
+  // ssh2's `env` option, which sshd's `AcceptEnv` rejects by default (ADR-0012).
+  async exec(
+    _ctx: SandboxContext,
+    argv: string[],
+    opts: SandboxExecOptions,
+  ): Promise<SandboxExecResult> {
+    const conn = await this.ensureConnection();
+    const cdPrefix = opts.cwd ? `cd ${shQuote(opts.cwd)} && ` : "";
+    const command = `${cdPrefix}${buildEnvPrefix(opts.env)}${argv
+      .map(shQuote)
+      .join(" ")}`;
+
+    const res = await this.runExec(
+      conn.client,
+      command,
+      opts.timeoutMs,
+      opts.stdoutCap,
+      opts.stderrCap,
     );
-
-    // Honour cwd by prefixing `cd <rootDir>/<cwd> && …` (no native WorkingDir
-    // over SSH). cwd is model input (schema-validated relative); rootDir is
-    // resolved-absolute. Both are single-quoted so neither escapes into shell
-    // syntax. The merged env (ADR-0004) is applied via `export` statements.
-    const cwd = input.cwd ? `${conn.rootDir}/${input.cwd}` : conn.rootDir;
-    const envPrefix = buildEnvPrefix(input.env);
-    const command = `cd ${shQuote(cwd)} && ${envPrefix}${input.command}`;
-
-    const res = await this.runExec(conn.client, command, timeoutMs);
     this.touchIdleTimer();
+    return res;
+  }
 
-    const truncated =
-      res.stdout.length >= MAX_SHELL_OUTPUT_BYTES ||
-      res.stderr.length >= MAX_SHELL_OUTPUT_BYTES;
+  // Read over SFTP: literal paths, no shell, no injection surface. The file is
+  // sized first so only `min(size, cap)` is ever requested — but the size stops
+  // there. Whether a capped read counts as truncated is core's single rule, not
+  // this adapter's to answer better than the Docker one can.
+  async readFile(
+    _ctx: SandboxContext,
+    absPath: string,
+    cap: number,
+  ): Promise<Buffer> {
+    const conn = await this.ensureConnection();
+    const sftp = await this.getSftp(conn);
 
-    return {
-      stdout: res.stdout.toString("utf8"),
-      stderr: res.stderr.toString("utf8"),
-      exitCode: res.exitCode,
-      truncated,
-      durationMs: res.durationMs,
-    };
+    const handle = await sftpOpen(sftp, absPath, "r");
+    try {
+      const size = await sftpFstatSize(sftp, handle);
+      return await sftpReadCapped(sftp, handle, Math.min(size, cap));
+    } finally {
+      await sftpClose(sftp, handle);
+      this.touchIdleTimer();
+    }
+  }
+
+  // Write over SFTP. `wx` fails atomically when the path is taken — a native
+  // create with no racy stat/open window — and `w` truncates-or-creates.
+  async writeFile(
+    _ctx: SandboxContext,
+    absPath: string,
+    bytes: Buffer,
+    mode: "create" | "overwrite",
+  ): Promise<void> {
+    const conn = await this.ensureConnection();
+    const sftp = await this.getSftp(conn);
+
+    await this.ensureParentDirs(sftp, conn.rootDir, absPath);
+
+    let handle: Buffer;
+    try {
+      handle = await sftpOpen(sftp, absPath, mode === "create" ? "wx" : "w");
+    } catch (cause) {
+      // `wx` fails for more than just a collision (permissions, a missing
+      // parent), so confirm which it was rather than reporting them alike.
+      if (mode === "create" && (await sftpStatExists(sftp, absPath))) {
+        throw new SandboxPathExistsError(absPath, { cause });
+      }
+      throw cause;
+    }
+
+    try {
+      await sftpWriteAll(sftp, handle, bytes);
+    } finally {
+      await sftpClose(sftp, handle);
+      this.touchIdleTimer();
+    }
   }
 
   // Open the SFTP subsystem lazily and reuse it for the rest of the turn. It
@@ -582,20 +578,23 @@ export class SshSandboxBackend implements SandboxBackend {
     });
   }
 
-  // `mkdir -p` the parent directories of a workspace-relative file path over
-  // SFTP (which has no recursive mkdir). Each segment is stat-probed first and
-  // created only if absent; the workspace root itself already exists. Literal
-  // paths throughout — no shell.
+  // `mkdir -p` the parent directories of a file over SFTP, which has no
+  // recursive mkdir. Each segment is stat-probed and created only if absent.
+  // The walk starts at the workspace root and never climbs above it: everything
+  // above is the host's, not ours to create. Literal paths throughout, no shell.
   private async ensureParentDirs(
     sftp: SFTPWrapper,
     rootDir: string,
-    relative: string,
+    absPath: string,
   ): Promise<void> {
-    const cleaned = relative.replace(/^\/+/, "");
-    const idx = cleaned.lastIndexOf("/");
-    if (idx === -1) return; // top-level file — parent is the (existing) root
-    const segments = cleaned
-      .slice(0, idx)
+    const idx = absPath.lastIndexOf("/");
+    if (idx === -1) return;
+    const parent = absPath.slice(0, idx);
+    // The root itself always exists — it was created at connect time.
+    if (!parent.startsWith(`${rootDir}/`)) return;
+
+    const segments = parent
+      .slice(rootDir.length + 1)
       .split("/")
       .filter((s) => s.length > 0);
     let dir = rootDir;
@@ -607,219 +606,6 @@ export class SshSandboxBackend implements SandboxBackend {
     }
   }
 
-  async fsRead(
-    _ctx: SandboxContext,
-    input: FsReadInput,
-  ): Promise<FsReadOutput> {
-    const conn = await this.ensureConnection();
-    const sftp = await this.getSftp(conn);
-    const target = absPath(conn.rootDir, input.path);
-
-    // Open, size, and read at most MAX_READ_BYTES. Reading min(size, cap) keeps
-    // memory bounded and makes `truncated` use the same `>=` convention as the
-    // Docker adapter (a file exactly at the cap reads `cap` bytes → truncated).
-    const handle = await sftpOpen(sftp, target, "r");
-    let raw: Buffer;
-    try {
-      const size = await sftpFstatSize(sftp, handle);
-      const readLen = Math.min(size, MAX_READ_BYTES);
-      raw = await sftpReadCapped(sftp, handle, readLen);
-    } finally {
-      await sftpClose(sftp, handle);
-    }
-    this.touchIdleTimer();
-
-    const truncated = raw.length >= MAX_READ_BYTES;
-    let content = decodeUtf8Strict(raw, "fs.read", input.path);
-
-    // Optional line window. SFTP has no server-side `sed`, so we slice the
-    // (already byte-capped) content in Node — each selected line is emitted with
-    // a trailing newline, matching `sed -n 'a,bp'`. Caveat: for a file larger
-    // than MAX_READ_BYTES the byte cap is hit before late lines are reached.
-    if (input.lineRange) {
-      const [start, end] = input.lineRange;
-      const body = content.endsWith("\n") ? content.slice(0, -1) : content;
-      const lines = body.length === 0 ? [] : body.split("\n");
-      content = lines
-        .slice(start - 1, end)
-        .map((line) => `${line}\n`)
-        .join("");
-    }
-
-    return { content, lineCount: countLines(content), truncated };
-  }
-
-  async fsWrite(
-    _ctx: SandboxContext,
-    input: FsWriteInput,
-  ): Promise<FsWriteOutput> {
-    const conn = await this.ensureConnection();
-    const sftp = await this.getSftp(conn);
-    const target = absPath(conn.rootDir, input.path);
-
-    await this.ensureParentDirs(sftp, conn.rootDir, input.path);
-
-    // `wx` fails atomically if the file exists (native create — no racy stat/open
-    // window); `w` truncates-or-creates for overwrite (ADR-0012).
-    const flag: OpenMode = input.mode === "create" ? "wx" : "w";
-    const contentBuf = Buffer.from(input.content, "utf8");
-
-    let handle: Buffer;
-    try {
-      handle = await sftpOpen(sftp, target, flag);
-    } catch (err) {
-      // Disambiguate the expected create-collision from a genuine open error
-      // (e.g. permissions) by checking existence after the fact.
-      if (input.mode === "create" && (await sftpStatExists(sftp, target))) {
-        throw new Error(
-          `fs.write: path already exists (mode=create): ${input.path}`,
-          { cause: err },
-        );
-      }
-      throw err;
-    }
-    try {
-      await sftpWriteAll(sftp, handle, contentBuf);
-    } finally {
-      await sftpClose(sftp, handle);
-    }
-    this.touchIdleTimer();
-
-    return { bytesWritten: contentBuf.length };
-  }
-
-  async fsEdit(
-    _ctx: SandboxContext,
-    input: FsEditInput,
-  ): Promise<FsEditOutput> {
-    const conn = await this.ensureConnection();
-    const sftp = await this.getSftp(conn);
-    const target = absPath(conn.rootDir, input.path);
-
-    // Read (capped, matching the Docker adapter), replace a unique occurrence,
-    // then overwrite. Same capped-read caveat as fs.read for very large files.
-    const readHandle = await sftpOpen(sftp, target, "r");
-    let raw: Buffer;
-    try {
-      const size = await sftpFstatSize(sftp, readHandle);
-      raw = await sftpReadCapped(
-        sftp,
-        readHandle,
-        Math.min(size, MAX_READ_BYTES),
-      );
-    } finally {
-      await sftpClose(sftp, readHandle);
-    }
-
-    const original = decodeUtf8Strict(raw, "fs.edit", input.path);
-    const first = original.indexOf(input.oldString);
-    if (first === -1) {
-      throw new Error(`fs.edit: oldString not found in ${input.path}`);
-    }
-    const second = original.indexOf(input.oldString, first + 1);
-    if (second !== -1) {
-      throw new Error(`fs.edit: oldString is not unique in ${input.path}`);
-    }
-
-    const updated =
-      original.slice(0, first) +
-      input.newString +
-      original.slice(first + input.oldString.length);
-
-    const writeHandle = await sftpOpen(sftp, target, "w");
-    try {
-      await sftpWriteAll(sftp, writeHandle, Buffer.from(updated, "utf8"));
-    } finally {
-      await sftpClose(sftp, writeHandle);
-    }
-    this.touchIdleTimer();
-
-    return { replacements: 1 };
-  }
-
-  // List directory entries via a single `find -printf` over `exec` (ADR-0012:
-  // one round-trip recursive listing, vs a per-directory SFTP walk). This is the
-  // only shell-injection surface in fs.*, so both model-supplied values that
-  // reach the command line — the list path and the glob — are single-quoted.
-  async fsList(
-    _ctx: SandboxContext,
-    input: FsListInput,
-  ): Promise<FsListOutput> {
-    const conn = await this.ensureConnection();
-    const target = input.path
-      ? absPath(conn.rootDir, input.path)
-      : conn.rootDir;
-
-    // Node-side truncation (below) is authoritative; `find` is not `| head`ed.
-    const parts = ["find", shQuote(target)];
-    if (!input.recursive) parts.push("-maxdepth", "1");
-    parts.push("-mindepth", "1");
-    if (input.glob) {
-      // -name matches a bare file-name glob; -path matches a pattern that
-      // contains a slash or `**`. `**` collapses to `*` for find(1) — a lossy
-      // but pragmatic translation (documented in the tool description), matching
-      // the Docker adapter. Single-quoting also stops the login shell from
-      // expanding the glob before find sees it, so find(1) does the matching.
-      if (input.glob.includes("/") || input.glob.includes("**")) {
-        parts.push("-path", shQuote(`*/${input.glob.replace(/\*\*/g, "*")}`));
-      } else {
-        parts.push("-name", shQuote(input.glob));
-      }
-    }
-    // Single-quoted so find receives the `\t`/`\n` escapes literally and
-    // interprets them itself (rather than the shell mangling them).
-    parts.push("-printf", `'%y\\t%s\\t%P\\n'`);
-    const command = parts.join(" ");
-
-    const res = await this.runExec(
-      conn.client,
-      command,
-      DEFAULT_SHELL_TIMEOUT_MS,
-      FS_LIST_OUTPUT_CAP,
-    );
-    this.touchIdleTimer();
-
-    // find exits non-zero on partial errors (e.g. an unreadable subdirectory)
-    // while still printing what it could — only fail hard when nothing came out.
-    if (res.exitCode !== 0 && res.stdout.length === 0) {
-      const detail = res.stderr.toString("utf8").trim() || "fs.list failed";
-      throw new Error(`fs.list: ${detail}`);
-    }
-
-    const lines = res.stdout
-      .toString("utf8")
-      .split("\n")
-      .filter((l) => l.length > 0);
-
-    const entries: FsListEntry[] = [];
-    let truncated = false;
-    for (const line of lines) {
-      const tab1 = line.indexOf("\t");
-      const tab2 = line.indexOf("\t", tab1 + 1);
-      if (tab1 === -1 || tab2 === -1) continue;
-      const typeChar = line.slice(0, tab1);
-      const sizeStr = line.slice(tab1 + 1, tab2);
-      const path = line.slice(tab2 + 1);
-      let type: "file" | "dir";
-      if (typeChar === "f") type = "file";
-      else if (typeChar === "d") type = "dir";
-      else continue; // ignore symlinks / sockets / devices in v1
-      const size = Number.parseInt(sizeStr, 10);
-      entries.push({
-        path,
-        type,
-        ...(Number.isFinite(size) ? { size } : {}),
-      });
-      if (entries.length >= MAX_LIST_ENTRIES) {
-        // Mark truncated only if find emitted more rows than we kept.
-        truncated = entries.length < lines.length;
-        break;
-      }
-    }
-
-    return { entries, truncated };
-  }
-
   // destroy() is a no-op beyond disconnecting (ADR-0012): the host is not
   // Platypus-owned, so we never mutate its filesystem. Just tear down our
   // connection so no socket or idle timer leaks.
@@ -828,3 +614,14 @@ export class SshSandboxBackend implements SandboxBackend {
     return Promise.resolve();
   }
 }
+
+/**
+ * The SSH Sandbox backend: this plugin's transport under core's fixed five-tool
+ * core. What the model sees comes from {@link createPosixSandbox}, so this
+ * adapter cannot drift from the Docker one on anything but the transport.
+ */
+export const createSshSandboxBackend = (
+  config: SshSandboxConfig,
+  credentials: SshSandboxCredentials,
+): SandboxBackend =>
+  createPosixSandbox(new SshSandboxTransport(config, credentials));

--- a/apps/backend/src/plugins/ssh/index.ts
+++ b/apps/backend/src/plugins/ssh/index.ts
@@ -4,7 +4,7 @@ import type {
 } from "@platypuschat/plugin-sdk";
 import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
 import {
-  SshSandboxBackend,
+  createSshSandboxBackend,
   sshSandboxConfigSchema,
   sshSandboxCredentialsSchema,
   type SshSandboxConfig,
@@ -28,7 +28,7 @@ const sshBackend: SandboxBackendContribution<
   name: "SSH (Remote Host)",
   configSchema: sshSandboxConfigSchema,
   credentialsSchema: sshSandboxCredentialsSchema,
-  create: (config, credentials) => new SshSandboxBackend(config, credentials),
+  create: (config, credentials) => createSshSandboxBackend(config, credentials),
 };
 
 export const plugin: PlatypusPlugin = {

--- a/apps/backend/src/sandbox/index.ts
+++ b/apps/backend/src/sandbox/index.ts
@@ -1,15 +1,23 @@
 import { createContributionRegistry } from "../registry/contribution-registry.ts";
 import type { SandboxBackendRegistration } from "./types.ts";
 
-// Output bounds, fixed by Platypus and identical across all adapters. Adapters
-// that can't honour these natively MUST truncate themselves and set the
-// `truncated` flag in their response. See ADR-0002.
+// Output bounds, fixed by Platypus and identical across all adapters (ADR-0002).
+// An adapter built on `createPosixSandbox` gets these applied for it — core
+// passes the caps down and sets `truncated` itself. One implementing
+// `SandboxBackend` directly MUST truncate to them and set the flag on its own.
 export const MAX_SHELL_OUTPUT_BYTES = 100_000;
 export const MAX_READ_BYTES = 1_000_000;
 export const MAX_LIST_ENTRIES = 1_000;
 
-// shell.exec timeouts. The hard cap is enforced both by the input schema and
-// by adapters; the default applies when the caller omits timeoutMs.
+// Byte cap on the raw `find` output behind `fs.list`. Larger than
+// MAX_SHELL_OUTPUT_BYTES because a recursive listing of up to MAX_LIST_ENTRIES
+// rows legitimately exceeds the shell-output cap. This only bounds memory —
+// truncation to MAX_LIST_ENTRIES is the authoritative limit.
+export const MAX_LIST_OUTPUT_BYTES = 4 * 1024 * 1024;
+
+// shell.exec timeouts. The input schema bounds what a model may ask for and
+// `createPosixSandbox` clamps what an adapter will actually wait for; the
+// default applies when the caller omits timeoutMs.
 export const DEFAULT_SHELL_TIMEOUT_MS = 60_000;
 export const MAX_SHELL_TIMEOUT_MS = 600_000;
 

--- a/apps/backend/src/sandbox/posix.test.ts
+++ b/apps/backend/src/sandbox/posix.test.ts
@@ -1,0 +1,777 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  DEFAULT_SHELL_TIMEOUT_MS,
+  MAX_LIST_ENTRIES,
+  MAX_LIST_OUTPUT_BYTES,
+  MAX_READ_BYTES,
+  MAX_SHELL_OUTPUT_BYTES,
+  MAX_SHELL_TIMEOUT_MS,
+} from "./index.ts";
+import { buildFindArgs, createPosixSandbox, parseFindOutput } from "./posix.ts";
+import {
+  SandboxPathExistsError,
+  type SandboxExecOptions,
+  type SandboxExecResult,
+  type SandboxTransport,
+} from "./transport.ts";
+import type { SandboxContext } from "./types.ts";
+
+// The Sandbox contract, proved once against an in-memory transport. This is the
+// suite that used to exist twice — against a dockerode fake and an ssh2 fake —
+// re-proving the same rules through two sets of plumbing. Every adapter that
+// goes through `createPosixSandbox` inherits what is asserted here, so an
+// adapter's own suite is free to test only that it drives its client correctly.
+//
+// No Docker daemon and no SSH host: the transport is five functions.
+
+const ctx: SandboxContext = {
+  orgId: "org-1",
+  workspaceId: "ws-abc",
+  userId: "user-1",
+};
+
+const ROOT = "/workspace";
+
+type ExecCall = { argv: string[]; opts: SandboxExecOptions };
+
+// A transport whose every primitive is steerable, recording what it was asked
+// to do. Files live in a plain map keyed by absolute path.
+const makeTransport = (
+  overrides: Partial<{
+    rootDir: string;
+    exec: (
+      argv: string[],
+      opts: SandboxExecOptions,
+    ) => Partial<SandboxExecResult>;
+    files: Map<string, Buffer>;
+  }> = {},
+) => {
+  const execCalls: ExecCall[] = [];
+  const writes: Array<{
+    path: string;
+    bytes: Buffer;
+    mode: "create" | "overwrite";
+  }> = [];
+  const files = overrides.files ?? new Map<string, Buffer>();
+  const destroyed: SandboxContext[] = [];
+  const rootDirCalls: SandboxContext[] = [];
+
+  const transport: SandboxTransport = {
+    rootDir: (c) => {
+      rootDirCalls.push(c);
+      return Promise.resolve(overrides.rootDir ?? ROOT);
+    },
+    exec: (_c, argv, opts) => {
+      execCalls.push({ argv, opts });
+      const result = overrides.exec?.(argv, opts) ?? {};
+      return Promise.resolve({
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        exitCode: 0,
+        durationMs: 1,
+        ...result,
+      });
+    },
+    readFile: (_c, absPath, cap) => {
+      const found = files.get(absPath);
+      if (!found) {
+        return Promise.reject(new Error(`No such file: ${absPath}`));
+      }
+      // Bytes only — the cap is applied, but whether that counts as truncated
+      // is core's to decide, which is exactly what these tests check.
+      return Promise.resolve(found.subarray(0, cap));
+    },
+    writeFile: (_c, absPath, bytes, mode) => {
+      if (mode === "create" && files.has(absPath)) {
+        return Promise.reject(new SandboxPathExistsError(absPath));
+      }
+      writes.push({ path: absPath, bytes, mode });
+      files.set(absPath, bytes);
+      return Promise.resolve();
+    },
+    destroy: (c) => {
+      destroyed.push(c);
+      return Promise.resolve();
+    },
+  };
+
+  return { transport, execCalls, writes, files, destroyed, rootDirCalls };
+};
+
+const findOutput = (
+  rows: Array<[type: string, size: string | number, path: string]>,
+): Buffer =>
+  Buffer.from(rows.map(([t, s, p]) => `${t}\t${s}\t${p}`).join("\n") + "\n");
+
+describe("createPosixSandbox — shell.exec", () => {
+  it("runs the command under /bin/sh -c in the workspace root", async () => {
+    const { transport, execCalls } = makeTransport();
+    await createPosixSandbox(transport).shellExec(ctx, { command: "ls -la" });
+
+    expect(execCalls).toHaveLength(1);
+    expect(execCalls[0].argv).toEqual(["/bin/sh", "-c", "ls -la"]);
+    expect(execCalls[0].opts.cwd).toBe(ROOT);
+  });
+
+  it("resolves cwd against the transport's root", async () => {
+    const { transport, execCalls } = makeTransport({ rootDir: "/srv/agent" });
+    await createPosixSandbox(transport).shellExec(ctx, {
+      command: "ls",
+      cwd: "sub/dir",
+    });
+
+    expect(execCalls[0].opts.cwd).toBe("/srv/agent/sub/dir");
+  });
+
+  it("passes the caller's env through untouched", async () => {
+    const { transport, execCalls } = makeTransport();
+    await createPosixSandbox(transport).shellExec(ctx, {
+      command: "env",
+      env: { FOO: "bar" },
+    });
+
+    expect(execCalls[0].opts.env).toEqual({ FOO: "bar" });
+  });
+
+  it("returns the transport's streams, exit code and duration", async () => {
+    const { transport } = makeTransport({
+      exec: () => ({
+        stdout: Buffer.from("out"),
+        stderr: Buffer.from("err"),
+        exitCode: 3,
+        durationMs: 42,
+      }),
+    });
+
+    await expect(
+      createPosixSandbox(transport).shellExec(ctx, { command: "x" }),
+    ).resolves.toEqual({
+      stdout: "out",
+      stderr: "err",
+      exitCode: 3,
+      truncated: false,
+      durationMs: 42,
+    });
+  });
+
+  it("defaults the timeout and caps output at the Platypus bounds", async () => {
+    const { transport, execCalls } = makeTransport();
+    await createPosixSandbox(transport).shellExec(ctx, { command: "x" });
+
+    expect(execCalls[0].opts).toMatchObject({
+      timeoutMs: DEFAULT_SHELL_TIMEOUT_MS,
+      stdoutCap: MAX_SHELL_OUTPUT_BYTES,
+      stderrCap: MAX_SHELL_OUTPUT_BYTES,
+    });
+  });
+
+  it("honours a caller timeout below the maximum", async () => {
+    const { transport, execCalls } = makeTransport();
+    await createPosixSandbox(transport).shellExec(ctx, {
+      command: "x",
+      timeoutMs: 5_000,
+    });
+
+    expect(execCalls[0].opts.timeoutMs).toBe(5_000);
+  });
+
+  it("clamps a caller timeout above the maximum", async () => {
+    // The bound is core's, so no adapter can be talked into waiting longer —
+    // this is the clamp both adapters used to hold a private copy of.
+    const { transport, execCalls } = makeTransport();
+    await createPosixSandbox(transport).shellExec(ctx, {
+      command: "x",
+      timeoutMs: MAX_SHELL_TIMEOUT_MS + 60_000,
+    });
+
+    expect(execCalls[0].opts.timeoutMs).toBe(MAX_SHELL_TIMEOUT_MS);
+  });
+
+  it("flags truncated when stdout sits on the cap", async () => {
+    const { transport } = makeTransport({
+      exec: () => ({ stdout: Buffer.alloc(MAX_SHELL_OUTPUT_BYTES, 0x61) }),
+    });
+
+    const res = await createPosixSandbox(transport).shellExec(ctx, {
+      command: "x",
+    });
+    expect(res.stdout).toHaveLength(MAX_SHELL_OUTPUT_BYTES);
+    expect(res.truncated).toBe(true);
+  });
+
+  it("flags truncated when only stderr sits on the cap", async () => {
+    const { transport } = makeTransport({
+      exec: () => ({ stderr: Buffer.alloc(MAX_SHELL_OUTPUT_BYTES, 0x61) }),
+    });
+
+    await expect(
+      createPosixSandbox(transport).shellExec(ctx, { command: "x" }),
+    ).resolves.toMatchObject({ truncated: true });
+  });
+
+  it("reports a timed-out command's exit code rather than throwing", async () => {
+    const { transport } = makeTransport({
+      exec: () => ({ exitCode: 124 }),
+    });
+
+    await expect(
+      createPosixSandbox(transport).shellExec(ctx, { command: "sleep 999" }),
+    ).resolves.toMatchObject({ exitCode: 124 });
+  });
+});
+
+describe("createPosixSandbox — fs.read", () => {
+  const withFile = (content: string, path = `${ROOT}/notes.txt`) =>
+    makeTransport({ files: new Map([[path, Buffer.from(content)]]) });
+
+  it("reads a file, counting its lines", async () => {
+    const { transport } = withFile("one\ntwo\nthree\n");
+
+    await expect(
+      createPosixSandbox(transport).fsRead(ctx, { path: "notes.txt" }),
+    ).resolves.toEqual({
+      content: "one\ntwo\nthree\n",
+      lineCount: 3,
+      truncated: false,
+    });
+  });
+
+  it("counts a trailing line with no newline", async () => {
+    const { transport } = withFile("a\nb\nc");
+
+    await expect(
+      createPosixSandbox(transport).fsRead(ctx, { path: "notes.txt" }),
+    ).resolves.toMatchObject({ lineCount: 3 });
+  });
+
+  it("reads an empty file as zero lines", async () => {
+    const { transport } = withFile("");
+
+    await expect(
+      createPosixSandbox(transport).fsRead(ctx, { path: "notes.txt" }),
+    ).resolves.toEqual({ content: "", lineCount: 0, truncated: false });
+  });
+
+  it("asks the transport for at most MAX_READ_BYTES", async () => {
+    const files = new Map([[`${ROOT}/big.txt`, Buffer.alloc(10, 0x61)]]);
+    const { transport } = makeTransport({ files });
+    const spy = vi.spyOn(transport, "readFile");
+
+    await createPosixSandbox(transport).fsRead(ctx, { path: "big.txt" });
+
+    expect(spy).toHaveBeenCalledWith(ctx, `${ROOT}/big.txt`, MAX_READ_BYTES);
+  });
+
+  it("flags truncated when the read came back filling the cap", async () => {
+    // Core owns this verdict, from the one `>= cap` rule it applies to every
+    // adapter. Leaving it to the transport is how the two adapters used to
+    // disagree about a file sitting exactly on the cap.
+    const { transport } = makeTransport({
+      files: new Map([
+        [`${ROOT}/big.txt`, Buffer.alloc(MAX_READ_BYTES + 100, 0x61)],
+      ]),
+    });
+
+    const res = await createPosixSandbox(transport).fsRead(ctx, {
+      path: "big.txt",
+    });
+    expect(res.content).toHaveLength(MAX_READ_BYTES);
+    expect(res.truncated).toBe(true);
+  });
+
+  it("does not flag a short read as truncated", async () => {
+    const { transport } = makeTransport({
+      files: new Map([[`${ROOT}/small.txt`, Buffer.from("abc")]]),
+    });
+
+    await expect(
+      createPosixSandbox(transport).fsRead(ctx, { path: "small.txt" }),
+    ).resolves.toMatchObject({ truncated: false });
+  });
+
+  it("rejects a file that is not valid UTF-8", async () => {
+    const { transport } = makeTransport({
+      files: new Map([[`${ROOT}/bin.dat`, Buffer.from([0xff, 0xfe, 0xff])]]),
+    });
+
+    await expect(
+      createPosixSandbox(transport).fsRead(ctx, { path: "bin.dat" }),
+    ).rejects.toThrow(/fs\.read: file is not valid UTF-8 \(bin\.dat\)/);
+  });
+
+  it("slices the requested line window, re-counting the slice", async () => {
+    const { transport } = withFile("one\ntwo\nthree\nfour\nfive\n");
+
+    await expect(
+      createPosixSandbox(transport).fsRead(ctx, {
+        path: "notes.txt",
+        lineRange: [2, 4],
+      }),
+    ).resolves.toEqual({
+      content: "two\nthree\nfour\n",
+      lineCount: 3,
+      truncated: false,
+    });
+  });
+
+  it("attributes a transport read failure to fs.read", async () => {
+    const { transport } = makeTransport();
+
+    await expect(
+      createPosixSandbox(transport).fsRead(ctx, { path: "missing.txt" }),
+    ).rejects.toThrow(/^fs\.read: No such file: \/workspace\/missing\.txt$/);
+  });
+});
+
+describe("createPosixSandbox — fs.write", () => {
+  it("writes UTF-8 bytes at the resolved path and reports the byte count", async () => {
+    const { transport, writes } = makeTransport();
+
+    await expect(
+      createPosixSandbox(transport).fsWrite(ctx, {
+        path: "a/b.txt",
+        content: "hello",
+        mode: "create",
+      }),
+    ).resolves.toEqual({ bytesWritten: 5 });
+
+    expect(writes[0]).toMatchObject({
+      path: `${ROOT}/a/b.txt`,
+      mode: "create",
+    });
+    expect(writes[0].bytes.toString("utf8")).toBe("hello");
+  });
+
+  it("counts bytes, not characters", async () => {
+    const { transport } = makeTransport();
+
+    await expect(
+      createPosixSandbox(transport).fsWrite(ctx, {
+        path: "e.txt",
+        content: "héllo 👋",
+        mode: "overwrite",
+      }),
+    ).resolves.toEqual({ bytesWritten: Buffer.byteLength("héllo 👋", "utf8") });
+  });
+
+  it("writes zero-length content", async () => {
+    const { transport } = makeTransport();
+
+    await expect(
+      createPosixSandbox(transport).fsWrite(ctx, {
+        path: "empty.txt",
+        content: "",
+        mode: "create",
+      }),
+    ).resolves.toEqual({ bytesWritten: 0 });
+  });
+
+  it("restates a create-collision in terms of the path the model asked for", async () => {
+    // The transport only ever sees the absolute path; the model asked about a
+    // relative one, and that is what the message has to name.
+    const { transport } = makeTransport({
+      files: new Map([[`${ROOT}/taken.txt`, Buffer.from("old")]]),
+    });
+
+    await expect(
+      createPosixSandbox(transport).fsWrite(ctx, {
+        path: "taken.txt",
+        content: "new",
+        mode: "create",
+      }),
+    ).rejects.toThrow("fs.write: path already exists (mode=create): taken.txt");
+  });
+
+  it("lets an unrelated write failure through untranslated", async () => {
+    const { transport } = makeTransport();
+    vi.spyOn(transport, "writeFile").mockRejectedValue(
+      new Error("Permission denied"),
+    );
+
+    await expect(
+      createPosixSandbox(transport).fsWrite(ctx, {
+        path: "x.txt",
+        content: "y",
+        mode: "overwrite",
+      }),
+    ).rejects.toThrow(/^Permission denied$/);
+  });
+
+  it("overwrites an existing file without complaint", async () => {
+    const { transport, files } = makeTransport({
+      files: new Map([[`${ROOT}/taken.txt`, Buffer.from("old")]]),
+    });
+
+    await createPosixSandbox(transport).fsWrite(ctx, {
+      path: "taken.txt",
+      content: "new",
+      mode: "overwrite",
+    });
+
+    expect(files.get(`${ROOT}/taken.txt`)?.toString("utf8")).toBe("new");
+  });
+});
+
+describe("createPosixSandbox — fs.edit", () => {
+  const withFile = (content: string) =>
+    makeTransport({
+      files: new Map([[`${ROOT}/code.ts`, Buffer.from(content)]]),
+    });
+
+  it("replaces the single occurrence and writes it back", async () => {
+    const { transport, files } = withFile("const a = 1;\nconst b = 2;\n");
+
+    await expect(
+      createPosixSandbox(transport).fsEdit(ctx, {
+        path: "code.ts",
+        oldString: "const b = 2;",
+        newString: "const b = 99;",
+      }),
+    ).resolves.toEqual({ replacements: 1 });
+
+    expect(files.get(`${ROOT}/code.ts`)?.toString("utf8")).toBe(
+      "const a = 1;\nconst b = 99;\n",
+    );
+  });
+
+  it("writes the edit back as an overwrite", async () => {
+    const { transport, writes } = withFile("x");
+
+    await createPosixSandbox(transport).fsEdit(ctx, {
+      path: "code.ts",
+      oldString: "x",
+      newString: "y",
+    });
+
+    expect(writes[0]).toMatchObject({
+      path: `${ROOT}/code.ts`,
+      mode: "overwrite",
+    });
+  });
+
+  it("rejects when oldString is absent, leaving the file alone", async () => {
+    const { transport, writes } = withFile("hello");
+
+    await expect(
+      createPosixSandbox(transport).fsEdit(ctx, {
+        path: "code.ts",
+        oldString: "nope",
+        newString: "y",
+      }),
+    ).rejects.toThrow("fs.edit: oldString not found in code.ts");
+    expect(writes).toHaveLength(0);
+  });
+
+  it("rejects when oldString is not unique, leaving the file alone", async () => {
+    const { transport, writes } = withFile("abc abc");
+
+    await expect(
+      createPosixSandbox(transport).fsEdit(ctx, {
+        path: "code.ts",
+        oldString: "abc",
+        newString: "z",
+      }),
+    ).rejects.toThrow("fs.edit: oldString is not unique in code.ts");
+    expect(writes).toHaveLength(0);
+  });
+
+  it("allows an empty newString (a deletion)", async () => {
+    const { transport, files } = withFile("keep DROP keep");
+
+    await createPosixSandbox(transport).fsEdit(ctx, {
+      path: "code.ts",
+      oldString: " DROP",
+      newString: "",
+    });
+
+    expect(files.get(`${ROOT}/code.ts`)?.toString("utf8")).toBe("keep keep");
+  });
+
+  it("rejects a file that is not valid UTF-8", async () => {
+    const { transport } = makeTransport({
+      files: new Map([[`${ROOT}/bin.dat`, Buffer.from([0xff, 0xfe])]]),
+    });
+
+    await expect(
+      createPosixSandbox(transport).fsEdit(ctx, {
+        path: "bin.dat",
+        oldString: "a",
+        newString: "b",
+      }),
+    ).rejects.toThrow(/fs\.edit: file is not valid UTF-8/);
+  });
+
+  it("attributes a transport read failure to fs.edit", async () => {
+    const { transport } = makeTransport();
+
+    await expect(
+      createPosixSandbox(transport).fsEdit(ctx, {
+        path: "missing.txt",
+        oldString: "a",
+        newString: "b",
+      }),
+    ).rejects.toThrow(/^fs\.edit: No such file/);
+  });
+});
+
+describe("buildFindArgs", () => {
+  it("lists one level by default", () => {
+    expect(buildFindArgs("/workspace", {})).toEqual([
+      "find",
+      "/workspace",
+      "-maxdepth",
+      "1",
+      "-mindepth",
+      "1",
+      "-printf",
+      "%y\\t%s\\t%P\\n",
+    ]);
+  });
+
+  it("drops -maxdepth when recursive", () => {
+    expect(buildFindArgs("/workspace", { recursive: true })).not.toContain(
+      "-maxdepth",
+    );
+  });
+
+  it("matches a bare glob with -name", () => {
+    const args = buildFindArgs("/workspace", { glob: "*.ts" });
+    expect(args[args.indexOf("-name") + 1]).toBe("*.ts");
+    expect(args).not.toContain("-path");
+  });
+
+  it("matches a slashed glob with -path", () => {
+    const args = buildFindArgs("/workspace", { glob: "src/*.ts" });
+    expect(args[args.indexOf("-path") + 1]).toBe("*/src/*.ts");
+  });
+
+  it("collapses ** to a single * for find(1)", () => {
+    const args = buildFindArgs("/workspace", { glob: "**/*.ts" });
+    expect(args[args.indexOf("-path") + 1]).toBe("*/*/*.ts");
+  });
+
+  it("leaves every element unquoted — quoting is the transport's job", () => {
+    const args = buildFindArgs("/workspace/it's", { glob: "*.ts" });
+    expect(args).toContain("/workspace/it's");
+  });
+});
+
+describe("parseFindOutput", () => {
+  it("parses type, size and path", () => {
+    expect(
+      parseFindOutput(
+        findOutput([
+          ["f", 12, "a.txt"],
+          ["d", 4096, "sub"],
+        ]).toString("utf8"),
+      ),
+    ).toEqual({
+      entries: [
+        { path: "a.txt", type: "file", size: 12 },
+        { path: "sub", type: "dir", size: 4096 },
+      ],
+      truncated: false,
+    });
+  });
+
+  it("drops entries that are neither file nor dir", () => {
+    const { entries } = parseFindOutput(
+      findOutput([
+        ["f", 1, "real.txt"],
+        ["l", 7, "link"],
+        ["s", 0, "sock"],
+        ["c", 0, "dev"],
+      ]).toString("utf8"),
+    );
+    expect(entries).toEqual([{ path: "real.txt", type: "file", size: 1 }]);
+  });
+
+  it("omits size when find printed something unparseable", () => {
+    const { entries } = parseFindOutput(
+      findOutput([["f", "?", "weird.txt"]]).toString("utf8"),
+    );
+    expect(entries).toEqual([{ path: "weird.txt", type: "file" }]);
+  });
+
+  it("returns nothing for empty output", () => {
+    expect(parseFindOutput("")).toEqual({ entries: [], truncated: false });
+  });
+
+  it("skips malformed rows rather than failing the listing", () => {
+    const { entries } = parseFindOutput("f\t1\tgood.txt\nnot-a-row\n");
+    expect(entries).toEqual([{ path: "good.txt", type: "file", size: 1 }]);
+  });
+
+  it("keeps a path containing tabs beyond the second separator", () => {
+    const { entries } = parseFindOutput("f\t1\thas\ttab.txt\n");
+    expect(entries).toEqual([{ path: "has\ttab.txt", type: "file", size: 1 }]);
+  });
+
+  it("caps at MAX_LIST_ENTRIES and flags truncated", () => {
+    const rows = Array.from(
+      { length: MAX_LIST_ENTRIES + 5 },
+      (_, i) => ["f", 1, `f${i}.txt`] as [string, number, string],
+    );
+    const out = parseFindOutput(findOutput(rows).toString("utf8"));
+
+    expect(out.entries).toHaveLength(MAX_LIST_ENTRIES);
+    expect(out.truncated).toBe(true);
+  });
+
+  it("does not flag truncated at exactly MAX_LIST_ENTRIES", () => {
+    const rows = Array.from(
+      { length: MAX_LIST_ENTRIES },
+      (_, i) => ["f", 1, `f${i}.txt`] as [string, number, string],
+    );
+    const out = parseFindOutput(findOutput(rows).toString("utf8"));
+
+    expect(out.entries).toHaveLength(MAX_LIST_ENTRIES);
+    expect(out.truncated).toBe(false);
+  });
+
+  it("does not flag truncated when the only dropped rows were unmodelled types", () => {
+    // The bug both adapters shipped: `truncated` was derived from the row count
+    // rather than the entry count, so a listing that filled exactly to the cap
+    // and skipped one symlink claimed to have been cut when nothing was.
+    const rows: Array<[string, number, string]> = [
+      ...Array.from(
+        { length: MAX_LIST_ENTRIES },
+        (_, i) => ["f", 1, `f${i}.txt`] as [string, number, string],
+      ),
+      ["l", 7, "a-symlink"],
+    ];
+    const out = parseFindOutput(findOutput(rows).toString("utf8"));
+
+    expect(out.entries).toHaveLength(MAX_LIST_ENTRIES);
+    expect(out.truncated).toBe(false);
+  });
+});
+
+describe("createPosixSandbox — fs.list", () => {
+  const listing = (
+    rows: Array<[string, string | number, string]>,
+    exitCode = 0,
+    stderr = "",
+  ) =>
+    makeTransport({
+      exec: () => ({
+        stdout: findOutput(rows),
+        stderr: Buffer.from(stderr),
+        exitCode,
+      }),
+    });
+
+  it("runs find under the workspace root with the list bounds", async () => {
+    const { transport, execCalls } = listing([["f", 1, "a.txt"]]);
+    await createPosixSandbox(transport).fsList(ctx, {});
+
+    expect(execCalls[0].argv[0]).toBe("find");
+    expect(execCalls[0].argv[1]).toBe(ROOT);
+    expect(execCalls[0].opts).toMatchObject({
+      cwd: ROOT,
+      timeoutMs: DEFAULT_SHELL_TIMEOUT_MS,
+      stdoutCap: MAX_LIST_OUTPUT_BYTES,
+      stderrCap: MAX_SHELL_OUTPUT_BYTES,
+    });
+  });
+
+  it("lists a subpath resolved against the root", async () => {
+    const { transport, execCalls } = listing([]);
+    await createPosixSandbox(transport).fsList(ctx, { path: "src" });
+
+    expect(execCalls[0].argv[1]).toBe(`${ROOT}/src`);
+  });
+
+  it("returns parsed entries", async () => {
+    const { transport } = listing([
+      ["f", 12, "a.txt"],
+      ["d", 4096, "sub"],
+    ]);
+
+    await expect(
+      createPosixSandbox(transport).fsList(ctx, {}),
+    ).resolves.toEqual({
+      entries: [
+        { path: "a.txt", type: "file", size: 12 },
+        { path: "sub", type: "dir", size: 4096 },
+      ],
+      truncated: false,
+    });
+  });
+
+  it("returns an empty listing for an empty directory", async () => {
+    const { transport } = makeTransport();
+
+    await expect(
+      createPosixSandbox(transport).fsList(ctx, {}),
+    ).resolves.toEqual({ entries: [], truncated: false });
+  });
+
+  it("returns the partial rows find printed before it failed", async () => {
+    // find exits non-zero on an unreadable subdirectory while still printing
+    // what it reached — those rows are more useful than an error.
+    const { transport } = listing(
+      [["f", 1, "reachable.txt"]],
+      1,
+      "Permission denied",
+    );
+
+    await expect(
+      createPosixSandbox(transport).fsList(ctx, { recursive: true }),
+    ).resolves.toMatchObject({
+      entries: [{ path: "reachable.txt", type: "file", size: 1 }],
+    });
+  });
+
+  it("throws with find's stderr when it failed and printed nothing", async () => {
+    const { transport } = makeTransport({
+      exec: () => ({
+        exitCode: 1,
+        stderr: Buffer.from(
+          "find: '/workspace/nope': No such file or directory\n",
+        ),
+      }),
+    });
+
+    await expect(
+      createPosixSandbox(transport).fsList(ctx, { path: "nope" }),
+    ).rejects.toThrow(/fs\.list: find: .*No such file or directory/);
+  });
+
+  it("falls back to a generic message when find failed silently", async () => {
+    const { transport } = makeTransport({ exec: () => ({ exitCode: 1 }) });
+
+    await expect(createPosixSandbox(transport).fsList(ctx, {})).rejects.toThrow(
+      "fs.list: fs.list failed",
+    );
+  });
+});
+
+describe("createPosixSandbox — lifecycle", () => {
+  it("delegates destroy to the transport with the context", async () => {
+    const { transport, destroyed } = makeTransport();
+    await createPosixSandbox(transport).destroy(ctx);
+
+    expect(destroyed).toEqual([ctx]);
+  });
+
+  it("resolves the root before every tool call, so a transport can lazily connect", async () => {
+    const { transport, rootDirCalls } = makeTransport({
+      files: new Map([[`${ROOT}/a.txt`, Buffer.from("x")]]),
+    });
+    const sandbox = createPosixSandbox(transport);
+
+    await sandbox.shellExec(ctx, { command: "x" });
+    await sandbox.fsRead(ctx, { path: "a.txt" });
+    await sandbox.fsWrite(ctx, { path: "b.txt", content: "y", mode: "create" });
+    await sandbox.fsEdit(ctx, {
+      path: "a.txt",
+      oldString: "x",
+      newString: "z",
+    });
+    await sandbox.fsList(ctx, {});
+
+    expect(rootDirCalls).toHaveLength(5);
+    expect(rootDirCalls.every((c) => c === ctx)).toBe(true);
+  });
+});

--- a/apps/backend/src/sandbox/posix.ts
+++ b/apps/backend/src/sandbox/posix.ts
@@ -1,0 +1,350 @@
+import {
+  DEFAULT_SHELL_TIMEOUT_MS,
+  MAX_LIST_ENTRIES,
+  MAX_LIST_OUTPUT_BYTES,
+  MAX_READ_BYTES,
+  MAX_SHELL_OUTPUT_BYTES,
+  MAX_SHELL_TIMEOUT_MS,
+} from "./index.ts";
+import { SandboxPathExistsError, type SandboxTransport } from "./transport.ts";
+import type {
+  FsEditInput,
+  FsEditOutput,
+  FsListEntry,
+  FsListInput,
+  FsListOutput,
+  FsReadInput,
+  FsReadOutput,
+  FsWriteInput,
+  FsWriteOutput,
+  SandboxBackend,
+  SandboxContext,
+  ShellExecInput,
+  ShellExecOutput,
+} from "./types.ts";
+
+// The fixed five-tool core (ADR-0002), implemented once over a {@link
+// SandboxTransport}. Every Platypus-defined bound lives here — the timeout
+// clamp, the output caps, the `truncated` convention, strict UTF-8, line
+// counting, the unique-`oldString` rule and the find(1) contract — so core
+// honours them *for* an adapter rather than trusting each adapter to.
+
+// Resolve a workspace-relative path against the transport's root. The input
+// schema already rejects a leading slash; stripping again is belt-and-braces
+// against a caller that bypasses it, since a doubled slash would silently
+// address a different file.
+const absPath = (rootDir: string, relative: string): string =>
+  `${rootDir}/${relative.replace(/^\/+/, "")}`;
+
+/**
+ * Decode as strict UTF-8. The fs.* tools deal in text and a lossy decode would
+ * hand the model mojibake it cannot tell from the real file, so an unreadable
+ * file is an error rather than a best guess. (`shell.exec` is deliberately
+ * lenient — arbitrary command output is not claimed to be text.)
+ */
+const decodeUtf8Strict = (
+  bytes: Buffer,
+  tool: string,
+  path: string,
+): string => {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw new Error(`${tool}: file is not valid UTF-8 (${path})`);
+  }
+};
+
+/**
+ * Lines in a chunk of text: newline-separated, with a trailing newline
+ * terminating the last line rather than starting an empty one. Empty content is
+ * zero lines.
+ */
+const countLines = (content: string): number => {
+  if (content.length === 0) return 0;
+  const lines = content.split("\n").length;
+  return content.endsWith("\n") ? lines - 1 : lines;
+};
+
+/**
+ * The 1-indexed, inclusive `[start, end]` window of `content`, each selected
+ * line re-terminated with a newline (matching `sed -n 'start,end p'`).
+ *
+ * Sliced here rather than server-side because the byte cap has already been
+ * applied: on a file past {@link MAX_READ_BYTES} the window is taken from the
+ * capped prefix, so lines beyond the cap are not reachable through `lineRange`.
+ */
+const sliceLines = (
+  content: string,
+  [start, end]: [number, number],
+): string => {
+  const body = content.endsWith("\n") ? content.slice(0, -1) : content;
+  const lines = body.length === 0 ? [] : body.split("\n");
+  return lines
+    .slice(start - 1, end)
+    .map((line) => `${line}\n`)
+    .join("");
+};
+
+/**
+ * Replace the one occurrence of `oldString`, or explain which rule it broke.
+ * Uniqueness is the point of the tool: a model that cannot say precisely which
+ * text it means should be made to widen its context, not silently edit the
+ * first of several matches.
+ */
+const replaceUnique = (original: string, input: FsEditInput): string => {
+  const first = original.indexOf(input.oldString);
+  if (first === -1) {
+    throw new Error(`fs.edit: oldString not found in ${input.path}`);
+  }
+  if (original.indexOf(input.oldString, first + 1) !== -1) {
+    throw new Error(`fs.edit: oldString is not unique in ${input.path}`);
+  }
+  return (
+    original.slice(0, first) +
+    input.newString +
+    original.slice(first + input.oldString.length)
+  );
+};
+
+/**
+ * The `find` argv behind `fs.list`. argv, not a command line: quoting is the
+ * transport's business, so nothing here is escaped.
+ *
+ * Truncation is done in Node rather than by piping to `head`, so `find` is
+ * never told to stop and the count of what it *would* have emitted stays
+ * knowable — that is what makes `truncated` honest.
+ */
+export const buildFindArgs = (
+  target: string,
+  input: Pick<FsListInput, "recursive" | "glob">,
+): string[] => {
+  const args = ["find", target];
+  if (!input.recursive) args.push("-maxdepth", "1");
+  args.push("-mindepth", "1");
+  if (input.glob) {
+    // `-name` matches a bare filename; a pattern containing a slash or `**` has
+    // to go through `-path`, which matches the whole path. `**` collapses to a
+    // single `*` because find(1) has no globstar — lossy, and documented in the
+    // tool description, but it keeps the common `**/*.ts` shape working.
+    if (input.glob.includes("/") || input.glob.includes("**")) {
+      args.push("-path", `*/${input.glob.replace(/\*\*/g, "*")}`);
+    } else {
+      args.push("-name", input.glob);
+    }
+  }
+  // Single argv element carrying find's own escapes — find(1) interprets `\t`
+  // and `\n` itself.
+  args.push("-printf", "%y\\t%s\\t%P\\n");
+  return args;
+};
+
+/**
+ * Parse `find -printf '%y\t%s\t%P\n'` output into entries, capped at {@link
+ * MAX_LIST_ENTRIES}.
+ *
+ * Every row is parsed before the cap is applied, so `truncated` counts entries
+ * dropped rather than *rows* dropped. Those differ whenever `find` emitted
+ * something this tool does not model — a symlink, a socket, a device — and
+ * conflating them reports a listing as truncated when nothing was actually cut.
+ */
+export const parseFindOutput = (stdout: string): FsListOutput => {
+  const entries: FsListEntry[] = [];
+  for (const line of stdout.split("\n")) {
+    if (line.length === 0) continue;
+    const tab1 = line.indexOf("\t");
+    const tab2 = line.indexOf("\t", tab1 + 1);
+    if (tab1 === -1 || tab2 === -1) continue;
+    const typeChar = line.slice(0, tab1);
+    // Only files and directories are modelled; a symlink, socket or device has
+    // no meaning for the fs.* tools and is dropped rather than guessed at.
+    if (typeChar !== "f" && typeChar !== "d") continue;
+    const size = Number.parseInt(line.slice(tab1 + 1, tab2), 10);
+    entries.push({
+      path: line.slice(tab2 + 1),
+      type: typeChar === "f" ? "file" : "dir",
+      // An unparseable size is omitted rather than reported as 0 or NaN — the
+      // field is optional precisely so it can be absent.
+      ...(Number.isFinite(size) ? { size } : {}),
+    });
+  }
+  return {
+    entries: entries.slice(0, MAX_LIST_ENTRIES),
+    truncated: entries.length > MAX_LIST_ENTRIES,
+  };
+};
+
+// Read a file through the transport, attributing a failure to the tool that
+// asked. A transport reports why it could not read; naming the tool is core's
+// job, so the same underlying error reads correctly from fs.read and fs.edit.
+const readForTool = async (
+  transport: SandboxTransport,
+  ctx: SandboxContext,
+  tool: string,
+  rootDir: string,
+  path: string,
+): Promise<Buffer> => {
+  try {
+    return await transport.readFile(
+      ctx,
+      absPath(rootDir, path),
+      MAX_READ_BYTES,
+    );
+  } catch (cause) {
+    const detail =
+      cause instanceof Error ? cause.message.trim() : String(cause);
+    throw new Error(`${tool}: ${detail || `${tool} failed`}`, { cause });
+  }
+};
+
+/**
+ * Build a {@link SandboxBackend} — the five model-facing tools — from a {@link
+ * SandboxTransport}.
+ *
+ * The transport supplies exec, file read/write, the workspace root and
+ * teardown; everything the model actually sees is assembled here, identically
+ * for every adapter that goes through this door.
+ */
+export const createPosixSandbox = (
+  transport: SandboxTransport,
+): SandboxBackend => ({
+  async shellExec(
+    ctx: SandboxContext,
+    input: ShellExecInput,
+  ): Promise<ShellExecOutput> {
+    const rootDir = await transport.rootDir(ctx);
+    // The clamp is core's, not the schema's: the schema bounds what a model may
+    // ask for, this bounds what any adapter will actually wait for.
+    const timeoutMs = Math.min(
+      input.timeoutMs ?? DEFAULT_SHELL_TIMEOUT_MS,
+      MAX_SHELL_TIMEOUT_MS,
+    );
+
+    const res = await transport.exec(ctx, ["/bin/sh", "-c", input.command], {
+      cwd: input.cwd ? absPath(rootDir, input.cwd) : rootDir,
+      env: input.env,
+      timeoutMs,
+      stdoutCap: MAX_SHELL_OUTPUT_BYTES,
+      stderrCap: MAX_SHELL_OUTPUT_BYTES,
+    });
+
+    return {
+      stdout: res.stdout.toString("utf8"),
+      stderr: res.stderr.toString("utf8"),
+      exitCode: res.exitCode,
+      // A stream sitting exactly on its cap cannot be told apart from one that
+      // overran it, so `>=` is the convention: err towards warning the model
+      // that it may not have the whole picture.
+      truncated:
+        res.stdout.length >= MAX_SHELL_OUTPUT_BYTES ||
+        res.stderr.length >= MAX_SHELL_OUTPUT_BYTES,
+      durationMs: res.durationMs,
+    };
+  },
+
+  async fsRead(ctx: SandboxContext, input: FsReadInput): Promise<FsReadOutput> {
+    const rootDir = await transport.rootDir(ctx);
+    const bytes = await readForTool(
+      transport,
+      ctx,
+      "fs.read",
+      rootDir,
+      input.path,
+    );
+
+    const decoded = decodeUtf8Strict(bytes, "fs.read", input.path);
+    const content = input.lineRange
+      ? sliceLines(decoded, input.lineRange)
+      : decoded;
+
+    return {
+      content,
+      lineCount: countLines(content),
+      // The same `>=` convention `shell.exec` uses, applied here rather than in
+      // each transport so no adapter can disagree about a file that lands
+      // exactly on the cap. Reported for the file, not the `lineRange` window:
+      // it means "there was more file", which is what the model needs to know.
+      truncated: bytes.length >= MAX_READ_BYTES,
+    };
+  },
+
+  async fsWrite(
+    ctx: SandboxContext,
+    input: FsWriteInput,
+  ): Promise<FsWriteOutput> {
+    const rootDir = await transport.rootDir(ctx);
+    const bytes = Buffer.from(input.content, "utf8");
+
+    try {
+      await transport.writeFile(
+        ctx,
+        absPath(rootDir, input.path),
+        bytes,
+        input.mode,
+      );
+    } catch (cause) {
+      // Re-stated in terms the model can act on: it asked about a relative
+      // path and never saw the absolute one the transport reports.
+      if (cause instanceof SandboxPathExistsError) {
+        throw new Error(
+          `fs.write: path already exists (mode=create): ${input.path}`,
+          { cause },
+        );
+      }
+      throw cause;
+    }
+
+    return { bytesWritten: bytes.length };
+  },
+
+  async fsEdit(ctx: SandboxContext, input: FsEditInput): Promise<FsEditOutput> {
+    const rootDir = await transport.rootDir(ctx);
+    const bytes = await readForTool(
+      transport,
+      ctx,
+      "fs.edit",
+      rootDir,
+      input.path,
+    );
+
+    const updated = replaceUnique(
+      decodeUtf8Strict(bytes, "fs.edit", input.path),
+      input,
+    );
+
+    await transport.writeFile(
+      ctx,
+      absPath(rootDir, input.path),
+      Buffer.from(updated, "utf8"),
+      "overwrite",
+    );
+
+    return { replacements: 1 };
+  },
+
+  async fsList(ctx: SandboxContext, input: FsListInput): Promise<FsListOutput> {
+    const rootDir = await transport.rootDir(ctx);
+    const target = input.path ? absPath(rootDir, input.path) : rootDir;
+
+    const res = await transport.exec(ctx, buildFindArgs(target, input), {
+      cwd: rootDir,
+      timeoutMs: DEFAULT_SHELL_TIMEOUT_MS,
+      stdoutCap: MAX_LIST_OUTPUT_BYTES,
+      stderrCap: MAX_SHELL_OUTPUT_BYTES,
+    });
+
+    // find exits non-zero on a partial failure — an unreadable subdirectory —
+    // while still printing everything it could reach. Returning those rows is
+    // more useful than failing the call, so only a run that produced nothing at
+    // all is treated as an error.
+    if (res.exitCode !== 0 && res.stdout.length === 0) {
+      const detail = res.stderr.toString("utf8").trim();
+      throw new Error(`fs.list: ${detail || "fs.list failed"}`);
+    }
+
+    return parseFindOutput(res.stdout.toString("utf8"));
+  },
+
+  destroy(ctx: SandboxContext): Promise<void> {
+    return transport.destroy(ctx);
+  },
+});

--- a/apps/backend/src/sandbox/transport.ts
+++ b/apps/backend/src/sandbox/transport.ts
@@ -1,0 +1,166 @@
+import type { SandboxContext } from "./types.ts";
+
+// The seam beneath a Sandbox adapter (ADR-0002/0003/0012).
+//
+// A `SandboxBackend` is the five model-facing tools plus every Platypus-defined
+// bound they must honour. Almost none of that is adapter business: the find(1)
+// output parser, the unique-`oldString` rule, strict UTF-8 decoding, line
+// counting, the truncation convention and the timeout clamp are the *contract*,
+// and two adapters implementing them separately means two chances to drift and
+// two places to fix a bug. What genuinely differs between Docker and SSH is the
+// transport — dockerode `exec`/`putArchive` versus ssh2 `exec`/SFTP.
+//
+// So the seam sits here instead, one level below the backend. An adapter
+// supplies these five primitives; {@link createPosixSandbox} implements the five
+// tools on top of them once, and owns the bounds for every adapter rather than
+// trusting each to honour them. A backend that cannot be expressed as a POSIX
+// transport is free to implement `SandboxBackend` directly — this is a shortcut
+// for the common case, not a new requirement.
+//
+// Every method takes the {@link SandboxContext} the tool call arrived with, for
+// the same reason `SandboxBackend` does: an adapter may serve more than one
+// Workspace from one instance, and `ctx.workspaceId` is the identity key it
+// finds or provisions its resource by.
+
+/** What a transport is asked to run one command under. */
+export interface SandboxExecOptions {
+  /**
+   * Absolute working directory inside the sandbox. Resolved by core against the
+   * transport's own {@link SandboxTransport.rootDir}, so it is already a real
+   * path on the far side rather than anything the model wrote.
+   */
+  cwd?: string;
+  /** Environment for this command, already merged by the layers above. */
+  env?: Record<string, string>;
+  /** Wall-clock budget. Core has already clamped it to the Platypus maximum. */
+  timeoutMs: number;
+  /** Stop accumulating stdout past this many bytes (keep draining). */
+  stdoutCap: number;
+  /** Stop accumulating stderr past this many bytes (keep draining). */
+  stderrCap: number;
+}
+
+/**
+ * One finished command. Buffers rather than strings: decoding is the contract's
+ * business — `shell.exec` is lenient about invalid UTF-8 where `fs.read` is
+ * strict — and a transport that decoded early would take that choice away.
+ */
+export interface SandboxExecResult {
+  stdout: Buffer;
+  stderr: Buffer;
+  /**
+   * The command's exit status, and `124` when it was killed for outrunning
+   * `timeoutMs` — the code a shell reports for exactly that, which is why a
+   * timeout needs no flag of its own alongside it.
+   */
+  exitCode: number;
+  durationMs: number;
+}
+
+/**
+ * A byte-capped output accumulator, for the `stdoutCap` / `stderrCap` half of
+ * {@link SandboxExecOptions}.
+ *
+ * Here rather than in each transport because the cap is a Platypus-defined
+ * bound like any other, and because getting it wrong is quiet: the sink keeps
+ * *accepting* chunks past the cap and merely stops storing them, so the
+ * underlying stream still drains. A transport that instead unsubscribed at the
+ * cap would leave the command blocked on a full pipe, and the failure would look
+ * like a hang rather than a truncation.
+ */
+export const createCappedSink = (cap: number) => {
+  const chunks: Buffer[] = [];
+  let bytes = 0;
+  return {
+    push(chunk: Buffer): void {
+      if (bytes >= cap) return;
+      const room = cap - bytes;
+      const take = chunk.length <= room ? chunk : chunk.subarray(0, room);
+      chunks.push(take);
+      bytes += take.length;
+    },
+    collect(): Buffer {
+      return Buffer.concat(chunks);
+    },
+  };
+};
+
+/**
+ * Thrown by {@link SandboxTransport.writeFile} when `mode: "create"` finds the
+ * path already taken. A distinct type rather than a message because the message
+ * an Operator sees names the *workspace-relative* path the model asked for, and
+ * a transport only ever sees the resolved absolute one — core translates.
+ */
+export class SandboxPathExistsError extends Error {
+  constructor(absPath: string, options?: { cause?: unknown }) {
+    super(`path already exists: ${absPath}`, options);
+    this.name = "SandboxPathExistsError";
+  }
+}
+
+/**
+ * The five primitives an adapter supplies. Everything the model sees is built
+ * from these by {@link createPosixSandbox}.
+ *
+ * This is the *whole* adapter surface: an implementation that finds itself
+ * parsing find(1) output, counting lines, or deciding what `truncated` means has
+ * taken on work the contract already owns.
+ */
+export interface SandboxTransport {
+  /**
+   * The absolute workspace root every relative path resolves against, and the
+   * lazy-initialisation hook: core calls it first in every tool, so this is
+   * where an adapter provisions its container or opens its connection. Called
+   * once per tool call, so it must be cheap on the warm path and safe under
+   * concurrent callers.
+   */
+  rootDir(ctx: SandboxContext): Promise<string>;
+
+  /**
+   * Run one command. `argv` is a command and its arguments already split, never
+   * a shell line — quoting is the transport's business, because only it knows
+   * whether one is needed (Docker passes argv straight to the daemon; SSH has a
+   * login shell in the way and must quote every element).
+   *
+   * Resolves for a command that failed or timed out — a non-zero `exitCode` is
+   * data, not an error. Reject only when the command could not be run at all.
+   */
+  exec(
+    ctx: SandboxContext,
+    argv: string[],
+    opts: SandboxExecOptions,
+  ): Promise<SandboxExecResult>;
+
+  /**
+   * Read at most `cap` bytes of an absolute path. Rejects when the file cannot
+   * be read; core prefixes the message with the tool that asked, so the reason
+   * (and only the reason) belongs in it.
+   *
+   * Bytes only — whether that counts as *truncated* is core's call, from the
+   * one `>= cap` rule it applies to every adapter. A transport reporting its
+   * own verdict is how the two adapters used to disagree about a file sitting
+   * exactly on the cap, and reading the size first (SFTP can, `cat` cannot) is
+   * not worth reopening that.
+   */
+  readFile(ctx: SandboxContext, absPath: string, cap: number): Promise<Buffer>;
+
+  /**
+   * Write bytes to an absolute path, creating any missing parent directories.
+   * `mode: "create"` must reject an existing path with a {@link
+   * SandboxPathExistsError}; `mode: "overwrite"` replaces whatever is there.
+   */
+  writeFile(
+    ctx: SandboxContext,
+    absPath: string,
+    bytes: Buffer,
+    mode: "create" | "overwrite",
+  ): Promise<void>;
+
+  /**
+   * Release whatever this adapter owns for the Sandbox. MUST be idempotent —
+   * safe to call on a resource that is already gone (ADR-0001). An adapter
+   * attached to a machine it does not own tears down its own connection and
+   * nothing else.
+   */
+  destroy(ctx: SandboxContext): Promise<void>;
+}


### PR DESCRIPTION
Closes #497

The two Sandbox adapters were not merely similar — six blocks were identical in semantics: the `find -printf` output parser, the find-argv builder (including the lossy `**`→`*` collapse), the unique-`oldString` replace, strict UTF-8 decoding, line counting, the `>= cap` truncation convention, and the timeout clamp. They shared a latent bug twice, and two ~1,000-line suites re-proved the same contract against different fakes.

## The seam

It now sits one level lower, at the transport rather than the whole `SandboxBackend`:

```ts
SandboxTransport {
  rootDir(ctx)
  exec(ctx, argv, opts)
  readFile(ctx, absPath, cap)
  writeFile(ctx, absPath, bytes, mode)
  destroy(ctx)
}
```

`createPosixSandbox(transport)` implements the five model-facing tools on top of these once and owns every Platypus-defined bound. argv goes in unquoted — Docker passes it straight to the daemon, SSH quotes each element for the login shell it cannot avoid.

`SandboxBackendContribution.create` still returns a `SandboxBackend`, so ADR-0002's fixed five-tool core and the published `@platypuschat/plugin-sdk` surface are untouched. A backend that cannot be expressed as a POSIX transport still implements `SandboxBackend` directly.

**Result:** Docker 728 → 574 lines, SSH 830 → 650, both pure transports. Neither file now contains `-printf`, `TextDecoder`, `oldString`, or the timeout clamp.

## The bug

`truncated = entries.length < lines.length` reported true when a symlink was skipped and nothing was actually cut. All rows are now parsed before the cap is applied, so `truncated` counts dropped **entries**, not dropped rows. Pinned by two tests, including the symlink case that used to lie.

## Tests

One contract suite on an in-memory transport — `sandbox/posix.test.ts`, 56 tests, no Docker daemon and no SSH host. The adapter suites drop to "is the client driven right": 26 Docker, 34 SSH. Every deleted adapter test was traced to a contract equivalent.

Full suite 1767 passing, `pnpm typecheck` 7/7, lint clean.

## Two boundary changes, both deliberate

- **`fs.read` + `lineRange` on Docker** was server-side `sed -n 'a,bp'`; it now reads the capped prefix and slices in Node. Lines past 1 MB stop being reachable that way — which is how SSH already behaved.
- **SSH `shell.exec`** now runs the model's command under `/bin/sh -c` instead of handing it to the login shell, which is what Docker has always done. Bash-isms that happened to work over SSH will now hit dash.

Both serve the documented goal that an Agent's Instructions must not depend on which backend it runs on. Flag either if you'd rather it were reverted.

## No docs change — checked, not skipped

`CLAUDE.md`'s table pairs `apps/backend/src/plugins/**` with `extending/index.mdx` and `self-hosting/configuration.mdx`. Neither needs an edit: `createPosixSandbox` and `SandboxTransport` live in backend core and are **not** exported from the plugin SDK, so `extending/sandbox-backends.mdx`'s "your adapter implements `SandboxBackend`" and its list of rules an adapter must honour stay true for a third-party author.

The corollary: the issue's "third adapter costs a transport only" win applies to **in-repo** adapters only. Exporting the seam through the SDK would be a separate, deliberate decision.

## Review notes

Two findings from the review pass were fixed before commit:

- **`truncated` had escaped core.** The first cut let each transport report its own verdict, so Docker (`>= cap`) and SSH (`size > cap`) disagreed about a file sitting exactly on the cap — reintroducing the divergence this refactor exists to remove, and reversing a deliberate pre-refactor decision. `readFile` now returns bytes only; core applies the one rule.
- **Residual duplication.** The cap-but-keep-draining accumulator still lived in both adapters; it is now a shared `createCappedSink`. Also dropped the unused `timedOut` field (exit 124 already encodes it) and a redundant `type ExecResult` alias both adapters had added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)