### PR TITLE
chore(backend): add a WorkspaceResource authority for Workspace-child resources

### DIFF
--- a/apps/backend/src/routes/attachment.ts
+++ b/apps/backend/src/routes/attachment.ts
@@ -11,7 +11,7 @@ import {
   requireWorkspaceAccess,
   workspaceScopeOf,
 } from "../middleware/authorization.ts";
-import { isUniqueViolation } from "../errors.ts";
+import { isUniqueViolation, NotFoundError } from "../errors.ts";
 import { resolveOrgScoped } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 
@@ -57,9 +57,8 @@ attachment.post(
       orgId,
     );
     if (!resource) {
-      return c.json(
-        { error: "Org-scoped resource not found in this organization" },
-        404,
+      throw new NotFoundError(
+        "Org-scoped resource not found in this organization",
       );
     }
 
@@ -106,7 +105,7 @@ attachment.delete(
       )
       .returning();
     if (result.length === 0) {
-      return c.json({ error: "Attachment not found" }, 404);
+      throw new NotFoundError("Attachment not found");
     }
     return c.json({ message: "Detached" });
   },

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -3,8 +3,12 @@ import { sValidator } from "@hono/standard-validator";
 import { z } from "zod";
 import { db } from "../index.ts";
 import { chat as chatTable } from "../db/schema.ts";
-import { NotFoundError, ValidationError } from "../services/chat-execution.ts";
+import {
+  NotFoundError as ChatTurnNotFoundError,
+  ValidationError,
+} from "../services/chat-execution.ts";
 import { FileValidationError } from "../services/file-gate.ts";
+import { NotFoundError } from "../errors.ts";
 import { chatSubmitSchema, chatUpdateSchema } from "@platypus/schemas";
 import { and, count, desc, eq, or, sql } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
@@ -14,6 +18,11 @@ import {
   requireWorkspaceOwner,
   workspaceScopeOf,
 } from "../middleware/authorization.ts";
+import {
+  requireOwned,
+  updateOwned,
+  ownedWhere,
+} from "../services/workspace-resource.ts";
 import type { Variables } from "../server.ts";
 import { type PlatypusUIMessage } from "../types.ts";
 import { rewriteStorageUrls, deleteFiles } from "../storage/utils.ts";
@@ -97,19 +106,9 @@ chat.get(
     const chatId = c.req.param("chatId");
     const { workspaceId } = workspaceScopeOf(c);
 
-    const record = await db
-      .select()
-      .from(chatTable)
-      .where(
-        and(eq(chatTable.id, chatId), eq(chatTable.workspaceId, workspaceId)),
-      )
-      .limit(1);
-    if (record.length === 0) {
-      return c.json({ error: "Chat not found" }, 404);
-    }
+    const chat = await requireOwned(db, "chat", chatId, workspaceId);
 
     // Rewrite storage:// URLs to HTTP URLs
-    const chat = record[0];
     const origin = getOrigin(c);
     if (chat.messages) {
       chat.messages = rewriteStorageUrls(
@@ -166,7 +165,7 @@ chat.post(
       if (error instanceof ValidationError) {
         return c.json({ message: error.message }, 400);
       }
-      if (error instanceof NotFoundError) {
+      if (error instanceof ChatTurnNotFoundError) {
         return c.json({ message: error.message }, 404);
       }
       throw error;
@@ -188,17 +187,7 @@ chat.post(
     // This is what makes a cross-workspace cancel return 404 rather than
     // silently no-op — runIds (which equal chat IDs) are otherwise the
     // only thing the registry sees.
-    const record = await db
-      .select({ id: chatTable.id })
-      .from(chatTable)
-      .where(
-        and(eq(chatTable.id, chatId), eq(chatTable.workspaceId, workspaceId)),
-      )
-      .limit(1);
-
-    if (record.length === 0) {
-      return c.json({ error: "Chat not found" }, 404);
-    }
+    await requireOwned(db, "chat", chatId, workspaceId);
 
     // Idempotent: cancel returns false for unknown / already-finished
     // runs, but we still respond 200 so flaky clients can safely retry.
@@ -218,29 +207,15 @@ chat.delete(
     const { workspaceId } = workspaceScopeOf(c);
 
     // First fetch the chat to get its messages for file cleanup
-    const chatRecord = await db
-      .select()
-      .from(chatTable)
-      .where(
-        and(eq(chatTable.id, chatId), eq(chatTable.workspaceId, workspaceId)),
-      )
-      .limit(1);
-
-    if (chatRecord.length === 0) {
-      return c.json({ error: "Chat not found" }, 404);
-    }
+    const chatRecord = await requireOwned(db, "chat", chatId, workspaceId);
 
     // Delete associated files from storage (best-effort)
-    if (chatRecord[0].messages) {
-      await deleteFiles(chatRecord[0].messages as PlatypusUIMessage[]);
+    if (chatRecord.messages) {
+      await deleteFiles(chatRecord.messages as PlatypusUIMessage[]);
     }
 
     // Delete the chat record
-    await db
-      .delete(chatTable)
-      .where(
-        and(eq(chatTable.id, chatId), eq(chatTable.workspaceId, workspaceId)),
-      );
+    await db.delete(chatTable).where(ownedWhere("chat", chatId, workspaceId));
 
     return c.json({ message: "Chat deleted successfully" }, 200);
   },
@@ -258,19 +233,18 @@ chat.put(
     const { workspaceId } = workspaceScopeOf(c);
     const { title, isPinned, tags } = c.req.valid("json");
 
-    const result = await db
-      .update(chatTable)
-      .set({ title, isPinned, tags, updatedAt: new Date() })
-      .where(
-        and(eq(chatTable.id, chatId), eq(chatTable.workspaceId, workspaceId)),
-      )
-      .returning();
+    const result = await updateOwned(db, "chat", chatId, workspaceId, {
+      title,
+      isPinned,
+      tags,
+      updatedAt: new Date(),
+    });
 
-    if (result.length === 0) {
-      return c.json({ error: "Chat not found" }, 404);
+    if (!result) {
+      throw new NotFoundError("Chat not found");
     }
 
-    return c.json(result[0]);
+    return c.json(result);
   },
 );
 

--- a/apps/backend/src/routes/dashboard.ts
+++ b/apps/backend/src/routes/dashboard.ts
@@ -19,6 +19,16 @@ import {
   requireWorkspaceAccess,
   workspaceScopeOf,
 } from "../middleware/authorization.ts";
+import {
+  requireOwned,
+  listOwned,
+  updateOwned,
+  deleteOwned,
+  requireOwnedWidget,
+  listOwnedWidgets,
+  updateOwnedWidget,
+  deleteOwnedWidget,
+} from "../services/workspace-resource.ts";
 import type { Variables } from "../server.ts";
 
 const dashboard = new Hono<{ Variables: Variables }>();
@@ -32,11 +42,12 @@ dashboard.get(
   requireWorkspaceAccess,
   async (c) => {
     const { workspaceId } = workspaceScopeOf(c);
-    const results = await db
-      .select()
-      .from(dashboardTable)
-      .where(eq(dashboardTable.workspaceId, workspaceId))
-      .orderBy(asc(dashboardTable.createdAt));
+    const results = await listOwned(
+      db,
+      "dashboard",
+      workspaceId,
+      asc(dashboardTable.createdAt),
+    );
     return c.json({ results });
   },
 );
@@ -94,15 +105,13 @@ dashboard.get(
   async (c) => {
     const dashboardId = c.req.param("dashboardId");
     const { workspaceId } = workspaceScopeOf(c);
-    const record = await db
-      .select()
-      .from(dashboardTable)
-      .where(eq(dashboardTable.id, dashboardId))
-      .limit(1);
-    if (!record.length || record[0].workspaceId !== workspaceId) {
-      return c.json({ error: "Dashboard not found" }, 404);
-    }
-    return c.json(record[0]);
+    const record = await requireOwned(
+      db,
+      "dashboard",
+      dashboardId,
+      workspaceId,
+    );
+    return c.json(record);
   },
 );
 
@@ -116,19 +125,13 @@ dashboard.put(
     const data = c.req.valid("json");
     const dashboardId = c.req.param("dashboardId");
     const { workspaceId } = workspaceScopeOf(c);
-    const existing = await db
-      .select({
-        id: dashboardTable.id,
-        workspaceId: dashboardTable.workspaceId,
-        name: dashboardTable.name,
-      })
-      .from(dashboardTable)
-      .where(eq(dashboardTable.id, dashboardId))
-      .limit(1);
-    if (!existing.length || existing[0].workspaceId !== workspaceId) {
-      return c.json({ error: "Dashboard not found" }, 404);
-    }
-    if (data.name && data.name !== existing[0].name) {
+    const existing = await requireOwned(
+      db,
+      "dashboard",
+      dashboardId,
+      workspaceId,
+    );
+    if (data.name && data.name !== existing.name) {
       const conflict = await db
         .select({ id: dashboardTable.id })
         .from(dashboardTable)
@@ -149,12 +152,17 @@ dashboard.put(
         );
       }
     }
-    const updated = await db
-      .update(dashboardTable)
-      .set({ ...data, updatedAt: new Date() })
-      .where(eq(dashboardTable.id, dashboardId))
-      .returning();
-    return c.json(updated[0]);
+    const updated = await updateOwned(
+      db,
+      "dashboard",
+      dashboardId,
+      workspaceId,
+      {
+        ...data,
+        updatedAt: new Date(),
+      },
+    );
+    return c.json(updated);
   },
 );
 
@@ -166,18 +174,8 @@ dashboard.delete(
   async (c) => {
     const dashboardId = c.req.param("dashboardId");
     const { workspaceId } = workspaceScopeOf(c);
-    const existing = await db
-      .select({
-        id: dashboardTable.id,
-        workspaceId: dashboardTable.workspaceId,
-      })
-      .from(dashboardTable)
-      .where(eq(dashboardTable.id, dashboardId))
-      .limit(1);
-    if (!existing.length || existing[0].workspaceId !== workspaceId) {
-      return c.json({ error: "Dashboard not found" }, 404);
-    }
-    await db.delete(dashboardTable).where(eq(dashboardTable.id, dashboardId));
+    await requireOwned(db, "dashboard", dashboardId, workspaceId);
+    await deleteOwned(db, "dashboard", dashboardId, workspaceId);
     return c.body(null, 204);
   },
 );
@@ -192,22 +190,12 @@ dashboard.get(
   async (c) => {
     const dashboardId = c.req.param("dashboardId");
     const { workspaceId } = workspaceScopeOf(c);
-    const dash = await db
-      .select({
-        id: dashboardTable.id,
-        workspaceId: dashboardTable.workspaceId,
-      })
-      .from(dashboardTable)
-      .where(eq(dashboardTable.id, dashboardId))
-      .limit(1);
-    if (!dash.length || dash[0].workspaceId !== workspaceId) {
-      return c.json({ error: "Dashboard not found" }, 404);
-    }
-    const results = await db
-      .select()
-      .from(widgetTable)
-      .where(eq(widgetTable.dashboardId, dashboardId))
-      .orderBy(asc(widgetTable.createdAt));
+    await requireOwned(db, "dashboard", dashboardId, workspaceId);
+    const results = await listOwnedWidgets(
+      db,
+      dashboardId,
+      asc(widgetTable.createdAt),
+    );
     return c.json({ results });
   },
 );
@@ -222,17 +210,7 @@ dashboard.post(
     const data = c.req.valid("json");
     const dashboardId = c.req.param("dashboardId");
     const { workspaceId } = workspaceScopeOf(c);
-    const dash = await db
-      .select({
-        id: dashboardTable.id,
-        workspaceId: dashboardTable.workspaceId,
-      })
-      .from(dashboardTable)
-      .where(eq(dashboardTable.id, dashboardId))
-      .limit(1);
-    if (!dash.length || dash[0].workspaceId !== workspaceId) {
-      return c.json({ error: "Dashboard not found" }, 404);
-    }
+    await requireOwned(db, "dashboard", dashboardId, workspaceId);
     const conflict = await db
       .select({ id: widgetTable.id })
       .from(widgetTable)
@@ -277,30 +255,9 @@ dashboard.put(
     const dashboardId = c.req.param("dashboardId");
     const widgetId = c.req.param("widgetId");
     const { workspaceId } = workspaceScopeOf(c);
-    const dash = await db
-      .select({
-        id: dashboardTable.id,
-        workspaceId: dashboardTable.workspaceId,
-      })
-      .from(dashboardTable)
-      .where(eq(dashboardTable.id, dashboardId))
-      .limit(1);
-    if (!dash.length || dash[0].workspaceId !== workspaceId) {
-      return c.json({ error: "Dashboard not found" }, 404);
-    }
-    const existing = await db
-      .select({
-        id: widgetTable.id,
-        dashboardId: widgetTable.dashboardId,
-        type: widgetTable.type,
-      })
-      .from(widgetTable)
-      .where(eq(widgetTable.id, widgetId))
-      .limit(1);
-    if (!existing.length || existing[0].dashboardId !== dashboardId) {
-      return c.json({ error: "Widget not found" }, 404);
-    }
-    if (existing[0].type !== body.type) {
+    await requireOwned(db, "dashboard", dashboardId, workspaceId);
+    const existing = await requireOwnedWidget(db, widgetId, dashboardId);
+    if (existing.type !== body.type) {
       return c.json({ error: "Widget type mismatch" }, 400);
     }
     if (body.title) {
@@ -324,16 +281,12 @@ dashboard.put(
         );
       }
     }
-    const updated = await db
-      .update(widgetTable)
-      .set({
-        data: body.data,
-        ...(body.title && { title: body.title }),
-        updatedAt: new Date(),
-      })
-      .where(eq(widgetTable.id, widgetId))
-      .returning();
-    return c.json(updated[0]);
+    const updated = await updateOwnedWidget(db, widgetId, dashboardId, {
+      data: body.data,
+      ...(body.title && { title: body.title }),
+      updatedAt: new Date(),
+    });
+    return c.json(updated);
   },
 );
 
@@ -346,26 +299,9 @@ dashboard.delete(
     const dashboardId = c.req.param("dashboardId");
     const widgetId = c.req.param("widgetId");
     const { workspaceId } = workspaceScopeOf(c);
-    const dash = await db
-      .select({
-        id: dashboardTable.id,
-        workspaceId: dashboardTable.workspaceId,
-      })
-      .from(dashboardTable)
-      .where(eq(dashboardTable.id, dashboardId))
-      .limit(1);
-    if (!dash.length || dash[0].workspaceId !== workspaceId) {
-      return c.json({ error: "Dashboard not found" }, 404);
-    }
-    const existing = await db
-      .select({ id: widgetTable.id, dashboardId: widgetTable.dashboardId })
-      .from(widgetTable)
-      .where(eq(widgetTable.id, widgetId))
-      .limit(1);
-    if (!existing.length || existing[0].dashboardId !== dashboardId) {
-      return c.json({ error: "Widget not found" }, 404);
-    }
-    await db.delete(widgetTable).where(eq(widgetTable.id, widgetId));
+    await requireOwned(db, "dashboard", dashboardId, workspaceId);
+    await requireOwnedWidget(db, widgetId, dashboardId);
+    await deleteOwnedWidget(db, widgetId, dashboardId);
     return c.body(null, 204);
   },
 );

--- a/apps/backend/src/routes/notification.ts
+++ b/apps/backend/src/routes/notification.ts
@@ -13,6 +13,8 @@ import {
   requireWorkspaceAccess,
   workspaceScopeOf,
 } from "../middleware/authorization.ts";
+import { requireOwned, deleteOwned } from "../services/workspace-resource.ts";
+import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 import { dispatchEvent } from "../services/event-dispatch.ts";
 import { avatarKeyToUrl } from "../utils/avatar-url.ts";
@@ -125,20 +127,7 @@ notification.post(
     const { orgId, workspaceId } = workspaceScopeOf(c);
 
     // Verify notification exists in this workspace
-    const existing = await db
-      .select({ id: notificationTable.id })
-      .from(notificationTable)
-      .where(
-        and(
-          eq(notificationTable.id, notificationId),
-          eq(notificationTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
-
-    if (existing.length === 0) {
-      return c.json({ error: "Notification not found" }, 404);
-    }
+    await requireOwned(db, "notification", notificationId, workspaceId);
 
     await db
       .insert(notificationReadTable)
@@ -216,18 +205,15 @@ notification.delete(
     const notificationId = c.req.param("notificationId");
     const { orgId, workspaceId } = workspaceScopeOf(c);
 
-    const result = await db
-      .delete(notificationTable)
-      .where(
-        and(
-          eq(notificationTable.id, notificationId),
-          eq(notificationTable.workspaceId, workspaceId),
-        ),
-      )
-      .returning();
+    const deleted = await deleteOwned(
+      db,
+      "notification",
+      notificationId,
+      workspaceId,
+    );
 
-    if (result.length === 0) {
-      return c.json({ error: "Notification not found" }, 404);
+    if (!deleted) {
+      throw new NotFoundError("Notification not found");
     }
 
     dispatchEvent(orgId, workspaceId, "notification.dismissed", {

--- a/apps/backend/src/routes/sandbox.ts
+++ b/apps/backend/src/routes/sandbox.ts
@@ -1,7 +1,6 @@
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { nanoid } from "nanoid";
-import { eq } from "drizzle-orm";
 import { db } from "../index.ts";
 import { sandbox as sandboxTable } from "../db/schema.ts";
 import { sandboxCreateSchema, sandboxUpdateSchema } from "@platypus/schemas";
@@ -12,6 +11,12 @@ import {
   requireWorkspaceConfigAccess,
   workspaceScopeOf,
 } from "../middleware/authorization.ts";
+import {
+  resolveOwnedSandbox,
+  requireOwnedSandbox,
+  updateOwnedSandbox,
+  deleteOwnedSandbox,
+} from "../services/workspace-resource.ts";
 import type { Variables } from "../server.ts";
 import { destroySandboxRow } from "../sandbox/teardown.ts";
 import { getSandboxBackend, getSandboxBackends } from "../sandbox/index.ts";
@@ -138,16 +143,9 @@ sandbox.get(
   requireWorkspaceAccess,
   async (c) => {
     const { workspaceId } = workspaceScopeOf(c);
-    const record = await db
-      .select()
-      .from(sandboxTable)
-      .where(eq(sandboxTable.workspaceId, workspaceId))
-      .limit(1);
-    if (record.length === 0) {
-      return c.json({ error: "Sandbox not configured" }, 404);
-    }
+    const record = await requireOwnedSandbox(db, workspaceId);
     const isAdmin = c.get("orgMembership")?.role === "admin";
-    return c.json(sanitizeSandboxResponse(record[0], isAdmin));
+    return c.json(sanitizeSandboxResponse(record, isAdmin));
   },
 );
 
@@ -189,12 +187,8 @@ sandbox.post(
       );
     }
 
-    const existing = await db
-      .select()
-      .from(sandboxTable)
-      .where(eq(sandboxTable.workspaceId, workspaceId))
-      .limit(1);
-    if (existing.length > 0) {
+    const existing = await resolveOwnedSandbox(db, workspaceId);
+    if (existing) {
       return c.json(
         { error: "Sandbox already configured for this workspace" },
         409,
@@ -246,15 +240,7 @@ sandbox.put(
     const force = c.req.query("force") === "true";
     const isAdmin = c.get("orgMembership")?.role === "admin";
 
-    const existing = await db
-      .select()
-      .from(sandboxTable)
-      .where(eq(sandboxTable.workspaceId, workspaceId))
-      .limit(1);
-    if (existing.length === 0) {
-      return c.json({ error: "Sandbox not configured" }, 404);
-    }
-    const current = existing[0];
+    const current = await requireOwnedSandbox(db, workspaceId);
 
     // Non-admin owner: restrict to name + userEnv, no backend/config changes.
     if (!isAdmin) {
@@ -267,17 +253,13 @@ sandbox.put(
           400,
         );
       }
-      const record = await db
-        .update(sandboxTable)
-        .set({
-          name: data.name,
-          ...(data.userEnv !== undefined ? { userEnv: data.userEnv } : {}),
-          updatedAt: new Date(),
-        })
-        .where(eq(sandboxTable.workspaceId, workspaceId))
-        .returning();
+      const record = await updateOwnedSandbox(db, workspaceId, {
+        name: data.name,
+        ...(data.userEnv !== undefined ? { userEnv: data.userEnv } : {}),
+        updatedAt: new Date(),
+      });
       // Non-admin owner — redact adminEnv values in the response.
-      return c.json(sanitizeSandboxResponse(record[0], false));
+      return c.json(sanitizeSandboxResponse(record!, false));
     }
 
     // Admin: full update.
@@ -355,16 +337,12 @@ sandbox.put(
       );
     }
 
-    const record = await db
-      .update(sandboxTable)
-      .set({
-        ...data,
-        updatedAt: new Date(),
-      })
-      .where(eq(sandboxTable.workspaceId, workspaceId))
-      .returning();
+    const record = await updateOwnedSandbox(db, workspaceId, {
+      ...data,
+      updatedAt: new Date(),
+    });
     // Reached only on the admin branch above.
-    return c.json(sanitizeSandboxResponse(record[0], true));
+    return c.json(sanitizeSandboxResponse(record!, true));
   },
 );
 
@@ -382,26 +360,19 @@ sandbox.delete(
     const { workspaceId } = workspaceScopeOf(c);
     const force = c.req.query("force") === "true";
 
-    const existing = await db
-      .select()
-      .from(sandboxTable)
-      .where(eq(sandboxTable.workspaceId, workspaceId))
-      .limit(1);
-    if (existing.length === 0) {
-      return c.json({ error: "Sandbox not configured" }, 404);
-    }
+    const existing = await requireOwnedSandbox(db, workspaceId);
 
     if (!force) {
       try {
-        await destroySandboxRow(existing[0]);
+        await destroySandboxRow(existing);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         logger.warn(
           {
             workspaceId,
-            sandboxId: existing[0].id,
-            backend: existing[0].backend,
-            plugin: getSandboxBackendPlugin(existing[0].backend) ?? null,
+            sandboxId: existing.id,
+            backend: existing.backend,
+            plugin: getSandboxBackendPlugin(existing.backend) ?? null,
             err,
           },
           "Sandbox destroy() failed; row preserved so the user can retry",
@@ -417,17 +388,15 @@ sandbox.delete(
       logger.warn(
         {
           workspaceId,
-          sandboxId: existing[0].id,
-          backend: existing[0].backend,
-          plugin: getSandboxBackendPlugin(existing[0].backend) ?? null,
+          sandboxId: existing.id,
+          backend: existing.backend,
+          plugin: getSandboxBackendPlugin(existing.backend) ?? null,
         },
         "Sandbox row force-deleted; adapter destroy() was skipped — external resources may leak",
       );
     }
 
-    await db
-      .delete(sandboxTable)
-      .where(eq(sandboxTable.workspaceId, workspaceId));
+    await deleteOwnedSandbox(db, workspaceId);
     return c.json({ message: "Sandbox deleted" });
   },
 );

--- a/apps/backend/src/routes/trigger.ts
+++ b/apps/backend/src/routes/trigger.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { z } from "zod";
 import { nanoid } from "nanoid";
-import { and, desc, eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { db } from "../index.ts";
 import {
   trigger as triggerTable,
@@ -17,6 +17,13 @@ import {
   workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import { resolveScoped } from "../services/scoped-resource.ts";
+import {
+  requireOwned,
+  listOwned,
+  updateOwned,
+  deleteOwned,
+} from "../services/workspace-resource.ts";
+import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
 import { validateCronExpression } from "../utils/cron.ts";
@@ -31,11 +38,12 @@ trigger.get(
   requireWorkspaceAccess,
   async (c) => {
     const { workspaceId } = workspaceScopeOf(c);
-    const results = await db
-      .select()
-      .from(triggerTable)
-      .where(eq(triggerTable.workspaceId, workspaceId))
-      .orderBy(desc(triggerTable.createdAt));
+    const results = await listOwned(
+      db,
+      "trigger",
+      workspaceId,
+      desc(triggerTable.createdAt),
+    );
     return c.json({ results });
   },
 );
@@ -50,22 +58,9 @@ trigger.get(
     const triggerId = c.req.param("triggerId");
     const { workspaceId } = workspaceScopeOf(c);
 
-    const record = await db
-      .select()
-      .from(triggerTable)
-      .where(
-        and(
-          eq(triggerTable.id, triggerId),
-          eq(triggerTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
+    const record = await requireOwned(db, "trigger", triggerId, workspaceId);
 
-    if (record.length === 0) {
-      return c.json({ error: "Trigger not found" }, 404);
-    }
-
-    return c.json(record[0]);
+    return c.json(record);
   },
 );
 
@@ -151,23 +146,10 @@ trigger.put(
     const data = c.req.valid("json");
 
     // Verify trigger exists in workspace
-    const existing = await db
-      .select()
-      .from(triggerTable)
-      .where(
-        and(
-          eq(triggerTable.id, triggerId),
-          eq(triggerTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
-
-    if (existing.length === 0) {
-      return c.json({ error: "Trigger not found" }, 404);
-    }
+    const existing = await requireOwned(db, "trigger", triggerId, workspaceId);
 
     // If agentId is being changed, verify new agent exists
-    if (data.agentId && data.agentId !== existing[0].agentId) {
+    if (data.agentId && data.agentId !== existing.agentId) {
       // See the create route: workspace-scoped, or Shared and attached here.
       const agentRecord = await resolveScoped(db, "agent", data.agentId, scope);
 
@@ -182,7 +164,7 @@ trigger.put(
     };
 
     // Determine the effective type (updated or existing)
-    const effectiveType = data.type ?? existing[0].type;
+    const effectiveType = data.type ?? existing.type;
 
     if (effectiveType === "event") {
       // Event triggers don't have nextRunAt
@@ -199,7 +181,7 @@ trigger.put(
       updateData.nextRunAt = null;
     } else if (effectiveType === "cron") {
       // Recompute nextRunAt if cron config changes
-      const config = (data.config ?? existing[0].config) as Record<
+      const config = (data.config ?? existing.config) as Record<
         string,
         unknown
       >;
@@ -215,15 +197,17 @@ trigger.put(
       }
     }
 
-    const record = await db
-      .update(triggerTable)
-      .set(updateData)
-      .where(eq(triggerTable.id, triggerId))
-      .returning();
+    const record = await updateOwned(
+      db,
+      "trigger",
+      triggerId,
+      workspaceId,
+      updateData,
+    );
 
     logger.info(`Updated trigger '${triggerId}'`);
 
-    return c.json(record[0], 200);
+    return c.json(record, 200);
   },
 );
 
@@ -238,18 +222,10 @@ trigger.delete(
     const triggerId = c.req.param("triggerId");
     const { workspaceId } = workspaceScopeOf(c);
 
-    const result = await db
-      .delete(triggerTable)
-      .where(
-        and(
-          eq(triggerTable.id, triggerId),
-          eq(triggerTable.workspaceId, workspaceId),
-        ),
-      )
-      .returning();
+    const deleted = await deleteOwned(db, "trigger", triggerId, workspaceId);
 
-    if (result.length === 0) {
-      return c.json({ error: "Trigger not found" }, 404);
+    if (!deleted) {
+      throw new NotFoundError("Trigger not found");
     }
 
     logger.info(`Deleted trigger '${triggerId}'`);
@@ -280,20 +256,7 @@ trigger.get(
     const offset = parseInt(offsetStr ?? "0") || 0;
 
     // Verify trigger exists in workspace
-    const triggerRecord = await db
-      .select()
-      .from(triggerTable)
-      .where(
-        and(
-          eq(triggerTable.id, triggerId),
-          eq(triggerTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
-
-    if (triggerRecord.length === 0) {
-      return c.json({ error: "Trigger not found" }, 404);
-    }
+    await requireOwned(db, "trigger", triggerId, workspaceId);
 
     const results = await db
       .select()

--- a/apps/backend/src/routes/webhook.ts
+++ b/apps/backend/src/routes/webhook.ts
@@ -2,16 +2,22 @@ import crypto from "node:crypto";
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { nanoid } from "nanoid";
-import { and, eq } from "drizzle-orm";
 import { db } from "../index.ts";
 import { webhook as webhookTable } from "../db/schema.ts";
-import { webhookCreateSchema, webhookUpdateSchema } from "@platypus/schemas";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
   requireWorkspaceAccess,
   workspaceScopeOf,
 } from "../middleware/authorization.ts";
+import {
+  requireOwned,
+  listOwned,
+  updateOwned,
+  deleteOwned,
+} from "../services/workspace-resource.ts";
+import { NotFoundError } from "../errors.ts";
+import { webhookCreateSchema, webhookUpdateSchema } from "@platypus/schemas";
 import type { Variables } from "../server.ts";
 
 const webhook = new Hono<{ Variables: Variables }>();
@@ -29,10 +35,7 @@ webhook.get(
   async (c) => {
     const { workspaceId } = workspaceScopeOf(c);
 
-    const results = await db
-      .select()
-      .from(webhookTable)
-      .where(eq(webhookTable.workspaceId, workspaceId));
+    const results = await listOwned(db, "webhook", workspaceId, null);
 
     return c.json({ results });
   },
@@ -94,22 +97,9 @@ webhook.get(
     const { workspaceId } = workspaceScopeOf(c);
     const webhookId = c.req.param("webhookId");
 
-    const results = await db
-      .select()
-      .from(webhookTable)
-      .where(
-        and(
-          eq(webhookTable.id, webhookId),
-          eq(webhookTable.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
+    const record = await requireOwned(db, "webhook", webhookId, workspaceId);
 
-    if (results.length === 0) {
-      return c.json({ error: "Webhook not found" }, 404);
-    }
-
-    return c.json(results[0]);
+    return c.json(record);
   },
 );
 
@@ -140,22 +130,19 @@ webhook.put(
     if (body.enabled !== undefined) updateData.enabled = body.enabled;
     if (body.events !== undefined) updateData.events = body.events;
 
-    const result = await db
-      .update(webhookTable)
-      .set(updateData)
-      .where(
-        and(
-          eq(webhookTable.id, webhookId),
-          eq(webhookTable.workspaceId, workspaceId),
-        ),
-      )
-      .returning();
+    const result = await updateOwned(
+      db,
+      "webhook",
+      webhookId,
+      workspaceId,
+      updateData,
+    );
 
-    if (result.length === 0) {
-      return c.json({ error: "Webhook not found" }, 404);
+    if (!result) {
+      throw new NotFoundError("Webhook not found");
     }
 
-    return c.json(result[0]);
+    return c.json(result);
   },
 );
 
@@ -169,18 +156,10 @@ webhook.delete(
     const { workspaceId } = workspaceScopeOf(c);
     const webhookId = c.req.param("webhookId");
 
-    const result = await db
-      .delete(webhookTable)
-      .where(
-        and(
-          eq(webhookTable.id, webhookId),
-          eq(webhookTable.workspaceId, workspaceId),
-        ),
-      )
-      .returning();
+    const deleted = await deleteOwned(db, "webhook", webhookId, workspaceId);
 
-    if (result.length === 0) {
-      return c.json({ error: "Webhook not found" }, 404);
+    if (!deleted) {
+      throw new NotFoundError("Webhook not found");
     }
 
     return c.json({ message: "Webhook deleted" });
@@ -197,25 +176,16 @@ webhook.post(
     const { workspaceId } = workspaceScopeOf(c);
     const webhookId = c.req.param("webhookId");
 
-    const result = await db
-      .update(webhookTable)
-      .set({
-        signingSecret: generateSigningSecret(),
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(webhookTable.id, webhookId),
-          eq(webhookTable.workspaceId, workspaceId),
-        ),
-      )
-      .returning();
+    const result = await updateOwned(db, "webhook", webhookId, workspaceId, {
+      signingSecret: generateSigningSecret(),
+      updatedAt: new Date(),
+    });
 
-    if (result.length === 0) {
-      return c.json({ error: "Webhook not found" }, 404);
+    if (!result) {
+      throw new NotFoundError("Webhook not found");
     }
 
-    return c.json(result[0]);
+    return c.json(result);
   },
 );
 

--- a/apps/backend/src/services/workspace-resource.test.ts
+++ b/apps/backend/src/services/workspace-resource.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+// test-utils installs the drizzle-orm mock, so it must be imported before the
+// operators this file asserts on — `eq`/`and` are spies only through that mock.
+import { mockDb, resetMockDb, asDb } from "../test-utils.ts";
+import { desc } from "drizzle-orm";
+import { trigger as triggerTable } from "../db/schema.ts";
+import {
+  resolveOwned,
+  requireOwned,
+  listOwned,
+  updateOwned,
+  deleteOwned,
+  ownedWhere,
+  resolveOwnedWidget,
+  requireOwnedWidget,
+  listOwnedWidgets,
+  updateOwnedWidget,
+  deleteOwnedWidget,
+  widgetOwnedWhere,
+  resolveOwnedSandbox,
+  requireOwnedSandbox,
+} from "./workspace-resource.ts";
+import { NotFoundError } from "../errors.ts";
+
+const workspaceId = "ws-1";
+
+describe("WorkspaceResource module", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+  });
+
+  describe("resolveOwned", () => {
+    it("returns the row when it exists in this workspace", async () => {
+      const row = { id: "chat-1", workspaceId, title: "Hello" };
+      mockDb.limit.mockResolvedValueOnce([row]);
+
+      const found = await resolveOwned(
+        asDb(mockDb),
+        "chat",
+        "chat-1",
+        workspaceId,
+      );
+      expect(found).toEqual(row);
+    });
+
+    it("returns null when the row is missing", async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const found = await resolveOwned(
+        asDb(mockDb),
+        "chat",
+        "chat-1",
+        workspaceId,
+      );
+      expect(found).toBeNull();
+    });
+  });
+
+  describe("requireOwned", () => {
+    it("returns the row when found", async () => {
+      const row = { id: "dash-1", workspaceId, name: "Dashboard" };
+      mockDb.limit.mockResolvedValueOnce([row]);
+
+      const found = await requireOwned(
+        asDb(mockDb),
+        "dashboard",
+        "dash-1",
+        workspaceId,
+      );
+      expect(found).toEqual(row);
+    });
+
+    it("throws NotFoundError with the type's label when missing", async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      await expect(
+        requireOwned(asDb(mockDb), "dashboard", "dash-1", workspaceId),
+      ).rejects.toThrow(NotFoundError);
+      await expect(
+        requireOwned(asDb(mockDb), "trigger", "trig-1", workspaceId),
+      ).rejects.toThrow("Trigger not found");
+    });
+  });
+
+  describe("listOwned", () => {
+    it("resolves via .where() alone when orderBy is null", async () => {
+      const rows = [{ id: "wh-1", workspaceId }];
+      mockDb.where.mockResolvedValueOnce(rows);
+
+      const results = await listOwned(
+        asDb(mockDb),
+        "webhook",
+        workspaceId,
+        null,
+      );
+      expect(results).toEqual(rows);
+      expect(mockDb.orderBy).not.toHaveBeenCalled();
+    });
+
+    it("chains .orderBy() when an order clause is passed", async () => {
+      const rows = [{ id: "trig-1", workspaceId }];
+      mockDb.orderBy.mockResolvedValueOnce(rows);
+
+      const results = await listOwned(
+        asDb(mockDb),
+        "trigger",
+        workspaceId,
+        desc(triggerTable.createdAt),
+      );
+      expect(results).toEqual(rows);
+      expect(mockDb.orderBy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("updateOwned", () => {
+    it("returns the updated row on success", async () => {
+      const updated = { id: "chat-1", workspaceId, title: "Renamed" };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const result = await updateOwned(
+        asDb(mockDb),
+        "chat",
+        "chat-1",
+        workspaceId,
+        {
+          title: "Renamed",
+        },
+      );
+      expect(result).toEqual(updated);
+    });
+
+    it("returns null when nothing matched", async () => {
+      mockDb.returning.mockResolvedValueOnce([]);
+
+      const result = await updateOwned(
+        asDb(mockDb),
+        "chat",
+        "chat-1",
+        workspaceId,
+        {
+          title: "Renamed",
+        },
+      );
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("deleteOwned", () => {
+    it("returns true when a row was deleted", async () => {
+      mockDb.returning.mockResolvedValueOnce([{ id: "wh-1" }]);
+
+      const deleted = await deleteOwned(
+        asDb(mockDb),
+        "webhook",
+        "wh-1",
+        workspaceId,
+      );
+      expect(deleted).toBe(true);
+    });
+
+    it("returns false when nothing matched", async () => {
+      mockDb.returning.mockResolvedValueOnce([]);
+
+      const deleted = await deleteOwned(
+        asDb(mockDb),
+        "webhook",
+        "wh-1",
+        workspaceId,
+      );
+      expect(deleted).toBe(false);
+    });
+  });
+
+  describe("ownedWhere", () => {
+    it("is a concrete SQL condition, not undefined", () => {
+      expect(ownedWhere("chat", "chat-1", workspaceId)).toBeTruthy();
+    });
+  });
+
+  // --- Widget: nested under Dashboard ---
+
+  const dashboardId = "dash-1";
+
+  describe("resolveOwnedWidget / requireOwnedWidget", () => {
+    it("resolves a widget scoped to its dashboard", async () => {
+      const row = { id: "widget-1", dashboardId };
+      mockDb.limit.mockResolvedValueOnce([row]);
+
+      const found = await resolveOwnedWidget(
+        asDb(mockDb),
+        "widget-1",
+        dashboardId,
+      );
+      expect(found).toEqual(row);
+    });
+
+    it("requireOwnedWidget throws NotFoundError when missing", async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      await expect(
+        requireOwnedWidget(asDb(mockDb), "widget-1", dashboardId),
+      ).rejects.toThrow("Widget not found");
+    });
+  });
+
+  describe("listOwnedWidgets", () => {
+    it("lists widgets on a dashboard", async () => {
+      const rows = [{ id: "widget-1", dashboardId }];
+      mockDb.where.mockResolvedValueOnce(rows);
+
+      const results = await listOwnedWidgets(asDb(mockDb), dashboardId, null);
+      expect(results).toEqual(rows);
+    });
+  });
+
+  describe("updateOwnedWidget / deleteOwnedWidget", () => {
+    it("updates a widget scoped to its dashboard", async () => {
+      const updated = { id: "widget-1", dashboardId, data: { value: 1 } };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const result = await updateOwnedWidget(
+        asDb(mockDb),
+        "widget-1",
+        dashboardId,
+        {
+          data: { value: 1 },
+        },
+      );
+      expect(result).toEqual(updated);
+    });
+
+    it("deletes a widget scoped to its dashboard", async () => {
+      mockDb.returning.mockResolvedValueOnce([{ id: "widget-1" }]);
+
+      const deleted = await deleteOwnedWidget(
+        asDb(mockDb),
+        "widget-1",
+        dashboardId,
+      );
+      expect(deleted).toBe(true);
+    });
+  });
+
+  describe("widgetOwnedWhere", () => {
+    it("is a concrete SQL condition, not undefined", () => {
+      expect(widgetOwnedWhere("widget-1", dashboardId)).toBeTruthy();
+    });
+  });
+
+  // --- Sandbox: workspace singleton ---
+
+  describe("resolveOwnedSandbox / requireOwnedSandbox", () => {
+    it("resolves the workspace's sandbox", async () => {
+      const row = { id: "sbx-1", workspaceId, backend: "docker" };
+      mockDb.limit.mockResolvedValueOnce([row]);
+
+      const found = await resolveOwnedSandbox(asDb(mockDb), workspaceId);
+      expect(found).toEqual(row);
+    });
+
+    it("requireOwnedSandbox throws NotFoundError when none configured", async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      await expect(
+        requireOwnedSandbox(asDb(mockDb), workspaceId),
+      ).rejects.toThrow("Sandbox not configured");
+    });
+  });
+});

--- a/apps/backend/src/services/workspace-resource.ts
+++ b/apps/backend/src/services/workspace-resource.ts
@@ -1,0 +1,353 @@
+import { and, eq, type SQL } from "drizzle-orm";
+import {
+  chat as chatTable,
+  dashboard as dashboardTable,
+  widget as widgetTable,
+  trigger as triggerTable,
+  webhook as webhookTable,
+  notification as notificationTable,
+  sandbox as sandboxTable,
+} from "../db/schema.ts";
+import { db } from "../index.ts";
+import { NotFoundError } from "../errors.ts";
+
+/**
+ * The **Workspace-child resource** (CONTEXT.md): a Chat, Dashboard, Trigger,
+ * Webhook, or Notification whose row lives at exactly one Workspace — no dual
+ * scope, no Attachment, unlike the Scoped resources in `scoped-resource.ts`.
+ * Containment is a single `workspaceId` equality, but that equality was being
+ * hand-rolled at each of the 13 route files that own one of these tables,
+ * with the write side (`UPDATE`/`DELETE`) frequently keyed on `eq(id)` alone
+ * once a preceding `SELECT` had already checked the Workspace — two statements
+ * standing in for one, so deleting the `SELECT` silently drops the
+ * containment check with no compile error and no failing test.
+ *
+ * `resolveOwned`/`requireOwned`/`listOwned` answer the read side; `ownedWhere`
+ * is the same predicate as a Drizzle condition, so `updateOwned`/`deleteOwned`
+ * pass it straight to `.where(...)` and a write can never reach a row a read
+ * would refuse. Modeled on `scoped-resource.ts`'s `requireScoped`/`resolveScoped`
+ * pair; `resolveOwned`/`listOwned` stay exception-free, `requireOwned` throws
+ * `NotFoundError` mapped centrally by `app.onError` (ADR-0010).
+ *
+ * Widget is a Workspace-child resource too, but nested one level down — it
+ * carries a `dashboardId`, not a `workspaceId`. It gets its own
+ * `resolveOwnedWidget`/`requireOwnedWidget`/`listOwnedWidgets`/`updateOwnedWidget`/
+ * `deleteOwnedWidget` scoped by the parent Dashboard's id, mirroring
+ * `services/kanban.ts`'s `withinScope` for Card/Column under Board — the
+ * caller establishes the Dashboard is in this Workspace once (`requireOwned`
+ * with type `"dashboard"`), then every Widget lookup scopes to that id.
+ *
+ * Sandbox is a Workspace-child resource with no `id` of its own to route on —
+ * it is a one-per-Workspace singleton addressed by `workspaceId` alone.
+ * `resolveOwnedSandbox`/`requireOwnedSandbox` give it the same
+ * resolve/require shape without a meaningless `id` parameter.
+ */
+
+type Database = typeof db;
+
+/** The flat Workspace-child resource types — one row per id, scoped by `workspaceId`. */
+export type WorkspaceResourceType =
+  "chat" | "dashboard" | "trigger" | "webhook" | "notification";
+
+type WorkspaceTable =
+  | typeof chatTable
+  | typeof dashboardTable
+  | typeof triggerTable
+  | typeof webhookTable
+  | typeof notificationTable;
+
+/** Maps each resource type to its Drizzle row type, for per-resource typing. */
+type RowOf = {
+  chat: typeof chatTable.$inferSelect;
+  dashboard: typeof dashboardTable.$inferSelect;
+  trigger: typeof triggerTable.$inferSelect;
+  webhook: typeof webhookTable.$inferSelect;
+  notification: typeof notificationTable.$inferSelect;
+};
+
+type RegistryEntry = {
+  /** The Drizzle table backing this resource type. */
+  table: WorkspaceTable;
+  /** Human label used in the `NotFoundError` message ("Chat not found"). */
+  label: string;
+};
+
+const REGISTRY: Record<WorkspaceResourceType, RegistryEntry> = {
+  chat: { table: chatTable, label: "Chat" },
+  dashboard: { table: dashboardTable, label: "Dashboard" },
+  trigger: { table: triggerTable, label: "Trigger" },
+  webhook: { table: webhookTable, label: "Webhook" },
+  notification: { table: notificationTable, label: "Notification" },
+};
+
+/**
+ * `and()` is typed to tolerate `undefined` operands and so widens to
+ * `SQL | undefined`. Every condition composed below is concrete, and a
+ * `.where(undefined)` would match the whole table — an unfiltered `UPDATE` or
+ * `DELETE`. Asserting once here keeps that shape out of the predicates'
+ * return types, so no caller can be handed it.
+ */
+const allOf = (...conditions: (SQL | undefined)[]): SQL => and(...conditions)!;
+
+/**
+ * The `WHERE` clause matching a single Workspace-child resource: this id, in
+ * this Workspace. The one place that condition is written — every read or
+ * write in this module composes it, so a write can never reach a row a read
+ * would refuse.
+ */
+export const ownedWhere = (
+  type: WorkspaceResourceType,
+  id: string,
+  workspaceId: string,
+): SQL => {
+  const { table } = REGISTRY[type];
+  return allOf(eq(table.id, id), eq(table.workspaceId, workspaceId));
+};
+
+/**
+ * Resolves a single Workspace-child resource, or `null` when it does not
+ * exist or is not in this Workspace. Never throws — absence is a normal
+ * outcome.
+ */
+export const resolveOwned = async <T extends WorkspaceResourceType>(
+  database: Database,
+  type: T,
+  id: string,
+  workspaceId: string,
+): Promise<RowOf[T] | null> => {
+  const { table } = REGISTRY[type];
+  const rows = await database
+    .select()
+    .from(table)
+    .where(ownedWhere(type, id, workspaceId))
+    .limit(1);
+  return (rows[0] as RowOf[T] | undefined) ?? null;
+};
+
+/**
+ * Like {@link resolveOwned} but throws `NotFoundError` when the resource does
+ * not exist or is not in this Workspace — for routes that treat absence as a
+ * 404.
+ */
+export const requireOwned = async <T extends WorkspaceResourceType>(
+  database: Database,
+  type: T,
+  id: string,
+  workspaceId: string,
+): Promise<RowOf[T]> => {
+  const row = await resolveOwned(database, type, id, workspaceId);
+  if (!row) {
+    throw new NotFoundError(`${REGISTRY[type].label} not found`);
+  }
+  return row;
+};
+
+/**
+ * Lists every resource of this type in the Workspace, ordered by `orderBy`, or
+ * unordered when passed `null`. `orderBy` is required (not optional) so a
+ * caller always states its intent explicitly rather than the ordering
+ * silently depending on whatever falsy value a condition happened to
+ * evaluate to. Never throws.
+ */
+export const listOwned = async <T extends WorkspaceResourceType>(
+  database: Database,
+  type: T,
+  workspaceId: string,
+  orderBy: SQL | null,
+): Promise<RowOf[T][]> => {
+  const { table } = REGISTRY[type];
+  const query = database
+    .select()
+    .from(table)
+    .where(eq(table.workspaceId, workspaceId));
+  const rows = orderBy === null ? await query : await query.orderBy(orderBy);
+  return rows as RowOf[T][];
+};
+
+/**
+ * Updates a Workspace-child resource, scoped by {@link ownedWhere} rather than
+ * `id` alone — the write side of the containment check {@link resolveOwned}
+ * reads, so a caller cannot update a row it could not have resolved. Returns
+ * the updated row, or `null` when nothing matched (not found, or not in this
+ * Workspace).
+ */
+export const updateOwned = async <T extends WorkspaceResourceType>(
+  database: Database,
+  type: T,
+  id: string,
+  workspaceId: string,
+  values: Partial<RowOf[T]>,
+): Promise<RowOf[T] | null> => {
+  const { table } = REGISTRY[type];
+  const rows = await database
+    .update(table)
+    .set(values)
+    .where(ownedWhere(type, id, workspaceId))
+    .returning();
+  return (rows[0] as RowOf[T] | undefined) ?? null;
+};
+
+/**
+ * Deletes a Workspace-child resource, scoped by {@link ownedWhere}. Returns
+ * whether a row was actually deleted, so a route can 404 on a no-op delete
+ * rather than assuming success.
+ */
+export const deleteOwned = async (
+  database: Database,
+  type: WorkspaceResourceType,
+  id: string,
+  workspaceId: string,
+): Promise<boolean> => {
+  const { table } = REGISTRY[type];
+  const rows = await database
+    .delete(table)
+    .where(ownedWhere(type, id, workspaceId))
+    .returning();
+  return rows.length > 0;
+};
+
+// --- Widget: nested under Dashboard, scoped by dashboardId ---
+
+type WidgetRow = typeof widgetTable.$inferSelect;
+
+/**
+ * The `WHERE` clause matching a single Widget within a given Dashboard. The
+ * caller is responsible for having already established that the Dashboard
+ * itself is in this Workspace (via `requireOwned(db, "dashboard", ...)`) —
+ * this predicate only narrows within that already-validated Dashboard.
+ */
+export const widgetOwnedWhere = (id: string, dashboardId: string): SQL =>
+  allOf(eq(widgetTable.id, id), eq(widgetTable.dashboardId, dashboardId));
+
+/** Resolves a single Widget on this Dashboard, or `null`. Never throws. */
+export const resolveOwnedWidget = async (
+  database: Database,
+  id: string,
+  dashboardId: string,
+): Promise<WidgetRow | null> => {
+  const rows = await database
+    .select()
+    .from(widgetTable)
+    .where(widgetOwnedWhere(id, dashboardId))
+    .limit(1);
+  return rows[0] ?? null;
+};
+
+/** Like {@link resolveOwnedWidget} but throws `NotFoundError` when absent. */
+export const requireOwnedWidget = async (
+  database: Database,
+  id: string,
+  dashboardId: string,
+): Promise<WidgetRow> => {
+  const row = await resolveOwnedWidget(database, id, dashboardId);
+  if (!row) {
+    throw new NotFoundError("Widget not found");
+  }
+  return row;
+};
+
+/**
+ * Lists every Widget on this Dashboard, ordered by `orderBy`, or unordered
+ * when passed `null`. Never throws.
+ */
+export const listOwnedWidgets = async (
+  database: Database,
+  dashboardId: string,
+  orderBy: SQL | null,
+): Promise<WidgetRow[]> => {
+  const query = database
+    .select()
+    .from(widgetTable)
+    .where(eq(widgetTable.dashboardId, dashboardId));
+  return orderBy === null ? query : query.orderBy(orderBy);
+};
+
+/** Updates a Widget, scoped by {@link widgetOwnedWhere}. */
+export const updateOwnedWidget = async (
+  database: Database,
+  id: string,
+  dashboardId: string,
+  values: Partial<WidgetRow>,
+): Promise<WidgetRow | null> => {
+  const rows = await database
+    .update(widgetTable)
+    .set(values)
+    .where(widgetOwnedWhere(id, dashboardId))
+    .returning();
+  return rows[0] ?? null;
+};
+
+/** Deletes a Widget, scoped by {@link widgetOwnedWhere}. */
+export const deleteOwnedWidget = async (
+  database: Database,
+  id: string,
+  dashboardId: string,
+): Promise<boolean> => {
+  const rows = await database
+    .delete(widgetTable)
+    .where(widgetOwnedWhere(id, dashboardId))
+    .returning();
+  return rows.length > 0;
+};
+
+// --- Sandbox: a one-per-Workspace singleton, no id of its own ---
+
+type SandboxRow = typeof sandboxTable.$inferSelect;
+
+/** Resolves this Workspace's sandbox, or `null` when none is configured. */
+export const resolveOwnedSandbox = async (
+  database: Database,
+  workspaceId: string,
+): Promise<SandboxRow | null> => {
+  const rows = await database
+    .select()
+    .from(sandboxTable)
+    .where(eq(sandboxTable.workspaceId, workspaceId))
+    .limit(1);
+  return rows[0] ?? null;
+};
+
+/**
+ * Like {@link resolveOwnedSandbox} but throws `NotFoundError` when none is
+ * configured — for routes that treat absence as a 404.
+ */
+export const requireOwnedSandbox = async (
+  database: Database,
+  workspaceId: string,
+): Promise<SandboxRow> => {
+  const row = await resolveOwnedSandbox(database, workspaceId);
+  if (!row) {
+    throw new NotFoundError("Sandbox not configured");
+  }
+  return row;
+};
+
+/**
+ * Updates this Workspace's sandbox, scoped by `workspaceId` — the write side
+ * of the containment check {@link resolveOwnedSandbox} reads. Returns the
+ * updated row, or `null` when none is configured.
+ */
+export const updateOwnedSandbox = async (
+  database: Database,
+  workspaceId: string,
+  values: Partial<SandboxRow>,
+): Promise<SandboxRow | null> => {
+  const rows = await database
+    .update(sandboxTable)
+    .set(values)
+    .where(eq(sandboxTable.workspaceId, workspaceId))
+    .returning();
+  return rows[0] ?? null;
+};
+
+/** Deletes this Workspace's sandbox. Returns whether a row was deleted. */
+export const deleteOwnedSandbox = async (
+  database: Database,
+  workspaceId: string,
+): Promise<boolean> => {
+  const rows = await database
+    .delete(sandboxTable)
+    .where(eq(sandboxTable.workspaceId, workspaceId))
+    .returning();
+  return rows.length > 0;
+};


### PR DESCRIPTION
## Summary

`requireScoped` (`services/scoped-resource.ts`) collapsed "resolve → null-check → 404" for the four dual-scope resource types (Agent/Skill/MCP/Provider), but the eight Workspace-child resource families — Chat, Dashboard, Widget, Trigger, Webhook, Notification, Sandbox, Attachment — still hand-rolled `eq(<table>.workspaceId, workspaceId)` predicates and inline `c.json({error}, 404)` responses across 13 route files. `dashboard.ts` in particular checked containment in JavaScript after the fact, and several writes (`dashboard.ts`, `trigger.ts:226`) were keyed on `eq(id)` alone once a preceding `SELECT` had already checked the workspace — deleting that `SELECT` would silently let a write escape its workspace.

- Adds `services/workspace-resource.ts`, a sibling to `scoped-resource.ts`, with a registry-backed `resolveOwned`/`requireOwned`/`listOwned`/`updateOwned`/`deleteOwned`/`ownedWhere` for the flat Workspace-child types (Chat, Dashboard, Trigger, Webhook, Notification).
- Widget gets its own parallel set (`resolveOwnedWidget`, etc.) scoped by its parent Dashboard's id, mirroring `services/kanban.ts`'s `withinScope`.
- Sandbox — a one-per-workspace singleton with no `id` of its own — gets `resolveOwnedSandbox`/`requireOwnedSandbox`/`updateOwnedSandbox`/`deleteOwnedSandbox`.
- Attachment's composite `(resourceType, resourceId)` key doesn't fit the id-based shape, so it's left out of the registry; its two inline 404s are converted to thrown `NotFoundError` directly.
- Migrates all 7 affected route files, fixing the two specifically-reported write-side gaps and routing every "not found" branch through the typed `NotFoundError` that ADR-0010's `app.onError` already maps centrally.

Closes #494.

## Test plan

- [x] `pnpm --filter backend typecheck` passes
- [x] `pnpm --filter backend lint` passes
- [x] `pnpm --filter backend test` — 121 test files / 1837 tests pass
- [x] New `services/workspace-resource.test.ts` unit-tests the module directly
- [x] Ran a `/code-review` (standards + spec sub-agents) and fixed the findings: inconsistent inline-404 vs thrown-`NotFoundError` handling, and dashboard.ts's delete routes not using the module's own `deleteOwned`/`deleteOwnedWidget` helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)