### PR TITLE
chore(backend): export the Shared-resource write predicate from the Scoped-resource authority

### DIFF
--- a/apps/backend/src/routes/org-agent.test.ts
+++ b/apps/backend/src/routes/org-agent.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+// test-utils installs the drizzle-orm mock; `isNull` is a spy only through it,
+// so that import must come first.
 import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
+import { isNull } from "drizzle-orm";
+import { agent as agentTable } from "../db/schema.ts";
 import app from "../server.ts";
 import { deleteAvatar } from "../services/avatar.ts";
 
@@ -88,6 +92,10 @@ describe("Organization Agent Routes", () => {
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual(updated);
+      // The write matches the Shared predicate, not `organizationId` alone: a
+      // row carrying both scope columns belongs to its Workspace and must not
+      // be editable from the Organization surface (ADR-0007).
+      expect(isNull).toHaveBeenCalledWith(agentTable.workspaceId);
     });
 
     it("blocks an update that references a workspace-private resource", async () => {

--- a/apps/backend/src/routes/org-agent.ts
+++ b/apps/backend/src/routes/org-agent.ts
@@ -3,7 +3,6 @@ import { sValidator } from "@hono/standard-validator";
 import { db } from "../index.ts";
 import { agent as agentTable } from "../db/schema.ts";
 import { agentUpdateSchema } from "@platypus/schemas";
-import { eq, and } from "drizzle-orm";
 import { dedupeArray } from "../utils.ts";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
@@ -12,6 +11,7 @@ import { SUB_AGENT_SELF_ASSIGNMENT_ERROR } from "../services/sub-agent-validatio
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
 import {
   listOrgScoped,
+  orgScopedWhere,
   requireOrgScoped,
   requireSharedDeletable,
 } from "../services/scoped-resource.ts";
@@ -98,9 +98,7 @@ orgAgent.put(
     const record = await db
       .update(agentTable)
       .set({ ...data, updatedAt: new Date() })
-      .where(
-        and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
-      )
+      .where(orgScopedWhere("agent", agentId, orgId))
       .returning();
     if (record.length === 0) {
       throw new NotFoundError("Agent not found");
@@ -130,9 +128,7 @@ orgAgent.post(
     const record = await db
       .update(agentTable)
       .set({ avatarKey: result.key, updatedAt: new Date() })
-      .where(
-        and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
-      )
+      .where(orgScopedWhere("agent", agentId, orgId))
       .returning();
     return c.json(agentWithAvatarUrl(record[0], baseUrl));
   },
@@ -155,9 +151,7 @@ orgAgent.delete(
     const record = await db
       .update(agentTable)
       .set({ avatarKey: null, updatedAt: new Date() })
-      .where(
-        and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
-      )
+      .where(orgScopedWhere("agent", agentId, orgId))
       .returning();
     return c.json(agentWithAvatarUrl(record[0], baseUrl));
   },
@@ -182,9 +176,7 @@ orgAgent.delete(
     const result = await db.transaction(async (tx) => {
       const rows = await tx
         .delete(agentTable)
-        .where(
-          and(eq(agentTable.id, agentId), eq(agentTable.organizationId, orgId)),
-        )
+        .where(orgScopedWhere("agent", agentId, orgId))
         .returning();
       if (rows.length > 0) {
         await scrubDeletedAgentReference(tx, "subAgentIds", agentId);

--- a/apps/backend/src/routes/org-attachment.test.ts
+++ b/apps/backend/src/routes/org-attachment.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+// test-utils installs the drizzle-orm mock; `isNull` is a spy only through it,
+// so that import must come first.
 import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
+import { isNull } from "drizzle-orm";
+import { agent as agentTable } from "../db/schema.ts";
 import app from "../server.ts";
 
 describe("Organization Attachment (central sharing) Routes", () => {
@@ -80,6 +84,10 @@ describe("Organization Attachment (central sharing) Routes", () => {
       });
       expect(res.status).toBe(201);
       expect(await res.json()).toEqual(att);
+      // Sharing is managed only for a genuinely Shared resource: the lookup
+      // requires no Workspace, so a row carrying both scope columns cannot be
+      // attached elsewhere on the strength of its org column (ADR-0007).
+      expect(isNull).toHaveBeenCalledWith(agentTable.workspaceId);
     });
 
     it("404s when the workspace is not in this org", async () => {

--- a/apps/backend/src/routes/org-attachment.ts
+++ b/apps/backend/src/routes/org-attachment.ts
@@ -3,16 +3,16 @@ import { nanoid } from "nanoid";
 import { db } from "../index.ts";
 import {
   attachment as attachmentTable,
-  agent as agentTable,
-  mcp as mcpTable,
-  provider as providerTable,
-  skill as skillTable,
   workspace as workspaceTable,
 } from "../db/schema.ts";
 import { and, eq } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { isUniqueViolation } from "../errors.ts";
+import {
+  isScopedResourceType,
+  resolveOrgScoped,
+} from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 
 // Org-surface management of where a Shared resource is attached (ADR-0007).
@@ -21,36 +21,6 @@ import type { Variables } from "../server.ts";
 // with?" and lets an Org Admin attach/detach workspaces centrally — the natural
 // place to manage sharing across many workspaces. All routes are admin-only.
 const orgAttachment = new Hono<{ Variables: Variables }>();
-
-const RESOURCE_TABLES = {
-  mcp: mcpTable,
-  provider: providerTable,
-  skill: skillTable,
-  agent: agentTable,
-} as const;
-
-type ResourceType = keyof typeof RESOURCE_TABLES;
-
-const isResourceType = (v: string | undefined): v is ResourceType =>
-  v === "mcp" || v === "provider" || v === "skill" || v === "agent";
-
-/**
- * Confirms a resource is org-scoped and belongs to this organization — you can
- * only manage sharing for a Shared resource, never a workspace-private one.
- */
-const orgResourceExists = async (
-  resourceType: ResourceType,
-  resourceId: string,
-  orgId: string,
-): Promise<boolean> => {
-  const table = RESOURCE_TABLES[resourceType];
-  const rows = await db
-    .select({ id: table.id })
-    .from(table)
-    .where(and(eq(table.id, resourceId), eq(table.organizationId, orgId)))
-    .limit(1);
-  return rows.length > 0;
-};
 
 /**
  * List the workspaces a Shared resource is attached to (admin only).
@@ -62,7 +32,7 @@ orgAttachment.get("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
   const resourceType = c.req.query("resourceType");
   const resourceId = c.req.query("resourceId");
 
-  if (!isResourceType(resourceType) || !resourceId) {
+  if (!isScopedResourceType(resourceType) || !resourceId) {
     return c.json(
       { error: "resourceType and resourceId query params are required" },
       400,
@@ -103,7 +73,7 @@ orgAttachment.post("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
   };
   const { resourceType, resourceId, workspaceId } = body;
 
-  if (!isResourceType(resourceType)) {
+  if (!isScopedResourceType(resourceType)) {
     return c.json({ error: "Invalid resourceType" }, 400);
   }
   if (!resourceId || !workspaceId) {
@@ -125,7 +95,10 @@ orgAttachment.post("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
     return c.json({ error: "Workspace not found in this organization" }, 404);
   }
 
-  if (!(await orgResourceExists(resourceType, resourceId, orgId))) {
+  // You can only manage sharing for a Shared resource, never a
+  // Workspace-private one (ADR-0007) — the same check the Workspace-surface
+  // attach route makes.
+  if (!(await resolveOrgScoped(db, resourceType, resourceId, orgId))) {
     return c.json(
       { error: "Org-scoped resource not found in this organization" },
       404,
@@ -160,7 +133,7 @@ orgAttachment.delete(
     const resourceId = c.req.param("resourceId");
     const workspaceId = c.req.param("workspaceId");
 
-    if (!isResourceType(resourceType)) {
+    if (!isScopedResourceType(resourceType)) {
       return c.json({ error: "Invalid resourceType" }, 400);
     }
 

--- a/apps/backend/src/routes/org-blueprint.ts
+++ b/apps/backend/src/routes/org-blueprint.ts
@@ -5,10 +5,7 @@ import { db } from "../index.ts";
 import {
   blueprint as blueprintTable,
   blueprintItem as blueprintItemTable,
-  agent as agentTable,
-  mcp as mcpTable,
   provider as providerTable,
-  skill as skillTable,
   workspace as workspaceTable,
 } from "../db/schema.ts";
 import {
@@ -23,6 +20,11 @@ import { requireOrgAccess } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { applyBlueprintsToWorkspace } from "../services/blueprint-apply.ts";
 import { isBlueprintReferencedByLiveInvitation } from "../services/blueprint-guard.ts";
+import {
+  listOrgScopedIds,
+  orgScopedWhereIn,
+  type ScopedResourceType,
+} from "../services/scoped-resource.ts";
 import { isUniqueViolation } from "../errors.ts";
 
 // Blueprint — a named, Organization-scoped macro that, applied to a Workspace,
@@ -32,15 +34,6 @@ import { isUniqueViolation } from "../errors.ts";
 // Workspaces. A Blueprint may only list org-scoped (Shared) resources, and all
 // management — and applying — is Org-Admin-only.
 const orgBlueprint = new Hono<{ Variables: Variables }>();
-
-const RESOURCE_TABLES = {
-  mcp: mcpTable,
-  provider: providerTable,
-  skill: skillTable,
-  agent: agentTable,
-} as const;
-
-type ResourceType = keyof typeof RESOURCE_TABLES;
 
 const NAME_CONFLICT = {
   error: "A blueprint with this name already exists in this organization",
@@ -69,7 +62,7 @@ const findNonSharedItems = async (
   items: BlueprintItem[],
   orgId: string,
 ): Promise<BlueprintItem[]> => {
-  const byType = new Map<ResourceType, string[]>();
+  const byType = new Map<ScopedResourceType, string[]>();
   for (const item of items) {
     const ids = byType.get(item.resourceType) ?? [];
     ids.push(item.resourceId);
@@ -78,12 +71,7 @@ const findNonSharedItems = async (
 
   const invalid: BlueprintItem[] = [];
   for (const [resourceType, ids] of byType) {
-    const table = RESOURCE_TABLES[resourceType];
-    const rows = await db
-      .select({ id: table.id })
-      .from(table)
-      .where(and(eq(table.organizationId, orgId), inArray(table.id, ids)));
-    const found = new Set(rows.map((r) => r.id));
+    const found = await listOrgScopedIds(db, resourceType, ids, orgId);
     for (const id of ids) {
       if (!found.has(id)) invalid.push({ resourceType, resourceId: id });
     }
@@ -172,12 +160,10 @@ const findInvalidMemoryProviders = async (
     })
     .from(providerTable)
     .where(
-      and(
-        eq(providerTable.organizationId, orgId),
-        inArray(
-          providerTable.id,
-          checks.map((c) => c.providerId),
-        ),
+      orgScopedWhereIn(
+        "provider",
+        checks.map((c) => c.providerId),
+        orgId,
       ),
     );
   const byId = new Map(rows.map((r) => [r.id, r]));

--- a/apps/backend/src/routes/org-mcp.ts
+++ b/apps/backend/src/routes/org-mcp.ts
@@ -12,7 +12,6 @@ import {
   mcpUpdateSchema,
   mcpTestSchema,
 } from "@platypus/schemas";
-import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   orgCredentialsVisible,
@@ -21,6 +20,7 @@ import {
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
 import {
   listOrgScoped,
+  orgScopedWhere,
   requireOrgScoped,
   resolveOrgScoped,
   requireSharedDeletable,
@@ -121,7 +121,7 @@ orgMcp.put(
         }),
         updatedAt: new Date(),
       })
-      .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.organizationId, orgId)))
+      .where(orgScopedWhere("mcp", mcpId, orgId))
       .returning();
     if (record.length === 0) {
       throw new NotFoundError("MCP not found");
@@ -149,7 +149,7 @@ orgMcp.delete(
     const result = await db.transaction(async (tx) => {
       const rows = await tx
         .delete(mcpTable)
-        .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.organizationId, orgId)))
+        .where(orgScopedWhere("mcp", mcpId, orgId))
         .returning();
       if (rows.length > 0) {
         await scrubDeletedAgentReference(tx, "toolSetIds", mcpId);
@@ -273,7 +273,7 @@ orgMcp.post(
       await db
         .update(mcpTable)
         .set({ ...OAUTH_TOKEN_CLEAR_FIELDS, updatedAt: new Date() })
-        .where(eq(mcpTable.id, mcpId));
+        .where(orgScopedWhere("mcp", mcpId, orgId));
       mcpRecord = { ...mcpRecord, ...OAUTH_TOKEN_CLEAR_FIELDS };
     }
 
@@ -316,7 +316,7 @@ orgMcp.post(
     const record = await db
       .update(mcpTable)
       .set({ ...OAUTH_TOKEN_CLEAR_FIELDS, updatedAt: new Date() })
-      .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.organizationId, orgId)))
+      .where(orgScopedWhere("mcp", mcpId, orgId))
       .returning();
 
     if (record.length === 0) {

--- a/apps/backend/src/routes/org-provider.ts
+++ b/apps/backend/src/routes/org-provider.ts
@@ -4,7 +4,6 @@ import { nanoid } from "nanoid";
 import { db } from "../index.ts";
 import { provider as providerTable } from "../db/schema.ts";
 import { providerCreateSchema, providerUpdateSchema } from "@platypus/schemas";
-import { eq, and } from "drizzle-orm";
 import { handleEmbeddingConfigChange } from "../services/embedding-invalidation.ts";
 import { dedupeModelConfigs } from "../services/model-capability.ts";
 import {
@@ -18,6 +17,7 @@ import {
 } from "../middleware/authorization.ts";
 import {
   listOrgScoped,
+  orgScopedWhere,
   requireOrgScoped,
   requireSharedDeletable,
 } from "../services/scoped-resource.ts";
@@ -114,12 +114,7 @@ orgProvider.put(
         ...data,
         updatedAt: new Date(),
       })
-      .where(
-        and(
-          eq(providerTable.id, providerId),
-          eq(providerTable.organizationId, orgId),
-        ),
-      )
+      .where(orgScopedWhere("provider", providerId, orgId))
       .returning();
 
     if (record.length === 0) {
@@ -157,12 +152,7 @@ orgProvider.delete(
 
     const result = await db
       .delete(providerTable)
-      .where(
-        and(
-          eq(providerTable.id, providerId),
-          eq(providerTable.organizationId, orgId),
-        ),
-      )
+      .where(orgScopedWhere("provider", providerId, orgId))
       .returning();
 
     if (result.length === 0) {

--- a/apps/backend/src/routes/org-skill.ts
+++ b/apps/backend/src/routes/org-skill.ts
@@ -4,12 +4,12 @@ import { nanoid } from "nanoid";
 import { db } from "../index.ts";
 import { skill as skillTable } from "../db/schema.ts";
 import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
-import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { requireOrgAccess } from "../middleware/authorization.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
 import {
   listOrgScoped,
+  orgScopedWhere,
   requireOrgScoped,
   requireSharedDeletable,
 } from "../services/scoped-resource.ts";
@@ -86,9 +86,7 @@ orgSkill.put(
         body: data.body,
         updatedAt: new Date(),
       })
-      .where(
-        and(eq(skillTable.id, skillId), eq(skillTable.organizationId, orgId)),
-      )
+      .where(orgScopedWhere("skill", skillId, orgId))
       .returning();
     if (record.length === 0) {
       throw new NotFoundError("Skill not found");
@@ -116,9 +114,7 @@ orgSkill.delete(
     const result = await db.transaction(async (tx) => {
       const rows = await tx
         .delete(skillTable)
-        .where(
-          and(eq(skillTable.id, skillId), eq(skillTable.organizationId, orgId)),
-        )
+        .where(orgScopedWhere("skill", skillId, orgId))
         .returning();
       if (rows.length > 0) {
         await scrubDeletedAgentReference(tx, "skillIds", skillId);

--- a/apps/backend/src/services/scoped-resource.test.ts
+++ b/apps/backend/src/services/scoped-resource.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 // test-utils installs the drizzle-orm mock, so it must be imported before the
-// operators this file asserts on — `inArray` is a spy only through that mock.
+// operators this file asserts on — `eq`/`inArray`/`isNull` are spies only
+// through that mock.
 import { mockDb, resetMockDb, asDb } from "../test-utils.ts";
-import { inArray, isNull } from "drizzle-orm";
-import { agent as agentTable } from "../db/schema.ts";
+import { eq, inArray, isNull } from "drizzle-orm";
+import { agent as agentTable, mcp as mcpTable } from "../db/schema.ts";
 import {
   resolveScoped,
   resolveScopedByName,
@@ -15,12 +16,16 @@ import {
   resolveOrgScoped,
   requireOrgScoped,
   listOrgScoped,
+  listOrgScopedIds,
+  orgScopedWhere,
+  orgScopedWhereIn,
+  isScopedResourceType,
 } from "./scoped-resource.ts";
 import { NotFoundError, LockedError, ConflictError } from "../errors.ts";
 
 const ctx = { orgId: "org-1", wsId: "ws-1" };
 
-describe("ScopedResource read module", () => {
+describe("ScopedResource module", () => {
   beforeEach(() => {
     resetMockDb();
     vi.clearAllMocks();
@@ -187,6 +192,76 @@ describe("ScopedResource read module", () => {
         "org-1",
       );
       expect(found).toBeNull();
+    });
+  });
+
+  describe("orgScopedWhere", () => {
+    it("matches on id, organization, and no workspace", () => {
+      orgScopedWhere("agent", "a1", "org-1");
+
+      expect(eq).toHaveBeenCalledWith(agentTable.id, "a1");
+      expect(eq).toHaveBeenCalledWith(agentTable.organizationId, "org-1");
+      // The part a hand-rolled `eq(organizationId)` write predicate leaves out:
+      // a row carrying both scope columns belongs to its Workspace and must not
+      // be written from the Organization surface (ADR-0007).
+      expect(isNull).toHaveBeenCalledWith(agentTable.workspaceId);
+    });
+
+    it("resolves the columns of the type it is given", () => {
+      orgScopedWhere("mcp", "m1", "org-1");
+
+      expect(eq).toHaveBeenCalledWith(mcpTable.id, "m1");
+      expect(isNull).toHaveBeenCalledWith(mcpTable.workspaceId);
+    });
+  });
+
+  describe("orgScopedWhereIn", () => {
+    it("matches on a set of ids, the organization, and no workspace", () => {
+      const ids = ["a1", "a2"];
+      orgScopedWhereIn("agent", ids, "org-1");
+
+      expect(inArray).toHaveBeenCalledWith(agentTable.id, ids);
+      expect(eq).toHaveBeenCalledWith(agentTable.organizationId, "org-1");
+      expect(isNull).toHaveBeenCalledWith(agentTable.workspaceId);
+    });
+  });
+
+  describe("listOrgScopedIds", () => {
+    it("returns the subset of ids that are Shared here", async () => {
+      const ids = ["a1", "a2", "gone"];
+      mockDb.where.mockResolvedValueOnce([{ id: "a1" }, { id: "a2" }]);
+
+      const found = await listOrgScopedIds(asDb(mockDb), "agent", ids, "org-1");
+      expect(found).toEqual(new Set(["a1", "a2"]));
+      expect(inArray).toHaveBeenCalledWith(agentTable.id, ids);
+      expect(isNull).toHaveBeenCalledWith(agentTable.workspaceId);
+    });
+
+    it("returns an empty set without querying when given no ids", async () => {
+      const found = await listOrgScopedIds(asDb(mockDb), "agent", [], "org-1");
+      expect(found).toEqual(new Set());
+      expect(mockDb.select).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isScopedResourceType", () => {
+    it("admits every registered resource type", () => {
+      for (const type of ["agent", "skill", "mcp", "provider"]) {
+        expect(isScopedResourceType(type)).toBe(true);
+      }
+    });
+
+    it("rejects a missing or unregistered type", () => {
+      expect(isScopedResourceType(undefined)).toBe(false);
+      expect(isScopedResourceType("blueprint")).toBe(false);
+      expect(isScopedResourceType("")).toBe(false);
+    });
+
+    it("rejects an inherited Object property name", () => {
+      // The value reaches this guard straight from a query param or request
+      // body, so membership is a real lookup rather than an `in` that would
+      // walk the prototype chain and admit "constructor" as a resource type.
+      expect(isScopedResourceType("constructor")).toBe(false);
     });
   });
 

--- a/apps/backend/src/services/scoped-resource.ts
+++ b/apps/backend/src/services/scoped-resource.ts
@@ -1,4 +1,4 @@
-import { and, eq, or, inArray, isNull } from "drizzle-orm";
+import { and, eq, or, inArray, isNull, type SQL } from "drizzle-orm";
 import {
   agent as agentTable,
   skill as skillTable,
@@ -11,18 +11,21 @@ import { ConflictError, LockedError, NotFoundError } from "../errors.ts";
 import { isResourceListedInBlueprint } from "./blueprint-guard.ts";
 
 /**
- * The read side of the **Scoped resource** (CONTEXT.md): an Agent, Skill, MCP,
- * or Provider whose row lives at exactly one scope — a Workspace or the
- * Organization, mutually exclusive (ADR-0007). Resolved relative to a
- * Workspace it yields a `(row, scope)` pair: Workspace-scoped rows are visible
- * directly; Organization-scoped (Shared) rows are visible only where an
- * **Attachment** exists, and are locked against Workspace-surface mutation.
+ * The **Scoped resource** (CONTEXT.md): an Agent, Skill, MCP, or Provider whose
+ * row lives at exactly one scope — a Workspace or the Organization, mutually
+ * exclusive (ADR-0007). Resolved relative to a Workspace it yields a
+ * `(row, scope)` pair: Workspace-scoped rows are visible directly;
+ * Organization-scoped (Shared) rows are visible only where an **Attachment**
+ * exists, and are locked against Workspace-surface mutation.
  *
  * The Organization surface asks a narrower question — "is this a Shared
  * resource of this Organization?" — with no Workspace and so no Attachment in
- * play. `resolveOrgScoped`/`requireOrgScoped`/`listOrgScoped` answer it, and
- * take a bare `orgId` rather than a {@link ScopeContext} for exactly that
- * reason.
+ * play. `resolveOrgScoped`/`requireOrgScoped`/`listOrgScoped`/`listOrgScopedIds`
+ * answer it for reads, and take a bare `orgId` rather than a
+ * {@link ScopeContext} for exactly that reason; {@link orgScopedWhere} answers
+ * it for writes, so an `UPDATE`/`DELETE` on the Organization surface matches the
+ * same rows a read would. `isNull(workspaceId)` — what actually makes a row
+ * Shared — is spelled once here, in {@link sharedWhere}, rather than in each route.
  *
  * Collapses the "resolve → null-check → org-scope-403" branch that the
  * dual-scope resource routes each re-implemented. `resolveScoped`/
@@ -80,10 +83,71 @@ const REGISTRY: Record<ScopedResourceType, RegistryEntry> = {
   provider: { table: providerTable, label: "Provider", noun: "provider" },
 };
 
+/** The registry's key set, for the runtime guard below. */
+const SCOPED_RESOURCE_TYPES = new Set<string>(Object.keys(REGISTRY));
+
+/**
+ * Whether an untrusted string names a Scoped-resource type — for the routes
+ * that take a `resourceType` from a query param or a request body, which
+ * otherwise each re-list the four names beside their own copy of the registry.
+ * The value is attacker-supplied and ends up keying the registry, so membership
+ * is a real lookup rather than an `in` that would walk the prototype chain.
+ */
+export const isScopedResourceType = (
+  value: string | undefined,
+): value is ScopedResourceType =>
+  value !== undefined && SCOPED_RESOURCE_TYPES.has(value);
+
 /** The Workspace a Scoped resource is resolved relative to. */
 export type ScopeContext = { orgId: string; wsId: string };
 
 type Database = typeof db;
+
+/**
+ * `and()` is typed to tolerate `undefined` operands and so widens to
+ * `SQL | undefined`. Every condition composed below is concrete, and a
+ * `.where(undefined)` would match the whole table — an unfiltered `UPDATE` or
+ * `DELETE` on the Organization surface. Asserting once here keeps that shape out
+ * of the predicates' return types, so no caller can be handed it.
+ */
+const allOf = (...conditions: (SQL | undefined)[]): SQL => and(...conditions)!;
+
+/**
+ * {@link isSharedRow} as SQL: at this Organization, and at no Workspace. The one
+ * place that condition is written — every query in this module, read or write,
+ * composes it.
+ */
+const sharedWhere = (table: ScopedTable, orgId: string): SQL =>
+  allOf(eq(table.organizationId, orgId), isNull(table.workspaceId));
+
+/**
+ * The `WHERE` clause matching a single **Shared resource** of this Organization
+ * — the write-side counterpart to {@link resolveOrgScoped}. An `UPDATE` or
+ * `DELETE` on the Organization surface passes it straight to `.where(...)`, so a
+ * write matches exactly the rows a read would rather than a hand-rolled
+ * `eq(organizationId)` that omits the Workspace check.
+ */
+export const orgScopedWhere = (
+  type: ScopedResourceType,
+  id: string,
+  orgId: string,
+): SQL => {
+  const { table } = REGISTRY[type];
+  return allOf(eq(table.id, id), sharedWhere(table, orgId));
+};
+
+/**
+ * {@link orgScopedWhere} over a set of ids — for the callers that validate a
+ * batch of references in one query rather than a row at a time.
+ */
+export const orgScopedWhereIn = (
+  type: ScopedResourceType,
+  ids: string[],
+  orgId: string,
+): SQL => {
+  const { table } = REGISTRY[type];
+  return allOf(inArray(table.id, ids), sharedWhere(table, orgId));
+};
 
 /**
  * Whether a row is a **Shared resource** of this Organization: org-scoped, and at
@@ -91,7 +155,8 @@ type Database = typeof db;
  * on write, not by a database constraint, so "has this organizationId" is not on
  * its own enough — a row holding both belongs to its Workspace and must not reach
  * another one on the strength of the org column. Absent rows are not Shared, so a
- * dangling id fails this too.
+ * dangling id fails this too. {@link sharedWhere} is the same rule as SQL, for
+ * the rows this module has yet to fetch.
  *
  * Exported because the Promotion guard (`findNonSharedReferences`) asks the same
  * question of rows it fetched itself.
@@ -193,19 +258,13 @@ export const resolveScopedByName = async <T extends ScopedResourceType>(
   const workspaceRow = workspaceRows[0] as RowOf[T] | undefined;
   if (workspaceRow) return { row: workspaceRow, scope: "workspace" };
 
-  // `isNull(workspaceId)` is what makes the row Shared: the scope columns are
-  // mutually exclusive on write, not by a database constraint, so a row carrying
-  // both must not reach another Workspace through that Workspace's Attachment.
+  // Only a genuinely Shared row answers here: a row carrying both scope columns
+  // belongs to its Workspace and must not reach another one through that
+  // Workspace's Attachment (see {@link sharedWhere}).
   const orgRows = await database
     .select()
     .from(table)
-    .where(
-      and(
-        eq(table.organizationId, ctx.orgId),
-        isNull(table.workspaceId),
-        eq(table.name, name),
-      ),
-    )
+    .where(and(sharedWhere(table, ctx.orgId), eq(table.name, name)))
     .limit(1);
   const orgRow = orgRows[0] as RowOf[T] | undefined;
   if (!orgRow) return null;
@@ -239,10 +298,9 @@ export const listScoped = async <T extends ScopedResourceType>(
     );
 
   // Shared rows appear in a Workspace only where attached (ADR-0007) — gate by
-  // an inner join on the Attachment table. `isNull(workspaceId)` is what makes
-  // the row org-scoped: the scope columns are mutually exclusive on write, not by
-  // a database constraint, so a row carrying both must not reach another
-  // Workspace through that Workspace's Attachment.
+  // an inner join on the Attachment table. Only genuinely Shared rows qualify:
+  // one carrying both scope columns belongs to its Workspace and must not reach
+  // another one through that Workspace's Attachment (see {@link sharedWhere}).
   const attachedRows = await database
     .select()
     .from(table)
@@ -256,8 +314,7 @@ export const listScoped = async <T extends ScopedResourceType>(
     )
     .where(
       and(
-        eq(table.organizationId, ctx.orgId),
-        isNull(table.workspaceId),
+        sharedWhere(table, ctx.orgId),
         ids ? inArray(table.id, ids) : undefined,
       ),
     );
@@ -301,12 +358,9 @@ export const listScopedByIds = <T extends ScopedResourceType>(
  * and so no Attachment to gate on. Returns `null` when the id is not a Shared
  * resource of this Organization. Never throws.
  *
- * `isNull(workspaceId)` carries the same defence `listScoped` applies to its
- * Organization half: the scope columns are mutually exclusive on write, not by a
- * database constraint, and a row carrying both belongs to its Workspace — it is
- * not Shared, and does not answer here. The org routes' own `UPDATE`/`DELETE`
- * clauses still match on `organizationId` alone; no route can write both columns,
- * so that gap is unreachable rather than closed.
+ * Reads {@link orgScopedWhere} — the same predicate the Organization surface's
+ * `UPDATE`/`DELETE` clauses match on, so a write can never reach a row this
+ * lookup would refuse.
  */
 export const resolveOrgScoped = async <T extends ScopedResourceType>(
   database: Database,
@@ -319,13 +373,7 @@ export const resolveOrgScoped = async <T extends ScopedResourceType>(
   const rows = await database
     .select()
     .from(table)
-    .where(
-      and(
-        eq(table.id, id),
-        eq(table.organizationId, orgId),
-        isNull(table.workspaceId),
-      ),
-    )
+    .where(orgScopedWhere(type, id, orgId))
     .limit(1);
   return (rows[0] as RowOf[T] | undefined) ?? null;
 };
@@ -362,8 +410,31 @@ export const listOrgScoped = async <T extends ScopedResourceType>(
   const rows = await database
     .select()
     .from(table)
-    .where(and(eq(table.organizationId, orgId), isNull(table.workspaceId)));
+    .where(sharedWhere(table, orgId));
   return rows as RowOf[T][];
+};
+
+/**
+ * The subset of `ids` that are Shared resources of this Organization, as a set
+ * of ids — for callers validating a list of references (a Blueprint's items)
+ * rather than reading rows, which can compare it against what they asked for and
+ * report the rest as blockers. Never throws; no query runs for an empty `ids`,
+ * which would otherwise reach the database as `IN ()`.
+ */
+export const listOrgScopedIds = async (
+  database: Database,
+  type: ScopedResourceType,
+  ids: string[],
+  orgId: string,
+): Promise<Set<string>> => {
+  if (ids.length === 0) return new Set();
+  const { table } = REGISTRY[type];
+
+  const rows = await database
+    .select({ id: table.id })
+    .from(table)
+    .where(orgScopedWhereIn(type, ids, orgId));
+  return new Set(rows.map((r) => r.id));
 };
 
 /**


### PR DESCRIPTION
Closes #498

## Problem

The Scoped-resource module consolidated the *read* side of "is this a Shared resource of this Organization?" and stopped there. Every Organization-surface route spelled its own `and(eq(id), eq(organizationId))` for `UPDATE`/`DELETE`, leaving out the `isNull(workspaceId)` the module documents as what actually makes a row Shared — ADR-0007's mutual exclusivity is a Zod refinement, not a database constraint. The module's own comment admitted the gap.

## Solution

Export the predicate, not just the reader.

- **`orgScopedWhere(type, id, orgId)`** and **`orgScopedWhereIn(type, ids, orgId)`** return the full `and(eq(id), eq(organizationId), isNull(workspaceId))` condition for `.where(...)` to take directly.
- **`isScopedResourceType`** — the registry's key set as the single guard for routes taking a `resourceType` from a query param or body.
- **`listOrgScopedIds`** — the Shared subset of a batch of ids, for reference validation.

Twelve hand-rolled write predicates across `org-agent`, `org-mcp`, `org-skill` and `org-provider` now take the predicate. `org-attachment`'s private `orgResourceExists` — which re-implemented `resolveOrgScoped` without the Workspace guard — and both verbatim copies of the `RESOURCE_TABLES` registry are deleted.

## Result

- "Is it Shared?" is defined once, for reads and writes alike. `isNull(workspaceId)` is now written at exactly one site, `sharedWhere`, which every query in the module composes.
- The predicates return a non-optional `SQL`, so a `.where(undefined)` — an unfiltered `UPDATE` or `DELETE` — cannot type-check.
- Adding a fifth Scoped-resource type touches one file.

## Beyond the ticket's list

Two writes were tightened that the issue did not enumerate. `org-mcp`'s `force=true` OAuth token clear matched on id alone with no org column at all, and `org-blueprint`'s memory-provider check read on `organizationId` alone. Both sit behind a prior resolve, so neither was reachable — but leaving them would have made them the only stragglers after the sweep. Happy to back either out.

## Testing

Predicate seam covered directly: `orgScopedWhere`, `orgScopedWhereIn`, `listOrgScopedIds` and `isScopedResourceType` are asserted in isolation, plus route-level pins that the org update and the org attach both match the Shared predicate. Full suite green — 1788 backend, 199 frontend, 122 schemas, docs contract — with `typecheck` and `lint` clean.

## Docs

No docs change owed: the diff touches no `.env.example`, no `packages/schemas` limits, no `plugins/**`, and no user-visible label.

## ADR

ADR-0007: not a reopening — this enforces the mutual-exclusivity rule the ADR states, in the module that already claims authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)