### PR TITLE
chore(ci): disable Turborepo telemetry in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  TURBO_TELEMETRY_DISABLED: "1"
+
 # Cancel superseded runs for the same ref (e.g. a new push to a PR branch).
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  TURBO_TELEMETRY_DISABLED: "1"
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Problem
Turborepo collects anonymous usage telemetry by default, sending outbound telemetry calls on each CI invocation that runs `turbo` (such as `test`, `typecheck`, and `lint`).

### Solution
Set `TURBO_TELEMETRY_DISABLED: "1"` at the top-level `env:` scope in `.github/workflows/ci.yml` and `.github/workflows/lint.yml` to prevent unsolicited outbound network telemetry from CI runners.

### Reference
- https://turborepo.dev/docs/telemetry#disable

Closes #506
