### PR TITLE
fix(frontend): stop pointing at a Web-search backend field that is not there

### DIFF
--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -779,6 +779,32 @@ describe("ProviderForm Web-search backend selector", () => {
     ).toBeNull();
   });
 
+  // The Native web search description carries a caveat about the selector below
+  // it. On a deployment with no search plugin installed the selector is not
+  // rendered, and the caveat sends the reader looking for a field that is not
+  // there.
+  it("does not mention the backend selector where it is not rendered", () => {
+    renderWithAdvancedOpen({});
+
+    expect(webBackendSelect()).toBeNull();
+    expect(
+      screen.queryByText(/selected a Web-search backend below/),
+    ).toBeNull();
+    expect(
+      screen.getByText(/Use this provider's built-in web_search tool/),
+    ).toBeInTheDocument();
+  });
+
+  it("mentions the backend selector once it is on the form", () => {
+    webBackendCatalog = CATALOG;
+    renderWithAdvancedOpen({});
+
+    expect(webBackendSelect()).not.toBeNull();
+    expect(
+      screen.getByText(/selected a Web-search backend below/),
+    ).toBeInTheDocument();
+  });
+
   // The recovery path for a stale id on a deployment where nothing is installed:
   // choosing None empties `webBackend`, which is the same value the field's own
   // visibility condition reads. Unlatched, the control unmounted here — mid-

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -1353,11 +1353,16 @@ const ProviderForm = ({
                     <FieldLabel htmlFor="nativeSearchEnabled">
                       Native web search
                     </FieldLabel>
+                    {/* The Web-search backend caveat only when that field is
+                    actually on the form — on a deployment with no search plugin
+                    installed it points at a control the reader cannot see. */}
                     <FieldDescription>
                       Use this provider&apos;s built-in web_search tool. Turn
                       off for endpoints that don&apos;t implement it (e.g. vLLM,
-                      Ollama, LiteLLM) — but not if you have selected a
-                      Web-search backend below, which this switch disables too.
+                      Ollama, LiteLLM)
+                      {showWebBackendField
+                        ? " — but not if you have selected a Web-search backend below, which this switch disables too."
+                        : "."}{" "}
                       This also hides the search toggle in chat.
                     </FieldDescription>
                   </div>


### PR DESCRIPTION
## Problem

On the Provider form, the **Native web search** description reads:

> Turn off for endpoints that don't implement it (e.g. vLLM, Ollama, LiteLLM) — but not if you have selected a Web-search backend below, which this switch disables too.

The **Web-search backend** selector it points at is conditional: it renders only when the deployment has a search-backend plugin installed, when the Provider already has a backend stored, or when the catalog request failed. On a deployment with no search plugin — the default — the caveat names a field that is not on the form.

## Fix

The clause is now tied to the same flag that renders the selector, so it appears only when there is a field below to point at. With nothing installed the description reads:

> Use this provider's built-in web_search tool. Turn off for endpoints that don't implement it (e.g. vLLM, Ollama, LiteLLM). This also hides the search toggle in chat.

## Tests

Two cases pin both directions — no mention when the selector is absent, the caveat present once it renders. The file's 46 tests pass.

No docs change: `concepts/providers.mdx` documents the field's visibility rules rather than quoting this copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)