### PR TITLE
chore(backend): route the built-in Docker and SSH plugin logs through the injected logger

### DIFF
--- a/apps/backend/src/plugins/docker/backend.test.ts
+++ b/apps/backend/src/plugins/docker/backend.test.ts
@@ -275,6 +275,13 @@ import {
   dockerSandboxConfigSchema,
 } from "./backend.ts";
 import { logger } from "../../logger.ts";
+import { plugin } from "./index.ts";
+import { loadPlugins } from "../loader.ts";
+import type { SandboxBackendContribution } from "@platypuschat/plugin-sdk";
+import {
+  makeFakePluginLogger,
+  type FakePluginLogger,
+} from "../../test-utils.ts";
 import {
   MAX_READ_BYTES,
   MAX_SHELL_OUTPUT_BYTES,
@@ -353,9 +360,21 @@ function setupFreshProvision() {
   queueExec({ exitCode: 0 });
 }
 
+// The `PluginLogger` seam core injects on the plugin's deploy-time block. The
+// adapter logs through this rather than core's logger, so any suite asserting on
+// a log line injects one and watches it — watching core's would pass vacuously.
+let pluginLogger: FakePluginLogger;
+
+const withPluginLogger = () => ({
+  config: { allowedNetworks: [] },
+  credentials: {},
+  logger: pluginLogger,
+});
+
 beforeEach(() => {
   resetMockState();
   vi.clearAllMocks();
+  pluginLogger = makeFakePluginLogger();
 });
 
 describe("DockerSandboxTransport — provisioning", () => {
@@ -576,9 +595,9 @@ describe("DockerSandboxTransport — destroy() idempotence", () => {
     mockState.containerStop = () =>
       Promise.reject(makeStatusError("no such container", 404));
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await expect(backend.destroy(ctx)).resolves.toBeUndefined();
-    expect(logger.warn).not.toHaveBeenCalled();
+    expect(pluginLogger.warn).not.toHaveBeenCalled();
   });
 
   it("swallows 304 (already stopped) on stop", async () => {
@@ -586,9 +605,9 @@ describe("DockerSandboxTransport — destroy() idempotence", () => {
     mockState.containerStop = () =>
       Promise.reject(makeStatusError("already stopped", 304));
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await expect(backend.destroy(ctx)).resolves.toBeUndefined();
-    expect(logger.warn).not.toHaveBeenCalled();
+    expect(pluginLogger.warn).not.toHaveBeenCalled();
   });
 
   it("swallows 404 on container remove and on volume remove", async () => {
@@ -598,9 +617,9 @@ describe("DockerSandboxTransport — destroy() idempotence", () => {
     mockState.volumeRemove = () =>
       Promise.reject(makeStatusError("not found", 404));
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await expect(backend.destroy(ctx)).resolves.toBeUndefined();
-    expect(logger.warn).not.toHaveBeenCalled();
+    expect(pluginLogger.warn).not.toHaveBeenCalled();
   });
 
   it("logs but proceeds when stop returns 500", async () => {
@@ -618,10 +637,10 @@ describe("DockerSandboxTransport — destroy() idempotence", () => {
       return Promise.resolve(undefined);
     };
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await backend.destroy(ctx);
 
-    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(pluginLogger.warn).toHaveBeenCalledTimes(1);
     expect(removeCalled).toBe(true);
     expect(volRemoveCalled).toBe(true);
   });
@@ -756,6 +775,142 @@ describe("DockerSandboxTransport — host reachability (ADR-0005)", () => {
         allowedNetworks: [],
       }).safeParse({ extraHosts: ["not a valid entry"] });
       expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe("DockerSandboxTransport — plugin-injected logger", () => {
+  // Core binds the injected logger to the manifest name before handing it over,
+  // so a line written through it is already attributed — which is why these
+  // assertions check the *fields the call site supplies* and never a `plugin`
+  // key of their own.
+
+  it("writes the image-pull line to the injected logger, not core's", async () => {
+    setupFreshProvision();
+    queueExec({ stdout: "hi", exitCode: 0 });
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
+    await backend.shellExec(ctx, { command: "echo hi" });
+
+    expect(mockState.pullCalls).toEqual(["debian:stable-slim"]);
+    // Same fields and message as before the routing change.
+    expect(pluginLogger.info).toHaveBeenCalledWith(
+      { image: "debian:stable-slim" },
+      "Pulling sandbox image",
+    );
+    // The whole point: core's logger is no longer the adapter's channel.
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("writes the destroy() warnings to the injected logger, not core's", async () => {
+    mockState.existingContainer = makeFakeContainer();
+    mockState.containerStop = () =>
+      Promise.reject(makeStatusError("internal", 500));
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
+    await backend.destroy(ctx);
+
+    expect(pluginLogger.warn).toHaveBeenCalledTimes(1);
+    expect(pluginLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "ws-abc" }),
+      "sandbox destroy: stop failed (continuing)",
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("names each teardown step it could not complete", async () => {
+    mockState.existingContainer = makeFakeContainer();
+    mockState.containerStop = () =>
+      Promise.reject(makeStatusError("internal", 500));
+    mockState.containerRemove = () =>
+      Promise.reject(makeStatusError("internal", 500));
+    mockState.volumeRemove = () =>
+      Promise.reject(makeStatusError("internal", 500));
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
+    await backend.destroy(ctx);
+
+    // All three still fire, at warn, with their original wording — teardown is
+    // best-effort and each step reports independently.
+    expect(pluginLogger.warn.mock.calls.map((c) => c[1])).toEqual([
+      "sandbox destroy: stop failed (continuing)",
+      "sandbox destroy: container remove failed (continuing)",
+      "sandbox destroy: volume remove failed",
+    ]);
+  });
+
+  it("degrades to silence when core injects no logger", async () => {
+    // `PluginConfigContext.logger` is optional under the SDK's append-only
+    // policy, so the adapter must not assume it. Core always supplies it; a
+    // directly-constructed adapter does not, and that must not throw.
+    mockState.existingContainer = makeFakeContainer();
+    mockState.containerStop = () =>
+      Promise.reject(makeStatusError("internal", 500));
+
+    const backend = createDockerSandboxBackend({}, {});
+    await expect(backend.destroy(ctx)).resolves.toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("reaches the adapter through the manifest's create()", async () => {
+    // The full contribution path core uses: the loader calls `create` with the
+    // plugin block as its third argument, and the manifest must forward it.
+    setupFreshProvision();
+    queueExec({ stdout: "hi", exitCode: 0 });
+    const contribution = plugin.contributes.sandboxBackends![0];
+    const backend = contribution.create({}, {}, withPluginLogger());
+    await backend.shellExec(ctx, { command: "echo hi" });
+
+    expect(pluginLogger.info).toHaveBeenCalledWith(
+      { image: "debian:stable-slim" },
+      "Pulling sandbox image",
+    );
+  });
+
+  it("carries the manifest name on its lines when loaded by the real loader", async () => {
+    // End to end through the path production takes — loader → deploy-time block
+    // → `create` → transport — because that is the only thing that proves the
+    // *attribution*. Every other test in this suite supplies its own logger and
+    // so would pass even if the loader bound the wrong name, or none. What an
+    // Operator greps for is `"plugin":"@platypus/docker"`, and this is the test
+    // that fails if that stops being what they get.
+    setupFreshProvision();
+    queueExec({ stdout: "hi", exitCode: 0 });
+
+    // Stands in for core's logger: records the bindings each child is made with
+    // and merges them into every line that child writes, exactly as pino does.
+    const lines: Array<{ bindings: object; fields: object; msg?: string }> = [];
+    const baseLogger = {
+      child: (bindings: Record<string, unknown>) => {
+        const write =
+          (level: string) => (objOrMsg: object | string, msg?: string) =>
+            lines.push({
+              bindings: { ...bindings, level },
+              fields: typeof objOrMsg === "string" ? {} : objOrMsg,
+              msg: typeof objOrMsg === "string" ? objOrMsg : msg,
+            });
+        return {
+          debug: write("debug"),
+          info: write("info"),
+          warn: write("warn"),
+          error: write("error"),
+        };
+      },
+    };
+
+    // A capturing registrar so this load does not collide with the
+    // module-global sandbox registry other suites in this file seed.
+    const captured: SandboxBackendContribution[] = [];
+    await loadPlugins({
+      pluginNames: ["@platypus/docker"],
+      registerSandbox: (c) => captured.push(c),
+      baseLogger,
+    });
+
+    const backend = captured[0].create({}, {});
+    await backend.shellExec(ctx, { command: "echo hi" });
+
+    expect(lines).toContainEqual({
+      bindings: { plugin: "@platypus/docker", level: "info" },
+      fields: { image: "debian:stable-slim" },
+      msg: "Pulling sandbox image",
     });
   });
 });

--- a/apps/backend/src/plugins/docker/backend.ts
+++ b/apps/backend/src/plugins/docker/backend.ts
@@ -2,7 +2,10 @@ import Docker from "dockerode";
 import type { Container, Exec } from "dockerode";
 import { PassThrough } from "node:stream";
 import { z } from "zod";
-import { logger } from "../../logger.ts";
+import type {
+  PluginConfigContext,
+  PluginLogger,
+} from "@platypuschat/plugin-sdk";
 import {
   MAX_SHELL_OUTPUT_BYTES,
   SANDBOX_WORKSPACE_ROOT,
@@ -300,10 +303,19 @@ export class DockerSandboxTransport implements SandboxTransport {
   private inflight: Map<string, Promise<Container>>;
   private networks: string[];
   private extraHosts: string[];
+  /**
+   * The logger core bound to `@platypus/docker` and injected on the plugin's
+   * deploy-time block (ADR-0013) — the same contract a third-party plugin gets,
+   * rather than the relative import of core's logger only an in-tree plugin ever
+   * had. Optional because {@link PluginConfigContext.logger} is, so every call
+   * site below is written `this.logger?.…`.
+   */
+  private logger?: PluginLogger;
 
   constructor(
     config: Partial<DockerSandboxConfig>,
     _credentials: DockerSandboxCredentials,
+    logger?: PluginLogger,
   ) {
     this.docker = new Docker();
     this.inflight = new Map();
@@ -311,6 +323,7 @@ export class DockerSandboxTransport implements SandboxTransport {
     // present), but tolerate a bare object too.
     this.networks = config?.networks ?? [];
     this.extraHosts = config?.extraHosts ?? [];
+    this.logger = logger;
   }
 
   // Idempotent, concurrency-safe provisioning. Concurrent callers for the
@@ -402,7 +415,7 @@ export class DockerSandboxTransport implements SandboxTransport {
     } catch (err) {
       if (!is404(err)) throw err;
     }
-    logger.info({ image: IMAGE }, "Pulling sandbox image");
+    this.logger?.info({ image: IMAGE }, "Pulling sandbox image");
     const stream = await this.docker.pull(IMAGE);
     await new Promise<void>((resolve, reject) => {
       this.docker.modem.followProgress(stream, (err: Error | null) =>
@@ -509,7 +522,7 @@ export class DockerSandboxTransport implements SandboxTransport {
         // Already stopped is 304 — swallow that too.
         const e = err as { statusCode?: number };
         if (e.statusCode !== 304) {
-          logger.warn(
+          this.logger?.warn(
             { workspaceId: ctx.workspaceId, err },
             "sandbox destroy: stop failed (continuing)",
           );
@@ -522,7 +535,7 @@ export class DockerSandboxTransport implements SandboxTransport {
       await this.docker.getContainer(name).remove({ force: true, v: false });
     } catch (err) {
       if (!is404(err)) {
-        logger.warn(
+        this.logger?.warn(
           { workspaceId: ctx.workspaceId, err },
           "sandbox destroy: container remove failed (continuing)",
         );
@@ -534,7 +547,7 @@ export class DockerSandboxTransport implements SandboxTransport {
       await this.docker.getVolume(vol).remove();
     } catch (err) {
       if (!is404(err)) {
-        logger.warn(
+        this.logger?.warn(
           { workspaceId: ctx.workspaceId, err },
           "sandbox destroy: volume remove failed",
         );
@@ -551,5 +564,8 @@ export class DockerSandboxTransport implements SandboxTransport {
 export const createDockerSandboxBackend = (
   config: Partial<DockerSandboxConfig>,
   credentials: DockerSandboxCredentials,
+  plugin?: PluginConfigContext,
 ): SandboxBackend =>
-  createPosixSandbox(new DockerSandboxTransport(config, credentials));
+  createPosixSandbox(
+    new DockerSandboxTransport(config, credentials, plugin?.logger),
+  );

--- a/apps/backend/src/plugins/docker/index.ts
+++ b/apps/backend/src/plugins/docker/index.ts
@@ -29,8 +29,12 @@ const dockerBackend: SandboxBackendContribution<
   // deploy-time config (below) at load time.
   configSchema: dockerSandboxConfigSchema,
   credentialsSchema: dockerSandboxCredentialsSchema,
-  create: (config, credentials) =>
-    createDockerSandboxBackend(config, credentials),
+  // The third argument is the plugin's deploy-time block, and it is forwarded
+  // for the logger core bound to this manifest's name: the adapter writes its
+  // image-pull and teardown lines through the same contract a third-party
+  // plugin gets, not through a relative import of core's logger.
+  create: (config, credentials, plugin) =>
+    createDockerSandboxBackend(config, credentials, plugin),
 };
 
 export const plugin: PlatypusPlugin = {

--- a/apps/backend/src/plugins/ssh/backend.test.ts
+++ b/apps/backend/src/plugins/ssh/backend.test.ts
@@ -287,6 +287,13 @@ import {
   sshSandboxCredentialsSchema,
 } from "./backend.ts";
 import { logger } from "../../logger.ts";
+import { plugin } from "./index.ts";
+import { loadPlugins } from "../loader.ts";
+import type { SandboxBackendContribution } from "@platypuschat/plugin-sdk";
+import {
+  makeFakePluginLogger,
+  type FakePluginLogger,
+} from "../../test-utils.ts";
 import { MAX_READ_BYTES, MAX_SHELL_OUTPUT_BYTES } from "../../sandbox/index.ts";
 import type { SandboxContext } from "../../sandbox/types.ts";
 
@@ -335,9 +342,21 @@ function queueExec(cfg: ExecConfig = {}) {
   mockState.execQueue.push(cfg);
 }
 
+// The `PluginLogger` seam core injects on the plugin's deploy-time block. The
+// adapter logs through this rather than core's logger, so any suite asserting on
+// a log line injects one and watches it — watching core's would pass vacuously.
+let pluginLogger: FakePluginLogger;
+
+const withPluginLogger = () => ({
+  config: {},
+  credentials: {},
+  logger: pluginLogger,
+});
+
 beforeEach(() => {
   resetMockState();
   vi.clearAllMocks();
+  pluginLogger = makeFakePluginLogger();
 });
 
 describe("sshSandboxConfigSchema / credentialsSchema", () => {
@@ -407,9 +426,13 @@ describe("SshSandboxTransport — connect", () => {
 
   it("warns loudly about MITM when no hostKey is pinned", async () => {
     queueExec({ exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.shellExec(ctx, { command: "true" });
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(pluginLogger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ host: "ssh.example.com" }),
       expect.stringContaining("WITHOUT host-key verification"),
     );
@@ -450,6 +473,7 @@ describe("SshSandboxTransport — host-key verification", () => {
       // A full `ssh-keyscan`-style line: the parser picks the base64 blob token.
       { ...CONFIG, hostKey: `ssh-ed25519 ${HOST_KEY_B64}` },
       CREDENTIALS,
+      withPluginLogger(),
     );
     await backend.shellExec(ctx, { command: "true" });
 
@@ -458,7 +482,7 @@ describe("SshSandboxTransport — host-key verification", () => {
     // The root-resolution exec ran → the connection is live.
     expect(mockState.execCommands.length).toBeGreaterThan(0);
     // No MITM warning is emitted when a pin is enforced.
-    expect(logger.warn).not.toHaveBeenCalled();
+    expect(pluginLogger.warn).not.toHaveBeenCalled();
   });
 
   it("rejects the connection with a clear error when the pin mismatches", async () => {
@@ -477,12 +501,16 @@ describe("SshSandboxTransport — host-key verification", () => {
 
   it("connects without a hostVerifier and warns exactly once when no hostKey is pinned", async () => {
     queueExec({ exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.shellExec(ctx, { command: "true" });
 
     expect(mockState.connectConfigs[0].hostVerifier).toBeUndefined();
-    expect(logger.warn).toHaveBeenCalledTimes(1);
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(pluginLogger.warn).toHaveBeenCalledTimes(1);
+    expect(pluginLogger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ host: "ssh.example.com" }),
       expect.stringContaining("WITHOUT host-key verification"),
     );
@@ -794,5 +822,107 @@ describe("SshSandboxTransport — fs.list (exec find)", () => {
     await backend.fsList(ctx, { path: `it's` });
     // classic '\'' escape idiom, matching shQuote.
     expect(lastFindCommand()).toContain(`'find' '${ROOT}/it'\\''s'`);
+  });
+});
+
+describe("SshSandboxTransport — plugin-injected logger", () => {
+  // ADR-0012's security-relevant line. Its level and exact wording are pinned
+  // here as well as in the host-key suite above: this is a routing change, and a
+  // warning an Operator relies on must survive it byte for byte.
+  it("writes the unpinned-host-key warning to the injected logger, not core's", async () => {
+    queueExec({ exitCode: 0 });
+
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
+    await backend.shellExec(ctx, { command: "true" });
+
+    expect(pluginLogger.warn).toHaveBeenCalledTimes(1);
+    expect(pluginLogger.warn).toHaveBeenCalledWith(
+      { host: "ssh.example.com", port: 22 },
+      "SSH sandbox connecting WITHOUT host-key verification — session and injected env are exposed to a MITM. Set `hostKey` to pin the host.",
+    );
+    // The whole point: core's logger is no longer the adapter's channel.
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("degrades to silence when core injects no logger", async () => {
+    // `PluginConfigContext.logger` is optional under the SDK's append-only
+    // policy. Core always supplies it; a directly-constructed adapter does not,
+    // and the connection must still be made rather than throwing.
+    queueExec({ exitCode: 0 });
+
+    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    await expect(
+      backend.shellExec(ctx, { command: "true" }),
+    ).resolves.toBeDefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("reaches the adapter through the manifest's create()", async () => {
+    // The full contribution path core uses: the loader calls `create` with the
+    // plugin block as its third argument, and the manifest must forward it.
+    queueExec({ exitCode: 0 });
+
+    const contribution = plugin.contributes.sandboxBackends![0];
+    const backend = contribution.create(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
+    await backend.shellExec(ctx, { command: "true" });
+
+    expect(pluginLogger.warn).toHaveBeenCalledWith(
+      { host: "ssh.example.com", port: 22 },
+      expect.stringContaining("WITHOUT host-key verification"),
+    );
+  });
+
+  it("carries the manifest name on the MITM warning when loaded by the real loader", async () => {
+    // End to end through the path production takes — loader → deploy-time block
+    // → `create` → transport. Every other test here supplies its own logger and
+    // would pass even if the loader bound the wrong name, or none. This warning
+    // is the one an Operator is most likely to alert on (ADR-0012), so what it
+    // is tagged with is worth pinning against the real loader.
+    queueExec({ exitCode: 0 });
+
+    // Stands in for core's logger: records the bindings each child is made with
+    // and merges them into every line that child writes, exactly as pino does.
+    const lines: Array<{ bindings: object; fields: object; msg?: string }> = [];
+    const baseLogger = {
+      child: (bindings: Record<string, unknown>) => {
+        const write =
+          (level: string) => (objOrMsg: object | string, msg?: string) =>
+            lines.push({
+              bindings: { ...bindings, level },
+              fields: typeof objOrMsg === "string" ? {} : objOrMsg,
+              msg: typeof objOrMsg === "string" ? objOrMsg : msg,
+            });
+        return {
+          debug: write("debug"),
+          info: write("info"),
+          warn: write("warn"),
+          error: write("error"),
+        };
+      },
+    };
+
+    const captured: SandboxBackendContribution[] = [];
+    await loadPlugins({
+      pluginNames: ["@platypus/ssh"],
+      registerSandbox: (c) => captured.push(c),
+      baseLogger,
+    });
+
+    const backend = captured[0].create(CONFIG, CREDENTIALS);
+    await backend.shellExec(ctx, { command: "true" });
+
+    expect(lines).toContainEqual({
+      bindings: { plugin: "@platypus/ssh", level: "warn" },
+      fields: { host: "ssh.example.com", port: 22 },
+      msg: "SSH sandbox connecting WITHOUT host-key verification — session and injected env are exposed to a MITM. Set `hostKey` to pin the host.",
+    });
   });
 });

--- a/apps/backend/src/plugins/ssh/backend.ts
+++ b/apps/backend/src/plugins/ssh/backend.ts
@@ -6,7 +6,10 @@ import {
   type SFTPWrapper,
 } from "ssh2";
 import { z } from "zod";
-import { logger } from "../../logger.ts";
+import type {
+  PluginConfigContext,
+  PluginLogger,
+} from "@platypuschat/plugin-sdk";
 import {
   DEFAULT_SHELL_TIMEOUT_MS,
   MAX_SHELL_OUTPUT_BYTES,
@@ -249,13 +252,27 @@ export class SshSandboxTransport implements SandboxTransport {
   private connection: Connection | null;
   private inflight: Promise<Connection> | null;
   private idleTimer: NodeJS.Timeout | null;
+  /**
+   * The logger core bound to `@platypus/ssh` and injected on the plugin's
+   * deploy-time block (ADR-0013) — see the Docker transport for why an in-tree
+   * plugin consumes the third-party contract rather than importing core's
+   * logger. Optional because {@link PluginConfigContext.logger} is, so the one
+   * call site below is written `this.logger?.…`; the connection is still made
+   * when it is absent, silently.
+   */
+  private logger?: PluginLogger;
 
-  constructor(config: SshSandboxConfig, credentials: SshSandboxCredentials) {
+  constructor(
+    config: SshSandboxConfig,
+    credentials: SshSandboxCredentials,
+    logger?: PluginLogger,
+  ) {
     this.config = config;
     this.credentials = credentials;
     this.connection = null;
     this.inflight = null;
     this.idleTimer = null;
+    this.logger = logger;
   }
 
   // Lazy-connect on first use; reuse the single connection across all tool calls
@@ -297,7 +314,7 @@ export class SshSandboxTransport implements SandboxTransport {
       // Public-key auth still prevents credential theft by an impostor host; the
       // residual risk is session/output exposure to a MITM. Pin `hostKey` on
       // internet-facing hosts.
-      logger.warn(
+      this.logger?.warn(
         { host, port },
         "SSH sandbox connecting WITHOUT host-key verification — session and injected env are exposed to a MITM. Set `hostKey` to pin the host.",
       );
@@ -623,5 +640,8 @@ export class SshSandboxTransport implements SandboxTransport {
 export const createSshSandboxBackend = (
   config: SshSandboxConfig,
   credentials: SshSandboxCredentials,
+  plugin?: PluginConfigContext,
 ): SandboxBackend =>
-  createPosixSandbox(new SshSandboxTransport(config, credentials));
+  createPosixSandbox(
+    new SshSandboxTransport(config, credentials, plugin?.logger),
+  );

--- a/apps/backend/src/plugins/ssh/index.ts
+++ b/apps/backend/src/plugins/ssh/index.ts
@@ -28,7 +28,12 @@ const sshBackend: SandboxBackendContribution<
   name: "SSH (Remote Host)",
   configSchema: sshSandboxConfigSchema,
   credentialsSchema: sshSandboxCredentialsSchema,
-  create: (config, credentials) => createSshSandboxBackend(config, credentials),
+  // The third argument is the plugin's deploy-time block, and it is forwarded
+  // for the logger core bound to this manifest's name: the adapter's
+  // unpinned-host-key warning (ADR-0012) goes out through the same contract a
+  // third-party plugin gets, not through a relative import of core's logger.
+  create: (config, credentials, plugin) =>
+    createSshSandboxBackend(config, credentials, plugin),
 };
 
 export const plugin: PlatypusPlugin = {

--- a/apps/backend/src/routes/sandbox.test.ts
+++ b/apps/backend/src/routes/sandbox.test.ts
@@ -9,6 +9,7 @@ import {
 import app from "../server.ts";
 import { registerSandboxBackend } from "../sandbox/index.ts";
 import { setLoadedPlugins } from "../plugins/registry.ts";
+import { logger } from "../logger.ts";
 
 // Register a backend directly (bypassing the loader) so the /backends catalog
 // has a stable entry to assert against, and record its owning plugin in the
@@ -339,6 +340,71 @@ describe("Sandbox Routes", () => {
       expect(res.status).toBe(200);
     });
 
+    it("attributes the force-change leak warning to the outgoing backend's plugin", async () => {
+      // The adapter that was skipped is the one that may have leaked, so it is
+      // the one `backend`/`plugin` name — the incoming backend rides along as
+      // `replacedBy` so neither key can be read as spanning both.
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "sbx-1",
+          workspaceId,
+          backend: ANNOTATED_BACKEND,
+          config: {},
+          credentials: {},
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([
+        {
+          id: "sbx-1",
+          workspaceId,
+          name: "Switched",
+          backend: CREDS_BACKEND,
+          config: {},
+          credentials: {},
+        },
+      ]);
+      setLoadedPlugins(
+        loadedPluginsFixture([], {
+          sandboxBackends: new Map([
+            [ANNOTATED_BACKEND, "@platypus/outgoing"],
+            [CREDS_BACKEND, "@platypus/incoming"],
+          ]),
+        }),
+      );
+      const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+      await app.request(`${baseUrl}?force=true`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "Switched",
+          backend: CREDS_BACKEND,
+          config: {},
+          credentials: { privateKey: "k" },
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: ANNOTATED_BACKEND,
+          plugin: "@platypus/outgoing",
+          replacedBy: CREDS_BACKEND,
+        }),
+        expect.stringContaining("external resources may leak"),
+      );
+      // The plugin taking over has leaked nothing and must not be named here.
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.objectContaining({ plugin: "@platypus/incoming" }),
+        expect.anything(),
+      );
+      warn.mockRestore();
+    });
+
     it("returns 404 when no sandbox is configured", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
@@ -386,6 +452,81 @@ describe("Sandbox Routes", () => {
       });
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ message: "Sandbox deleted" });
+    });
+
+    it("names the owning plugin on the force-delete leak warning", async () => {
+      // Core's own line about a plugin's adapter carries the plugin under the
+      // same `plugin` key the adapter's own lines do, so an Operator filtering
+      // by plugin sees core's half of the story too.
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "sbx-1",
+          workspaceId,
+          backend: ANNOTATED_BACKEND,
+          config: {},
+          credentials: {},
+        },
+      ]);
+      setLoadedPlugins(
+        loadedPluginsFixture([], {
+          sandboxBackends: new Map([[ANNOTATED_BACKEND, "@platypus/test"]]),
+        }),
+      );
+      const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+      const res = await app.request(`${baseUrl}?force=true`, {
+        method: "DELETE",
+      });
+
+      expect(res.status).toBe(200);
+      expect(warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: ANNOTATED_BACKEND,
+          plugin: "@platypus/test",
+          sandboxId: "sbx-1",
+        }),
+        expect.stringContaining("external resources may leak"),
+      );
+      warn.mockRestore();
+    });
+
+    it("reports no owner rather than omitting the key for an unowned backend", async () => {
+      // A backend belonging to no loaded plugin is a real state (the plugin was
+      // dropped from PLATYPUS_PLUGINS). `null` says "no owner"; an absent key
+      // would read as "not asked", and the line would drop out of a filter that
+      // is looking for exactly this case.
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]);
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "sbx-1",
+          workspaceId,
+          backend: "no-such-backend",
+          config: {},
+          credentials: {},
+        },
+      ]);
+      setLoadedPlugins(loadedPluginsFixture());
+      const warn = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+      await app.request(`${baseUrl}?force=true`, { method: "DELETE" });
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          backend: "no-such-backend",
+          plugin: null,
+        }),
+        expect.stringContaining("external resources may leak"),
+      );
+      warn.mockRestore();
     });
 
     it("returns 500 when destroy() fails and preserves the row", async () => {

--- a/apps/backend/src/routes/sandbox.ts
+++ b/apps/backend/src/routes/sandbox.ts
@@ -319,7 +319,13 @@ sandbox.put(
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         logger.warn(
-          { workspaceId, sandboxId: current.id, err },
+          {
+            workspaceId,
+            sandboxId: current.id,
+            backend: current.backend,
+            plugin: getSandboxBackendPlugin(current.backend) ?? null,
+            err,
+          },
           "Sandbox backend change blocked: previous adapter's destroy() failed",
         );
         return c.json(
@@ -334,8 +340,15 @@ sandbox.put(
         {
           workspaceId,
           sandboxId: current.id,
-          oldBackend: current.backend,
-          newBackend: data.backend,
+          // `backend`/`plugin` co-refer on every line here, and on this one they
+          // name the adapter that was skipped — the one whose external resources
+          // may now be leaked, and so the one an Operator filtering by plugin is
+          // looking for. The incoming backend has leaked nothing, which is why it
+          // is `replacedBy` rather than the `newBackend` half of an old/new pair:
+          // a symmetric pair invites `plugin` to be read as spanning both.
+          backend: current.backend,
+          plugin: getSandboxBackendPlugin(current.backend) ?? null,
+          replacedBy: data.backend,
         },
         "Sandbox backend force-changed; previous adapter's destroy() was skipped — external resources may leak",
       );
@@ -383,7 +396,13 @@ sandbox.delete(
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         logger.warn(
-          { workspaceId, sandboxId: existing[0].id, err },
+          {
+            workspaceId,
+            sandboxId: existing[0].id,
+            backend: existing[0].backend,
+            plugin: getSandboxBackendPlugin(existing[0].backend) ?? null,
+            err,
+          },
           "Sandbox destroy() failed; row preserved so the user can retry",
         );
         return c.json(
@@ -399,6 +418,7 @@ sandbox.delete(
           workspaceId,
           sandboxId: existing[0].id,
           backend: existing[0].backend,
+          plugin: getSandboxBackendPlugin(existing[0].backend) ?? null,
         },
         "Sandbox row force-deleted; adapter destroy() was skipped — external resources may leak",
       );

--- a/apps/backend/src/sandbox/teardown.ts
+++ b/apps/backend/src/sandbox/teardown.ts
@@ -6,6 +6,7 @@ import {
   sandboxTeardownFailure as sandboxTeardownFailureTable,
 } from "../db/schema.ts";
 import { logger } from "../logger.ts";
+import { getSandboxBackendPlugin } from "../plugins/registry.ts";
 import { getSandboxBackend } from "./index.ts";
 
 type SandboxRow = typeof sandboxTable.$inferSelect;
@@ -68,8 +69,14 @@ export const destroyWorkspaceSandboxes = async (
         await destroySandboxRow(row);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+        // Core's line about a plugin's adapter, so it binds the owning plugin
+        // under the same `plugin` key the adapter's own lines carry — an
+        // Operator filtering on one plugin should get both halves of the story.
+        // `null` when the backend belongs to no loaded plugin, which is one way
+        // a cascade teardown fails in the first place.
+        const plugin = getSandboxBackendPlugin(row.backend) ?? null;
         logger.warn(
-          { workspaceId, sandboxId: row.id, backend: row.backend, err },
+          { workspaceId, sandboxId: row.id, backend: row.backend, plugin, err },
           "Sandbox destroy() failed during workspace cascade; recording ledger entry",
         );
         try {
@@ -81,8 +88,17 @@ export const destroyWorkspaceSandboxes = async (
             error: message,
           });
         } catch (ledgerErr) {
+          // The ledger row is what an Operator reconciles a leaked resource
+          // from, so when the insert itself fails this line is all they get —
+          // it carries the backend and plugin the lost row would have named.
           logger.error(
-            { workspaceId, sandboxId: row.id, err: ledgerErr },
+            {
+              workspaceId,
+              sandboxId: row.id,
+              backend: row.backend,
+              plugin,
+              err: ledgerErr,
+            },
             "Failed to record sandbox teardown failure",
           );
         }

--- a/apps/backend/src/test-utils.ts
+++ b/apps/backend/src/test-utils.ts
@@ -1,4 +1,5 @@
 import { vi, type Mock } from "vitest";
+import type { PluginLogger } from "@platypuschat/plugin-sdk";
 import type {
   ContributionOwners,
   LoadedPlugin,
@@ -274,4 +275,31 @@ export const loadedPluginsFixture = (
     webBackends: new Map(),
     ...owners,
   },
+});
+
+/**
+ * One level of a spy-backed {@link PluginLogger}. Typed to accept either call
+ * shape the contract declares — `(fields, msg)` and `(msg)` — because a spy
+ * typed to only the first is not assignable to the overloaded member and every
+ * call site would need a cast.
+ */
+type PluginLoggerSpy = Mock<(objOrMsg: object | string, msg?: string) => void>;
+
+/**
+ * A spy-backed {@link PluginLogger}: the seam core injects on a plugin's
+ * deploy-time block (ADR-0013). Tests for a built-in plugin assert on this
+ * rather than on core's logger, which the plugin no longer writes to.
+ */
+export interface FakePluginLogger extends PluginLogger {
+  debug: PluginLoggerSpy;
+  info: PluginLoggerSpy;
+  warn: PluginLoggerSpy;
+  error: PluginLoggerSpy;
+}
+
+export const makeFakePluginLogger = (): FakePluginLogger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
 });

--- a/apps/backend/src/tools/index.ts
+++ b/apps/backend/src/tools/index.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import { db } from "../index.ts";
 import { sandbox as sandboxTable } from "../db/schema.ts";
 import { getSandboxBackend } from "../sandbox/index.ts";
+import { getSandboxBackendPlugin } from "../plugins/registry.ts";
 import { createContributionRegistry } from "../registry/contribution-registry.ts";
 import { createSandboxTools } from "../sandbox/tools.ts";
 import { logger } from "../logger.ts";
@@ -81,10 +82,17 @@ registerToolSet(SANDBOX_TOOLSET_ID, {
     if (rows.length === 0) return {};
 
     const row = rows[0];
+    // Every line below is core's, but the subject of all three is a *plugin's*
+    // adapter, so each binds the owning plugin under the same `plugin` key the
+    // plugin's own lines carry. Otherwise an Operator filtering on one plugin
+    // gets the adapter's own lines and none of core's about it. `null` rather
+    // than absent when the backend belongs to no loaded plugin — the first case
+    // below is exactly that, and "no owner" is the answer, not "unasked".
+    const plugin = getSandboxBackendPlugin(row.backend) ?? null;
     const registration = getSandboxBackend(row.backend);
     if (!registration) {
       logger.warn(
-        { backend: row.backend, sandboxId: row.id },
+        { backend: row.backend, plugin, sandboxId: row.id },
         "Sandbox backend not registered; skipping sandbox tools for this turn",
       );
       return {};
@@ -93,7 +101,12 @@ registerToolSet(SANDBOX_TOOLSET_ID, {
     const configResult = registration.configSchema.safeParse(row.config ?? {});
     if (!configResult.success) {
       logger.warn(
-        { sandboxId: row.id, issues: configResult.error.issues },
+        {
+          backend: row.backend,
+          plugin,
+          sandboxId: row.id,
+          issues: configResult.error.issues,
+        },
         "Sandbox config failed adapter validation; skipping sandbox tools",
       );
       return {};
@@ -104,7 +117,12 @@ registerToolSet(SANDBOX_TOOLSET_ID, {
     );
     if (!credentialsResult.success) {
       logger.warn(
-        { sandboxId: row.id, issues: credentialsResult.error.issues },
+        {
+          backend: row.backend,
+          plugin,
+          sandboxId: row.id,
+          issues: credentialsResult.error.issues,
+        },
         "Sandbox credentials failed adapter validation; skipping sandbox tools",
       );
       return {};

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -75,6 +75,11 @@ Operator's `LOG_LEVEL` decides which of your lines are written — the same cont
 they have over core's. [Plugin API &
 config](/extending/plugin-api-and-config#logging) has the shape and the levels.
 
+The bundled Docker and SSH Sandbox backends write through this same logger, so
+what you are given is what the two most involved Plugins in the box get. If it
+turns out not to be enough for something you are building, that is a gap worth
+reporting rather than a reason to reach for `console`.
+
 ## Web-search backends
 
 A **Web-search backend** fills the **Search** toggle in Chat for Providers whose

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -154,7 +154,11 @@ empty list unless it says otherwise, and silently runs without web-fetch.
 - **A plugin logs into your stream, under your `LOG_LEVEL`.** Lines a plugin
   writes carry `"plugin":"<name>"` and are formatted and filtered exactly like
   core's own, so raising `LOG_LEVEL` to `debug` while diagnosing one plugin
-  raises everything else with it.
+  raises everything else with it. The bundled Docker and SSH backends are tagged
+  the same way as any third-party plugin, and Platypus's own lines about a
+  Sandbox backend — an adapter that failed to tear down, a backend that is no
+  longer registered — carry the same tag. Filtering on one plugin gets you both
+  sides: what the plugin reported, and what Platypus reported about it.
 
 <Callout type="warning">
   **`compose.sandbox.yaml` replaces `PLATYPUS_PLUGINS` — it does not merge.**


### PR DESCRIPTION
Closes #491.

The in-tree Docker and SSH plugins imported core's logger by relative path — an
option that exists only because they live inside the backend tree. Now that #502
puts a logger on `PluginConfigContext`, they consume the same contract they ask
third parties to use: each transport holds the injected `PluginLogger` and writes
through it, so their lines carry the manifest name the way any third-party
plugin's do.

Routing only. Every message, level and structured field is unchanged.

## Call sites left on the direct import

**None.** All five — the Docker image pull, its three teardown warnings, and the
SSH unpinned-host-key warning — already sat inside a transport instance that
receives the plugin block, so nothing needed context threaded through unrelated
code. The two test files still import core's logger, deliberately: they assert
`expect(logger.warn).not.toHaveBeenCalled()`, which is what pins that the routing
actually changed rather than merely gained a second channel.

## The SSH host-key warning

ADR-0012's warning keeps its level and its wording. Both are now asserted
verbatim, and against the **real loader** rather than a hand-rolled context — so
what is pinned is that an Operator greps `"plugin":"@platypus/ssh"` and finds it,
not merely that some logger was called. Removing the `plugin` forwarding from a
manifest turns those two tests red and nothing else.

## The web-backends criterion, and what replaced it

The issue asks to even out core's warn lines about web backends, which "bind the
plugin name on some lines and not others". **That defect isn't in the tree.** All
nine log lines in `composeWebBackend` already bind `plugin: pluginName`, and have
since the extension point landed — `git log -S "plugin: pluginName" --
apps/backend/src/web-backends/index.ts` returns only #384 and #393, and the one
later commit on that file (#485) doesn't touch the logging.

Rather than no-op the criterion, this PR serves its stated rationale — *"so
plugin-authored and core-authored lines about the same plugin are queryable
together"* — where the gap actually is: core's own lines about plugin-contributed
**sandbox** backends, which carried `backend` but never `plugin`. That is the
symmetry this change earns, since it is what puts `plugin: "@platypus/docker"` on
the adapter's own lines in the first place.

Nine lines now bind it, via `getSandboxBackendPlugin`:

| File | Lines |
| --- | --- |
| `src/tools/index.ts` | 3 (two of which didn't carry `backend` either) |
| `src/sandbox/teardown.ts` | 2, including the ledger-insert failure — the line an Operator is left with when the reconciliation row itself fails to write |
| `src/routes/sandbox.ts` | 4 |

`null` rather than an absent key when a backend belongs to no loaded plugin:
"no owner" is the answer, and it is exactly the case someone filtering would be
hunting for.

One of those four route lines needed more than a new field. The force-change leak
warning read `oldBackend` / `plugin` / `newBackend` — a bare `plugin` between a
symmetric pair reads as covering both, when it only ever resolves the outgoing
one. On a line whose subject is a leaked external resource that is worth getting
right, so `backend`/`plugin` now co-refer as they do everywhere else and the
incoming backend is `replacedBy`. Neither old field name had any consumer.

## Testing

11 new tests; 6 existing updated off the old seam. The pre-existing Docker
teardown and SSH host-key suites asserted on core's logger — left alone they
would have passed vacuously, since core's logger is now never called, so they
inject a `FakePluginLogger` and watch that instead.

Full suite green: 1780 backend, 199 frontend, 122 schemas, 25 docs, 10 SDK,
5 examples. `pnpm typecheck` and `pnpm lint` clean.

## Docs

Per the table in `CLAUDE.md`, a `src/plugins/**` change owes both
`extending/index.mdx` and `self-hosting/configuration.mdx`. The latter already
promised that plugin lines carry `"plugin":"<name>"` — this change is what makes
that true for the bundled backends — and now also documents that Platypus's own
lines about a Sandbox backend carry the same tag. The former tells plugin authors
that the two most involved plugins in the box write through the logger they are
being handed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
