### PR TITLE
feat(backend): compose Tool sets like Web backends, behind one disposable tool session

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,10 @@ _Avoid_: max tokens, token limit, context window (that names the total capacity)
 **Tool set**:
 A named bundle of Tools an Agent can be granted. Either contributed by a Plugin (registered in code) or backed by an MCP server.
 
+**Tool session**:
+One Agent's Tool sets, resolved for one Chat turn, together with the connections opened to serve them. Sessions nest: a Sub-Agent's session is opened on its first delegation and closes with the parent's, so a turn has exactly one thing to dispose however many tool sources it reached. A Tool set that cannot serve the turn — a factory that throws, an unreachable MCP — costs its own Tools and no more.
+_Avoid_: tool context (that is the scope handed to a Tool set factory), tool loader.
+
 **MCP**:
 A Model Context Protocol server registered at Workspace scope, or — as a Shared resource — at Organization scope. Resolves to a Tool set at Chat-turn time.
 

--- a/apps/backend/src/plugins/extension-points.ts
+++ b/apps/backend/src/plugins/extension-points.ts
@@ -4,6 +4,7 @@ import type {
   WebBackendContribution,
 } from "@platypuschat/plugin-sdk";
 import type { SandboxBackendRegistration } from "../sandbox/index.ts";
+import { composeToolSet, type ToolSetRegistration } from "../tools/index.ts";
 import {
   composeWebBackend,
   MAX_WEB_TIMEOUT_MS,
@@ -24,10 +25,14 @@ import type { ExtensionPoint } from "./contribution-pipeline.ts";
 // `this` when spread, and its factories must be called on the author's own
 // object.
 
-/** The Tool-set point (ADR-0013). Registers `{ name, category, description, tools }`. */
+/**
+ * The Tool-set point (ADR-0013). Registers core's *composed* registration — core
+ * owns everything between the contribution's factory and the model — rather than
+ * the raw `{ name, category, description, tools }`.
+ */
 export const toolSetPoint = (
-  register: (id: string, definition: Omit<ToolSetContribution, "id">) => void,
-): ExtensionPoint<Omit<ToolSetContribution, "id">> => ({
+  register: (id: string, registration: ToolSetRegistration) => void,
+): ExtensionPoint<ToolSetRegistration> => ({
   noun: "tool set",
   idField: "id",
   validate: (contribution, { pluginName, rawId }) => {
@@ -50,18 +55,15 @@ export const toolSetPoint = (
       );
     }
   },
-  prepare: (contribution, { plugin }) => {
-    const { name, category, description, tools } =
-      contribution as unknown as ToolSetContribution;
-    // Bind the shared plugin config into the factory so core's registry and its
-    // Chat-turn callers stay ignorant of it: they invoke the stored factory with
-    // only the ToolSetContext, as before. A static-map tool set has no factory
-    // to inject into and is registered untouched.
-    const boundTools =
-      typeof tools === "function"
-        ? (context: Parameters<typeof tools>[0]) => tools(context, plugin)
-        : tools;
-    return { name, category, description, tools: boundTools };
+  prepare: (raw, { pluginName, id, plugin }) => {
+    const contribution = raw as unknown as ToolSetContribution;
+    // Core wraps the contribution here, binding the same shared plugin config
+    // that every other contribution factory receives. What lands in the registry
+    // is the finished, guarded builder — per-turn callers never see the raw
+    // `tools`. The contribution goes in by reference, with the namespaced id
+    // alongside it rather than spread over it, for the same prototype/`this`
+    // reason as the sandbox and web points.
+    return composeToolSet({ contribution, id, plugin, pluginName });
   },
   register,
 });

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -22,13 +22,17 @@ import {
   type PluginLoggerParent,
 } from "./loader.ts";
 import { plugin as examplePlugin } from "./example/index.ts";
-import { registerToolSet, getToolSet } from "../tools/index.ts";
+import {
+  registerToolSet,
+  getToolSet,
+  type ToolSetRegistration,
+} from "../tools/index.ts";
 
 // A capturing `register` and the builtin/import module shapes the loader expects.
 const makeRegister = () => {
-  const calls: Array<{ id: string; def: Omit<ToolSetContribution, "id"> }> = [];
-  const register = (id: string, def: Omit<ToolSetContribution, "id">) => {
-    calls.push({ id, def });
+  const calls: Array<{ id: string; registration: ToolSetRegistration }> = [];
+  const register = (id: string, registration: ToolSetRegistration) => {
+    calls.push({ id, registration });
   };
   return { register, calls };
 };
@@ -1035,9 +1039,9 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
       toolSet?: PluginConfigContext;
       sandbox?: PluginConfigContext;
     } = {};
-    const registered: Record<string, Omit<ToolSetContribution, "id">> = {};
-    const register = (id: string, def: Omit<ToolSetContribution, "id">) => {
-      registered[id] = def;
+    const registered: Record<string, ToolSetRegistration> = {};
+    const register = (id: string, registration: ToolSetRegistration) => {
+      registered[id] = registration;
     };
     const sandboxCalls: SandboxBackendContribution[] = [];
     const registerSandbox = (c: SandboxBackendContribution) => {
@@ -1061,9 +1065,7 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
 
     // Tool-set factory: invoked as core would at Chat-turn time, with ctx only.
     // Third-party ids are namespaced, so the registry key is prefixed.
-    const toolsFactory = registered["acmecloud.managed"].tools;
-    expect(typeof toolsFactory).toBe("function");
-    await (toolsFactory as (ctx: unknown) => unknown)({
+    await registered["acmecloud.managed"].buildTurnTools({
       workspaceId: "w",
       agentId: "a",
       orgId: "o",
@@ -1091,9 +1093,9 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
       toolSet?: PluginConfigContext;
       sandbox?: PluginConfigContext;
     } = {};
-    const registered: Record<string, Omit<ToolSetContribution, "id">> = {};
-    const register = (id: string, def: Omit<ToolSetContribution, "id">) => {
-      registered[id] = def;
+    const registered: Record<string, ToolSetRegistration> = {};
+    const register = (id: string, registration: ToolSetRegistration) => {
+      registered[id] = registration;
     };
     const sandboxCalls: SandboxBackendContribution[] = [];
 
@@ -1112,7 +1114,7 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
       },
     });
 
-    await (registered["acmecloud.managed"].tools as (ctx: unknown) => unknown)({
+    await registered["acmecloud.managed"].buildTurnTools({
       workspaceId: "w",
       agentId: "a",
       orgId: "o",
@@ -1168,7 +1170,7 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
 
   it("passes undefined config/credentials to plugins declaring no schemas", async () => {
     let seenPlugin: PluginConfigContext | undefined;
-    const registered: Record<string, Omit<ToolSetContribution, "id">> = {};
+    const registered: Record<string, ToolSetRegistration> = {};
 
     await loadPlugins({
       pluginNames: ["noschema"],
@@ -1194,12 +1196,12 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
             },
           } satisfies PlatypusPlugin,
         }),
-      register: (id, def) => {
-        registered[id] = def;
+      register: (id, registration) => {
+        registered[id] = registration;
       },
     });
 
-    await (registered["noschema.plain"].tools as (ctx: unknown) => unknown)({
+    await registered["noschema.plain"].buildTurnTools({
       workspaceId: "w",
       agentId: "a",
       orgId: "o",
@@ -1272,7 +1274,7 @@ describe("loadPlugins — plugin logger injection", () => {
     baseLogger: PluginLoggerParent;
     seen: Record<string, PluginConfigContext | undefined>;
   }) => {
-    const registered: Record<string, Omit<ToolSetContribution, "id">> = {};
+    const registered: Record<string, ToolSetRegistration> = {};
     const sandboxCalls: SandboxBackendContribution[] = [];
     const { registerWeb, calls: webCalls } = makeWebRegister();
 
@@ -1283,17 +1285,15 @@ describe("loadPlugins — plugin logger injection", () => {
         Promise.resolve({
           plugin: loggingManifest(opts.pluginName, opts.seen),
         }),
-      register: (id, def) => {
-        registered[id] = def;
+      register: (id, registration) => {
+        registered[id] = registration;
       },
       registerSandbox: (c) => sandboxCalls.push(c),
       registerWeb,
       baseLogger: opts.baseLogger,
     });
 
-    await (
-      registered[`${opts.pluginName}.tools`].tools as (ctx: unknown) => unknown
-    )({
+    await registered[`${opts.pluginName}.tools`].buildTurnTools({
       workspaceId: "w",
       agentId: "a",
       orgId: "o",
@@ -1372,15 +1372,15 @@ describe("loadPlugins — example third-party plugin", () => {
   // Proves the documented example plugin wires one shared credential block into
   // BOTH its Sandbox backend and its management Tool set (ADR-0013).
   it("shares one credential block across its two contributions", async () => {
-    const registered: Record<string, Omit<ToolSetContribution, "id">> = {};
+    const registered: Record<string, ToolSetRegistration> = {};
     const sandboxCalls: SandboxBackendContribution[] = [];
 
     const { plugins: loaded } = await loadPlugins({
       pluginNames: ["example-cloud-sandbox"],
       builtinPlugins: {},
       importPlugin: () => Promise.resolve({ plugin: examplePlugin }),
-      register: (id, def) => {
-        registered[id] = def;
+      register: (id, registration) => {
+        registered[id] = registration;
       },
       registerSandbox: (c) => sandboxCalls.push(c),
       pluginConfig: {
@@ -1409,17 +1409,18 @@ describe("loadPlugins — example third-party plugin", () => {
     expect(backend.region).toBe("ap");
 
     // Management tool set: its tool description reflects the SAME token/region.
-    const toolsFactory = registered["example-cloud-sandbox.management"]
-      .tools as unknown as (
-      ctx: unknown,
-    ) => Promise<Record<string, { execute: (i: unknown) => Promise<string> }>>;
-    const tools = await toolsFactory({
+    const tools = (await registered[
+      "example-cloud-sandbox.management"
+    ].buildTurnTools({
       workspaceId: "w",
       agentId: "a",
       orgId: "o",
       frontendUrl: undefined,
       userId: "u",
-    });
+    })) as unknown as Record<
+      string,
+      { execute: (i: unknown) => Promise<string> }
+    >;
     const msg = await tools.listSandboxes.execute({});
     expect(msg).toContain("ap");
     expect(msg).toContain("dtn");
@@ -1471,8 +1472,8 @@ describe("loadPlugins — the documented quickstart package", () => {
     // the switch with `name`, so those are the two strings the reader hunts for.
     expect(calls).toHaveLength(1);
     expect(calls[0].id).toBe("example.greeting");
-    expect(calls[0].def.name).toBe("Greeting");
-    expect(calls[0].def.category).toBe("Examples");
+    expect(calls[0].registration.name).toBe("Greeting");
+    expect(calls[0].registration.category).toBe("Examples");
   });
 });
 
@@ -1778,10 +1779,7 @@ describe("loadPlugins — example third-party npm package (end to end)", () => {
     expect(set.category).toBe("Examples");
     expect(getToolSet("greeting")).toBeUndefined();
 
-    if (typeof set.tools !== "function") {
-      throw new Error("expected a tool-set factory");
-    }
-    const tools = await set.tools({
+    const tools = await set.buildTurnTools({
       workspaceId: "ws-1",
       agentId: "agent-1",
       orgId: "org-1",
@@ -1818,7 +1816,7 @@ describe("loadPlugins — example third-party npm package (end to end)", () => {
       baseLogger,
     });
 
-    await (calls[0].def.tools as (ctx: unknown) => unknown)({
+    await calls[0].registration.buildTurnTools({
       workspaceId: "ws-1",
       agentId: "agent-1",
       orgId: "org-1",

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -5,11 +5,10 @@ import {
   type PluginConfigContext,
   type PluginLogger,
   type SandboxBackendContribution,
-  type ToolSetContribution,
 } from "@platypuschat/plugin-sdk";
 import { logger } from "../logger.ts";
 import { ALWAYS_ON_PLUGINS, BUILTIN_PLUGINS } from "./builtin.ts";
-import { registerToolSet } from "../tools/index.ts";
+import { registerToolSet, type ToolSetRegistration } from "../tools/index.ts";
 import { registerSandboxBackend } from "../sandbox/index.ts";
 import {
   registerWebBackend,
@@ -116,8 +115,13 @@ export interface LoadPluginsOptions {
   builtinPlugins?: Record<string, () => Promise<PluginModule>>;
   /** Resolves a third-party plugin. Defaults to dynamic `import()`. */
   importPlugin?: (name: string) => Promise<PluginModule>;
-  /** Registers one Tool set contribution. Defaults to the core `registerToolSet`. */
-  register?: (id: string, def: Omit<ToolSetContribution, "id">) => void;
+  /**
+   * Registers one Tool set. Takes the *composed* registration — core has already
+   * wrapped the contribution's factory in its own guard — rather than the raw
+   * contribution, for the same reason `registerWeb` does (ADR-0013/0014).
+   * Defaults to the core `registerToolSet`.
+   */
+  register?: (id: string, registration: ToolSetRegistration) => void;
   /** Registers one Sandbox-backend contribution. Defaults to core `registerSandboxBackend`. */
   registerSandbox?: (contribution: SandboxBackendContribution) => void;
   /**

--- a/apps/backend/src/plugins/tools-platform/index.test.ts
+++ b/apps/backend/src/plugins/tools-platform/index.test.ts
@@ -99,31 +99,22 @@ describe("@platypus/tools-platform — loaded into the core registry", () => {
     }
   });
 
-  it("resolves each tool set's factory to a non-empty tool map at chat-turn time", () => {
+  it("resolves each tool set to a non-empty tool map at chat-turn time", async () => {
     for (const id of EXPECTED_IDS) {
-      const set = getToolSet(id)!;
-      expect(typeof set.tools).toBe("function");
-      const tools =
-        typeof set.tools === "function" ? set.tools(ctx) : set.tools;
+      const tools = await getToolSet(id)!.buildTurnTools(ctx);
       expect(Object.keys(tools).length).toBeGreaterThan(0);
     }
   });
 
-  it("resolves the read/write agent-management split tools as before", () => {
-    const discovery = getToolSet("agent-discovery")!;
+  it("resolves the read/write agent-management split tools as before", async () => {
     const discoveryTools =
-      typeof discovery.tools === "function"
-        ? discovery.tools(ctx)
-        : discovery.tools;
+      await getToolSet("agent-discovery")!.buildTurnTools(ctx);
     expect(Object.keys(discoveryTools).sort()).toEqual(
       ["getAgent", "listAgents", "listModelProviders", "listToolSets"].sort(),
     );
 
-    const management = getToolSet("agent-management")!;
     const managementTools =
-      typeof management.tools === "function"
-        ? management.tools(ctx)
-        : management.tools;
+      await getToolSet("agent-management")!.buildTurnTools(ctx);
     expect(Object.keys(managementTools).sort()).toEqual(
       ["createAgent", "deleteAgent", "updateAgent"].sort(),
     );

--- a/apps/backend/src/plugins/web-fetch/index.test.ts
+++ b/apps/backend/src/plugins/web-fetch/index.test.ts
@@ -63,11 +63,9 @@ describe("@platypus/web-fetch plugin manifest", () => {
     const set = getToolSet("web-fetch")!;
     expect(set.name).toBe("Web Fetch");
     expect(set.category).toBe("Web");
-    // The loader binds the plugin config into a factory; resolving it (as a Chat
-    // turn would) yields the fetchUrl tool.
-    expect(typeof set.tools).toBe("function");
-    if (typeof set.tools !== "function") throw new Error("expected factory");
-    const tools = await set.tools({
+    // The loader binds the plugin config into the composed builder; resolving it
+    // (as a Chat turn would) yields the fetchUrl tool.
+    const tools = await set.buildTurnTools({
       workspaceId: "w",
       agentId: "a",
       orgId: "o",

--- a/apps/backend/src/routes/org-tool.ts
+++ b/apps/backend/src/routes/org-tool.ts
@@ -21,13 +21,12 @@ orgTool.get("/", requireAuth, requireOrgAccess(), async (c) => {
     name: toolSet.name,
     category: toolSet.category,
     description: toolSet.description,
-    tools:
-      typeof toolSet.tools === "function"
-        ? []
-        : Object.entries(toolSet.tools).map(([toolId, tool]) => ({
-            id: toolId,
-            description: tool.description || "No description",
-          })),
+    // Named tools only for a static-map set; a factory's depend on the
+    // Workspace and are not knowable ahead of a turn.
+    tools: Object.entries(toolSet.staticTools ?? {}).map(([toolId, tool]) => ({
+      id: toolId,
+      description: tool.description || "No description",
+    })),
   }));
 
   const mcps = await listOrgScoped(db, "mcp", orgId);

--- a/apps/backend/src/routes/tool.test.ts
+++ b/apps/backend/src/routes/tool.test.ts
@@ -15,18 +15,21 @@ vi.mock("../tools/index.ts", () => ({
       name: "Math",
       category: "Utilities",
       description: "Math tools",
-      tools: {
+      // A static-map set names its tools ahead of any turn…
+      staticTools: {
         add: { description: "Add numbers" },
       },
+      buildTurnTools: vi.fn(),
     },
     // A core-internal static set (e.g. `sandbox`) with no owning plugin: it
-    // must annotate as core/built-in, not crash.
+    // must annotate as core/built-in, not crash. …and a factory-backed set
+    // names none, since what it serves depends on the Workspace.
     {
       id: "sandbox",
       name: "Sandbox",
       category: "Sandbox",
       description: "Sandbox tools",
-      tools: () => ({}),
+      buildTurnTools: vi.fn(),
     },
   ]),
 }));
@@ -85,15 +88,18 @@ describe("Tool Routes", () => {
           name: "Math",
           category: "Utilities",
           plugin: "@platypus/tools-basic",
+          tools: [{ id: "add", description: "Add numbers" }],
         }),
       );
 
-      // A set with no owning plugin annotates as core/built-in, not blank.
+      // A set with no owning plugin annotates as core/built-in, not blank, and
+      // a factory-backed one names no individual tools.
       expect(json.results).toContainEqual(
         expect.objectContaining({
           id: "sandbox",
           name: "Sandbox",
           plugin: "core (built-in)",
+          tools: [],
         }),
       );
 

--- a/apps/backend/src/routes/tool.ts
+++ b/apps/backend/src/routes/tool.ts
@@ -31,13 +31,14 @@ tool.get(
       category: toolSet.category,
       description: toolSet.description,
       plugin: getToolSetPlugin(toolSet.id) ?? CORE_BUILTIN_OWNER,
-      tools:
-        typeof toolSet.tools === "function"
-          ? []
-          : Object.entries(toolSet.tools).map(([toolId, tool]) => ({
-              id: toolId,
-              description: tool.description || "No description",
-            })),
+      // Named tools only for a static-map set; a factory's depend on the
+      // Workspace and are not knowable ahead of a turn.
+      tools: Object.entries(toolSet.staticTools ?? {}).map(
+        ([toolId, tool]) => ({
+          id: toolId,
+          description: tool.description || "No description",
+        }),
+      ),
     }));
 
     // The MCPs this Workspace may actually use: its own, plus the Shared

--- a/apps/backend/src/runs/sub-agent-lifecycle.test.ts
+++ b/apps/backend/src/runs/sub-agent-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import type { Tool } from "ai";
 import { z } from "zod";
 
 vi.mock("../logger.ts", () => ({
@@ -117,15 +118,16 @@ describe("a delegated run inside a parent run", () => {
           { type: "text-end", id: "t1" },
         ]),
       ),
-      tools: {
-        slowWork: {
-          inputSchema: z.object({}),
-          execute: async () => {
-            await sleep(SUB_AGENT_MS);
-            return "done";
+      loadTools: () =>
+        Promise.resolve({
+          slowWork: {
+            inputSchema: z.object({}),
+            execute: async () => {
+              await sleep(SUB_AGENT_MS);
+              return "done";
+            },
           },
-        },
-      },
+        } as unknown as Record<string, Tool>),
       parentRun: { runId: "parent", scope: parentScope },
     });
 
@@ -182,7 +184,7 @@ describe("a delegated run inside a parent run", () => {
           { type: "text-end", id: "t1" },
         ]),
       ),
-      tools: {},
+      loadTools: () => Promise.resolve({}),
       parentRun: { runId: "parent", scope: parentScope },
     });
 

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -98,7 +98,7 @@ import {
   composeWebBackend,
   registerWebBackend,
 } from "../web-backends/index.ts";
-import { registerToolSet } from "../tools/index.ts";
+import { composeToolSet, registerToolSet } from "../tools/index.ts";
 import { logger } from "../logger.ts";
 import { FileValidationError } from "./file-gate.ts";
 import { resetExtractedTextCache } from "./file-extraction.ts";
@@ -377,6 +377,44 @@ describe("chat-execution", () => {
       expect(turn.stream.system).toContain("Research Agent");
       expect(turn.stream.system).toContain("Shared Agent");
       expect(turn.stream.system).not.toContain("## Unavailable Sub-Agents");
+    });
+
+    // A parent with MCP-backed delegates used to connect to — and warn about —
+    // every one of their servers on every turn, delegation or not. The delegate
+    // now opens its own session when it is first invoked.
+    it("opens no connections for a delegate the turn never invokes", async () => {
+      const subAgent = {
+        ...baseAgent,
+        id: "sub-mcp",
+        name: "Research Agent",
+        toolSetIds: ["mcp-1"],
+      };
+      const parent = { ...baseAgent, subAgentIds: ["sub-mcp"] };
+
+      const queries = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        agents: [parent, subAgent],
+        providers: [baseProvider],
+        mcps: [
+          {
+            id: "mcp-1",
+            workspaceId: "ws-1",
+            url: "https://mcp.example.com",
+            authType: "None",
+          } as never,
+        ],
+      });
+      const getMcp = vi.spyOn(queries, "getMcp");
+
+      const turn = await prepareChatTurn(
+        { ...baseInput, request: { agentId: parent.id } },
+        queries,
+      );
+
+      expect(turn.stream.tools).toHaveProperty("delegateToResearchAgent");
+      expect(mockCreateMCPClient).not.toHaveBeenCalled();
+      expect(getMcp).not.toHaveBeenCalled();
+      await turn.dispose();
     });
 
     it("does not resolve a sub-agent that is not visible in the invoking Workspace, and reports it by id", async () => {
@@ -1124,29 +1162,57 @@ describe("chat-execution", () => {
   });
 
   describe("Static tool-set resolution", () => {
-    it("propagates factory errors without falling back to MCP lookup", async () => {
-      const factoryError = new Error("tool-set factory failed");
+    it("costs a throwing tool set its own tools, not the turn, and never falls back to MCP", async () => {
       const toolSetId = "test.throwing-factory";
-      registerToolSet(toolSetId, {
-        name: "Throwing test Tool set",
-        category: "Test",
-        tools: vi.fn().mockRejectedValue(factoryError),
-      });
+      registerToolSet(
+        toolSetId,
+        composeToolSet({
+          id: toolSetId,
+          pluginName: "test-plugin",
+          contribution: {
+            name: "Throwing test Tool set",
+            category: "Test",
+            tools: vi
+              .fn()
+              .mockRejectedValue(new Error("tool-set factory failed")),
+          },
+        }),
+      );
 
-      const agentWithToolSet = { ...baseAgent, toolSetIds: [toolSetId] };
+      const workingId = "test.working-set";
+      registerToolSet(
+        workingId,
+        composeToolSet({
+          id: workingId,
+          pluginName: "test-plugin",
+          contribution: {
+            name: "Working test Tool set",
+            category: "Test",
+            tools: { stillHere: { description: "x" } as never },
+          },
+        }),
+      );
+
+      const agentWithToolSets = {
+        ...baseAgent,
+        toolSetIds: [toolSetId, workingId],
+      };
       const queries = createInMemoryChatTurnQueries({
         workspaces: [baseWorkspace],
-        agents: [agentWithToolSet],
+        agents: [agentWithToolSets],
         providers: [baseProvider],
       });
       const getMcp = vi.spyOn(queries, "getMcp");
 
-      await expect(
-        prepareChatTurn(
-          { ...baseInput, request: { agentId: agentWithToolSet.id } },
-          queries,
-        ),
-      ).rejects.toBe(factoryError);
+      const turn = await prepareChatTurn(
+        { ...baseInput, request: { agentId: agentWithToolSets.id } },
+        queries,
+      );
+
+      // The turn runs, without the broken plugin's tools and with everything
+      // else the Agent was granted.
+      expect(turn.stream.tools).toHaveProperty("stillHere");
+      // A registered id is never re-read as an MCP, however its factory ended.
       expect(getMcp).not.toHaveBeenCalled();
     });
   });
@@ -1393,22 +1459,22 @@ describe("chat-execution", () => {
         .execute;
     };
 
-    it("normalizes a Date-containing result on the promise-resolved path", async () => {
-      const execute = wrapSingle(() =>
-        Promise.resolve({
-          createdAt: new Date("2026-07-13T10:20:30.000Z"),
-        }),
-      );
-      const result = (await execute({}, {})) as { createdAt: string };
-      expect(result.createdAt).toBe("2026-07-13T10:20:30.000Z");
+    // Activity events and nothing else: normalizing results is the loader
+    // seam's job now (`normalizeToolResults`), so it holds whether or not a turn
+    // supplies an `onActivity` callback. This wrapper hands the value back
+    // exactly as the tool returned it.
+    it("passes a resolved result through untouched", async () => {
+      const createdAt = new Date("2026-07-13T10:20:30.000Z");
+      const execute = wrapSingle(() => Promise.resolve({ createdAt }));
+      const result = (await execute({}, {})) as { createdAt: Date };
+      expect(result.createdAt).toBe(createdAt);
     });
 
-    it("normalizes a Date-containing result on the synchronous path", () => {
-      const execute = wrapSingle(() => ({
-        createdAt: new Date("2026-07-13T10:20:30.000Z"),
-      }));
-      const result = execute({}, {}) as { createdAt: string };
-      expect(result.createdAt).toBe("2026-07-13T10:20:30.000Z");
+    it("passes a synchronous result through untouched", () => {
+      const createdAt = new Date("2026-07-13T10:20:30.000Z");
+      const execute = wrapSingle(() => ({ createdAt }));
+      const result = execute({}, {}) as { createdAt: Date };
+      expect(result.createdAt).toBe(createdAt);
     });
 
     it("leaves the async-iterable path intact (yields pass through untouched)", async () => {
@@ -1429,7 +1495,7 @@ describe("chat-execution", () => {
       expect(parts[0].date).toBeInstanceOf(Date);
     });
 
-    it("brackets a normalized result with start and end activity events", async () => {
+    it("brackets a resolved result with start and end activity events", async () => {
       const onActivity = vi.fn<(event: ToolActivityEvent) => void>();
       const wrapped = wrapToolsWithActivity(
         {

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -1,7 +1,3 @@
-import {
-  experimental_createMCPClient as createMCPClient,
-  type MCPClient,
-} from "@ai-sdk/mcp";
 import { openProvider, type OpenedProvider } from "./provider.ts";
 import { eq } from "drizzle-orm";
 import { db } from "../index.ts";
@@ -13,7 +9,11 @@ import {
   sandbox as sandboxTable,
   workspace as workspaceTable,
 } from "../db/schema.ts";
-import { getToolSet } from "../tools/index.ts";
+import {
+  openToolSession,
+  type ToolSession,
+  type ToolSessionScope,
+} from "../tools/tool-session.ts";
 import { createLoadSkillTool } from "../tools/skill.ts";
 import {
   createSubAgentTools,
@@ -41,7 +41,6 @@ import {
 } from "../web-backends/index.ts";
 import type { LanguageModel, Tool } from "ai";
 import { logger } from "../logger.ts";
-import { buildMcpTransportConfig } from "./mcp-oauth-provider.ts";
 import { inlineFileUrls } from "../storage/utils.ts";
 import {
   maxExtractedTextCharsForModel,
@@ -547,18 +546,30 @@ export const prepareChatTurn = async (
   const opened = openProvider(provider);
   const model = opened.languageModel(resolvedModelId);
 
+  // Where this turn runs, shared by the Agent and every delegate it may reach.
+  const scope: ToolSessionScope = {
+    orgId,
+    workspaceId,
+    userId: user.id,
+    frontendUrl,
+  };
+  // Started before the `Promise.all` rather than inside it because the delegates
+  // built alongside it nest their own sessions into this one — they take the
+  // promise, not the session, and await it only if they are ever invoked.
+  const sessionPromise = openToolSession(scope, agent, queries);
+
   const [
-    { tools, mcpClients },
+    session,
     skills,
-    { subAgents, unavailableSubAgents, subAgentTools, subAgentMcpClients },
+    { subAgents, unavailableSubAgents, subAgentTools },
     userContexts,
     memories,
     sandboxEnvKeys,
     searchTools,
   ] = await Promise.all([
-    loadTools(queries, agent, workspaceId, orgId, frontendUrl, user.id),
+    sessionPromise,
     loadSkills(queries, agent, orgId, workspaceId),
-    loadSubAgents(queries, agent, orgId, workspaceId, frontendUrl, run),
+    loadSubAgents(queries, agent, scope, sessionPromise, run),
     queries.getUserContexts(user.id, workspaceId),
     queries.getRecentMemories(user.id, workspaceId),
     queries.getSandboxEnvKeys(workspaceId),
@@ -570,12 +581,11 @@ export const prepareChatTurn = async (
     ),
   ]);
 
-  const allMcpClients = [...mcpClients, ...subAgentMcpClients];
-
   // Assignment order is the precedence order, and it is deliberate: search lands
-  // after `loadTools` so it wins over an agent/MCP tool that happens to share a
-  // name (exactly as native search already did), and before `subAgentTools` so a
-  // sub-agent's tools still win over search.
+  // after the session's tools so it wins over an agent/MCP tool that happens to
+  // share a name (exactly as native search already did), and before
+  // `subAgentTools` so a sub-agent's tools still win over search.
+  const tools: Record<string, Tool> = { ...session.tools };
   Object.assign(tools, searchTools);
   Object.assign(tools, subAgentTools);
 
@@ -605,6 +615,10 @@ export const prepareChatTurn = async (
     tools.loadSkill = createLoadSkillTool(orgId, workspaceId);
   }
 
+  // Activity events only. Result normalization (#321) is no longer bolted on
+  // here: it happens for every tool the Tool session loads, whether or not this
+  // turn is being observed. The tools core adds itself above — search, the
+  // sub-agent delegates, `loadSkill` — return core-owned JSON shapes.
   const wrappedTools = onActivity
     ? wrapToolsWithActivity(tools, onActivity)
     : tools;
@@ -632,19 +646,6 @@ export const prepareChatTurn = async (
       ),
     },
   );
-
-  let disposed = false;
-  const dispose = async () => {
-    if (disposed) return;
-    disposed = true;
-    for (const client of allMcpClients) {
-      try {
-        await client.close();
-      } catch (e) {
-        logger.error({ error: e }, "Error closing MCP client");
-      }
-    }
-  };
 
   const systemPrompt = generation.systemPrompt!;
 
@@ -686,7 +687,9 @@ export const prepareChatTurn = async (
       presencePenalty: agent ? undefined : generation.presencePenalty,
       seed: agent ? undefined : generation.seed,
     },
-    dispose,
+    // The session closes what it opened, delegates' nested sessions included —
+    // the caller no longer reconciles two lists of clients to get there.
+    dispose: session.dispose,
   };
 };
 
@@ -824,70 +827,6 @@ const resolveChatContext = async (
   };
 };
 
-const loadTools = async (
-  queries: ChatTurnQueries,
-  agent: Pick<AgentRow, "id" | "toolSetIds"> | undefined,
-  workspaceId: string,
-  orgId: string,
-  frontendUrl: string | undefined,
-  userId?: string,
-): Promise<{ tools: Record<string, Tool>; mcpClients: MCPClient[] }> => {
-  const tools: Record<string, Tool> = {};
-  const mcpClients: MCPClient[] = [];
-
-  if (!agent || !agent.toolSetIds || agent.toolSetIds.length === 0) {
-    return { tools, mcpClients };
-  }
-
-  for (const toolSetId of agent.toolSetIds) {
-    const toolSet = getToolSet(toolSetId);
-    if (!toolSet) {
-      // Static tool set not found — fall back to MCP lookup.
-      const mcp = await queries.getMcp(toolSetId, orgId, workspaceId);
-      if (mcp && mcp.url) {
-        // An unreachable MCP must fail soft: log a warning and contribute no
-        // tools, rather than throwing and killing the whole Chat turn. A Shared
-        // (org-scoped) MCP has org-wide blast radius, so a single down server
-        // must not break every attached Workspace's chats at once (ADR-0007).
-        try {
-          const mcpClient = await createMCPClient({
-            transport: buildMcpTransportConfig(mcp),
-          });
-          const mcpTools = await mcpClient.tools();
-          Object.assign(tools, mcpTools);
-          mcpClients.push(mcpClient);
-        } catch (error) {
-          logger.warn(
-            { error, mcpId: mcp.id, scope: mcp.organizationId ? "org" : "ws" },
-            `MCP '${toolSetId}' is unreachable; skipping its tools`,
-          );
-        }
-      } else if (mcp) {
-        logger.warn(`MCP '${toolSetId}' has no URL configured`);
-      } else {
-        logger.warn(
-          `Tool set with id '${toolSetId}' not found as static tool set or MCP`,
-        );
-      }
-      continue;
-    }
-
-    const resolvedTools =
-      typeof toolSet.tools === "function"
-        ? await toolSet.tools({
-            workspaceId,
-            agentId: agent.id,
-            orgId,
-            frontendUrl,
-            userId: userId || "",
-          })
-        : toolSet.tools;
-    Object.assign(tools, resolvedTools);
-  }
-
-  return { tools, mcpClients };
-};
-
 const resolveGenerationConfig = (
   data: ChatTurnRequest,
   agent: AgentRow | undefined,
@@ -923,25 +862,23 @@ const UNRESOLVED_SUB_AGENT_REASON =
 const loadSubAgents = async (
   queries: ChatTurnQueries,
   agent: AgentRow | undefined,
-  orgId: string,
-  workspaceId: string,
-  frontendUrl: string | undefined,
+  scope: ToolSessionScope,
+  session: Promise<ToolSession>,
   run: ParentRunContext | undefined,
 ): Promise<{
   subAgents: Array<{ id: string; name: string; description?: string | null }>;
   unavailableSubAgents: SubAgentFailure[];
   subAgentTools: Record<string, Tool>;
-  subAgentMcpClients: MCPClient[];
 }> => {
   if (!agent?.subAgentIds || agent.subAgentIds.length === 0) {
     return {
       subAgents: [],
       unavailableSubAgents: [],
       subAgentTools: {},
-      subAgentMcpClients: [],
     };
   }
 
+  const { orgId, workspaceId } = scope;
   const assignedIds = [...new Set(agent.subAgentIds)];
   const subAgentRecords = await queries.getSubAgentsByIds(
     assignedIds,
@@ -956,8 +893,6 @@ const loadSubAgents = async (
   const unresolved: SubAgentFailure[] = assignedIds
     .filter((id) => !resolvedIds.has(id))
     .map((id) => ({ id, reason: UNRESOLVED_SUB_AGENT_REASON }));
-
-  const subAgentMcpClients: MCPClient[] = [];
 
   const { tools: subAgentTools, failures } = await createSubAgentTools(
     subAgentRecords,
@@ -991,17 +926,20 @@ const loadSubAgents = async (
         maxOutputTokens: maxOutputTokensForModel(subProvider, subModelId),
       };
     },
+    // Called on a delegate's FIRST invocation, not now: a parent with three
+    // MCP-backed delegates used to open — and warn about — every one of their
+    // servers on every Chat turn, whether or not it delegated. The nested
+    // session closes with the parent's, so a delegate never hands its
+    // connections back to be remembered.
+    //
+    // The delegate runs under its parent's Workspace and user (its scope is
+    // chained from theirs, and `actorUserId` walks back up to the same human), so
+    // its Tool sets resolve against the same identity. They used to be handed an
+    // empty `userId`, which silently blanked the user a delegate's tools ran as.
     async (subAgentId: string, toolSetIds: string[]) => {
-      const subAgentRecord = subAgentRecords.find((sa) => sa.id === subAgentId);
-      const { tools: subTools, mcpClients } = await loadTools(
-        queries,
-        subAgentRecord ?? { id: subAgentId, toolSetIds },
-        workspaceId,
-        orgId,
-        frontendUrl,
-      );
-      subAgentMcpClients.push(...mcpClients);
-      return subTools;
+      const parent = await session;
+      const nested = await parent.nest({ id: subAgentId, toolSetIds });
+      return nested.tools;
     },
     run,
   );
@@ -1022,6 +960,5 @@ const loadSubAgents = async (
     subAgents,
     unavailableSubAgents: [...unresolved, ...failures],
     subAgentTools,
-    subAgentMcpClients,
   };
 };

--- a/apps/backend/src/services/tool-activity.ts
+++ b/apps/backend/src/services/tool-activity.ts
@@ -1,5 +1,4 @@
 import type { Tool } from "ai";
-import { normalizeToolResult } from "./tool-result.ts";
 
 /**
  * Per-tool-call lifecycle event surfaced to the run lifecycle.
@@ -20,10 +19,10 @@ export type ToolActivityEvent = {
  * before it runs and an `end` event once it settles — on every exit path,
  * including a synchronous throw and a consumer that drains an async generator.
  *
- * The wrapper also normalizes value-returning results (issue #321): AI SDK v7
- * validates each tool result against a strict JSON-value schema on the next
- * step, and a raw Drizzle `Date` fails it. The async-iterable path is exempt —
- * its yields are streamed UI parts, not the value fed to the model.
+ * Activity events and nothing else. Result normalization (issue #321) used to
+ * ride here too, which mounted a correctness guarantee on an optional
+ * observability parameter: a turn with no `onActivity` got no normalization. It
+ * now happens unconditionally at the loader seam — see `normalizeToolResults`.
  *
  * Lives outside `chat-execution.ts` because both the parent turn and a
  * sub-agent's own tool set need it, and the sub-agent tool builder is imported
@@ -64,9 +63,7 @@ export const wrapToolsWithActivity = (
           result != null &&
           typeof (result as { then?: unknown }).then === "function"
         ) {
-          return (result as Promise<unknown>)
-            .then(normalizeToolResult)
-            .finally(finish);
+          return (result as Promise<unknown>).finally(finish);
         }
         // Async iterable / generator path (sub-agent tools). Wrap it so the
         // "end" event fires once the consumer drains the iterator.
@@ -86,11 +83,8 @@ export const wrapToolsWithActivity = (
             }
           })();
         }
-        // Normalize before finish() so the sync path mirrors the promise path:
-        // a throw (e.g. a BigInt in the result) happens before the "end" event.
-        const normalized = normalizeToolResult(result);
         finish();
-        return normalized;
+        return result;
       },
     };
   }

--- a/apps/backend/src/services/tool-result.ts
+++ b/apps/backend/src/services/tool-result.ts
@@ -1,3 +1,5 @@
+import type { Tool } from "ai";
+
 /**
  * Coerce a tool result to plain JSON (issue #321).
  *
@@ -13,12 +15,65 @@
  * normalizer. A top-level `undefined`/function return (whose `JSON.stringify` is
  * `undefined`) is passed through unchanged instead of crashing `JSON.parse`.
  *
- * Lives in its own module because the tool-activity wrapper that applies it is
- * shared between a parent turn and a delegated sub-agent run, and this module
- * must stay free of both.
+ * Lives in its own module because the loader seam that applies it is shared
+ * between a parent turn and a delegated sub-agent run, and this module must stay
+ * free of both.
  */
 export const normalizeToolResult = (value: unknown): unknown => {
   const json = JSON.stringify(value);
   if (json === undefined) return value;
   return JSON.parse(json);
+};
+
+/**
+ * Wrap every tool in a map so its result is normalized on the way back to the
+ * model.
+ *
+ * Applied at the loader seam — `composeToolSet` for a Tool set, the MCP branch of
+ * a Tool session — so that every tool a plugin or an MCP server contributes is
+ * covered whether or not the turn happens to be observed. It used to ride on
+ * `wrapToolsWithActivity`, which meant a correctness guarantee only held when an
+ * optional `onActivity` callback was supplied.
+ *
+ * The tools core builds itself (search, `loadSkill`, the sub-agent delegates)
+ * return core-owned JSON shapes and are deliberately not wrapped here.
+ *
+ * The async-iterable path is exempt for the same reason it always was: its yields
+ * are streamed UI parts, not the value fed to the model.
+ */
+export const normalizeToolResults = (
+  tools: Record<string, Tool>,
+): Record<string, Tool> => {
+  const normalized: Record<string, Tool> = {};
+  for (const [name, t] of Object.entries(tools)) {
+    const execute = (t as { execute?: unknown }).execute;
+    if (typeof execute !== "function") {
+      normalized[name] = t;
+      continue;
+    }
+    const runExecute = execute as (args: unknown, options: unknown) => unknown;
+    normalized[name] = {
+      ...t,
+      execute: (args: unknown, options: unknown) => {
+        // Called on the tool it came from, so a tool set may write `execute` as
+        // a method reaching sibling state through `this`.
+        const result = runExecute.call(t, args, options);
+        if (
+          result != null &&
+          typeof (result as { then?: unknown }).then === "function"
+        ) {
+          return (result as Promise<unknown>).then(normalizeToolResult);
+        }
+        if (
+          result != null &&
+          typeof (result as Record<symbol, unknown>)[Symbol.asyncIterator] ===
+            "function"
+        ) {
+          return result;
+        }
+        return normalizeToolResult(result);
+      },
+    };
+  }
+  return normalized;
 };

--- a/apps/backend/src/tools/index.test.ts
+++ b/apps/backend/src/tools/index.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Tool } from "ai";
+import type { ToolSetContribution } from "@platypuschat/plugin-sdk";
 
 // Mock the db used by transitive imports (the sandbox tool set, etc.)
 vi.mock("../index.ts", () => ({
@@ -22,12 +24,14 @@ vi.mock("../storage/index.ts", () => ({
 }));
 
 import {
+  composeToolSet,
   getToolSets,
   getToolSet,
   hasToolSet,
   registerToolSet,
   SANDBOX_TOOLSET_ID,
 } from "./index.ts";
+import { logger } from "../logger.ts";
 
 // The store's own contract — miss semantics, duplicate rejection, prototype-key
 // safety, listing, reset — is covered once in
@@ -77,7 +81,10 @@ describe("Tool Set Registry", () => {
       expect(set).toBeDefined();
       expect(set.name).toBe("Sandbox");
       expect(set.category).toBe("Sandbox");
-      expect(typeof set.tools).toBe("function");
+      // What the registry holds is core's composed builder, never the raw
+      // factory — the same shape a plugin's contribution is stored as.
+      expect(typeof set.buildTurnTools).toBe("function");
+      expect(set.staticTools).toBeUndefined();
     });
 
     it("returns undefined for an unregistered id", () => {
@@ -95,26 +102,160 @@ describe("Tool Set Registry", () => {
   });
 
   describe("registerToolSet", () => {
+    const composed = (id: string, name: string) =>
+      composeToolSet({
+        id,
+        pluginName: "test-plugin",
+        contribution: { name, category: "Test", tools: {} },
+      });
+
     it("keys on the tool-set id, so a duplicate is refused", () => {
       expect(() =>
-        registerToolSet(SANDBOX_TOOLSET_ID, {
-          name: "Duplicate",
-          category: "Test",
-          tools: {},
-        }),
+        registerToolSet(SANDBOX_TOOLSET_ID, composed("dup", "Duplicate")),
       ).toThrow(
         `Tool set '${SANDBOX_TOOLSET_ID}' has already been registered.`,
       );
     });
 
     it("registers a new tool set and returns it with its id folded in", () => {
-      const set = registerToolSet("test-only-set", {
-        name: "Test Only",
-        category: "Test",
-        tools: {},
-      });
+      const set = registerToolSet(
+        "test-only-set",
+        composed("test-only-set", "Test Only"),
+      );
       expect(set.id).toBe("test-only-set");
       expect(getToolSet("test-only-set")).toBe(set);
     });
+  });
+});
+
+// What core owns between a plugin's factory and the model (ADR-0013), and the
+// mirror of `composeWebBackend`'s coverage in `web-backends/index.test.ts`.
+describe("composeToolSet", () => {
+  const ctx = {
+    orgId: "org-1",
+    workspaceId: "ws-1",
+    agentId: "agent-1",
+    userId: "user-1",
+    frontendUrl: undefined,
+  };
+
+  const compose = (tools: ToolSetContribution["tools"], pluginName = "acme") =>
+    composeToolSet({
+      id: "acme.widgets",
+      pluginName,
+      contribution: { name: "Widgets", category: "Test", tools },
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("serves no tools — rather than failing the turn — when the factory throws", async () => {
+    const registration = compose(() => {
+      throw new Error("no API key");
+    });
+
+    await expect(registration.buildTurnTools(ctx)).resolves.toEqual({});
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ plugin: "acme", toolSet: "acme.widgets" }),
+      expect.stringContaining("Tool set factory threw"),
+    );
+  });
+
+  it("serves no tools when a factory resolves to something that is not a tool map", async () => {
+    const registration = compose(
+      () => "oops" as unknown as Record<string, Tool>,
+    );
+
+    await expect(registration.buildTurnTools(ctx)).resolves.toEqual({});
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ plugin: "acme", toolSet: "acme.widgets" }),
+      expect.stringContaining("no tool map"),
+    );
+  });
+
+  // #321: a raw Drizzle `Date` fails the next step's prompt validation. The
+  // guarantee used to hold only when the turn supplied an `onActivity` callback.
+  it("normalizes every tool's result, with no observability wrapper in play", async () => {
+    const createdAt = new Date("2026-08-06T00:00:00.000Z");
+    const registration = compose({
+      listBoards: {
+        execute: () => Promise.resolve([{ id: "b1", createdAt }]),
+      } as unknown as Tool,
+      now: { execute: () => ({ at: createdAt }) } as unknown as Tool,
+    });
+
+    const tools = await registration.buildTurnTools(ctx);
+    const exec = (name: string) =>
+      (
+        tools[name] as unknown as {
+          execute: (a: unknown, o: unknown) => unknown;
+        }
+      ).execute({}, {});
+
+    await expect(exec("listBoards")).resolves.toEqual([
+      { id: "b1", createdAt: createdAt.toISOString() },
+    ]);
+    expect(exec("now")).toEqual({ at: createdAt.toISOString() });
+  });
+
+  it("leaves a tool with no execute function alone", async () => {
+    const bare = { description: "no execute" } as unknown as Tool;
+    const tools = await compose({ bare }).buildTurnTools(ctx);
+    expect(tools.bare).toBe(bare);
+  });
+
+  it("names both plugins when it takes a tool name an earlier tool set claimed", async () => {
+    const claimed = new Map([
+      ["search", { toolSetId: "other.set", plugin: "other" }],
+    ]);
+
+    const tools = await compose({
+      search: { execute: () => ({}) } as unknown as Tool,
+    }).buildTurnTools(ctx, claimed);
+
+    // The later one still wins — assignment order is the precedence order — but
+    // the swap is no longer silent.
+    expect(tools).toHaveProperty("search");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: "search",
+        plugin: "acme",
+        shadowedToolSet: "other.set",
+        shadowedPlugin: "other",
+      }),
+      expect.stringContaining("same tool name"),
+    );
+  });
+
+  it("says nothing when no name is contested", async () => {
+    const claimed = new Map([
+      ["listBoards", { toolSetId: "other.set", plugin: "other" }],
+    ]);
+
+    await compose({
+      search: { execute: () => ({}) } as unknown as Tool,
+    }).buildTurnTools(ctx, claimed);
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("binds the plugin's deploy-time config into the factory", async () => {
+    const tools = vi.fn().mockResolvedValue({});
+    const plugin = { config: { region: "eu" }, credentials: undefined };
+    await composeToolSet({
+      id: "acme.widgets",
+      pluginName: "acme",
+      plugin,
+      contribution: { name: "Widgets", category: "Test", tools },
+    }).buildTurnTools(ctx);
+
+    expect(tools).toHaveBeenCalledWith(ctx, plugin);
+  });
+
+  it("exposes a static map to the catalogs, and a factory's tools not at all", () => {
+    const staticTool = { description: "static" } as unknown as Tool;
+    expect(compose({ staticTool }).staticTools).toEqual({ staticTool });
+    expect(compose(() => ({})).staticTools).toBeUndefined();
   });
 });

--- a/apps/backend/src/tools/index.ts
+++ b/apps/backend/src/tools/index.ts
@@ -3,48 +3,228 @@ import { eq } from "drizzle-orm";
 import { db } from "../index.ts";
 import { sandbox as sandboxTable } from "../db/schema.ts";
 import { getSandboxBackend } from "../sandbox/index.ts";
-import { getSandboxBackendPlugin } from "../plugins/registry.ts";
+import {
+  CORE_BUILTIN_OWNER,
+  getSandboxBackendPlugin,
+} from "../plugins/registry.ts";
 import { createContributionRegistry } from "../registry/contribution-registry.ts";
 import { createSandboxTools } from "../sandbox/tools.ts";
+import { normalizeToolResults } from "../services/tool-result.ts";
 import { logger } from "../logger.ts";
 
 // The Extension-point surface lives in the published SDK; re-export the context
 // type so core's internal callers keep importing it from here.
 export type { ToolSetContext } from "@platypuschat/plugin-sdk";
-import type { ToolSetContext } from "@platypuschat/plugin-sdk";
+import type {
+  PluginConfigContext,
+  ToolSetContext,
+  ToolSetContribution,
+} from "@platypuschat/plugin-sdk";
 
-type ToolSet = {
+/**
+ * Who put a tool name into a turn's tool map. Carried alongside the map so a
+ * collision can name the Tool set that lost the name *and* the plugin that owns
+ * it — an Operator debugging a shadowed tool has neither otherwise.
+ */
+export type ToolOwner = {
+  /** The Tool set the tool came from, or the MCP id on the MCP branch. */
+  toolSetId: string;
+  /**
+   * The contributing plugin's manifest name (or {@link CORE_BUILTIN_OWNER} for a
+   * core registration), and `null` for tools that came from an MCP server, which
+   * belongs to no plugin.
+   */
+  plugin: string | null;
+};
+
+/**
+ * What the Tool-set registry stores: identity for the catalogs, plus core's
+ * *composed* per-turn builder — never the contribution's raw `tools`. The same
+ * shape the Web-search-backend registry holds (ADR-0014), for the same reason:
+ * everything between a plugin's factory and the model is core's, so there is one
+ * place that owns it rather than one per caller.
+ */
+export type ToolSetRegistration = {
   id: string;
   name: string;
   category: string;
   description?: string;
-  tools:
-    | { [toolId: string]: Tool }
-    | ((
-        context: ToolSetContext,
-      ) => Record<string, Tool> | Promise<Record<string, Tool>>);
+  /**
+   * This Tool set's model-facing Tools for one Chat turn — resolved, guarded,
+   * and result-normalized. Never rejects: a Tool set that cannot serve this turn
+   * contributes no tools instead of failing it.
+   *
+   * `claimed` is the turn's accumulating tool map as it stands, so a name this
+   * Tool set is about to take from an earlier one is reported rather than
+   * silently swapped. Optional: a caller resolving a single Tool set in
+   * isolation has no turn map to compare against.
+   */
+  buildTurnTools: (
+    context: ToolSetContext,
+    claimed?: ReadonlyMap<string, ToolOwner>,
+  ) => Promise<Record<string, Tool>>;
+  /**
+   * The contribution's tools when it declared them as a static map, for the
+   * catalogs that name individual tools ahead of any turn. Undefined for a
+   * factory: what it serves depends on the Workspace, so only a turn can say.
+   */
+  staticTools?: Record<string, Tool>;
 };
 
 // The Tool-set instance of the shared Extension-point registry — same store,
 // same miss semantics, and same duplicate-id error as the Sandbox and Web-search
 // backend registries.
-const TOOL_SETS = createContributionRegistry<ToolSet>({ noun: "Tool set" });
+const TOOL_SETS = createContributionRegistry<ToolSetRegistration>({
+  noun: "Tool set",
+});
 
 export const registerToolSet = (
   toolSetId: string,
-  toolSet: Omit<ToolSet, "id">,
-): ToolSet => TOOL_SETS.register(toolSetId, { id: toolSetId, ...toolSet });
+  registration: Omit<ToolSetRegistration, "id">,
+): ToolSetRegistration =>
+  TOOL_SETS.register(toolSetId, { ...registration, id: toolSetId });
 
 /** The Tool set registered under `toolSetId`, or `undefined` if none is. */
-export const getToolSet = (toolSetId: string): ToolSet | undefined =>
-  TOOL_SETS.get(toolSetId);
+export const getToolSet = (
+  toolSetId: string,
+): ToolSetRegistration | undefined => TOOL_SETS.get(toolSetId);
 
 /** Whether `toolSetId` names a statically-registered Tool set. */
 export const hasToolSet = (toolSetId: string): boolean =>
   TOOL_SETS.has(toolSetId);
 
 /** Every registered Tool set, in registration order. Each carries its own id. */
-export const getToolSets = (): readonly ToolSet[] => TOOL_SETS.list();
+export const getToolSets = (): readonly ToolSetRegistration[] =>
+  TOOL_SETS.list();
+
+/**
+ * Warn for every name `incoming` takes from a Tool set that already claimed it
+ * this turn.
+ *
+ * The later contributor wins, as it always has — assignment order is the
+ * precedence order a Chat turn is built on. What changes is that the swap is
+ * now on the record: an Agent granted two Tool sets that both define `search`
+ * used to serve one of them with no trace of the other, and which one depended
+ * on the order the ids happen to sit in on the Agent row.
+ */
+export const reportToolNameCollisions = (
+  incoming: Record<string, Tool>,
+  claimed: ReadonlyMap<string, ToolOwner> | undefined,
+  owner: ToolOwner,
+): void => {
+  if (!claimed || claimed.size === 0) return;
+  for (const tool of Object.keys(incoming)) {
+    const incumbent = claimed.get(tool);
+    if (!incumbent) continue;
+    logger.warn(
+      {
+        tool,
+        toolSet: owner.toolSetId,
+        plugin: owner.plugin,
+        shadowedToolSet: incumbent.toolSetId,
+        shadowedPlugin: incumbent.plugin,
+      },
+      "Two tool sets contribute the same tool name; the later one wins this turn",
+    );
+  }
+};
+
+export interface ComposeToolSetOptions {
+  /**
+   * The contribution exactly as its author wrote it. Its `tools` factory is
+   * called on this object — never on a copy — so a class-instance contribution
+   * keeps its prototype and its `this`. The namespaced id rides {@link id}.
+   */
+  contribution: Omit<ToolSetContribution, "id">;
+  /** The id this Tool set registers under (namespaced, for a third-party plugin). */
+  id: string;
+  /** The plugin's boot-resolved deploy-time config/credentials (ADR-0013). */
+  plugin?: PluginConfigContext;
+  /** Owning plugin's manifest name, for attribution in every log line. */
+  pluginName: string;
+}
+
+/**
+ * Wrap one Tool-set contribution into the registration core stores.
+ *
+ * This is where core takes ownership of everything between a plugin's factory
+ * and the model: the deploy-time config binding, catch-and-degrade on the
+ * factory, per-tool result normalization, and collision reporting against the
+ * turn's tool map.
+ *
+ * Boot stays fail-loud and runtime resolution stays graceful (ADR-0013): a
+ * factory that throws costs the turn this Tool set's tools, not the turn — the
+ * posture the Web-search point already takes, and the one the MCP branch of a
+ * Tool session has always taken for an unreachable server.
+ *
+ * No timeout, unlike a Web-search backend's executors: `ToolSetContribution`
+ * declares no per-call budget, and the factories in the field legitimately reach
+ * the database and a Sandbox backend on the way to building their tools. A
+ * hanging factory still pins the turn open; a ceiling for that belongs on the
+ * contribution, where an author can state it.
+ */
+export const composeToolSet = (
+  options: ComposeToolSetOptions,
+): ToolSetRegistration => {
+  const { contribution, id, plugin, pluginName } = options;
+  const { name, category, description, tools } = contribution;
+
+  const buildTurnTools = async (
+    context: ToolSetContext,
+    claimed?: ReadonlyMap<string, ToolOwner>,
+  ): Promise<Record<string, Tool>> => {
+    let resolved: unknown = tools;
+    if (typeof tools === "function") {
+      try {
+        resolved = await tools(context, plugin);
+      } catch (cause) {
+        logger.warn(
+          {
+            plugin: pluginName,
+            toolSet: id,
+            orgId: context.orgId,
+            workspaceId: context.workspaceId,
+            agentId: context.agentId,
+            cause,
+          },
+          "Tool set factory threw; serving none of its tools this turn",
+        );
+        return {};
+      }
+    }
+
+    // The TS type makes `tools` a map or a factory returning one; a third-party
+    // *JS* plugin can return anything, and `Object.assign(turn, "oops")` spreads
+    // a string's indices into the turn's tool map rather than failing.
+    if (
+      typeof resolved !== "object" ||
+      resolved === null ||
+      Array.isArray(resolved)
+    ) {
+      logger.warn(
+        { plugin: pluginName, toolSet: id },
+        "Tool set resolved to no tool map; serving none of its tools this turn",
+      );
+      return {};
+    }
+
+    const turnTools = normalizeToolResults(resolved as Record<string, Tool>);
+    reportToolNameCollisions(turnTools, claimed, {
+      toolSetId: id,
+      plugin: pluginName,
+    });
+    return turnTools;
+  };
+
+  return {
+    id,
+    name,
+    category,
+    description,
+    buildTurnTools,
+    ...(typeof tools === "function" ? {} : { staticTools: tools }),
+  };
+};
 
 // Tool set ID constants for referencing registered tool sets by name
 export const MEMORY_TOOLSET_ID = "memory";
@@ -68,79 +248,94 @@ export const MEMORY_TOOLSET_ID = "memory";
 // warning log). See ADR-0001 / ADR-0002.
 export const SANDBOX_TOOLSET_ID = "sandbox";
 
-registerToolSet(SANDBOX_TOOLSET_ID, {
-  name: "Sandbox",
-  category: "Sandbox",
-  description:
-    "Shell and filesystem access inside the workspace's configured sandbox",
-  tools: async ({ workspaceId, orgId, userId }) => {
-    const rows = await db
-      .select()
-      .from(sandboxTable)
-      .where(eq(sandboxTable.workspaceId, workspaceId))
-      .limit(1);
-    if (rows.length === 0) return {};
+// Registered through `composeToolSet` like every plugin contribution — a core
+// built-in is a Tool set on the same terms, and its factory reads a row and
+// builds an adapter's tools, so it earns the same guard.
+registerToolSet(
+  SANDBOX_TOOLSET_ID,
+  composeToolSet({
+    id: SANDBOX_TOOLSET_ID,
+    pluginName: CORE_BUILTIN_OWNER,
+    contribution: {
+      name: "Sandbox",
+      category: "Sandbox",
+      description:
+        "Shell and filesystem access inside the workspace's configured sandbox",
+      tools: async ({ workspaceId, orgId, userId }) => {
+        const rows = await db
+          .select()
+          .from(sandboxTable)
+          .where(eq(sandboxTable.workspaceId, workspaceId))
+          .limit(1);
+        if (rows.length === 0) return {};
 
-    const row = rows[0];
-    // Every line below is core's, but the subject of all three is a *plugin's*
-    // adapter, so each binds the owning plugin under the same `plugin` key the
-    // plugin's own lines carry. Otherwise an Operator filtering on one plugin
-    // gets the adapter's own lines and none of core's about it. `null` rather
-    // than absent when the backend belongs to no loaded plugin — the first case
-    // below is exactly that, and "no owner" is the answer, not "unasked".
-    const plugin = getSandboxBackendPlugin(row.backend) ?? null;
-    const registration = getSandboxBackend(row.backend);
-    if (!registration) {
-      logger.warn(
-        { backend: row.backend, plugin, sandboxId: row.id },
-        "Sandbox backend not registered; skipping sandbox tools for this turn",
-      );
-      return {};
-    }
+        const row = rows[0];
+        // Every line below is core's, but the subject of all three is a *plugin's*
+        // adapter, so each binds the owning plugin under the same `plugin` key the
+        // plugin's own lines carry. Otherwise an Operator filtering on one plugin
+        // gets the adapter's own lines and none of core's about it. `null` rather
+        // than absent when the backend belongs to no loaded plugin — the first case
+        // below is exactly that, and "no owner" is the answer, not "unasked".
+        const plugin = getSandboxBackendPlugin(row.backend) ?? null;
+        const registration = getSandboxBackend(row.backend);
+        if (!registration) {
+          logger.warn(
+            { backend: row.backend, plugin, sandboxId: row.id },
+            "Sandbox backend not registered; skipping sandbox tools for this turn",
+          );
+          return {};
+        }
 
-    const configResult = registration.configSchema.safeParse(row.config ?? {});
-    if (!configResult.success) {
-      logger.warn(
-        {
-          backend: row.backend,
-          plugin,
-          sandboxId: row.id,
-          issues: configResult.error.issues,
-        },
-        "Sandbox config failed adapter validation; skipping sandbox tools",
-      );
-      return {};
-    }
+        const configResult = registration.configSchema.safeParse(
+          row.config ?? {},
+        );
+        if (!configResult.success) {
+          logger.warn(
+            {
+              backend: row.backend,
+              plugin,
+              sandboxId: row.id,
+              issues: configResult.error.issues,
+            },
+            "Sandbox config failed adapter validation; skipping sandbox tools",
+          );
+          return {};
+        }
 
-    const credentialsResult = registration.credentialsSchema.safeParse(
-      row.credentials ?? {},
-    );
-    if (!credentialsResult.success) {
-      logger.warn(
-        {
-          backend: row.backend,
-          plugin,
-          sandboxId: row.id,
-          issues: credentialsResult.error.issues,
-        },
-        "Sandbox credentials failed adapter validation; skipping sandbox tools",
-      );
-      return {};
-    }
+        const credentialsResult = registration.credentialsSchema.safeParse(
+          row.credentials ?? {},
+        );
+        if (!credentialsResult.success) {
+          logger.warn(
+            {
+              backend: row.backend,
+              plugin,
+              sandboxId: row.id,
+              issues: credentialsResult.error.issues,
+            },
+            "Sandbox credentials failed adapter validation; skipping sandbox tools",
+          );
+          return {};
+        }
 
-    const backend = registration.create(
-      configResult.data,
-      credentialsResult.data,
-    );
-    // Two-tier env (ADR-0004 amendment, ADR-0006): adminEnv wins over userEnv.
-    // The combined map is then merged over the model-provided input.env inside
-    // createSandboxTools (workspace wins), giving the full precedence order
-    // adminEnv ▸ userEnv ▸ input.env.
-    const workspaceEnv = { ...(row.userEnv ?? {}), ...(row.adminEnv ?? {}) };
-    return createSandboxTools(
-      backend,
-      { orgId, workspaceId, userId },
-      workspaceEnv,
-    );
-  },
-});
+        const backend = registration.create(
+          configResult.data,
+          credentialsResult.data,
+        );
+        // Two-tier env (ADR-0004 amendment, ADR-0006): adminEnv wins over userEnv.
+        // The combined map is then merged over the model-provided input.env inside
+        // createSandboxTools (workspace wins), giving the full precedence order
+        // adminEnv ▸ userEnv ▸ input.env.
+        const workspaceEnv = {
+          ...(row.userEnv ?? {}),
+          ...(row.adminEnv ?? {}),
+        };
+        return createSandboxTools(
+          backend,
+          { orgId, workspaceId, userId },
+          workspaceEnv,
+        );
+      },
+    },
+  }),
+);

--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -100,11 +100,19 @@ const parentScope: WorkspaceScope = workspaceScope(
   true,
 );
 
+/**
+ * A delegate's tools as the lazy loader it now takes: they are opened on first
+ * invocation, so the option is a thunk rather than a resolved map.
+ */
+const toolsOf =
+  (tools: Record<string, Tool>) => (): Promise<Record<string, Tool>> =>
+    Promise.resolve(tools);
+
 const baseOptions = {
   id: "agent-1",
   name: "Research Agent",
   model: modelOf(step([])),
-  tools: {} as Record<string, Tool>,
+  loadTools: toolsOf({}),
 };
 
 /** Build the delegate tool, run one delegation, collect every yield. */
@@ -278,12 +286,12 @@ describe("createSubAgentTool", () => {
             ...text("t1", "Sub-agent result"),
           ]),
         ),
-        tools: {
+        loadTools: toolsOf({
           webFetch: {
             inputSchema: z.object({}),
             execute: () => Promise.resolve("result"),
-          } as unknown as Tool,
-        },
+          },
+        }),
       });
 
       const final = yielded.at(-1)!;
@@ -346,12 +354,12 @@ describe("createSubAgentTool", () => {
           step(toolCall("tc1", "listBoards", "{}"), { unified: "tool-calls" }),
           step([]),
         ),
-        tools: {
+        loadTools: toolsOf({
           listBoards: {
             inputSchema: z.object({}),
             execute: () => Promise.resolve([{ id: "b1", name: "Board One" }]),
-          } as unknown as Tool,
-        },
+          },
+        }),
       });
 
       // Not silently empty — carries the tool name and the result payload so the
@@ -429,12 +437,12 @@ describe("createSubAgentTool", () => {
           step(toolCall("tc1", "webFetch", "{}"), { unified: "tool-calls" }),
           step([]),
         ),
-        tools: {
+        loadTools: toolsOf({
           webFetch: {
             inputSchema: z.object({}),
             execute: () => Promise.reject(new Error("Connection refused")),
-          } as unknown as Tool,
-        },
+          },
+        }),
       });
 
       expect(yielded.at(-1)!.entries).toContainEqual({
@@ -456,12 +464,12 @@ describe("createSubAgentTool", () => {
           step(toolCall("tc1", "webFetch", raw), { unified: "tool-calls" }),
           step([]),
         ),
-        tools: {
+        loadTools: toolsOf({
           webFetch: {
             inputSchema: z.object({ url: z.string() }),
             execute: () => Promise.resolve("ok"),
-          } as unknown as Tool,
-        },
+          },
+        }),
       });
 
       // The same message the run driver logs, so an Operator greps once and
@@ -489,12 +497,12 @@ describe("createSubAgentTool", () => {
           }),
           step([]),
         ),
-        tools: {
+        loadTools: toolsOf({
           webFetch: {
             inputSchema: z.object({ url: z.string() }),
             execute: () => Promise.resolve("page text"),
-          } as unknown as Tool,
-        },
+          },
+        }),
       });
 
       expect(
@@ -516,16 +524,16 @@ describe("createSubAgentTool", () => {
           ),
           step([]),
         ),
-        tools: {
+        loadTools: toolsOf({
           search: {
             inputSchema: z.object({}),
             execute: () => Promise.resolve("a"),
-          } as unknown as Tool,
+          },
           fetch: {
             inputSchema: z.object({}),
             execute: () => Promise.resolve("b"),
-          } as unknown as Tool,
-        },
+          },
+        }),
       });
 
       expect(yielded[0].entries).toHaveLength(1);
@@ -608,12 +616,12 @@ describe("createSubAgentTool", () => {
           step(toolCall("tc1", "noop", "{}"), { unified: "tool-calls" }),
           step(text("t1", "done")),
         ),
-        tools: {
+        loadTools: toolsOf({
           noop: {
             inputSchema: z.object({}),
             execute: () => Promise.resolve("ok"),
-          } as unknown as Tool,
-        },
+          },
+        }),
       });
 
       const finished = vi
@@ -713,12 +721,12 @@ describe("createSubAgentTool", () => {
           }),
           step(text("t1", "One card.")),
         ),
-        tools: {
+        loadTools: toolsOf({
           listCards: {
             inputSchema: z.object({}),
             execute: () => Promise.resolve([{ id: "c1" }]),
-          } as unknown as Tool,
-        },
+          },
+        }),
       });
 
       expect(yielded.at(-1)!).not.toHaveProperty("truncatedByTokenLimit");
@@ -811,46 +819,36 @@ describe("createSubAgentTool", () => {
     });
   });
 
-  // Regression for #321 recurring one level down. The parent turn normalizes
-  // tool results in its activity wrapper; a sub-agent's own tools used to go
-  // from `loadTools` straight into the delegated run untouched, so a raw
-  // Drizzle `Date` failed the sub-agent's next-step prompt validation.
-  describe("sub-agent tool results", () => {
-    it("normalizes Date values out of an async tool result", async () => {
-      const createdAt = new Date("2026-08-06T00:00:00.000Z");
-      await delegate({
-        tools: {
-          listBoards: {
-            inputSchema: z.object({}),
-            execute: () => Promise.resolve([{ id: "b1", createdAt }]),
-          } as unknown as Tool,
-        },
-      });
+  // A delegate's tools are opened when it is invoked, not when it is built, so
+  // a parent that never delegates opens none of their MCP connections. Results
+  // arrive already normalized — the Tool session that loads them owns that
+  // (#321 one level down), which is why this wrapper no longer touches them.
+  describe("sub-agent tools", () => {
+    it("opens its tools on invocation, not when the delegate is built", async () => {
+      const loadTools = vi.fn().mockResolvedValue({});
+      const { tool } = createSubAgentTool({ ...baseOptions, loadTools });
+      expect(loadTools).not.toHaveBeenCalled();
 
-      const result = await streamArgs().tools.listBoards.execute({}, {});
-      expect(result).toEqual([
-        { id: "b1", createdAt: createdAt.toISOString() },
-      ]);
+      const gen = tool.execute(
+        { task: "Do something" },
+        {} as ToolExecutionOptions<Record<string, unknown>>,
+      ) as AsyncGenerator<SubAgentActivity>;
+      for await (const _ of gen) void _;
+
+      expect(loadTools).toHaveBeenCalledTimes(1);
     });
 
-    it("normalizes a synchronous tool result too", async () => {
-      await delegate({
-        tools: {
-          now: {
-            inputSchema: z.object({}),
-            execute: () => ({ at: new Date("2026-08-06T00:00:00.000Z") }),
-          } as unknown as Tool,
-        },
-      });
-
-      expect(streamArgs().tools.now.execute({}, {})).toEqual({
-        at: "2026-08-06T00:00:00.000Z",
-      });
+    it("reports a failure to open them to the parent as a tool error", async () => {
+      await expect(
+        delegate({
+          loadTools: () => Promise.reject(new Error("MCP handshake failed")),
+        }),
+      ).rejects.toThrow(/MCP handshake failed/);
     });
 
-    it("leaves a tool without an execute function alone", async () => {
+    it("hands the delegated run the tools it opened", async () => {
       const bare = { description: "no execute" } as unknown as Tool;
-      await delegate({ tools: { bare } });
+      await delegate({ loadTools: toolsOf({ bare }) });
 
       expect(streamArgs().tools.bare).toBe(bare);
     });
@@ -947,7 +945,17 @@ describe("createSubAgentTools", () => {
     expect(result.tools).toHaveProperty("delegateToCoder");
     expect(result.failures).toEqual([]);
     expect(createModelFn).toHaveBeenCalledTimes(2);
-    expect(loadToolsFn).toHaveBeenCalledTimes(2);
+    // Building the delegates opens nothing: each sub-agent's tools are loaded
+    // if and when the parent actually delegates to it.
+    expect(loadToolsFn).not.toHaveBeenCalled();
+
+    await runTool(result.tools.delegateToResearch);
+    expect(loadToolsFn).toHaveBeenCalledExactlyOnceWith("sa-1", ["ts1"]);
+
+    // Memoized per delegate: a second delegation in the same turn reuses the
+    // tools — and the connections — the first one opened.
+    await runTool(result.tools.delegateToResearch);
+    expect(loadToolsFn).toHaveBeenCalledTimes(1);
   });
 
   // The ceiling belongs to the sub-agent's own (Provider, model) pair, which

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -178,7 +178,13 @@ interface SubAgentToolOptions {
   description?: string;
   instructions?: string;
   model: LanguageModel;
-  tools: Record<string, Tool>;
+  /**
+   * This sub-agent's own tools, opened on first delegation rather than supplied
+   * up front: a parent that never delegates must not pay for — or warn about —
+   * the MCP servers its delegates would have used (the sub-agent's half of the
+   * Tool session, see `tool-session.ts`).
+   */
+  loadTools: () => Promise<Record<string, Tool>>;
   maxSteps?: number;
   /**
    * Free-text security directives from THIS sub-agent's resolved provider,
@@ -223,7 +229,7 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
     description,
     instructions,
     model,
-    tools,
+    loadTools,
     maxSteps = DEFAULT_AGENT_MAX_STEPS,
     securityGuardrails,
     sampling,
@@ -354,14 +360,18 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
           let entries: SubAgentActivityEntry[] = [];
 
           try {
+            // Inside the try: opening this delegate's own tools can fail the
+            // same way its stream can, and it reaches the parent as a tool error
+            // either way rather than an unattributed throw.
+            const tools = await loadTools();
             const result = streamText({
               ...buildModelInvocation(
                 {
                   ...plan,
-                  // Wrapped per invocation: the wrapper holds THIS run's per-step
-                  // stall timer down for the duration of each tool call, and
-                  // normalizes results so a raw Drizzle `Date` can't fail the
-                  // sub-agent's next-step prompt validation (#321 one level down).
+                  // Wrapped per invocation: the wrapper holds THIS run's
+                  // per-step stall timer down for the duration of each tool
+                  // call. Results arrive already normalized — the Tool session
+                  // that loaded them owns that (#321 one level down).
                   tools: wrapToolsWithActivity(tools, run.onActivity),
                 },
                 { abortSignal: run.handle.signal },
@@ -514,9 +524,13 @@ export type SubAgentFailure = { id: string; name?: string; reason: string };
  * A sub-agent that fails to initialize is skipped rather than failing the whole
  * turn, and is reported in `failures` so the caller can stop advertising it.
  *
+ * `loadToolsFn` is called on a delegate's first invocation rather than here, so
+ * building the delegation tools costs no connections. A failure to load them is
+ * therefore reported to the parent as a tool error, not as a `failures` entry.
+ *
  * @param subAgents List of sub-agent configurations from the database
  * @param createModelFn Factory function to create a model instance for a sub-agent
- * @param loadToolsFn Async function to load tools for a sub-agent
+ * @param loadToolsFn Async function to load tools for a sub-agent, called lazily
  * @param parentRun The run these delegates will nest inside, when there is one
  * @returns The callable tools keyed by tool name, plus the sub-agents that failed
  */
@@ -565,11 +579,11 @@ export const createSubAgentTools = async (
       const { model, securityGuardrails, maxOutputTokens } =
         await createModelFn(subAgent.providerId, subAgent.modelId);
 
-      // Load the sub-agent's tools
-      const subAgentTools = await loadToolsFn(
-        subAgent.id,
-        subAgent.toolSetIds || [],
-      );
+      // The sub-agent's tools are opened on its first delegation, not here.
+      // Memoized so a delegate called twice in one turn resolves them once.
+      let toolsPromise: Promise<Record<string, Tool>> | undefined;
+      const loadTools = () =>
+        (toolsPromise ??= loadToolsFn(subAgent.id, subAgent.toolSetIds || []));
 
       // Create the tool
       const { toolName, tool } = createSubAgentTool({
@@ -578,7 +592,7 @@ export const createSubAgentTools = async (
         description: subAgent.description || undefined,
         instructions: subAgent.instructions || undefined,
         model,
-        tools: subAgentTools,
+        loadTools,
         maxSteps: subAgent.maxSteps ?? DEFAULT_AGENT_MAX_STEPS,
         securityGuardrails,
         sampling: resolveSamplingSettings(subAgent),

--- a/apps/backend/src/tools/tool-session.test.ts
+++ b/apps/backend/src/tools/tool-session.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Tool } from "ai";
+
+// Mock the db used by transitive imports (the sandbox tool set, etc.)
+vi.mock("../index.ts", () => ({ db: {} }));
+
+vi.mock("../logger.ts", () => ({
+  logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../services/event-dispatch.ts", () => ({ dispatchEvent: vi.fn() }));
+vi.mock("../services/sub-agent-validation.ts", () => ({
+  validateSubAgentAssignment: vi.fn(),
+}));
+vi.mock("../storage/index.ts", () => ({ getStorage: vi.fn() }));
+
+// Which plugin contributed which Tool set — the loader's answer at boot, and
+// what a collision line names.
+const { pluginOwners } = vi.hoisted(() => ({
+  pluginOwners: new Map<string, string>(),
+}));
+vi.mock("../plugins/registry.ts", () => ({
+  CORE_BUILTIN_OWNER: "core (built-in)",
+  getToolSetPlugin: (id: string) => pluginOwners.get(id),
+  getSandboxBackendPlugin: () => undefined,
+}));
+
+const { mockCreateMCPClient } = vi.hoisted(() => ({
+  mockCreateMCPClient: vi.fn(),
+}));
+vi.mock("@ai-sdk/mcp", () => ({
+  experimental_createMCPClient: mockCreateMCPClient,
+  auth: vi.fn(),
+}));
+
+import { openToolSession, type ToolSessionScope } from "./tool-session.ts";
+import { composeToolSet, registerToolSet } from "./index.ts";
+import { logger } from "../logger.ts";
+import type { mcp as mcpTable } from "../db/schema.ts";
+
+type McpRow = typeof mcpTable.$inferSelect;
+
+const scope: ToolSessionScope = {
+  orgId: "org-1",
+  workspaceId: "ws-1",
+  userId: "user-1",
+  frontendUrl: undefined,
+};
+
+/** The Agent a session resolves for, with the ids it was granted. */
+const grantedAgent = (...toolSetIds: string[]) => ({
+  id: "agent-1",
+  toolSetIds,
+});
+
+const toolNamed = (name: string): Tool =>
+  ({ description: name }) as unknown as Tool;
+
+/** Register a Tool set through the composed path a plugin's would take. */
+const register = (
+  id: string,
+  tools: Parameters<typeof composeToolSet>[0]["contribution"]["tools"],
+  pluginName = "acme",
+) => {
+  pluginOwners.set(id, pluginName);
+  registerToolSet(
+    id,
+    composeToolSet({
+      id,
+      pluginName,
+      contribution: { name: id, category: "Test", tools },
+    }),
+  );
+};
+
+const mcpRow = (overrides: Partial<McpRow> = {}): McpRow =>
+  ({
+    id: "mcp-1",
+    organizationId: null,
+    workspaceId: "ws-1",
+    name: "Test MCP",
+    url: "https://mcp.example.com",
+    headers: null,
+    authType: "None",
+    bearerToken: null,
+    ...overrides,
+  }) as unknown as McpRow;
+
+/** A queries seam serving exactly the MCP rows a test declares. */
+const queriesFor = (rows: McpRow[]) => ({
+  getMcp: vi.fn((id: string) =>
+    Promise.resolve(rows.find((r) => r.id === id) ?? null),
+  ),
+});
+
+const noMcps = () => queriesFor([]);
+
+describe("openToolSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // `clearAllMocks` keeps queued `*Once` values, and the Tool-set registry is
+    // module-global for the file — so the connection queue is reset here, and
+    // every test registers its Tool sets under ids of its own.
+    mockCreateMCPClient.mockReset();
+  });
+
+  it("serves nothing, and needs no lookups, for an Agent with no tool sets", async () => {
+    const queries = noMcps();
+    const session = await openToolSession(scope, undefined, queries);
+
+    expect(session.tools).toEqual({});
+    expect(queries.getMcp).not.toHaveBeenCalled();
+    await expect(session.dispose()).resolves.toBeUndefined();
+  });
+
+  it("resolves each registered Tool set with the session's scope", async () => {
+    const factory = vi.fn().mockResolvedValue({ alpha: toolNamed("alpha") });
+    register("set.alpha", factory);
+    register("set.beta", { beta: toolNamed("beta") });
+
+    const session = await openToolSession(
+      scope,
+      grantedAgent("set.alpha", "set.beta"),
+      noMcps(),
+    );
+
+    expect(Object.keys(session.tools).sort()).toEqual(["alpha", "beta"]);
+    expect(factory).toHaveBeenCalledWith(
+      {
+        orgId: "org-1",
+        workspaceId: "ws-1",
+        agentId: "agent-1",
+        userId: "user-1",
+        frontendUrl: undefined,
+      },
+      undefined,
+    );
+  });
+
+  it("keeps serving the other Tool sets when one's factory throws", async () => {
+    register("set.broken", () => {
+      throw new Error("no API key");
+    });
+    register("set.fine", { fine: toolNamed("fine") });
+
+    const session = await openToolSession(
+      scope,
+      grantedAgent("set.broken", "set.fine"),
+      noMcps(),
+    );
+
+    expect(Object.keys(session.tools)).toEqual(["fine"]);
+  });
+
+  // Assignment order is the precedence order, as it always was. What is new is
+  // that the swap is reported, naming the Tool set and plugin that lost.
+  it("reports a tool name one Tool set takes from another", async () => {
+    register("set.first", { search: toolNamed("first") }, "first-plugin");
+    register("set.second", { search: toolNamed("second") }, "second-plugin");
+
+    const session = await openToolSession(
+      scope,
+      grantedAgent("set.first", "set.second"),
+      noMcps(),
+    );
+
+    expect(session.tools.search).toEqual(toolNamed("second"));
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tool: "search",
+        toolSet: "set.second",
+        plugin: "second-plugin",
+        shadowedToolSet: "set.first",
+        shadowedPlugin: "first-plugin",
+      }),
+      expect.stringContaining("same tool name"),
+    );
+  });
+
+  describe("the MCP branch", () => {
+    const connected = (tools: Record<string, unknown>) => {
+      const close = vi.fn().mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValueOnce({
+        tools: vi.fn().mockResolvedValue(tools),
+        close,
+      });
+      return close;
+    };
+
+    it("serves an MCP server's tools for an id no Tool set claims, and closes it on dispose", async () => {
+      const close = connected({ mcpTool: toolNamed("mcpTool") });
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("mcp-1"),
+        queriesFor([mcpRow()]),
+      );
+
+      expect(session.tools).toHaveProperty("mcpTool");
+      expect(close).not.toHaveBeenCalled();
+
+      await session.dispose();
+      expect(close).toHaveBeenCalledTimes(1);
+
+      // Idempotent: the caller runs it on abort and again on finish.
+      await session.dispose();
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it("normalizes an MCP tool's result", async () => {
+      const createdAt = new Date("2026-08-06T00:00:00.000Z");
+      connected({
+        listItems: {
+          execute: () => Promise.resolve({ createdAt }),
+        },
+      });
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("mcp-1"),
+        queriesFor([mcpRow()]),
+      );
+      const execute = (
+        session.tools.listItems as unknown as {
+          execute: (a: unknown, o: unknown) => Promise<unknown>;
+        }
+      ).execute;
+
+      await expect(execute({}, {})).resolves.toEqual({
+        createdAt: createdAt.toISOString(),
+      });
+    });
+
+    it("fails soft when the server is unreachable, leaving nothing to close", async () => {
+      mockCreateMCPClient.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+      register("set.survivor", { fine: toolNamed("fine") });
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("mcp-1", "set.survivor"),
+        queriesFor([mcpRow()]),
+      );
+
+      expect(Object.keys(session.tools)).toEqual(["fine"]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ mcpId: "mcp-1", scope: "ws" }),
+        expect.stringContaining("unreachable"),
+      );
+      await expect(session.dispose()).resolves.toBeUndefined();
+    });
+
+    it("closes a server that connects and then fails to list its tools", async () => {
+      const close = vi.fn().mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValueOnce({
+        tools: vi.fn().mockRejectedValue(new Error("protocol error")),
+        close,
+      });
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("mcp-1"),
+        queriesFor([mcpRow()]),
+      );
+
+      expect(session.tools).toEqual({});
+      await session.dispose();
+      // The socket used to stay open for the life of the process: the client
+      // was only remembered once its tool listing had succeeded.
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it("warns for an MCP with no URL configured", async () => {
+      const session = await openToolSession(
+        scope,
+        grantedAgent("mcp-1"),
+        queriesFor([mcpRow({ url: null })]),
+      );
+
+      expect(session.tools).toEqual({});
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("has no URL configured"),
+      );
+      expect(mockCreateMCPClient).not.toHaveBeenCalled();
+    });
+
+    it("warns for an id that is neither a Tool set nor an MCP", async () => {
+      const session = await openToolSession(
+        scope,
+        grantedAgent("ghost"),
+        noMcps(),
+      );
+
+      expect(session.tools).toEqual({});
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("not found as static tool set or MCP"),
+      );
+    });
+
+    it("reports a tool name an MCP server takes from a Tool set", async () => {
+      register("set.shadowed", { search: toolNamed("first") }, "first-plugin");
+      connected({ search: toolNamed("mcp") });
+
+      await openToolSession(
+        scope,
+        grantedAgent("set.shadowed", "mcp-1"),
+        queriesFor([mcpRow()]),
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tool: "search",
+          toolSet: "mcp-1",
+          // An MCP server belongs to no plugin, and says so rather than
+          // reading as an unanswered question.
+          plugin: null,
+          shadowedToolSet: "set.shadowed",
+          shadowedPlugin: "first-plugin",
+        }),
+        expect.stringContaining("same tool name"),
+      );
+    });
+
+    it("closes every connection even when one close throws", async () => {
+      const failing = vi.fn().mockRejectedValue(new Error("socket gone"));
+      mockCreateMCPClient.mockResolvedValueOnce({
+        tools: vi.fn().mockResolvedValue({ a: toolNamed("a") }),
+        close: failing,
+      });
+      const second = connected({ b: toolNamed("b") });
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("mcp-1", "mcp-2"),
+        queriesFor([mcpRow(), mcpRow({ id: "mcp-2" })]),
+      );
+
+      await expect(session.dispose()).resolves.toBeUndefined();
+      expect(failing).toHaveBeenCalled();
+      expect(second).toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe("nested sessions", () => {
+    const connected = (tools: Record<string, unknown>) => {
+      const close = vi.fn().mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValueOnce({
+        tools: vi.fn().mockResolvedValue(tools),
+        close,
+      });
+      return close;
+    };
+
+    it("keeps a delegate's tools to itself and closes them with the parent", async () => {
+      register("set.parent", { parentTool: toolNamed("parentTool") });
+      const parent = await openToolSession(
+        scope,
+        grantedAgent("set.parent"),
+        queriesFor([mcpRow()]),
+      );
+
+      const close = connected({ delegateTool: toolNamed("delegateTool") });
+      const child = await parent.nest({
+        id: "sub-agent-1",
+        toolSetIds: ["mcp-1"],
+      });
+
+      // The delegate's tools are its own — a parent must not be able to call
+      // them directly.
+      expect(child.tools).toHaveProperty("delegateTool");
+      expect(parent.tools).not.toHaveProperty("delegateTool");
+
+      // One dispose, at the seam that opened everything.
+      await parent.dispose();
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it("resolves the delegate's Tool sets under its own Agent id", async () => {
+      const factory = vi.fn().mockResolvedValue({});
+      register("set.delegate", factory);
+
+      const parent = await openToolSession(scope, grantedAgent(), noMcps());
+      await parent.nest({ id: "sub-agent-1", toolSetIds: ["set.delegate"] });
+
+      expect(factory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: "sub-agent-1",
+          // …and under the parent's Workspace and user: a delegated run is a run
+          // for the same human, in the same Workspace.
+          workspaceId: "ws-1",
+          userId: "user-1",
+        }),
+        undefined,
+      );
+    });
+
+    it("closes a session opened after the parent was already disposed", async () => {
+      const parent = await openToolSession(
+        scope,
+        grantedAgent(),
+        queriesFor([mcpRow()]),
+      );
+      await parent.dispose();
+
+      const close = connected({ late: toolNamed("late") });
+      const child = await parent.nest({
+        id: "sub-agent-1",
+        toolSetIds: ["mcp-1"],
+      });
+
+      // An abort can cancel the turn while a delegate is still unwinding, so a
+      // session opened after teardown releases itself rather than leaking…
+      expect(close).toHaveBeenCalledTimes(1);
+      // …and serves no tools, rather than tools whose connections are shut.
+      expect(child.tools).toEqual({});
+    });
+  });
+});

--- a/apps/backend/src/tools/tool-session.ts
+++ b/apps/backend/src/tools/tool-session.ts
@@ -1,0 +1,216 @@
+import {
+  experimental_createMCPClient as createMCPClient,
+  type MCPClient,
+} from "@ai-sdk/mcp";
+import type { Tool } from "ai";
+import type { mcp as mcpTable } from "../db/schema.ts";
+import { logger } from "../logger.ts";
+import { CORE_BUILTIN_OWNER, getToolSetPlugin } from "../plugins/registry.ts";
+import { buildMcpTransportConfig } from "../services/mcp-oauth-provider.ts";
+import { normalizeToolResults } from "../services/tool-result.ts";
+import {
+  getToolSet,
+  reportToolNameCollisions,
+  type ToolOwner,
+  type ToolSetContext,
+} from "./index.ts";
+
+type McpRow = typeof mcpTable.$inferSelect;
+
+/**
+ * Where the turn is running: the Workspace, the Organization, and the human it
+ * is running for. Everything a delegate shares with the parent that spawned it,
+ * which is why the Agent is not part of it — that is the one thing a nested
+ * session changes.
+ *
+ * Declared as the SDK's `ToolSetContext` minus its `agentId` rather than as a
+ * fresh list of fields, so a field added to the context reaches Tool-set
+ * factories without a second edit here.
+ */
+export type ToolSessionScope = Omit<ToolSetContext, "agentId">;
+
+/** The Agent a session resolves Tool sets for — the parent, or one delegate. */
+export type ToolSessionAgent = {
+  id: string;
+  toolSetIds?: readonly string[] | null;
+};
+
+/**
+ * The MCP lookup a session needs. Deliberately the one method rather than the
+ * Chat turn's whole query surface: a session resolves tool sets, not a turn.
+ * `ChatTurnQueries` satisfies it structurally.
+ */
+export type ToolSessionQueries = {
+  getMcp(
+    id: string,
+    orgId: string,
+    workspaceId: string,
+  ): Promise<McpRow | null>;
+};
+
+/**
+ * The tools an Agent's assigned Tool sets serve for one turn, and the connections
+ * opened to serve them.
+ *
+ * A session, not a tool map plus a client array, because those two are one fact:
+ * the turn used to decide what it had opened in three places — `loadTools`
+ * returned clients, the sub-agent loader accumulated a second list by mutating a
+ * captured array, and `prepareChatTurn` merged both and hand-rolled the teardown.
+ * A third tool source would have leaked its connections silently. Here whatever
+ * opens a connection registers its own close, and a caller sees one `dispose`.
+ */
+export type ToolSession = {
+  /** The Tools this session's Tool sets contributed, keyed by tool name. */
+  tools: Record<string, Tool>;
+  /**
+   * Open a session for another Agent — a delegate — under this session's scope,
+   * whose connections close with this one's. Lifetime nests so a delegate never
+   * hands its clients back to a caller to remember.
+   */
+  nest: (agent: ToolSessionAgent) => Promise<ToolSession>;
+  /**
+   * Close everything this session and its nested sessions opened. Idempotent, and
+   * never throws: the caller runs it on abort and on finish alike.
+   */
+  dispose: () => Promise<void>;
+};
+
+/**
+ * Resolve an Agent's assigned Tool sets into a turn's tools, opening whatever
+ * connections that takes. A turn with no Agent (`undefined`) opens an empty
+ * session, which is still a session — the caller disposes it the same way.
+ *
+ * Each assigned id is a registered Tool set or, failing that, an MCP server — the
+ * two kinds an Agent's `toolSetIds` can name. Both fail soft: an id that resolves
+ * to neither, a Tool set whose factory throws, an MCP server that is unreachable
+ * — each costs its own tools and nothing else. A Chat turn is not the place to
+ * discover that a plugin is broken (ADR-0013: strict at boot, forgiving at
+ * runtime), and a Shared org-scoped MCP has org-wide blast radius (ADR-0007).
+ */
+export const openToolSession = async (
+  scope: ToolSessionScope,
+  agent: ToolSessionAgent | undefined,
+  queries: ToolSessionQueries,
+): Promise<ToolSession> => {
+  const tools: Record<string, Tool> = {};
+  // Tool name -> where it came from. Handed to each Tool set as it resolves so
+  // it can report the names it is about to take, and the reason this is a Map
+  // rather than the tool map alone.
+  const owners = new Map<string, ToolOwner>();
+  const closers: Array<() => Promise<void>> = [];
+
+  const claim = (incoming: Record<string, Tool>, owner: ToolOwner): void => {
+    for (const [name, tool] of Object.entries(incoming)) {
+      tools[name] = tool;
+      owners.set(name, owner);
+    }
+  };
+
+  /** Resolve one assigned id — a registered Tool set, or else an MCP server. */
+  const open = async (
+    toolSetId: string,
+    context: ToolSetContext,
+  ): Promise<void> => {
+    const registration = getToolSet(toolSetId);
+    if (registration) {
+      const turnTools = await registration.buildTurnTools(context, owners);
+      claim(turnTools, {
+        toolSetId,
+        // A Tool set belonging to no loaded plugin is a core registration, and
+        // reads as one — the annotation the Tools catalog already uses. `null`
+        // is reserved for the MCP branch, where there is genuinely no plugin.
+        plugin: getToolSetPlugin(toolSetId) ?? CORE_BUILTIN_OWNER,
+      });
+      return;
+    }
+
+    // Not a registered Tool set — the id names an MCP server, or nothing.
+    const mcp = await queries.getMcp(toolSetId, scope.orgId, scope.workspaceId);
+    if (!mcp) {
+      logger.warn(
+        `Tool set with id '${toolSetId}' not found as static tool set or MCP`,
+      );
+      return;
+    }
+    if (!mcp.url) {
+      logger.warn(`MCP '${toolSetId}' has no URL configured`);
+      return;
+    }
+
+    const warnUnreachable = (error: unknown) => {
+      logger.warn(
+        { error, mcpId: mcp.id, scope: mcp.organizationId ? "org" : "ws" },
+        `MCP '${toolSetId}' is unreachable; skipping its tools`,
+      );
+    };
+
+    let client: MCPClient;
+    try {
+      client = await createMCPClient({
+        transport: buildMcpTransportConfig(mcp),
+      });
+    } catch (error) {
+      warnUnreachable(error);
+      return;
+    }
+
+    // Registered the moment the connection exists, and before anything else can
+    // fail on it — a server that connects and then fails to list its tools used
+    // to leave the socket open for the life of the process.
+    closers.push(() => client.close());
+
+    let mcpTools: Record<string, Tool>;
+    try {
+      mcpTools = await client.tools();
+    } catch (error) {
+      warnUnreachable(error);
+      return;
+    }
+
+    const owner: ToolOwner = { toolSetId, plugin: null };
+    const normalized = normalizeToolResults(mcpTools);
+    reportToolNameCollisions(normalized, owners, owner);
+    claim(normalized, owner);
+  };
+
+  if (agent) {
+    // What a Tool-set factory is handed: the turn's scope with this session's
+    // Agent on it, so a parent's and a delegate's differ by exactly the Agent.
+    const context: ToolSetContext = { ...scope, agentId: agent.id };
+    // Sequentially: each Tool set is shown the names the ones before it claimed.
+    for (const toolSetId of agent.toolSetIds ?? []) {
+      await open(toolSetId, context);
+    }
+  }
+
+  let disposed = false;
+  const dispose = async (): Promise<void> => {
+    if (disposed) return;
+    disposed = true;
+    for (const close of closers) {
+      try {
+        await close();
+      } catch (e) {
+        logger.error({ error: e }, "Error closing a tool session's connection");
+      }
+    }
+  };
+
+  const nest: ToolSession["nest"] = async (nestedAgent) => {
+    const child = await openToolSession(scope, nestedAgent, queries);
+    // A delegate can be invoked while the turn is being torn down (an abort
+    // cancels the parent run, and the delegate's generator is resumed to unwind
+    // it), so a session opened after `dispose` has nothing left to attach to.
+    // It is closed at once and serves no tools: handing back tools whose
+    // connections are already shut would fail the delegate mid-call, where
+    // having none simply leaves it without them.
+    if (disposed) {
+      await child.dispose();
+      return { ...child, tools: {} };
+    }
+    closers.push(child.dispose);
+    return child;
+  };
+
+  return { tools, nest, dispose };
+};

--- a/apps/docs/content/extending/index.mdx
+++ b/apps/docs/content/extending/index.mdx
@@ -64,6 +64,12 @@ factory, aborts startup with an error naming the Plugin and the entry that
 failed. The package types catch these mistakes in TypeScript; the same checks
 protect deployments that load JavaScript or a malformed package.
 
+Strict at boot, forgiving at runtime: once loaded, a Contribution that fails
+during a Chat turn — a Tool set factory that throws, a Web-search backend that
+times out — costs that turn its own tools and is logged against your Plugin. It
+never fails the turn, so one broken Plugin cannot take a deployment's chats down
+with it.
+
 Contribution ids are trimmed before they are namespaced, so surrounding
 whitespace never reaches a stored id.
 

--- a/apps/docs/content/extending/tool-sets.mdx
+++ b/apps/docs/content/extending/tool-sets.mdx
@@ -104,6 +104,23 @@ tools**, not throw. The core `sandbox` set is the model: in a Workspace with no
 Sandbox configured it returns an empty map and the turn proceeds without shell
 tools. Boot is strict; runtime is forgiving.
 
+If a factory throws anyway, core catches it: the turn serves none of that set's
+tools, logs a warning naming your Plugin and the set, and carries on with
+everything else the Agent was granted. One broken Tool set costs its own tools,
+never the chat. Returning an empty map is still the better habit — the outcome
+is the same, and you get to say _why_ through the
+[logger](/extending/plugin-api-and-config#logging).
+
+## Tool names
+
+<Callout type="warning">
+  Tool names are **not** namespaced the way ids are. An Agent granted two Tool
+  sets that both define `search` gets one of them — whichever sits later in its
+  list — and the other's tool is never offered to the model. Core logs a warning
+  naming both sets and both Plugins. Prefix the names in your set
+  (`acmeSearch`) if a collision with a set you don't control would be confusing.
+</Callout>
+
 ## Adding one to a core plugin
 
 If you are working in the repository rather than shipping your own package, a

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -151,6 +151,12 @@ empty list unless it says otherwise, and silently runs without web-fetch.
   tools. Two plugins whose Tool set ids collide also abort startup.
 - **New gate-able core plugins in a later release are not auto-enabled** — add
   them to your pinned list to opt in.
+- **After boot, a failing plugin is a warning, not an outage.** A Tool set whose
+  factory throws during a Chat turn, or an MCP server that is unreachable,
+  contributes no tools to that turn and logs a `warn` naming the plugin and the
+  tool set. The chat still runs — with fewer tools, which reads to a user as an
+  Agent that suddenly can't do something. That warning is the only signal, so it
+  is worth alerting on.
 - **A plugin logs into your stream, under your `LOG_LEVEL`.** Lines a plugin
   writes carry `"plugin":"<name>"` and are formatted and filtered exactly like
   core's own, so raising `LOG_LEVEL` to `debug` while diagnosing one plugin


### PR DESCRIPTION
Closes #492.

Core owned turn-time composition for one Extension point and not the other: `composeWebBackend` guards a backend's factory and hands the registry a finished builder, while a Tool set's raw `tools` went straight into the Chat turn. This gives the Tool-set point the same shape, and puts connection lifetime behind one session.

## What changed

**`composeToolSet`** — the Tool-set mirror of `composeWebBackend`. The registry now stores a composed `ToolSetRegistration` (`buildTurnTools`, plus `staticTools` for the catalogs that name individual tools) rather than a contribution's raw `tools`; the plugin loader and the core `sandbox` registration both go through it. It owns:

- the deploy-time config binding;
- catch-and-degrade on the factory, with plugin attribution — one throwing plugin costs its own tools, not the turn (ADR-0013's "strict at boot, forgiving at runtime");
- collision reporting against the turn's accumulating tool map, naming the Tool set and plugin that lost the name. Precedence is unchanged (later wins) — the swap is simply no longer silent;
- per-tool result normalisation.

**`openToolSession`** (new `tools/tool-session.ts`) — owns connection lifetime. `loadTools` is gone from `chat-execution.ts`; the session is a loop over registrations plus the MCP fallback. Sessions nest: a delegate's opens on its first invocation and hands its `dispose` to the parent's, so a turn has one `dispose` instead of two client lists reconciled by the caller — and a parent with idle MCP-backed delegates no longer opens (and warns about) their servers on every turn.

**Normalisation** (#321) moves off `wrapToolsWithActivity` — which mounted a correctness guarantee on an optional observability parameter — onto the loader seam, where it holds whether or not a turn is observed. `wrapToolsWithActivity` now carries activity events only.

**Leak fix**: an MCP server that connects and then fails to list its tools is now closed, rather than left open for the life of the process.

## Behaviour changes worth a second opinion

- **A delegate's Tool sets now resolve with the acting user's id.** They were handed an empty string, which silently blanked the user a delegate's tools ran as. Strictly more correct — a delegated run is a run for the same human — but it is a change the issue did not ask for.
- **A delegate's tool-load failure now reaches the parent as a tool error** rather than an `unavailableSubAgents` entry. Inherent to loading lazily; the realistic surface is tiny, since the session catches everything except a database error.

## Deliberately not done

**No timeout on a Tool-set factory.** The issue describes a "throwing/hanging" factory; only the throwing half is implemented. `ToolSetContribution` declares no per-call budget, and real factories legitimately reach the database and a Sandbox backend on the way to building their tools, so a core-invented ceiling would cut off honest work. A hanging factory still pins the turn open — a ceiling for that belongs on the contribution, where an author can state it.

## Docs

Shipped in this PR: `extending/tool-sets.mdx` (runtime degradation, and a Callout for the tool-name-collision trap), `extending/index.mdx`, `self-hosting/configuration.mdx` (the new `warn` an Operator should alert on), and a **Tool session** entry in the `CONTEXT.md` glossary.

## Testing

`pnpm typecheck`, `pnpm lint` and `pnpm test` all pass — 1804 backend tests, 199 frontend, docs contract included.

New coverage: `tools/tool-session.test.ts` (15 tests — resolution, both fail-soft MCP paths, disposal and idempotency, nesting, collisions) and a `composeToolSet` suite in `tools/index.test.ts`. Two existing tests changed meaning deliberately: a throwing tool-set factory no longer rejects the turn, and the activity wrapper no longer normalises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
