### PR TITLE
chore(backend): make WorkspaceScope the one scope currency

### DIFF
--- a/apps/backend/src/middleware/authorization.test.ts
+++ b/apps/backend/src/middleware/authorization.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { Hono } from "hono";
 import { mockDb, resetMockDb } from "../test-utils.ts";
+import type { Variables } from "../server.ts";
 import {
+  orgScopeOf,
   requireOrgAccess,
   requireWorkspaceAccess,
   requireSuperAdmin,
+  workspaceScopeOf,
 } from "./authorization.ts";
 
 describe("Authorization Middleware", () => {
@@ -88,6 +91,7 @@ describe("Authorization Middleware", () => {
       Variables: {
         user: unknown;
         orgMembership: unknown;
+        orgScope: unknown;
         isWorkspaceOwner: unknown;
         db: unknown;
       };
@@ -96,13 +100,20 @@ describe("Authorization Middleware", () => {
         Variables: {
           user: unknown;
           orgMembership: unknown;
+          orgScope: unknown;
           isWorkspaceOwner: unknown;
           db: unknown;
         };
       }>();
       app.use("*", async (c, next) => {
         c.set("user", user);
+        // Both of these are what requireOrgAccess leaves behind; this stub
+        // stands in for it, so requireWorkspaceAccess sees its prerequisite.
         c.set("orgMembership", orgMembership);
+        c.set("orgScope", {
+          orgId: "org-1",
+          principal: { kind: "user", userId: "u1", name: "Ada" },
+        });
         c.set("db", mockDb);
         await next();
       });
@@ -234,6 +245,131 @@ describe("Authorization Middleware", () => {
       );
       expect(res.status).toBe(404);
       expect(await res.json()).toEqual({ error: "Workspace not found" });
+    });
+  });
+
+  describe("scope accessors", () => {
+    /**
+     * A route under the real middleware chain, so the accessors are read
+     * exactly where a handler reads them.
+     */
+    const buildApp = (user: {
+      id: string;
+      role: string;
+    }): Hono<{ Variables: Variables }> => {
+      const app = new Hono<{ Variables: Variables }>();
+      app.use("*", async (c, next) => {
+        // requireAuth would set both; stand in for it.
+        c.set("user", user as never);
+        c.set("userScope", {
+          principal: { kind: "user", userId: user.id, name: "Ada" },
+        });
+        c.set("db", mockDb as never);
+        await next();
+      });
+      app.get("/organizations/:orgId/only", requireOrgAccess(), (c) =>
+        c.json(orgScopeOf(c)),
+      );
+      app.get(
+        "/organizations/:orgId/workspaces/:workspaceId/test",
+        requireOrgAccess(),
+        requireWorkspaceAccess,
+        (c) => c.json(workspaceScopeOf(c)),
+      );
+      app.get("/unguarded", (c) => c.json(workspaceScopeOf(c)));
+      app.get("/unguarded-org", (c) => c.json(orgScopeOf(c)));
+      // Hono turns a handler throw into a 500; surface the message so the
+      // wiring mistake is assertable.
+      app.onError((err, c) => c.text(err.message, 500));
+      return app;
+    };
+
+    it("returns the org scope the middleware resolved", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { organizationId: "org-1", userId: "u1", role: "member" },
+      ]);
+
+      const app = buildApp({ id: "u1", role: "user" });
+      const res = await app.request("/organizations/org-1/only");
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        orgId: "org-1",
+        principal: { kind: "user", userId: "u1", name: "Ada" },
+      });
+    });
+
+    it("returns the workspace scope the middleware resolved", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { organizationId: "org-1", userId: "u1", role: "member" },
+        ])
+        .mockResolvedValueOnce([{ ownerId: "u1", organizationId: "org-1" }]);
+
+      const app = buildApp({ id: "u1", role: "user" });
+      const res = await app.request(
+        "/organizations/org-1/workspaces/ws-1/test",
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        orgId: "org-1",
+        workspaceId: "ws-1",
+        isWorkspaceOwner: true,
+        principal: { kind: "user", userId: "u1", name: "Ada" },
+      });
+    });
+
+    it("carries isWorkspaceOwner: false for a non-owning org admin", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { organizationId: "org-1", userId: "u1", role: "admin" },
+        ])
+        .mockResolvedValueOnce([
+          { ownerId: "other-user", organizationId: "org-1" },
+        ]);
+
+      const app = buildApp({ id: "u1", role: "user" });
+      const res = await app.request(
+        "/organizations/org-1/workspaces/ws-1/test",
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ isWorkspaceOwner: false });
+    });
+
+    it("resolves the scope for a super admin, who bypasses the membership check", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "other-user", organizationId: "org-1" },
+      ]);
+
+      const app = buildApp({ id: "admin-1", role: "admin" });
+      const res = await app.request(
+        "/organizations/org-1/workspaces/ws-1/test",
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        orgId: "org-1",
+        workspaceId: "ws-1",
+        isWorkspaceOwner: false,
+      });
+    });
+
+    it("throws when the workspace middleware did not run", async () => {
+      const app = buildApp({ id: "u1", role: "user" });
+
+      const res = await app.request("/unguarded");
+      expect(res.status).toBe(500);
+      expect(await res.text()).toMatch(/requireWorkspaceAccess/);
+    });
+
+    it("throws when the org middleware did not run", async () => {
+      const app = buildApp({ id: "u1", role: "user" });
+
+      const res = await app.request("/unguarded-org");
+      expect(res.status).toBe(500);
+      expect(await res.text()).toMatch(/requireOrgAccess/);
     });
   });
 

--- a/apps/backend/src/middleware/authorization.ts
+++ b/apps/backend/src/middleware/authorization.ts
@@ -11,10 +11,54 @@ import type {
   OrganizationMembership,
   Variables,
 } from "../server.ts";
-import { orgScope, userScope, workspaceScope } from "../scope.ts";
+import {
+  orgScope,
+  userScope,
+  workspaceScope,
+  type OrgScope,
+  type WorkspaceScope,
+} from "../scope.ts";
 
 /** Hono environment for these middleware: carries the request-scoped Variables. */
 type Env = { Variables: Variables };
+
+/**
+ * The Organization scope {@link requireOrgAccess} resolved for this request —
+ * who is asking, and which Organization they were cleared for.
+ *
+ * Throws when that middleware did not run, which is a wiring mistake in the
+ * route table rather than anything the caller did: the alternative is every
+ * handler re-reading `c.req.param("orgId")!`, asserting an invariant it cannot
+ * see. `app.onError` maps the throw to a 500 (ADR-0010), which is the honest
+ * answer — the route is misconfigured.
+ */
+export const orgScopeOf = (c: Context<Env>): OrgScope => {
+  const scope = c.get("orgScope");
+  if (!scope) {
+    throw new Error(
+      "No organization scope on this request: requireOrgAccess must run before the handler",
+    );
+  }
+  return scope;
+};
+
+/**
+ * The Workspace scope {@link requireWorkspaceAccess} resolved for this request:
+ * the Organization scope plus the Workspace and whether the caller owns it.
+ *
+ * This is the currency handlers pass down — `listScoped(db, "agent", scope)`,
+ * `requireBoard(db, scope, id)` — so route bodies never parse the URL. Throws
+ * on the same wiring mistake {@link orgScopeOf} does.
+ */
+export const workspaceScopeOf = (c: Context<Env>): WorkspaceScope => {
+  const scope = c.get("workspaceScope");
+  if (!scope) {
+    throw new Error(
+      "No workspace scope on this request: requireWorkspaceAccess must run before the handler",
+    );
+  }
+  return scope;
+};
 
 /**
  * Checks if a user is a super admin based on their role field.
@@ -174,8 +218,10 @@ export const requireWorkspaceAccess = createMiddleware<Env>(async (c, next) => {
   const db = c.get("db");
   const orgMembership = c.get("orgMembership")!;
 
+  // The Organization half is already resolved and proved; only the Workspace id
+  // is still unread, and this middleware is the one place that reads it.
+  const parent = orgScopeOf(c);
   const workspaceId = c.req.param("workspaceId");
-  const orgId = c.req.param("orgId");
 
   if (!workspaceId) {
     return c.json({ error: "Workspace ID required" }, 400);
@@ -192,49 +238,30 @@ export const requireWorkspaceAccess = createMiddleware<Env>(async (c, next) => {
     return c.json({ error: "Workspace not found" }, 404);
   }
 
-  // Cross-org guard: the workspace must belong to the organization named in
-  // the path. Without this, an admin (or super admin) of org A who knows a
-  // workspace id in org B could operate on it via /organizations/A/workspaces/B.
-  // Reply 404 (not 403) so we don't leak the existence of other orgs' workspaces.
-  // Applies uniformly to the member, org-admin, and super-admin branches below.
-  if (orgId && ws.organizationId !== orgId) {
+  // Cross-org guard: the workspace must belong to the organization the caller
+  // was cleared for. Without this, an admin (or super admin) of org A who knows
+  // a workspace id in org B could operate on it via
+  // /organizations/A/workspaces/B. Reply 404 (not 403) so we don't leak the
+  // existence of other orgs' workspaces. Applies uniformly to the member,
+  // org-admin, and super-admin cases below.
+  if (ws.organizationId !== parent.orgId) {
     return c.json({ error: "Workspace not found" }, 404);
   }
 
   const isOwner = ws.ownerId === user.id;
 
-  // Super admins bypass ownership checks but still record ownership.
-  if (isSuperAdmin(user)) {
-    c.set("isWorkspaceOwner", isOwner);
-    const parent = c.get("orgScope");
-    if (parent) {
-      c.set("workspaceScope", workspaceScope(parent, workspaceId, isOwner));
-    }
-    await next();
-    return;
-  }
-
-  // Org admins have access to all workspaces in their organization.
-  if (orgMembership.role === "admin") {
-    c.set("isWorkspaceOwner", isOwner);
-    const parent = c.get("orgScope");
-    if (parent) {
-      c.set("workspaceScope", workspaceScope(parent, workspaceId, isOwner));
-    }
-    await next();
-    return;
-  }
-
-  // Regular members can only access their own workspaces
-  if (!isOwner) {
+  // Super admins and org admins reach any workspace in the organization; a
+  // regular member reaches only their own. Ownership is recorded either way —
+  // an admin operating on someone else's workspace is not its owner, and the
+  // routes that gate on ownership (ADR-0006) need to know.
+  const mayAccess =
+    isSuperAdmin(user) || orgMembership.role === "admin" || isOwner;
+  if (!mayAccess) {
     return c.json({ error: "No access to this workspace" }, 403);
   }
 
-  c.set("isWorkspaceOwner", true);
-  const parent = c.get("orgScope");
-  if (parent) {
-    c.set("workspaceScope", workspaceScope(parent, workspaceId, true));
-  }
+  c.set("isWorkspaceOwner", isOwner);
+  c.set("workspaceScope", workspaceScope(parent, workspaceId, isOwner));
   await next();
 });
 
@@ -340,11 +367,11 @@ export const workspaceConfigAccess = async (
   }
 
   const db = c.get("db");
-  const workspaceId = c.req.param("workspaceId");
+  const { workspaceId } = workspaceScopeOf(c);
   const [ws] = await db
     .select({ flag: workspaceTable[delegationFlag] })
     .from(workspaceTable)
-    .where(eq(workspaceTable.id, workspaceId!))
+    .where(eq(workspaceTable.id, workspaceId))
     .limit(1);
 
   if (!ws?.flag) {

--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -13,6 +13,7 @@ import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
   requireWorkspaceAccess,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { validateSubAgentAssignment } from "../services/sub-agent-validation.ts";
@@ -47,8 +48,7 @@ agent.post(
   sValidator("json", agentCreateSchema),
   async (c) => {
     const data = c.req.valid("json");
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
 
     // Deduplicate arrays
     if (data.toolSetIds) {
@@ -64,7 +64,7 @@ agent.post(
     // Validate sub-agent assignments
     if (data.subAgentIds && data.subAgentIds.length > 0) {
       const validation = await validateSubAgentAssignment(
-        { orgId, wsId: workspaceId },
+        scope,
         "", // No ID yet for new agent
         data.subAgentIds,
       );
@@ -82,7 +82,7 @@ agent.post(
       .values({
         id: nanoid(),
         ...data,
-        workspaceId,
+        workspaceId: scope.workspaceId,
         organizationId: null,
       })
       .returning();
@@ -97,11 +97,9 @@ agent.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
     const baseUrl = getOrigin(c);
 
-    const scoped = await listScoped(db, "agent", { orgId, wsId: workspaceId });
+    const scoped = await listScoped(db, "agent", workspaceScopeOf(c));
     const results = scoped.map(({ row, scope }) => ({
       ...agentWithAvatarUrl(row, baseUrl),
       scope,
@@ -118,14 +116,14 @@ agent.get(
   requireWorkspaceAccess,
   async (c) => {
     const agentId = c.req.param("agentId");
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
     const baseUrl = getOrigin(c);
 
-    const found = await requireScoped(db, "agent", agentId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    const found = await requireScoped(
+      db,
+      "agent",
+      agentId,
+      workspaceScopeOf(c),
+    );
     return c.json({
       ...agentWithAvatarUrl(found.row, baseUrl),
       scope: found.scope,
@@ -143,8 +141,7 @@ agent.put(
   async (c) => {
     const agentId = c.req.param("agentId");
     const data = c.req.valid("json");
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
 
     // Deduplicate arrays
     if (data.toolSetIds) {
@@ -160,17 +157,14 @@ agent.put(
     // A Shared Agent is a single source of truth edited only on the Organization
     // surface (ADR-0007); requireWorkspaceMutable throws NotFound (→404) when the
     // Agent is not visible here, then Locked (→403) when it is org-scoped.
-    await requireWorkspaceMutable(db, "agent", agentId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    await requireWorkspaceMutable(db, "agent", agentId, scope);
 
     const baseUrl = getOrigin(c);
 
     // Workspace-scoped update.
     if (data.subAgentIds) {
       const validation = await validateSubAgentAssignment(
-        { orgId, wsId: workspaceId },
+        scope,
         agentId,
         data.subAgentIds,
       );
@@ -188,7 +182,7 @@ agent.put(
       .where(
         and(
           eq(agentTable.id, agentId),
-          eq(agentTable.workspaceId, workspaceId),
+          eq(agentTable.workspaceId, scope.workspaceId),
         ),
       )
       .returning();
@@ -204,15 +198,11 @@ agent.post(
   requireWorkspaceAccess,
   async (c) => {
     const agentId = c.req.param("agentId");
-    const workspaceId = c.req.param("workspaceId")!;
-    const orgId = c.req.param("orgId")!;
+    const scope = workspaceScopeOf(c);
     const baseUrl = getOrigin(c);
 
     // Shared agents are managed only on the Organization surface (ADR-0007).
-    const found = await requireWorkspaceMutable(db, "agent", agentId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    const found = await requireWorkspaceMutable(db, "agent", agentId, scope);
 
     const body = await c.req.parseBody();
     const result = await storeAvatar(
@@ -230,7 +220,7 @@ agent.post(
       .where(
         and(
           eq(agentTable.id, agentId),
-          eq(agentTable.workspaceId, workspaceId),
+          eq(agentTable.workspaceId, scope.workspaceId),
         ),
       )
       .returning();
@@ -247,15 +237,11 @@ agent.delete(
   requireWorkspaceAccess,
   async (c) => {
     const agentId = c.req.param("agentId");
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
     const baseUrl = getOrigin(c);
 
     // Shared agents are managed only on the Organization surface (ADR-0007).
-    const found = await requireWorkspaceMutable(db, "agent", agentId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    const found = await requireWorkspaceMutable(db, "agent", agentId, scope);
 
     await deleteAvatar(found.row.avatarKey);
 
@@ -265,7 +251,7 @@ agent.delete(
       .where(
         and(
           eq(agentTable.id, agentId),
-          eq(agentTable.workspaceId, workspaceId),
+          eq(agentTable.workspaceId, scope.workspaceId),
         ),
       )
       .returning();
@@ -282,16 +268,12 @@ agent.delete(
   requireWorkspaceAccess,
   async (c) => {
     const agentId = c.req.param("agentId");
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
 
     // A Shared Agent is deleted only from the Organization surface (ADR-0007):
     // requireWorkspaceMutable throws NotFound (→404) when the Agent is not
     // visible here, then Locked (→403) when it is org-scoped.
-    const found = await requireWorkspaceMutable(db, "agent", agentId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    const found = await requireWorkspaceMutable(db, "agent", agentId, scope);
 
     await deleteAvatar(found.row.avatarKey);
 
@@ -300,7 +282,7 @@ agent.delete(
       .where(
         and(
           eq(agentTable.id, agentId),
-          eq(agentTable.workspaceId, workspaceId),
+          eq(agentTable.workspaceId, scope.workspaceId),
         ),
       );
     return c.json({ message: "Agent deleted" });
@@ -324,8 +306,7 @@ agent.post(
   requireOrgAccess(["admin"]),
   requireWorkspaceAccess,
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const { orgId, workspaceId } = workspaceScopeOf(c);
     const agentId = c.req.param("agentId");
     const baseUrl = getOrigin(c);
 

--- a/apps/backend/src/routes/attachment.ts
+++ b/apps/backend/src/routes/attachment.ts
@@ -9,6 +9,7 @@ import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
   requireWorkspaceAccess,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import { isUniqueViolation } from "../errors.ts";
 import { resolveOrgScoped } from "../services/scoped-resource.ts";
@@ -27,7 +28,7 @@ attachment.get(
   requireOrgAccess(["admin"]),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const results = await db
       .select()
       .from(attachmentTable)
@@ -44,8 +45,7 @@ attachment.post(
   requireWorkspaceAccess,
   sValidator("json", attachmentCreateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const { orgId, workspaceId } = workspaceScopeOf(c);
     const { resourceType, resourceId } = c.req.valid("json");
 
     // The resource must be org-scoped and belong to this organization — you can
@@ -88,7 +88,7 @@ attachment.delete(
   requireOrgAccess(["admin"]),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const resourceType = c.req.param("resourceType");
     const resourceId = c.req.param("resourceId");
 

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -12,6 +12,7 @@ import {
   requireOrgAccess,
   requireWorkspaceAccess,
   requireWorkspaceOwner,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { type PlatypusUIMessage } from "../types.ts";
@@ -39,7 +40,7 @@ chat.get(
     }),
   ),
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const { limit: limitStr, offset: offsetStr, search } = c.req.valid("query");
 
     const limit = Math.min(parseInt(limitStr ?? "100") || 100, 100);
@@ -94,7 +95,7 @@ chat.get(
   requireWorkspaceAccess,
   async (c) => {
     const chatId = c.req.param("chatId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
 
     const record = await db
       .select()
@@ -129,7 +130,7 @@ chat.post(
   requireWorkspaceOwner,
   sValidator("json", chatSubmitSchema),
   async (c) => {
-    const scope = c.get("workspaceScope")!;
+    const scope = workspaceScopeOf(c);
     const data = c.req.valid("json");
 
     const input: RunInput = {
@@ -181,7 +182,7 @@ chat.post(
   requireWorkspaceOwner,
   async (c) => {
     const chatId = c.req.param("chatId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
 
     // Verify the chat belongs to this workspace before signalling cancel.
     // This is what makes a cross-workspace cancel return 404 rather than
@@ -214,7 +215,7 @@ chat.delete(
   requireWorkspaceOwner,
   async (c) => {
     const chatId = c.req.param("chatId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
 
     // First fetch the chat to get its messages for file cleanup
     const chatRecord = await db
@@ -254,7 +255,7 @@ chat.put(
   sValidator("json", chatUpdateSchema),
   async (c) => {
     const chatId = c.req.param("chatId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const { title, isPinned, tags } = c.req.valid("json");
 
     const result = await db

--- a/apps/backend/src/routes/dashboard.ts
+++ b/apps/backend/src/routes/dashboard.ts
@@ -17,6 +17,7 @@ import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
   requireWorkspaceAccess,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 
@@ -30,7 +31,7 @@ dashboard.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const results = await db
       .select()
       .from(dashboardTable)
@@ -48,7 +49,7 @@ dashboard.post(
   sValidator("json", dashboardCreateSchema),
   async (c) => {
     const data = c.req.valid("json");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const conflict = await db
       .select({ id: dashboardTable.id })
       .from(dashboardTable)
@@ -92,7 +93,7 @@ dashboard.get(
   requireWorkspaceAccess,
   async (c) => {
     const dashboardId = c.req.param("dashboardId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const record = await db
       .select()
       .from(dashboardTable)
@@ -114,7 +115,7 @@ dashboard.put(
   async (c) => {
     const data = c.req.valid("json");
     const dashboardId = c.req.param("dashboardId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const existing = await db
       .select({
         id: dashboardTable.id,
@@ -164,7 +165,7 @@ dashboard.delete(
   requireWorkspaceAccess,
   async (c) => {
     const dashboardId = c.req.param("dashboardId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const existing = await db
       .select({
         id: dashboardTable.id,
@@ -190,7 +191,7 @@ dashboard.get(
   requireWorkspaceAccess,
   async (c) => {
     const dashboardId = c.req.param("dashboardId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const dash = await db
       .select({
         id: dashboardTable.id,
@@ -220,7 +221,7 @@ dashboard.post(
   async (c) => {
     const data = c.req.valid("json");
     const dashboardId = c.req.param("dashboardId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const dash = await db
       .select({
         id: dashboardTable.id,
@@ -275,7 +276,7 @@ dashboard.put(
     const body = c.req.valid("json");
     const dashboardId = c.req.param("dashboardId");
     const widgetId = c.req.param("widgetId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const dash = await db
       .select({
         id: dashboardTable.id,
@@ -344,7 +345,7 @@ dashboard.delete(
   async (c) => {
     const dashboardId = c.req.param("dashboardId");
     const widgetId = c.req.param("widgetId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const dash = await db
       .select({
         id: dashboardTable.id,

--- a/apps/backend/src/routes/invitation.ts
+++ b/apps/backend/src/routes/invitation.ts
@@ -10,7 +10,7 @@ import {
 import { invitationCreateSchema } from "@platypus/schemas";
 import { eq, and, inArray, asc } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
-import { requireOrgAccess } from "../middleware/authorization.ts";
+import { orgScopeOf, requireOrgAccess } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
 
@@ -27,7 +27,7 @@ invitation.post(
   requireOrgAccess(["admin"]),
   sValidator("json", invitationCreateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const data = c.req.valid("json");
     const user = c.get("user")!;
 
@@ -127,7 +127,7 @@ invitation.post(
 
 /** List all invitations for an organization (org admin only) */
 invitation.get("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
 
   const results = await db
     .select()
@@ -169,7 +169,7 @@ invitation.delete(
   requireOrgAccess(["admin"]),
   async (c) => {
     const invitationId = c.req.param("invitationId");
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
 
     const result = await db
       .delete(invitationTable)

--- a/apps/backend/src/routes/kanban.ts
+++ b/apps/backend/src/routes/kanban.ts
@@ -31,6 +31,7 @@ import {
   requireWorkspaceAccess,
   requireWorkspaceOwner,
   isSuperAdmin,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { NotFoundError } from "../errors.ts";
@@ -61,10 +62,12 @@ import {
 
 const kanban = new Hono<{ Variables: Variables }>();
 
-/** Everything the module needs to place this request: which board, in which Workspace. */
+/**
+ * Everything the module needs to place this request: the Workspace the
+ * middleware already resolved, narrowed to the board this route addresses.
+ */
 const scopeOf = (c: Context<{ Variables: Variables }>): KanbanScope => ({
-  orgId: c.req.param("orgId")!,
-  workspaceId: c.req.param("workspaceId")!,
+  ...workspaceScopeOf(c),
   boardId: c.req.param("boardId"),
 });
 
@@ -83,7 +86,7 @@ kanban.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const results = await db
       .select()
       .from(kanbanBoardTable)
@@ -103,7 +106,7 @@ kanban.post(
   sValidator("json", kanbanBoardCreateSchema),
   async (c) => {
     const data = c.req.valid("json");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const id = nanoid();
     const now = new Date();
 
@@ -172,7 +175,7 @@ kanban.put(
   sValidator("json", kanbanBoardUpdateSchema),
   async (c) => {
     const boardId = c.req.param("boardId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const data = c.req.valid("json");
 
     // Labels the update drops are gone from the board, so the cards using them
@@ -211,7 +214,7 @@ kanban.delete(
   requireWorkspaceOwner,
   async (c) => {
     const boardId = c.req.param("boardId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
 
     const result = await db
       .delete(kanbanBoardTable)

--- a/apps/backend/src/routes/mcp.ts
+++ b/apps/backend/src/routes/mcp.ts
@@ -19,6 +19,7 @@ import {
   requireWorkspaceAccess,
   requireWorkspaceConfigAccess,
   workspaceCredentialsVisible,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import {
   mcpReadModel,
@@ -64,6 +65,7 @@ mcp.post(
   sValidator("json", mcpCreateSchema),
   async (c) => {
     const data = c.req.valid("json");
+    const { workspaceId } = workspaceScopeOf(c);
     const record = await db
       .insert(mcpTable)
       .values({
@@ -73,7 +75,7 @@ mcp.post(
         // and Skills. Spreading the body let a caller name another Workspace, or
         // set `organizationId` and mint a Shared MCP from the Workspace surface,
         // which only an Org Admin may do (ADR-0006, ADR-0007).
-        workspaceId: c.req.param("workspaceId")!,
+        workspaceId,
         organizationId: null,
       })
       .returning();
@@ -88,12 +90,9 @@ mcp.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
-
     // Workspace-scoped MCPs plus the Shared (org-scoped) MCPs attached here
     // (ADR-0007), each tagged with its scope for the frontend.
-    const scoped = await listScoped(db, "mcp", { orgId, wsId: workspaceId });
+    const scoped = await listScoped(db, "mcp", workspaceScopeOf(c));
     // Request credentials are revealed only to a caller who may manage this MCP
     // (ADR-0006) — the same rule the write routes reject on. The rows still list,
     // because granting an MCP to an Agent does not require self-management.
@@ -114,12 +113,7 @@ mcp.get(
   requireWorkspaceAccess,
   async (c) => {
     const mcpId = c.req.param("mcpId");
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
-    const found = await requireScoped(db, "mcp", mcpId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    const found = await requireScoped(db, "mcp", mcpId, workspaceScopeOf(c));
     // See the list route: redacted unless this caller may manage the MCP.
     const reveal = await workspaceCredentialsVisible(c, "mcp");
     return c.json(mcpReadModel(found.row, { reveal, scope: found.scope }));
@@ -136,18 +130,14 @@ mcp.put(
   sValidator("json", mcpUpdateSchema),
   async (c) => {
     const mcpId = c.req.param("mcpId");
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
     const data = c.req.valid("json");
 
     // A Shared MCP is a single source of truth edited only on the Organization
     // surface (ADR-0007); requireWorkspaceMutable throws NotFound (→404) when the
     // MCP is not visible here, then Locked (→403) when it is org-scoped. On
     // success the row is guaranteed Workspace-scoped.
-    const { row } = await requireWorkspaceMutable(db, "mcp", mcpId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    const { row } = await requireWorkspaceMutable(db, "mcp", mcpId, scope);
 
     // If the URL is changing, clear stored OAuth tokens (they're server-specific)
     const urlChanged = row.url !== data.url;
@@ -163,7 +153,12 @@ mcp.put(
         }),
         updatedAt: new Date(),
       })
-      .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.workspaceId, workspaceId)))
+      .where(
+        and(
+          eq(mcpTable.id, mcpId),
+          eq(mcpTable.workspaceId, scope.workspaceId),
+        ),
+      )
       .returning();
     return c.json(sanitizeMcpResponse(record[0]), 200);
   },
@@ -178,20 +173,21 @@ mcp.delete(
   requireMcpConfigAccess,
   async (c) => {
     const mcpId = c.req.param("mcpId");
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
 
     // A Shared MCP is deleted only from the Organization surface (ADR-0007):
     // requireWorkspaceMutable throws NotFound (→404) when the MCP is not visible
     // here, then Locked (→403) when it is org-scoped.
-    await requireWorkspaceMutable(db, "mcp", mcpId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    await requireWorkspaceMutable(db, "mcp", mcpId, scope);
 
     await db
       .delete(mcpTable)
-      .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.workspaceId, workspaceId)))
+      .where(
+        and(
+          eq(mcpTable.id, mcpId),
+          eq(mcpTable.workspaceId, scope.workspaceId),
+        ),
+      )
       .returning();
     return c.json({ message: "MCP deleted" });
   },
@@ -209,10 +205,13 @@ mcp.post(
     const data = c.req.valid("json");
 
     let mcpClient;
+    // Read outside the try: the catch below turns anything thrown into a 400
+    // "connection failed", which is the wrong answer for a misconfigured route.
+    const { workspaceId } = workspaceScopeOf(c);
+
     try {
       // For OAuth, use authProvider with stored tokens
       if (data.authType === "OAuth" && data.mcpId) {
-        const workspaceId = c.req.param("workspaceId")!;
         const mcpRecord = await db
           .select()
           .from(mcpTable)
@@ -315,7 +314,7 @@ mcp.post(
   requireMcpConfigAccess,
   async (c) => {
     const mcpId = c.req.param("mcpId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
 
     const mcpRecord = await db
       .select()
@@ -408,7 +407,7 @@ mcp.post(
   requireMcpConfigAccess,
   async (c) => {
     const mcpId = c.req.param("mcpId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
 
     const record = await db
       .update(mcpTable)

--- a/apps/backend/src/routes/member.ts
+++ b/apps/backend/src/routes/member.ts
@@ -5,14 +5,18 @@ import { organizationMember, user as userTable } from "../db/schema.ts";
 import { organizationMemberUpdateSchema } from "@platypus/schemas";
 import { eq, and, count } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
-import { requireOrgAccess, isSuperAdmin } from "../middleware/authorization.ts";
+import {
+  isSuperAdmin,
+  orgScopeOf,
+  requireOrgAccess,
+} from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 
 const member = new Hono<{ Variables: Variables }>();
 
 /** List all organization members */
 member.get("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
 
   const members = await db
     .select({
@@ -48,7 +52,7 @@ member.get(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const memberId = c.req.param("memberId");
 
     const [m] = await db
@@ -95,7 +99,7 @@ member.patch(
   requireOrgAccess(["admin"]),
   sValidator("json", organizationMemberUpdateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const memberId = c.req.param("memberId");
     const { role: newRole } = c.req.valid("json");
     const currentUser = c.get("user")!;
@@ -156,7 +160,7 @@ member.delete(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const memberId = c.req.param("memberId");
     const currentUser = c.get("user")!;
 

--- a/apps/backend/src/routes/notification.ts
+++ b/apps/backend/src/routes/notification.ts
@@ -11,6 +11,7 @@ import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
   requireWorkspaceAccess,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { dispatchEvent } from "../services/event-dispatch.ts";
@@ -26,7 +27,7 @@ notification.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const user = c.get("user")!;
     const limit = Math.min(
       Math.max(parseInt(c.req.query("limit") || "50", 10) || 50, 1),
@@ -86,7 +87,7 @@ notification.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const user = c.get("user")!;
 
     const result = await db
@@ -121,7 +122,7 @@ notification.post(
   async (c) => {
     const notificationId = c.req.param("notificationId");
     const user = c.get("user")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const { orgId, workspaceId } = workspaceScopeOf(c);
 
     // Verify notification exists in this workspace
     const existing = await db
@@ -148,7 +149,7 @@ notification.post(
       })
       .onConflictDoNothing();
 
-    dispatchEvent(c.req.param("orgId")!, workspaceId, "notification.read", {
+    dispatchEvent(orgId, workspaceId, "notification.read", {
       notificationId,
       userId: user.id,
     });
@@ -164,7 +165,7 @@ notification.post(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { orgId, workspaceId } = workspaceScopeOf(c);
     const user = c.get("user")!;
 
     // Get all unread notification IDs
@@ -194,7 +195,7 @@ notification.post(
         })),
       );
 
-      dispatchEvent(c.req.param("orgId")!, workspaceId, "notification.read", {
+      dispatchEvent(orgId, workspaceId, "notification.read", {
         notificationIds: unread.map((n) => n.id),
         userId: user.id,
         bulk: true,
@@ -213,7 +214,7 @@ notification.delete(
   requireWorkspaceAccess,
   async (c) => {
     const notificationId = c.req.param("notificationId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { orgId, workspaceId } = workspaceScopeOf(c);
 
     const result = await db
       .delete(notificationTable)
@@ -229,14 +230,9 @@ notification.delete(
       return c.json({ error: "Notification not found" }, 404);
     }
 
-    dispatchEvent(
-      c.req.param("orgId")!,
-      workspaceId,
-      "notification.dismissed",
-      {
-        notificationId,
-      },
-    );
+    dispatchEvent(orgId, workspaceId, "notification.dismissed", {
+      notificationId,
+    });
 
     return c.json({ message: "Notification deleted" });
   },

--- a/apps/backend/src/routes/org-agent.ts
+++ b/apps/backend/src/routes/org-agent.ts
@@ -6,7 +6,7 @@ import { agentUpdateSchema } from "@platypus/schemas";
 import { eq, and } from "drizzle-orm";
 import { dedupeArray } from "../utils.ts";
 import { requireAuth } from "../middleware/authentication.ts";
-import { requireOrgAccess } from "../middleware/authorization.ts";
+import { orgScopeOf, requireOrgAccess } from "../middleware/authorization.ts";
 import { findNonSharedReferences } from "../services/agent-scope-validation.ts";
 import { SUB_AGENT_SELF_ASSIGNMENT_ERROR } from "../services/sub-agent-validation.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
@@ -38,7 +38,7 @@ function agentWithAvatarUrl(
 
 /** List org-scoped Agents */
 orgAgent.get("/", requireAuth, requireOrgAccess(), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const baseUrl = getOrigin(c);
   const results = await listOrgScoped(db, "agent", orgId);
   return c.json({
@@ -48,7 +48,7 @@ orgAgent.get("/", requireAuth, requireOrgAccess(), async (c) => {
 
 /** Get an org-scoped Agent by ID */
 orgAgent.get("/:agentId", requireAuth, requireOrgAccess(), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const agentId = c.req.param("agentId");
   const baseUrl = getOrigin(c);
   const record = await requireOrgScoped(db, "agent", agentId, orgId);
@@ -62,7 +62,7 @@ orgAgent.put(
   requireOrgAccess(["admin"]),
   sValidator("json", agentUpdateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const agentId = c.req.param("agentId");
     const data = c.req.valid("json");
     const baseUrl = getOrigin(c);
@@ -115,7 +115,7 @@ orgAgent.post(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const agentId = c.req.param("agentId");
     const baseUrl = getOrigin(c);
 
@@ -144,7 +144,7 @@ orgAgent.delete(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const agentId = c.req.param("agentId");
     const baseUrl = getOrigin(c);
 
@@ -169,7 +169,7 @@ orgAgent.delete(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const agentId = c.req.param("agentId");
 
     // A Shared resource cannot be deleted while anything still points at it —

--- a/apps/backend/src/routes/org-attachment.ts
+++ b/apps/backend/src/routes/org-attachment.ts
@@ -11,7 +11,7 @@ import {
 } from "../db/schema.ts";
 import { and, eq } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
-import { requireOrgAccess } from "../middleware/authorization.ts";
+import { orgScopeOf, requireOrgAccess } from "../middleware/authorization.ts";
 import { isUniqueViolation } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
@@ -58,7 +58,7 @@ const orgResourceExists = async (
  * attachment with its workspace name so the org surface can show "Shared with".
  */
 orgAttachment.get("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const resourceType = c.req.query("resourceType");
   const resourceId = c.req.query("resourceId");
 
@@ -95,7 +95,7 @@ orgAttachment.get("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
 
 /** Attach an org-scoped Shared resource to a workspace (admin only) */
 orgAttachment.post("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const body = (await c.req.json().catch(() => ({}))) as {
     resourceType?: string;
     resourceId?: string;
@@ -155,7 +155,7 @@ orgAttachment.delete(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const resourceType = c.req.param("resourceType");
     const resourceId = c.req.param("resourceId");
     const workspaceId = c.req.param("workspaceId");

--- a/apps/backend/src/routes/org-blueprint.ts
+++ b/apps/backend/src/routes/org-blueprint.ts
@@ -19,7 +19,7 @@ import {
 } from "@platypus/schemas";
 import { and, eq, inArray } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
-import { requireOrgAccess } from "../middleware/authorization.ts";
+import { orgScopeOf, requireOrgAccess } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { applyBlueprintsToWorkspace } from "../services/blueprint-apply.ts";
 import { isBlueprintReferencedByLiveInvitation } from "../services/blueprint-guard.ts";
@@ -225,7 +225,7 @@ orgBlueprint.post(
   requireOrgAccess(["admin"]),
   sValidator("json", blueprintCreateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const {
       name,
       description,
@@ -323,7 +323,7 @@ orgBlueprint.post(
 
 /** List Blueprints, each with its items (admin only) */
 orgBlueprint.get("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const blueprints = await db
     .select()
     .from(blueprintTable)
@@ -345,7 +345,7 @@ orgBlueprint.get(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const blueprintId = c.req.param("blueprintId");
     const [record] = await db
       .select()
@@ -375,7 +375,7 @@ orgBlueprint.put(
   requireOrgAccess(["admin"]),
   sValidator("json", blueprintUpdateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const blueprintId = c.req.param("blueprintId");
     const {
       name,
@@ -494,7 +494,7 @@ orgBlueprint.delete(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const blueprintId = c.req.param("blueprintId");
 
     // A Blueprint cannot be deleted while a live pending invitation references
@@ -540,7 +540,7 @@ orgBlueprint.post(
   requireOrgAccess(["admin"]),
   sValidator("json", blueprintApplySchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const blueprintId = c.req.param("blueprintId");
     const { workspaceId } = c.req.valid("json");
 

--- a/apps/backend/src/routes/org-mcp.ts
+++ b/apps/backend/src/routes/org-mcp.ts
@@ -16,6 +16,7 @@ import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   orgCredentialsVisible,
+  orgScopeOf,
   requireOrgAccess,
 } from "../middleware/authorization.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
@@ -52,7 +53,7 @@ orgMcp.post(
   requireOrgAccess(["admin"]),
   sValidator("json", mcpCreateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const data = c.req.valid("json");
 
     // A duplicate name surfaces as a Postgres unique violation, mapped to 409
@@ -72,7 +73,7 @@ orgMcp.post(
 
 /** List org-scoped MCPs */
 orgMcp.get("/", requireAuth, requireOrgAccess(), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const results = await listOrgScoped(db, "mcp", orgId);
   // This route admits any Organization member — a Shared MCP has to be listable
   // to be granted. Only an Org Admin sees its request credentials (ADR-0006).
@@ -84,7 +85,7 @@ orgMcp.get("/", requireAuth, requireOrgAccess(), async (c) => {
 
 /** Get an org-scoped MCP by ID */
 orgMcp.get("/:mcpId", requireAuth, requireOrgAccess(), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const mcpId = c.req.param("mcpId");
   const record = await requireOrgScoped(db, "mcp", mcpId, orgId);
   // See the list route: request credentials are Org-Admin-only (ADR-0006).
@@ -99,7 +100,7 @@ orgMcp.put(
   requireOrgAccess(["admin"]),
   sValidator("json", mcpUpdateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const mcpId = c.req.param("mcpId");
     const data = c.req.valid("json");
 
@@ -136,7 +137,7 @@ orgMcp.delete(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const mcpId = c.req.param("mcpId");
 
     // A Shared resource cannot be deleted while anything still points at it —
@@ -172,11 +173,14 @@ orgMcp.post(
   async (c) => {
     const data = c.req.valid("json");
 
+    // Read outside the try: the catch below turns anything thrown into a 400
+    // "connection failed", which is the wrong answer for a misconfigured route.
+    const { orgId } = orgScopeOf(c);
+
     let mcpClient;
     try {
       // For OAuth, use authProvider with stored tokens
       if (data.authType === "OAuth" && data.mcpId) {
-        const orgId = c.req.param("orgId")!;
         const mcpRecord = await resolveOrgScoped(db, "mcp", data.mcpId, orgId);
 
         if (!mcpRecord) {
@@ -245,7 +249,7 @@ orgMcp.post(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const mcpId = c.req.param("mcpId");
 
     let mcpRecord = await resolveOrgScoped(db, "mcp", mcpId, orgId);
@@ -310,7 +314,7 @@ orgMcp.post(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const mcpId = c.req.param("mcpId");
 
     const record = await db

--- a/apps/backend/src/routes/org-provider.ts
+++ b/apps/backend/src/routes/org-provider.ts
@@ -14,6 +14,7 @@ import {
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   orgCredentialsVisible,
+  orgScopeOf,
   requireOrgAccess,
 } from "../middleware/authorization.ts";
 import {
@@ -34,7 +35,7 @@ orgProvider.post(
   requireOrgAccess(["admin"]),
   sValidator("json", providerCreateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const data = c.req.valid("json");
 
     if (data.modelIds) {
@@ -59,7 +60,7 @@ orgProvider.post(
 
 /** List all organization providers */
 orgProvider.get("/", requireAuth, requireOrgAccess(), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const rows = await listOrgScoped(db, "provider", orgId);
 
   // This route admits any Organization member — a Shared Provider has to be
@@ -72,7 +73,7 @@ orgProvider.get("/", requireAuth, requireOrgAccess(), async (c) => {
 
 /** Get an organization provider by ID */
 orgProvider.get("/:providerId", requireAuth, requireOrgAccess(), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const providerId = c.req.param("providerId");
 
   const record = await requireOrgScoped(db, "provider", providerId, orgId);
@@ -89,7 +90,7 @@ orgProvider.put(
   requireOrgAccess(["admin"]),
   sValidator("json", providerUpdateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const providerId = c.req.param("providerId");
     const data = c.req.valid("json");
 
@@ -147,7 +148,7 @@ orgProvider.delete(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const providerId = c.req.param("providerId");
 
     // A Shared resource cannot be deleted while anything still points at it —

--- a/apps/backend/src/routes/org-skill.ts
+++ b/apps/backend/src/routes/org-skill.ts
@@ -6,7 +6,7 @@ import { skill as skillTable } from "../db/schema.ts";
 import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
 import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
-import { requireOrgAccess } from "../middleware/authorization.ts";
+import { orgScopeOf, requireOrgAccess } from "../middleware/authorization.ts";
 import { scrubDeletedAgentReference } from "../services/agent-references.ts";
 import {
   listOrgScoped,
@@ -29,7 +29,7 @@ orgSkill.post(
   requireOrgAccess(["admin"]),
   sValidator("json", skillCreateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     // Agent associations are a workspace concern; org-scoped Skills carry none.
     const { agentIds: _agentIds, ...data } = c.req.valid("json");
 
@@ -52,14 +52,14 @@ orgSkill.post(
 
 /** List org-scoped Skills */
 orgSkill.get("/", requireAuth, requireOrgAccess(), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const results = await listOrgScoped(db, "skill", orgId);
   return c.json({ results });
 });
 
 /** Get an org-scoped Skill by ID */
 orgSkill.get("/:skillId", requireAuth, requireOrgAccess(), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const skillId = c.req.param("skillId");
   const record = await requireOrgScoped(db, "skill", skillId, orgId);
   return c.json(record);
@@ -72,7 +72,7 @@ orgSkill.put(
   requireOrgAccess(["admin"]),
   sValidator("json", skillUpdateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const skillId = c.req.param("skillId");
     const { agentIds: _agentIds, ...data } = c.req.valid("json");
 
@@ -103,7 +103,7 @@ orgSkill.delete(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const skillId = c.req.param("skillId");
 
     // A Shared resource cannot be deleted while anything still points at it —

--- a/apps/backend/src/routes/org-tool.ts
+++ b/apps/backend/src/routes/org-tool.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { getToolSets } from "../tools/index.ts";
 import { db } from "../index.ts";
 import { requireAuth } from "../middleware/authentication.ts";
-import { requireOrgAccess } from "../middleware/authorization.ts";
+import { orgScopeOf, requireOrgAccess } from "../middleware/authorization.ts";
 import { listOrgScoped } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 
@@ -14,7 +14,7 @@ import type { Variables } from "../server.ts";
 const orgTool = new Hono<{ Variables: Variables }>();
 
 orgTool.get("/", requireAuth, requireOrgAccess(), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
 
   const toolSetsList = getToolSets().map((toolSet) => ({
     id: toolSet.id,

--- a/apps/backend/src/routes/organization.ts
+++ b/apps/backend/src/routes/organization.ts
@@ -13,6 +13,7 @@ import {
 import { eq, inArray } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
+  orgScopeOf,
   requireOrgAccess,
   requireSuperAdmin,
   isSuperAdmin,
@@ -72,7 +73,7 @@ organization.get("/", requireAuth, async (c) => {
 
 /** Get a organization by ID */
 organization.get("/:orgId", requireAuth, requireOrgAccess(), async (c) => {
-  const orgId = c.req.param("orgId");
+  const { orgId } = orgScopeOf(c);
   const record = await db
     .select()
     .from(organizationTable)
@@ -91,7 +92,7 @@ organization.put(
   requireOrgAccess(["admin"]),
   sValidator("json", organizationUpdateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId");
+    const { orgId } = orgScopeOf(c);
     const data = c.req.valid("json");
     const record = await db
       .update(organizationTable)
@@ -111,7 +112,7 @@ organization.delete(
   requireAuth,
   requireOrgAccess(["admin"]),
   async (c) => {
-    const orgId = c.req.param("orgId");
+    const { orgId } = orgScopeOf(c);
     await db.delete(organizationTable).where(eq(organizationTable.id, orgId));
     return c.json({ message: "Organization deleted" });
   },

--- a/apps/backend/src/routes/provider.ts
+++ b/apps/backend/src/routes/provider.ts
@@ -17,6 +17,7 @@ import {
   requireWorkspaceAccess,
   requireWorkspaceConfigAccess,
   workspaceCredentialsVisible,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import { providerReadModel } from "../services/credential-redaction.ts";
 import {
@@ -42,6 +43,7 @@ provider.post(
   sValidator("json", providerCreateSchema),
   async (c) => {
     const data = c.req.valid("json");
+    const { workspaceId } = workspaceScopeOf(c);
     if (data.modelIds) {
       data.modelIds = dedupeModelConfigs(data.modelIds);
     }
@@ -56,7 +58,7 @@ provider.post(
         // and Skills. Spreading the body let a caller name another Workspace, or
         // set `organizationId` and mint a Shared Provider from the Workspace
         // surface, which only an Org Admin may do (ADR-0006, ADR-0007).
-        workspaceId: c.req.param("workspaceId")!,
+        workspaceId,
         organizationId: null,
       })
       .returning();
@@ -71,13 +73,7 @@ provider.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
-
-    const scoped = await listScoped(db, "provider", {
-      orgId,
-      wsId: workspaceId,
-    });
+    const scoped = await listScoped(db, "provider", workspaceScopeOf(c));
     // Credentials are revealed only to a caller who may manage this Provider
     // (ADR-0006) — the same rule the write routes reject on. The rows themselves
     // still list, because selecting a Provider on an Agent or Chat does not
@@ -97,14 +93,14 @@ provider.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
     const providerId = c.req.param("providerId");
 
-    const found = await requireScoped(db, "provider", providerId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    const found = await requireScoped(
+      db,
+      "provider",
+      providerId,
+      workspaceScopeOf(c),
+    );
     // See the list route: redacted unless this caller may manage the Provider.
     const reveal = await workspaceCredentialsVisible(c, "provider");
     return c.json(providerReadModel(found.row, { reveal, scope: found.scope }));
@@ -120,8 +116,7 @@ provider.put(
   requireWorkspaceConfigAccess("providerSelfManagement"),
   sValidator("json", providerUpdateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
     const providerId = c.req.param("providerId");
     const data = c.req.valid("json");
     if (data.modelIds) {
@@ -132,10 +127,7 @@ provider.put(
     // Organization surface (ADR-0007); requireWorkspaceMutable throws NotFound
     // (→404) when the Provider is not visible here, then Locked (→403) when it
     // is org-scoped.
-    await requireWorkspaceMutable(db, "provider", providerId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    await requireWorkspaceMutable(db, "provider", providerId, scope);
 
     // Detect and handle embedding config changes before the update
     await handleEmbeddingConfigChange(providerId, data);
@@ -157,7 +149,7 @@ provider.put(
       .where(
         and(
           eq(providerTable.id, providerId),
-          eq(providerTable.workspaceId, workspaceId),
+          eq(providerTable.workspaceId, scope.workspaceId),
         ),
       )
       .returning();
@@ -185,24 +177,20 @@ provider.delete(
   requireWorkspaceAccess,
   requireWorkspaceConfigAccess("providerSelfManagement"),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
     const providerId = c.req.param("providerId");
 
     // A Shared Provider is deleted only from the Organization surface
     // (ADR-0007): requireWorkspaceMutable throws NotFound (→404) when the
     // Provider is not visible here, then Locked (→403) when it is org-scoped.
-    await requireWorkspaceMutable(db, "provider", providerId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    await requireWorkspaceMutable(db, "provider", providerId, scope);
 
     await db
       .delete(providerTable)
       .where(
         and(
           eq(providerTable.id, providerId),
-          eq(providerTable.workspaceId, workspaceId),
+          eq(providerTable.workspaceId, scope.workspaceId),
         ),
       );
     return c.json({ message: "Provider deleted" });

--- a/apps/backend/src/routes/sandbox.ts
+++ b/apps/backend/src/routes/sandbox.ts
@@ -10,6 +10,7 @@ import {
   requireOrgAccess,
   requireWorkspaceAccess,
   requireWorkspaceConfigAccess,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { destroySandboxRow } from "../sandbox/teardown.ts";
@@ -136,7 +137,7 @@ sandbox.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const record = await db
       .select()
       .from(sandboxTable)
@@ -159,7 +160,7 @@ sandbox.post(
   requireSandboxAdmin,
   sValidator("json", sandboxCreateSchema),
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const data = c.req.valid("json");
 
     const configError = validateSandboxConfig(data.backend, data.config);
@@ -240,7 +241,7 @@ sandbox.put(
   requireWorkspaceAccess,
   sValidator("json", sandboxUpdateSchema),
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const data = c.req.valid("json");
     const force = c.req.query("force") === "true";
     const isAdmin = c.get("orgMembership")?.role === "admin";
@@ -378,7 +379,7 @@ sandbox.delete(
   requireWorkspaceAccess,
   requireSandboxAdmin,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const force = c.req.query("force") === "true";
 
     const existing = await db

--- a/apps/backend/src/routes/skill.ts
+++ b/apps/backend/src/routes/skill.ts
@@ -13,6 +13,7 @@ import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
   requireWorkspaceAccess,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import {
   listScoped,
@@ -31,12 +32,9 @@ skill.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
-
     // Workspace-scoped Skills plus the attached org-scoped (Shared) ones, each
     // tagged with its scope for the frontend (locked cards for org).
-    const scoped = await listScoped(db, "skill", { orgId, wsId: workspaceId });
+    const scoped = await listScoped(db, "skill", workspaceScopeOf(c));
     const results = scoped.map(({ row, scope }) => ({ ...row, scope }));
 
     return c.json({ results });
@@ -50,16 +48,12 @@ skill.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
     const skillId = c.req.param("skillId");
 
     // Resolve the Skill visible here — Workspace-scoped, or an attached
     // org-scoped (Shared) one (ADR-0007); not visible → 404 via onError.
-    const found = await requireScoped(db, "skill", skillId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    const found = await requireScoped(db, "skill", skillId, scope);
 
     // Find workspace agents that have this skill assigned
     const agentsWithSkill = await db
@@ -67,7 +61,7 @@ skill.get(
       .from(agentTable)
       .where(
         and(
-          eq(agentTable.workspaceId, workspaceId),
+          eq(agentTable.workspaceId, scope.workspaceId),
           sql`${agentTable.skillIds} @> ${JSON.stringify([skillId])}::jsonb`,
         ),
       );
@@ -88,7 +82,7 @@ skill.post(
   requireWorkspaceAccess,
   sValidator("json", skillCreateSchema),
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const { agentIds, ...data } = c.req.valid("json");
 
     const newId = nanoid();
@@ -138,18 +132,14 @@ skill.put(
   requireWorkspaceAccess,
   sValidator("json", skillUpdateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
     const skillId = c.req.param("skillId");
     const { agentIds, ...data } = c.req.valid("json");
 
     // A Shared Skill is a single source of truth edited only on the Organization
     // surface (ADR-0007); requireWorkspaceMutable throws NotFound (→404) when the
     // Skill is not visible here, then Locked (→403) when it is org-scoped.
-    await requireWorkspaceMutable(db, "skill", skillId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    await requireWorkspaceMutable(db, "skill", skillId, scope);
 
     // A duplicate name surfaces as a Postgres unique violation, mapped to 409
     // by the central onError (ADR-0010).
@@ -162,7 +152,7 @@ skill.put(
       .where(
         and(
           eq(skillTable.id, skillId),
-          eq(skillTable.workspaceId, workspaceId),
+          eq(skillTable.workspaceId, scope.workspaceId),
         ),
       )
       .returning();
@@ -174,7 +164,7 @@ skill.put(
 
       // Remove skill from agents not in the new list
       const removeWhere = [
-        eq(agentTable.workspaceId, workspaceId),
+        eq(agentTable.workspaceId, scope.workspaceId),
         sql`${agentTable.skillIds} @> ${skillIdJson}::jsonb`,
       ];
       if (agentIds.length > 0) {
@@ -198,7 +188,7 @@ skill.put(
           })
           .where(
             and(
-              eq(agentTable.workspaceId, workspaceId),
+              eq(agentTable.workspaceId, scope.workspaceId),
               inArray(agentTable.id, agentIds),
               sql`NOT ${agentTable.skillIds} @> ${skillIdJson}::jsonb`,
             ),
@@ -217,17 +207,13 @@ skill.delete(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
     const skillId = c.req.param("skillId");
 
     // A Shared Skill is deleted only from the Organization surface (ADR-0007):
     // requireWorkspaceMutable throws NotFound (→404) when the Skill is not
     // visible here, then Locked (→403) when it is org-scoped.
-    await requireWorkspaceMutable(db, "skill", skillId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    await requireWorkspaceMutable(db, "skill", skillId, scope);
 
     // Check if skill is referenced by any agent
     const referencingAgents = await db
@@ -235,7 +221,7 @@ skill.delete(
       .from(agentTable)
       .where(
         and(
-          eq(agentTable.workspaceId, workspaceId),
+          eq(agentTable.workspaceId, scope.workspaceId),
           sql`${agentTable.skillIds} @> ${JSON.stringify([skillId])}::jsonb`,
         ),
       )
@@ -256,7 +242,7 @@ skill.delete(
       .where(
         and(
           eq(skillTable.id, skillId),
-          eq(skillTable.workspaceId, workspaceId),
+          eq(skillTable.workspaceId, scope.workspaceId),
         ),
       );
 
@@ -281,8 +267,7 @@ skill.post(
   requireOrgAccess(["admin"]),
   requireWorkspaceAccess,
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const { orgId, workspaceId } = workspaceScopeOf(c);
     const skillId = c.req.param("skillId");
 
     // Only a workspace-scoped Skill in this workspace can be promoted.

--- a/apps/backend/src/routes/tool.ts
+++ b/apps/backend/src/routes/tool.ts
@@ -6,6 +6,7 @@ import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
   requireWorkspaceAccess,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import { listScoped } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
@@ -19,8 +20,6 @@ tool.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
     // Get static tools. Each set is annotated with the `plugin` that
     // contributed it (ADR-0013 observability); the core-internal `sandbox` set is
     // a static registration (not a plugin contribution), so it reads as
@@ -43,7 +42,7 @@ tool.get(
     // The MCPs this Workspace may actually use: its own, plus the Shared
     // (org-scoped) ones attached to it (ADR-0007) — the same set `GET /mcps`
     // lists, resolved through the same authority.
-    const mcps = await listScoped(db, "mcp", { orgId, wsId: workspaceId });
+    const mcps = await listScoped(db, "mcp", workspaceScopeOf(c));
     const mcpList = mcps.map(({ row }) => ({
       id: row.id,
       name: row.name,

--- a/apps/backend/src/routes/trigger.ts
+++ b/apps/backend/src/routes/trigger.ts
@@ -14,6 +14,7 @@ import {
   requireOrgAccess,
   requireWorkspaceAccess,
   requireWorkspaceOwner,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import { resolveScoped } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
@@ -29,7 +30,7 @@ trigger.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const results = await db
       .select()
       .from(triggerTable)
@@ -47,7 +48,7 @@ trigger.get(
   requireWorkspaceAccess,
   async (c) => {
     const triggerId = c.req.param("triggerId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
 
     const record = await db
       .select()
@@ -78,16 +79,13 @@ trigger.post(
   sValidator("json", triggerCreateSchema),
   async (c) => {
     const data = c.req.valid("json");
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
+    const { workspaceId } = scope;
 
     // The Agent must be usable here: workspace-scoped, or a Shared one attached
     // to this Workspace (ADR-0007) — the same set the run resolves when the
     // trigger fires.
-    const agentRecord = await resolveScoped(db, "agent", data.agentId, {
-      orgId,
-      wsId: workspaceId,
-    });
+    const agentRecord = await resolveScoped(db, "agent", data.agentId, scope);
 
     if (!agentRecord) {
       return c.json({ error: "Agent not found in this workspace" }, 400);
@@ -148,8 +146,8 @@ trigger.put(
   sValidator("json", triggerUpdateSchema),
   async (c) => {
     const triggerId = c.req.param("triggerId");
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId")!;
+    const scope = workspaceScopeOf(c);
+    const { workspaceId } = scope;
     const data = c.req.valid("json");
 
     // Verify trigger exists in workspace
@@ -171,10 +169,7 @@ trigger.put(
     // If agentId is being changed, verify new agent exists
     if (data.agentId && data.agentId !== existing[0].agentId) {
       // See the create route: workspace-scoped, or Shared and attached here.
-      const agentRecord = await resolveScoped(db, "agent", data.agentId, {
-        orgId,
-        wsId: workspaceId,
-      });
+      const agentRecord = await resolveScoped(db, "agent", data.agentId, scope);
 
       if (!agentRecord) {
         return c.json({ error: "Agent not found in this workspace" }, 400);
@@ -241,7 +236,7 @@ trigger.delete(
   requireWorkspaceOwner,
   async (c) => {
     const triggerId = c.req.param("triggerId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
 
     const result = await db
       .delete(triggerTable)
@@ -278,7 +273,7 @@ trigger.get(
   ),
   async (c) => {
     const triggerId = c.req.param("triggerId");
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const { limit: limitStr, offset: offsetStr } = c.req.valid("query");
 
     const limit = Math.min(parseInt(limitStr ?? "100") || 100, 100);

--- a/apps/backend/src/routes/webhook.ts
+++ b/apps/backend/src/routes/webhook.ts
@@ -10,6 +10,7 @@ import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
   requireWorkspaceAccess,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 
@@ -26,7 +27,7 @@ webhook.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
 
     const results = await db
       .select()
@@ -45,7 +46,7 @@ webhook.post(
   requireWorkspaceAccess,
   sValidator("json", webhookCreateSchema),
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const body = c.req.valid("json" as never) as {
       name: string;
       url: string;
@@ -90,7 +91,7 @@ webhook.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const webhookId = c.req.param("webhookId");
 
     const results = await db
@@ -120,7 +121,7 @@ webhook.put(
   requireWorkspaceAccess,
   sValidator("json", webhookUpdateSchema),
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const webhookId = c.req.param("webhookId");
     const body = c.req.valid("json" as never) as {
       name?: string;
@@ -165,7 +166,7 @@ webhook.delete(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const webhookId = c.req.param("webhookId");
 
     const result = await db
@@ -193,7 +194,7 @@ webhook.post(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId")!;
+    const { workspaceId } = workspaceScopeOf(c);
     const webhookId = c.req.param("webhookId");
 
     const result = await db

--- a/apps/backend/src/routes/workspace.test.ts
+++ b/apps/backend/src/routes/workspace.test.ts
@@ -277,7 +277,9 @@ describe("Workspace Routes", () => {
         expect.anything(),
         "provider",
         "provider-other-org",
-        { orgId: "org-1", wsId: "ws-1" },
+        // The middleware's WorkspaceScope, passed through: what pins the fix is
+        // that the org/workspace pair reaches resolveScoped at all.
+        expect.objectContaining({ orgId: "org-1", workspaceId: "ws-1" }),
       );
       expect(mockDb.update).not.toHaveBeenCalled();
     });

--- a/apps/backend/src/routes/workspace.ts
+++ b/apps/backend/src/routes/workspace.ts
@@ -13,8 +13,10 @@ import {
 import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
+  orgScopeOf,
   requireOrgAccess,
   requireWorkspaceAccess,
+  workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import { resolveScoped } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
@@ -30,7 +32,7 @@ workspace.post(
   sValidator("json", workspaceCreateSchema),
   async (c) => {
     const user = c.get("user")!;
-    const orgId = c.req.param("orgId")!;
+    const { orgId } = orgScopeOf(c);
     const data = c.req.valid("json");
 
     // ownerId is admin-assignable (ADR-0008); default to the calling admin
@@ -72,7 +74,7 @@ workspace.post(
 
 /** List all workspaces */
 workspace.get("/", requireAuth, requireOrgAccess(), async (c) => {
-  const orgId = c.req.param("orgId")!;
+  const { orgId } = orgScopeOf(c);
   const orgMembership = c.get("orgMembership")!;
   const user = c.get("user")!;
 
@@ -105,7 +107,7 @@ workspace.get(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId");
+    const { workspaceId } = workspaceScopeOf(c);
     const record = await db
       .select()
       .from(workspaceTable)
@@ -126,8 +128,8 @@ workspace.put(
   requireWorkspaceAccess,
   sValidator("json", workspaceUpdateSchema),
   async (c) => {
-    const orgId = c.req.param("orgId")!;
-    const workspaceId = c.req.param("workspaceId");
+    const scope = workspaceScopeOf(c);
+    const { workspaceId } = scope;
     const data = c.req.valid("json");
 
     // Delegation flags (ADR-0006) are admin-only. A non-admin owner may edit
@@ -151,7 +153,7 @@ workspace.put(
         db,
         "provider",
         data.memoryExtractionProviderId,
-        { orgId, wsId: workspaceId },
+        scope,
       );
 
       if (!resolved) {
@@ -174,7 +176,7 @@ workspace.put(
         db,
         "provider",
         data.memoryEmbeddingProviderId,
-        { orgId, wsId: workspaceId },
+        scope,
       );
 
       if (!resolved) {
@@ -216,7 +218,7 @@ workspace.delete(
   requireOrgAccess(),
   requireWorkspaceAccess,
   async (c) => {
-    const workspaceId = c.req.param("workspaceId");
+    const { workspaceId } = workspaceScopeOf(c);
     // Best-effort sandbox teardown before the DB cascade fires. Never throws;
     // failures are recorded in sandbox_teardown_failure (ADR-0001).
     await destroyWorkspaceSandboxes(workspaceId);

--- a/apps/backend/src/scope.ts
+++ b/apps/backend/src/scope.ts
@@ -42,10 +42,25 @@ export type OrgScope = UserScope & {
   orgId: string;
 };
 
-export type WorkspaceScope = OrgScope & {
+/**
+ * Which Workspace a lookup is placed in, with no actor attached — the half of a
+ * {@link WorkspaceScope} that a data-access module actually reads.
+ *
+ * Kept separate from `WorkspaceScope` because not every caller has a
+ * `Principal` to offer: the Agent-facing Tools are built from the SDK's
+ * `ToolSetContext`, which carries ids across the plugin boundary and cannot
+ * name a backend-internal principal type. A `WorkspaceScope` satisfies this
+ * structurally, so a handler passes the middleware's value straight through.
+ */
+export type ScopeContext = {
+  orgId: string;
   workspaceId: string;
-  isWorkspaceOwner: boolean;
 };
+
+export type WorkspaceScope = OrgScope &
+  ScopeContext & {
+    isWorkspaceOwner: boolean;
+  };
 
 // === Factories ===
 

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -302,7 +302,7 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
     // Sandbox/MCP tools still rebind to that invoking Workspace via loadTools.
     const found = await resolveScoped(db, "agent", id, {
       orgId,
-      wsId: workspaceId,
+      workspaceId,
     });
     return found?.row ?? null;
   },
@@ -310,7 +310,7 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
   async getProvider(id, orgId, workspaceId) {
     const found = await resolveScoped(db, "provider", id, {
       orgId,
-      wsId: workspaceId,
+      workspaceId,
     });
     return (found?.row as Provider | undefined) ?? null;
   },
@@ -318,7 +318,7 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
   async getSkillsByIds(ids, orgId, workspaceId) {
     const visible = await listScopedByIds(db, "skill", ids, {
       orgId,
-      wsId: workspaceId,
+      workspaceId,
     });
 
     // A workspace-scoped Skill wins a name collision with an attached org-scoped
@@ -338,7 +338,7 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
   async getMcp(id, orgId, workspaceId) {
     const found = await resolveScoped(db, "mcp", id, {
       orgId,
-      wsId: workspaceId,
+      workspaceId,
     });
     return found?.row ?? null;
   },
@@ -351,7 +351,7 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
     // prompt, and its Provider then failed to resolve.
     const visible = await listScopedByIds(db, "agent", ids, {
       orgId,
-      wsId: workspaceId,
+      workspaceId,
     });
 
     // Returned in assignment order so the prompt lists sub-agents the way the

--- a/apps/backend/src/services/chat-metadata.ts
+++ b/apps/backend/src/services/chat-metadata.ts
@@ -93,7 +93,7 @@ export const generateChatMetadata = async (
   // makes it visible to this Workspace (ADR-0007).
   const found = await resolveScoped(db, "provider", effectiveProviderId, {
     orgId,
-    wsId: workspaceId,
+    workspaceId,
   });
   if (!found) {
     // Titling is fire-and-forget, so an unresolvable provider leaves chats

--- a/apps/backend/src/services/kanban.ts
+++ b/apps/backend/src/services/kanban.ts
@@ -16,6 +16,7 @@ import {
 } from "../db/schema.ts";
 import { user } from "../db/auth-schema.ts";
 import { NotFoundError, ValidationError } from "../errors.ts";
+import type { ScopeContext } from "../scope.ts";
 import { dispatchEvent } from "./event-dispatch.ts";
 import { listScopedByIds } from "./scoped-resource.ts";
 import { calculateCardPosition } from "../utils/kanban-positioning.ts";
@@ -44,14 +45,14 @@ import {
 export type KanbanActor = { userId: string } | { agentId: string };
 
 /**
- * Where a lookup may reach. `boardId` narrows it to a single board (the HTTP
+ * Where a lookup may reach: a {@link ScopeContext} — so the HTTP surface hands
+ * over the `WorkspaceScope` its middleware resolved, unchanged — plus an
+ * optional board. `boardId` narrows the reach to a single board (the HTTP
  * surface, which addresses cards through their board); left out, any board in
  * the Workspace matches (the Tool surface, whose Agent works Workspace-wide).
  * Either way the Workspace is the outer boundary — nothing resolves across it.
  */
-export type KanbanScope = {
-  orgId: string;
-  workspaceId: string;
+export type KanbanScope = ScopeContext & {
   boardId?: string;
 };
 
@@ -368,7 +369,7 @@ export const pruneCardLabelsForBoard = async (
 export const requireValidAssignees = async (
   database: Database,
   assignees: KanbanCardAssignee[] | undefined,
-  scope: Pick<KanbanScope, "orgId" | "workspaceId">,
+  scope: ScopeContext,
 ): Promise<void> => {
   if (!assignees || assignees.length === 0) return;
 
@@ -393,10 +394,7 @@ export const requireValidAssignees = async (
           .from(user)
           .where(and(eq(user.role, "admin"), inArray(user.id, userIds)))
       : Promise.resolve([]),
-    listScopedByIds(database, "agent", agentIds, {
-      orgId: scope.orgId,
-      wsId: scope.workspaceId,
-    }),
+    listScopedByIds(database, "agent", agentIds, scope),
   ]);
 
   // Super admins may hold no org membership record, so the two sets combine.

--- a/apps/backend/src/services/scoped-resource.test.ts
+++ b/apps/backend/src/services/scoped-resource.test.ts
@@ -18,7 +18,7 @@ import {
 } from "./scoped-resource.ts";
 import { NotFoundError, LockedError, ConflictError } from "../errors.ts";
 
-const ctx = { orgId: "org-1", wsId: "ws-1" };
+const ctx = { orgId: "org-1", workspaceId: "ws-1" };
 
 describe("ScopedResource read module", () => {
   beforeEach(() => {

--- a/apps/backend/src/services/scoped-resource.ts
+++ b/apps/backend/src/services/scoped-resource.ts
@@ -7,6 +7,7 @@ import {
   attachment as attachmentTable,
 } from "../db/schema.ts";
 import { db } from "../index.ts";
+import type { ScopeContext } from "../scope.ts";
 import { ConflictError, LockedError, NotFoundError } from "../errors.ts";
 import { isResourceListedInBlueprint } from "./blueprint-guard.ts";
 
@@ -80,9 +81,6 @@ const REGISTRY: Record<ScopedResourceType, RegistryEntry> = {
   provider: { table: providerTable, label: "Provider", noun: "provider" },
 };
 
-/** The Workspace a Scoped resource is resolved relative to. */
-export type ScopeContext = { orgId: string; wsId: string };
-
 type Database = typeof db;
 
 /**
@@ -107,14 +105,14 @@ const isAttached = async (
   database: Database,
   type: ScopedResourceType,
   id: string,
-  wsId: string,
+  workspaceId: string,
 ): Promise<boolean> => {
   const [attached] = await database
     .select({ id: attachmentTable.id })
     .from(attachmentTable)
     .where(
       and(
-        eq(attachmentTable.workspaceId, wsId),
+        eq(attachmentTable.workspaceId, workspaceId),
         eq(attachmentTable.resourceType, type),
         eq(attachmentTable.resourceId, id),
       ),
@@ -144,7 +142,7 @@ export const resolveScoped = async <T extends ScopedResourceType>(
       and(
         eq(table.id, id),
         or(
-          eq(table.workspaceId, ctx.wsId),
+          eq(table.workspaceId, ctx.workspaceId),
           eq(table.organizationId, ctx.orgId),
         ),
       ),
@@ -156,13 +154,13 @@ export const resolveScoped = async <T extends ScopedResourceType>(
   // Classified by which scope the row actually carries, not by elimination: a row
   // holding both columns would otherwise fall through to "workspace" and be
   // visible here on the strength of its organizationId alone.
-  if (row.workspaceId === ctx.wsId) {
+  if (row.workspaceId === ctx.workspaceId) {
     return { row, scope: "workspace" };
   }
   if (!isSharedRow(row, ctx.orgId)) return null;
 
   // A Shared resource is visible here only through an Attachment (ADR-0007).
-  if (!(await isAttached(database, type, id, ctx.wsId))) return null;
+  if (!(await isAttached(database, type, id, ctx.workspaceId))) return null;
   return { row, scope: "organization" };
 };
 
@@ -188,7 +186,7 @@ export const resolveScopedByName = async <T extends ScopedResourceType>(
   const workspaceRows = await database
     .select()
     .from(table)
-    .where(and(eq(table.workspaceId, ctx.wsId), eq(table.name, name)))
+    .where(and(eq(table.workspaceId, ctx.workspaceId), eq(table.name, name)))
     .limit(1);
   const workspaceRow = workspaceRows[0] as RowOf[T] | undefined;
   if (workspaceRow) return { row: workspaceRow, scope: "workspace" };
@@ -210,7 +208,8 @@ export const resolveScopedByName = async <T extends ScopedResourceType>(
   const orgRow = orgRows[0] as RowOf[T] | undefined;
   if (!orgRow) return null;
 
-  if (!(await isAttached(database, type, orgRow.id, ctx.wsId))) return null;
+  if (!(await isAttached(database, type, orgRow.id, ctx.workspaceId)))
+    return null;
   return { row: orgRow, scope: "organization" };
 };
 
@@ -233,7 +232,7 @@ export const listScoped = async <T extends ScopedResourceType>(
     .from(table)
     .where(
       and(
-        eq(table.workspaceId, ctx.wsId),
+        eq(table.workspaceId, ctx.workspaceId),
         ids ? inArray(table.id, ids) : undefined,
       ),
     );
@@ -251,7 +250,7 @@ export const listScoped = async <T extends ScopedResourceType>(
       and(
         eq(attachmentTable.resourceId, table.id),
         eq(attachmentTable.resourceType, type),
-        eq(attachmentTable.workspaceId, ctx.wsId),
+        eq(attachmentTable.workspaceId, ctx.workspaceId),
       ),
     )
     .where(

--- a/apps/backend/src/services/sub-agent-validation.test.ts
+++ b/apps/backend/src/services/sub-agent-validation.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { mockDb, resetMockDb } from "../test-utils.ts";
 import { validateSubAgentAssignment } from "./sub-agent-validation.ts";
 
-const ctx = { orgId: "org-1", wsId: "workspace-1" };
+const ctx = { orgId: "org-1", workspaceId: "workspace-1" };
 
 /**
  * Stubs the two queries `listScoped` runs: the Workspace-scoped rows, then the

--- a/apps/backend/src/services/sub-agent-validation.ts
+++ b/apps/backend/src/services/sub-agent-validation.ts
@@ -1,5 +1,6 @@
 import { db } from "../index.ts";
-import { listScopedByIds, type ScopeContext } from "./scoped-resource.ts";
+import { listScopedByIds } from "./scoped-resource.ts";
+import type { ScopeContext } from "../scope.ts";
 
 /**
  * Rejection message for an Agent listed among its own sub-agents. Shared with

--- a/apps/backend/src/tools/agent-discovery.ts
+++ b/apps/backend/src/tools/agent-discovery.ts
@@ -4,11 +4,8 @@ import { db } from "../index.ts";
 import { getToolSets } from "../tools/index.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
 import { providerModelReferences } from "../services/model-capability.ts";
-import {
-  listScoped,
-  resolveScoped,
-  type ScopeContext,
-} from "../services/scoped-resource.ts";
+import { listScoped, resolveScoped } from "../services/scoped-resource.ts";
+import type { ScopeContext } from "../scope.ts";
 import type { Provider } from "@platypus/schemas";
 
 /**
@@ -48,7 +45,7 @@ export function createAgentDiscoveryTools(
   orgId: string,
   frontendUrl: string | undefined,
 ): Record<string, Tool> {
-  const ctx: ScopeContext = { orgId, wsId: workspaceId };
+  const ctx: ScopeContext = { orgId, workspaceId };
 
   const listToolSets = tool({
     description:

--- a/apps/backend/src/tools/agent-management.ts
+++ b/apps/backend/src/tools/agent-management.ts
@@ -8,8 +8,8 @@ import { validateSubAgentAssignment } from "../services/sub-agent-validation.ts"
 import {
   resolveScoped,
   workspaceMutationLockedMessage,
-  type ScopeContext,
 } from "../services/scoped-resource.ts";
+import type { ScopeContext } from "../scope.ts";
 import { getStorage } from "../storage/index.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
 
@@ -30,7 +30,7 @@ export function createAgentManagementTools(
   orgId: string,
   frontendUrl: string | undefined,
 ): Record<string, Tool> {
-  const ctx: ScopeContext = { orgId, wsId: workspaceId };
+  const ctx: ScopeContext = { orgId, workspaceId };
 
   /**
    * Resolves an Agent this Workspace may write to, for the mutating tools. An
@@ -103,7 +103,7 @@ export function createAgentManagementTools(
       if (data.subAgentIds && data.subAgentIds.length > 0) {
         const newId = nanoid();
         const validation = await validateSubAgentAssignment(
-          { orgId, wsId: workspaceId },
+          { orgId, workspaceId },
           newId,
           data.subAgentIds,
         );

--- a/apps/backend/src/tools/kanban.ts
+++ b/apps/backend/src/tools/kanban.ts
@@ -85,7 +85,7 @@ export function createKanbanTools(
     return { ...result.card, ...(url && { url }) };
   };
 
-  const listAgents = createListAgentsTool({ orgId, wsId: workspaceId });
+  const listAgents = createListAgentsTool({ orgId, workspaceId });
 
   const listBoards = tool({
     description: "List all kanban boards in the current workspace.",

--- a/apps/backend/src/tools/skill-management.ts
+++ b/apps/backend/src/tools/skill-management.ts
@@ -9,8 +9,8 @@ import {
   listScoped,
   resolveScopedByName,
   workspaceMutationLockedMessage,
-  type ScopeContext,
 } from "../services/scoped-resource.ts";
+import type { ScopeContext } from "../scope.ts";
 
 // Field constraints come from the shared schema so the agent-facing tool can
 // never drift from the bounds the HTTP routes and the web form enforce.
@@ -29,7 +29,7 @@ export function createSkillManagementTools(
   orgId: string,
   frontendUrl: string | undefined,
 ): Record<string, Tool> {
-  const ctx: ScopeContext = { orgId, wsId: workspaceId };
+  const ctx: ScopeContext = { orgId, workspaceId };
 
   const listSkills = tool({
     description:

--- a/apps/backend/src/tools/skill.ts
+++ b/apps/backend/src/tools/skill.ts
@@ -15,7 +15,7 @@ export const createLoadSkillTool = (orgId: string, workspaceId: string) =>
       // org-scoped (Shared) one where attached to this workspace (ADR-0007).
       const found = await resolveScopedByName(db, "skill", name, {
         orgId,
-        wsId: workspaceId,
+        workspaceId,
       });
 
       if (!found) {

--- a/apps/backend/src/tools/trigger.ts
+++ b/apps/backend/src/tools/trigger.ts
@@ -6,11 +6,8 @@ import { db } from "../index.ts";
 import { trigger as triggerTable } from "../db/schema.ts";
 import { validateCronExpression } from "../utils/cron.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
-import {
-  listScoped,
-  resolveScoped,
-  type ScopeContext,
-} from "../services/scoped-resource.ts";
+import { listScoped, resolveScoped } from "../services/scoped-resource.ts";
+import type { ScopeContext } from "../scope.ts";
 
 export function createTriggerTools(
   workspaceId: string,
@@ -20,7 +17,7 @@ export function createTriggerTools(
   // A trigger may point at any Agent this Workspace can run — its own, or a
   // Shared one attached to it (ADR-0007), which is exactly what the Chat turn
   // resolves when the trigger fires.
-  const ctx: ScopeContext = { orgId, wsId: workspaceId };
+  const ctx: ScopeContext = { orgId, workspaceId };
 
   const listAgents = tool({
     description:


### PR DESCRIPTION
Closes #493.

## What

The authorization middleware already resolved the Workspace, its Organization
and `isWorkspaceOwner` into a typed `WorkspaceScope` — but exactly one handler
read it. Everywhere else the route body re-derived the same facts from the URL
with `c.req.param("orgId")!` / `c.req.param("workspaceId")!`: 144 non-null
assertions of an invariant the type system could not see.

Handlers now read the scope through `workspaceScopeOf(c)` / `orgScopeOf(c)`,
which throw when their middleware did not run. One assertion instead of 144, and
route bodies that no longer parse URLs.

- `ScopeContext` moves to `scope.ts`, renames `wsId` to `workspaceId`, and
  becomes the narrow half a `WorkspaceScope` structurally satisfies — so the
  middleware's value passes straight into `listScoped` / `requireScoped` /
  `requireWorkspaceMutable` with no `{ orgId, wsId }` shim.
- `KanbanScope` is that same type plus an optional board, so the HTTP and Tool
  surfaces share it.
- `requireWorkspaceAccess`'s three near-identical role branches collapse to one
  access decision, and it now sets the scope unconditionally rather than only
  when `requireOrgAccess` happened to leave one behind. Its cross-org guard
  reads the Organization from the resolved scope, so it can no longer be
  skipped by a missing path param.

## Deviation from the issue

The issue asked for `KanbanScope = WorkspaceScope & { boardId? }`. It is
`ScopeContext & { boardId? }` instead. `WorkspaceScope` carries a `Principal`,
and the Agent-facing Kanban tools are built from the SDK's `ToolSetContext`,
which carries ids across the published plugin boundary and cannot name a
backend-internal type — the literal shape would force that surface to fabricate
a principal. The kanban module also already names its actor (`KanbanActor`), so
a `principal` beside it would be a second overlapping notion of the same thing.
The HTTP surface still hands its `WorkspaceScope` over unchanged, which is what
the issue was after.

One consequence: the issue's "`isWorkspaceOwner` reaches services for free" does
not land — the value rides on the object, but services typed on `ScopeContext`
cannot read it. Nothing needs it today; a service that later does can widen its
own parameter to `WorkspaceScope`.

## Beyond the issue

`orgScopeOf` is not in the issue, which names only `workspaceScopeOf`. It is
needed to reach the headline number: 73 of the 144 assertions were `orgId`, many
on Organization-only routes with no Workspace in play.

## Verification

`pnpm typecheck` and `pnpm test` green across the monorepo — backend 1786,
frontend 199, schemas 122, docs 25, SDK 10, examples 5. New tests cover both
accessors: the scope each returns for member, org-admin and super-admin callers,
and the throw when the middleware did not run.

No docs change owed — the diff touches no path in CLAUDE.md's docs table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)