### PR TITLE
fix: namespace MCP tools to prevent built-in collisions

### DIFF
--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -1269,7 +1269,7 @@ describe("chat-execution", () => {
         queries,
       );
 
-      expect(turn.stream.tools).toHaveProperty("mcpTool");
+      expect(turn.stream.tools).toHaveProperty("mcp__mcp-1__mcpTool");
       await turn.dispose();
     });
 
@@ -1294,7 +1294,7 @@ describe("chat-execution", () => {
         queries,
       );
 
-      expect(turn.stream.tools).not.toHaveProperty("mcpTool");
+      expect(turn.stream.tools).not.toHaveProperty("mcp__mcp-1__mcpTool");
       await turn.dispose();
     });
 
@@ -1324,7 +1324,7 @@ describe("chat-execution", () => {
         queries,
       );
 
-      expect(turn.stream.tools).not.toHaveProperty("mcpTool");
+      expect(turn.stream.tools).not.toHaveProperty("mcp__mcp-1__mcpTool");
       await turn.dispose();
     });
   });

--- a/apps/backend/src/tools/tool-session.test.ts
+++ b/apps/backend/src/tools/tool-session.test.ts
@@ -187,7 +187,7 @@ describe("openToolSession", () => {
       return close;
     };
 
-    it("serves an MCP server's tools for an id no Tool set claims, and closes it on dispose", async () => {
+    it("serves namespaced MCP tools for an id no Tool set claims, and closes it on dispose", async () => {
       const close = connected({ mcpTool: toolNamed("mcpTool") });
 
       const session = await openToolSession(
@@ -196,7 +196,7 @@ describe("openToolSession", () => {
         queriesFor([mcpRow()]),
       );
 
-      expect(session.tools).toHaveProperty("mcpTool");
+      expect(session.tools).toHaveProperty("mcp__mcp-1__mcpTool");
       expect(close).not.toHaveBeenCalled();
 
       await session.dispose();
@@ -221,7 +221,7 @@ describe("openToolSession", () => {
         queriesFor([mcpRow()]),
       );
       const execute = (
-        session.tools.listItems as unknown as {
+        session.tools["mcp__mcp-1__listItems"] as unknown as {
           execute: (a: unknown, o: unknown) => Promise<unknown>;
         }
       ).execute;
@@ -296,26 +296,20 @@ describe("openToolSession", () => {
       );
     });
 
-    it("reports a tool name an MCP server takes from a Tool set", async () => {
+    it("namespaces MCP tools so they cannot shadow a Tool set", async () => {
       register("set.shadowed", { search: toolNamed("first") }, "first-plugin");
       connected({ search: toolNamed("mcp") });
 
-      await openToolSession(
+      const session = await openToolSession(
         scope,
         grantedAgent("set.shadowed", "mcp-1"),
         queriesFor([mcpRow()]),
       );
 
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          tool: "search",
-          toolSet: "mcp-1",
-          // An MCP server belongs to no plugin, and says so rather than
-          // reading as an unanswered question.
-          plugin: null,
-          shadowedToolSet: "set.shadowed",
-          shadowedPlugin: "first-plugin",
-        }),
+      expect(session.tools.search).toEqual(toolNamed("first"));
+      expect(session.tools["mcp__mcp-1__search"]).toEqual(toolNamed("mcp"));
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.objectContaining({ tool: "search" }),
         expect.stringContaining("same tool name"),
       );
     });
@@ -367,8 +361,8 @@ describe("openToolSession", () => {
 
       // The delegate's tools are its own — a parent must not be able to call
       // them directly.
-      expect(child.tools).toHaveProperty("delegateTool");
-      expect(parent.tools).not.toHaveProperty("delegateTool");
+      expect(child.tools).toHaveProperty("mcp__mcp-1__delegateTool");
+      expect(parent.tools).not.toHaveProperty("mcp__mcp-1__delegateTool");
 
       // One dispose, at the seam that opened everything.
       await parent.dispose();

--- a/apps/backend/src/tools/tool-session.ts
+++ b/apps/backend/src/tools/tool-session.ts
@@ -17,6 +17,12 @@ import {
 
 type McpRow = typeof mcpTable.$inferSelect;
 
+const MCP_TOOL_PREFIX = "mcp__";
+const MCP_TOOL_SEPARATOR = "__";
+
+const namespaceMcpToolName = (toolSetId: string, toolName: string): string =>
+  `${MCP_TOOL_PREFIX}${toolSetId}${MCP_TOOL_SEPARATOR}${toolName}`;
+
 /**
  * Where the turn is running: the Workspace, the Organization, and the human it
  * is running for. Everything a delegate shares with the parent that spawned it,
@@ -169,8 +175,14 @@ export const openToolSession = async (
 
     const owner: ToolOwner = { toolSetId, plugin: null };
     const normalized = normalizeToolResults(mcpTools);
-    reportToolNameCollisions(normalized, owners, owner);
-    claim(normalized, owner);
+    const namespaced = Object.fromEntries(
+      Object.entries(normalized).map(([name, tool]) => [
+        namespaceMcpToolName(toolSetId, name),
+        tool,
+      ]),
+    );
+    reportToolNameCollisions(namespaced, owners, owner);
+    claim(namespaced, owner);
   };
 
   if (agent) {


### PR DESCRIPTION
## Summary

Fixes #467.

MCP tools are now namespaced before they enter the chat tool map as `mcp__<tool-set-id>__<tool-name>`. This prevents an MCP server from shadowing a built-in tool such as `web_search`, so a server-provided payload cannot be misclassified by the Web-search card or have its URLs presented as native citations.

The change is isolated to MCP session resolution. Built-in tool precedence remains unchanged, and MCP tools continue to be normalized and disposed through the existing session lifecycle. The new names are model-visible and will be used in newly stored tool parts; existing stored history is not rewritten.

## Reproduction

1. Configure an MCP server that exposes a tool named `web_search` and returns a payload shaped like `{ "results": [...] }`.
2. Assign that MCP server to an agent and start a chat turn.
3. Before this change, the raw MCP tool name is merged as `web_search`, which collides with the native Web-search tool.
4. The frontend shape fallback can then render the MCP result as the compact native Web-search card and lift its URLs into the message Sources row, while the MCP payload itself is not rendered as a generic tool result.
5. After this change, the tool is exposed as `mcp__<tool-set-id>__web_search`; it cannot overwrite the native `web_search` entry and is rendered as an ordinary MCP tool result.

## Changes

- Namespace every MCP tool with its stable tool-set ID before collision reporting and insertion into the turn map.
- Update tool-session and chat-turn regression coverage, including nested sessions and organization-scoped MCP resolution.

## Verification

- `pnpm format`
- `pnpm --filter @platypus/backend lint`
- `pnpm --filter @platypus/backend typecheck`
- `pnpm --filter @platypus/backend exec vitest run --maxWorkers=1`

The complete backend suite passed: 120 test files and 1,818 tests. The repository root lint attempt was terminated by the sandbox under memory pressure; the affected backend lint gate passed serially. The checkout uses Node 22 while the repository declares Node >=24, and pnpm reports that engine warning, but the targeted and full backend checks completed successfully.