### PR TITLE
fix(frontend): trace the @swc/helpers ESM files into the standalone image

### DIFF
--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -10,6 +10,15 @@ const nextConfig: NextConfig = {
   },
   basePath: process.env.BASE_PATH || undefined,
   output: "standalone",
+  // @swc/helpers 0.5.23 added a "module-sync" export condition that resolves
+  // ahead of "default". Node >=22.10 honours it for require(), so next/dist
+  // loads the esm/ helpers at runtime while the standalone file tracer still
+  // only follows the cjs/ ones and leaves esm/ out of the image.
+  outputFileTracingIncludes: {
+    "**/*": [
+      "../../node_modules/.pnpm/@swc+helpers@*/node_modules/@swc/helpers/esm/**",
+    ],
+  },
   ...(allowedDevOrigins.length > 0 && { allowedDevOrigins }),
 };
 


### PR DESCRIPTION
## Problem

v2.7.0's frontend image crashes at startup, before serving a single request:

```
Error: Cannot find module '/app/node_modules/.pnpm/next@16.3.1_.../node_modules/@swc/helpers/esm/_interop_require_default.js'
    at createEsmNotFoundErr (node:internal/modules/cjs/loader:1554:15)
    at .../next/dist/server/require-hook.js:68:36
  code: 'MODULE_NOT_FOUND'
frontend-1 exited with code 1
```

## Cause

#482 bumped `next` 16.2.9 → 16.3.1, which pulls `@swc/helpers` 0.5.15 → 0.5.23. That
release added a `"module-sync"` export condition ahead of `"default"` on all 108 helper
subpaths, which flips how `require()` resolves them on Node ≥22.10:

| `@swc/helpers` | `require("@swc/helpers/_/_interop_require_default")` resolves to |
| --- | --- |
| 0.5.15 | `cjs/_interop_require_default.cjs` |
| 0.5.23 | `esm/_interop_require_default.js` |

84 files in `next/dist` require those subpaths. Next's output-file tracer still follows
the CJS variants at build time, so `.next/standalone` ships `cjs/` and `package.json`
with no `esm/` directory at all — while Node 24 in the container asks for `esm/`.

The build passes and the container dies at module load. This is not Docker-specific:
`node .next/standalone/apps/frontend/server.js` reproduces the identical stack trace.

## Fix

Force the `esm/` helpers into the trace via `outputFileTracingIncludes`, so the image
carries both resolutions.

## Verification

- Reproduced the crash from an unfixed standalone build — same `createEsmNotFoundErr` trace as the report.
- After the fix, `.next/standalone/.../@swc/helpers/` contains `cjs`, `esm`, `package.json`.
- Built `apps/frontend/Dockerfile --target runner` and ran the container: `✓ Ready`, `GET /sign-in` → HTTP 200, process stays up.
- `pnpm --filter @platypus/frontend typecheck` clean.

## Notes

- No docs change is triggered — `next.config.ts` is not in the CLAUDE.md docs table and nothing user-facing changed.
- `apps/docs` is also on next 16.3.1 but builds through OpenNext/Cloudflare rather than standalone tracing, so it is on a different code path and is not touched here.
- Worth a follow-up: `build-and-push.yml` builds and pushes release images without ever booting one, which is why a boot-time crash reached users. A `docker run` + `curl` smoke step would have caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
