### PR TITLE
feat(backend): collapse the three run drivers into runs/drive

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,10 @@ A configurable preset that pins a Provider, model, Instructions, generation para
 **Sub-Agent**:
 An Agent referenced by a parent Agent and exposed to it as a delegate Tool. Invoking it starts a run in its own right — bounded by the same per-step and per-run timeouts the parent turn was started under, and cancelled when the parent is — but never a Chat: nothing about a delegated run is persisted.
 
+**Drive**:
+Running a resolved turn's model loop inside a registered run, through to a terminal status. Takes one of three shapes according to who is waiting on it: an interactive **Chat turn**, a delegated **Sub-Agent**, or a headless Trigger. Whichever shape, the drive owns the model invocation and its stop conditions, the succeeded / failed / cancelled decision, and recording an **Output ceiling** cutoff; the entry point that asked for it keeps only the result shape it hands back to its own caller.
+_Avoid_: driver, run executor, generation loop.
+
 **Instructions**:
 The free-text behaviour brief a User writes on an Agent — or on a Chat with no Agent. One input to the System prompt rather than the whole of it: it renders as the first fragment and cannot suppress the Platypus-owned fragments that follow.
 _Avoid_: system prompt (that names the composed artefact), prompt, persona.

--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -1101,7 +1101,13 @@ describe("AgentRunner.stream — success & interruption", () => {
       ],
     });
     queue.end();
-    await tick();
+    // The run is finished by the drive once the background snapshot branch
+    // drains (and teardown disposes the turn, pushing the racing snapshot).
+    // Await that drain deterministically before reading the terminal sink write.
+    await vi.waitFor(
+      () => expect(runRegistry.has("s-late-snapshot")).toBe(false),
+      { timeout: 2_000 },
+    );
 
     const finish = sink.events.at(-1) as Extract<
       LifecycleEvent,

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -261,9 +261,10 @@ export class AgentRunner {
       agentId: state.turn!.resolved.agentId,
       generateMessageId: createIdGenerator({ prefix: "msg", size: 16 }),
       toolDurations,
-      // Interactive runs leave no-progress off — a human can stop those.
-      stopSnapshotsAfterFinal: true,
-      returnResponse: true,
+      // An interactive Chat turn: no-progress left off (a human can stop
+      // those), a stream error rendered inline rather than failing the run,
+      // and a client stream split off.
+      mode: "chat",
       onToolExecutionEnd: ({ toolCall, toolExecutionMs }) => {
         toolDurations.set(toolCall.toolCallId, toolExecutionMs);
       },

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -2,13 +2,8 @@ import {
   convertToModelMessages,
   createIdGenerator,
   createUIMessageStreamResponse,
-  generateText,
-  readUIMessageStream,
-  streamText,
 } from "ai";
-import { formatStreamError, isTruncatedByTokenLimit } from "./stream-error.ts";
-import { createMessageMetadata } from "./message-metadata.ts";
-import { applyToolDurations } from "./tool-durations.ts";
+import type { ModelMessage } from "ai";
 import {
   prepareChatTurn,
   validateTurnAttachments,
@@ -20,13 +15,7 @@ import { actorUserId, type WorkspaceScope } from "../scope.ts";
 import type { PlatypusUIMessage } from "../types.ts";
 import { runRegistry, type RunTimeouts } from "./run-registry.ts";
 import { startRun } from "./run-lifecycle.ts";
-import { buildModelInvocation } from "./run-plan.ts";
-import { computeStats } from "./run-stats.ts";
-import {
-  createNoProgressDetector,
-  NoProgressError,
-  type NoProgressDetector,
-} from "./no-progress.ts";
+import { driveOnce, driveStreamed } from "./drive.ts";
 import type {
   ResolvedRunPlan,
   RunId,
@@ -144,14 +133,11 @@ export class AgentRunner {
     origin?: string;
     frontendUrl?: string;
     timeouts?: RunTimeouts;
-    /**
-     * Unattended (trigger/scheduled) runs enable no-progress detection: a
-     * stuck model that re-issues the same call for the same result is aborted
-     * before it burns compute up to the step ceiling. Interactive runs leave
-     * it off — a human can stop those themselves.
-     */
-    unattended?: boolean;
-  }) {
+  }): Promise<{
+    state: RunState;
+    run: ReturnType<typeof startRun>;
+    modelMessages: ModelMessage[];
+  }> {
     const { scope, input, sink } = params;
 
     // File gate (issue #328): reject a turn carrying a file the target model
@@ -225,25 +211,12 @@ export class AgentRunner {
     const plan: ResolvedRunPlan = { resolved: state.turn.resolved };
     await sink.onResolved({ runId: input.runId, plan });
 
-    // Unattended runs gain a second stop condition alongside the step
-    // ceiling: when the model makes no progress (same call → same result,
-    // K times) the loop halts before issuing yet another wasteful step.
-    // `tripped()` is read after generation to record the run as failed.
-    const noProgress: NoProgressDetector | null = params.unattended
-      ? createNoProgressDetector()
-      : null;
+    // The conversation is converted once, here, and handed to whichever drive
+    // the caller picks — `stream` for an HTTP client, `generate` for a headless
+    // run. The drives own the model call and the terminal decision from there.
+    const modelMessages = await convertToModelMessages(state.turn.stream.messages);
 
-    // Built once and shared by both invocations, by the same assembly a
-    // delegated run uses.
-    const modelArgs = {
-      ...buildModelInvocation(state.turn.stream, {
-        abortSignal: run.handle.signal,
-        extraStopCondition: noProgress?.stopCondition,
-      }),
-      messages: await convertToModelMessages(state.turn.stream.messages),
-    };
-
-    return { state, run, modelArgs, noProgress };
+    return { state, run, modelMessages };
   }
 
   async stream(params: {
@@ -253,7 +226,7 @@ export class AgentRunner {
     options: StreamOptions;
   }): Promise<Response> {
     const { input, options } = params;
-    const { state, run, modelArgs } = await this.setup({
+    const { state, run, modelMessages } = await this.setup({
       scope: params.scope,
       input,
       sink: params.sink,
@@ -262,77 +235,57 @@ export class AgentRunner {
       timeouts: options.timeouts,
     });
 
-    logger.debug({ systemPrompt: modelArgs.system }, "System prompt for chat");
+    logger.debug(
+      { systemPrompt: state.turn?.stream.system },
+      "System prompt for chat",
+    );
 
     // How long each locally-executed tool took, keyed by `toolCallId`. The SDK
-    // has already measured it; we only hold onto it long enough to stamp it onto
-    // the outgoing chunks and onto the finished messages (see
-    // `injectToolDurations` and `applyToolDurations`). Provider-executed tools
+    // has already measured it; the drive holds it long enough to stamp it onto
+    // the finished messages (see `applyToolDurations`). Provider-executed tools
     // never reach this callback and so carry no duration.
     const toolDurations = new Map<string, number>();
 
-    // Whether `onFinish` has handed over the finished messages. The two branches
-    // of the tee below race: the source can finish while the snapshot branch
-    // still has chunks buffered, and disposing the turn is real I/O that gives
-    // that branch time to drain. A snapshot arriving after the handover is
-    // strictly worse than what it would overwrite — same content, minus the
-    // tool durations — so the snapshot stops writing once this is set.
-    let finalMessagesReceived = false;
-
-    const result = streamText({
-      ...modelArgs,
-      onStepFinish: (step) => run.onStep(step),
+    // The drive runs the model loop and folds the stream; this runner keeps
+    // only the teeing (one branch is the HTTP body, the other is drained to
+    // keep `state.messages` fresh for the sink's mid-run flush) and the
+    // response. Terminal status, the output-ceiling cutoff and the no-progress
+    // stop condition are all decided inside `runs/drive.ts`.
+    const drive = driveStreamed({
+      plan: state.turn!.stream,
+      modelMessages,
+      run,
+      originalMessages: input.messages,
+      agentId: state.turn!.resolved.agentId,
+      generateMessageId: createIdGenerator({ prefix: "msg", size: 16 }),
+      toolDurations,
+      // Interactive runs leave no-progress off — a human can stop those.
+      stopSnapshotsAfterFinal: true,
+      returnResponse: true,
       onToolExecutionEnd: ({ toolCall, toolExecutionMs }) => {
         toolDurations.set(toolCall.toolCallId, toolExecutionMs);
       },
-    });
-
-    // Build the UI message stream and tee it. The response body consumes
-    // one branch; we drain the other server-side so a disconnected
-    // client (cancelling the response branch) doesn't propagate back to
-    // the source. The source keeps pulling as long as the snapshot
-    // branch is being read, so `onFinish` only fires on natural
-    // completion — not when the consumer cancels with partial state.
-    const uiStream = result.toUIMessageStream<PlatypusUIMessage>({
-      originalMessages: input.messages,
-      generateMessageId: createIdGenerator({ prefix: "msg", size: 16 }),
-      messageMetadata: createMessageMetadata(
-        state.turn?.resolved.agentId,
-        toolDurations,
-      ),
-      onError: (error) => formatStreamError(error),
-      onFinish: async ({ messages: finalMessages }) => {
-        // Stamped onto the parts here as well as travelling out as metadata:
-        // this is the per-part form the persisted messages use, and the one a
-        // reload reads. Setting the flag first closes the snapshot branch's
-        // window to overwrite this, so the sink's terminal write observes it.
-        finalMessagesReceived = true;
-        state.messages = applyToolDurations(finalMessages, toolDurations);
-        const { status, error } = run.statusFromSignal();
-        await run.finish(status, error);
+      // The terminal finish (with tool durations applied) is what the sink's
+      // final write must observe.
+      onFinal: (messages) => {
+        state.messages = messages;
       },
     });
 
-    const [forResponse, forSnapshot] = uiStream.tee();
-
-    // Read the snapshot branch as message snapshots and keep `state.messages`
-    // up to date. ChatSink's FlushScheduler then writes the in-progress
-    // assistant message to the DB on each onProgress bump, so a user who
-    // reconnects mid-run sees the partial answer (not just their own
-    // input message).
+    // Consume the snapshot branch server-side. The response body drives one
+    // branch; we drain the other so a disconnected client (cancelling the
+    // response branch) doesn't propagate back to the source — the run keeps
+    // pulling as long as the snapshot branch is being read. The drive stops
+    // yielding after the final handover, so this never overwrites the folded
+    // final with a duration-less snapshot.
     void (async () => {
       try {
-        for await (const message of readUIMessageStream<PlatypusUIMessage>({
-          stream: forSnapshot,
-          onError: (err) =>
-            logger.error(
-              { err, runId: input.runId },
-              "Snapshot stream parse error",
-            ),
-        })) {
-          // Keep draining after the handover — the branch is still teed to a
-          // live source — but stop writing; `onFinish` has the better copy.
-          if (finalMessagesReceived) continue;
+        for await (const message of drive.snapshots) {
+          // Keep `state.messages` current so ChatSink's FlushScheduler writes
+          // the in-progress assistant message on each onProgress bump — a user
+          // who reconnects mid-run sees the partial answer. The drive stops
+          // yielding after the final handover, so this never overwrites the
+          // folded final with a duration-less snapshot.
           state.messages = [...input.messages, message];
         }
       } catch (err) {
@@ -340,10 +293,14 @@ export class AgentRunner {
           { err, runId: input.runId },
           "Server-side UI stream consumer error",
         );
+      } finally {
+        await drive.done;
       }
-    })();
+    })().catch((err) =>
+      logger.error({ err, runId: input.runId }, "Chat drive background error"),
+    );
 
-    return createUIMessageStreamResponse({ stream: forResponse });
+    return createUIMessageStreamResponse({ stream: drive.response! });
   }
 
   /**
@@ -359,92 +316,25 @@ export class AgentRunner {
     const { input } = params;
     const options = params.options ?? {};
     // No `origin`: headless callers don't have file URLs to inline.
-    // Headless runs are unattended → enable no-progress detection.
-    const { run, modelArgs, noProgress } = await this.setup({
+    const { state, run, modelMessages } = await this.setup({
       scope: params.scope,
       input,
       sink: params.sink,
       frontendUrl: options.frontendUrl,
       timeouts: options.timeouts,
+    });
+
+    // Headless runs are unattended → the drive enables no-progress detection.
+    // The drive computes the stats, records the output-ceiling cutoff, decides
+    // the terminal status and finishes the run — this entry point only returns.
+    const { text, stats } = await driveOnce({
+      plan: state.turn!.stream,
+      modelMessages,
+      run,
       unattended: true,
     });
 
-    const startTime = Date.now();
-    try {
-      const result = await generateText({
-        ...modelArgs,
-        onStepFinish: (step) => run.onStep(step),
-      });
-
-      const stats = computeStats(result as Parameters<typeof computeStats>[0]);
-      // The terminal finish only, as on the streamed path: a step inside a tool
-      // loop can end at the ceiling and the run still recover. Set before
-      // `finish`, which is what carries the run's stats to `sink.onFinish` —
-      // the sink's record is the only channel an unattended run has.
-      if (isTruncatedByTokenLimit(result.finishReason)) {
-        stats.truncatedByTokenLimit = true;
-      }
-      run.setStats(stats);
-
-      // The no-progress stop condition halts the loop cleanly (the SDK
-      // resolves normally), so the abort is surfaced here rather than via the
-      // catch path. Record the run as failed with a machine-readable reason.
-      const trip = noProgress?.tripped() ?? null;
-      if (trip) {
-        const err = new NoProgressError(trip.toolName, trip.count);
-        logger.warn(
-          {
-            runId: input.runId,
-            toolName: trip.toolName,
-            count: trip.count,
-            duration: Date.now() - startTime,
-            // Carried here too: this path returns before the completion log
-            // below, so without it a no-progress run records neither reason.
-            finishReason: result.finishReason,
-            rawFinishReason: result.rawFinishReason,
-            stats,
-          },
-          "Run aborted: no progress",
-        );
-        await run.finish("failed", err);
-        return { text: result.text, stats };
-      }
-
-      // Nobody is watching an unattended run, so this log is the only record
-      // of how it ended. Carry both reasons for the same reason `onStep` does.
-      logger.info(
-        {
-          runId: input.runId,
-          duration: Date.now() - startTime,
-          responseLength: result.text.length,
-          finishReason: result.finishReason,
-          rawFinishReason: result.rawFinishReason,
-          stats,
-        },
-        "Run generate completed",
-      );
-
-      await run.finish("succeeded");
-      return { text: result.text, stats };
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      logger.error(
-        {
-          error,
-          runId: input.runId,
-          duration: Date.now() - startTime,
-        },
-        "Run generate failed",
-      );
-      // A cancelled run is recorded as cancelled; a timed-out one stays a
-      // failure, and so does anything the model call threw on its own.
-      const aborted = run.statusFromSignal();
-      await run.finish(
-        aborted.status === "cancelled" ? "cancelled" : "failed",
-        err,
-      );
-      throw err;
-    }
+    return { text, stats };
   }
 }
 

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -15,7 +15,7 @@ import { actorUserId, type WorkspaceScope } from "../scope.ts";
 import type { PlatypusUIMessage } from "../types.ts";
 import { runRegistry, type RunTimeouts } from "./run-registry.ts";
 import { startRun } from "./run-lifecycle.ts";
-import { driveOnce, driveStreamed } from "./drive.ts";
+import { driveChat, driveOnce } from "./drive.ts";
 import type {
   ResolvedRunPlan,
   RunId,
@@ -136,6 +136,10 @@ export class AgentRunner {
   }): Promise<{
     state: RunState;
     run: ReturnType<typeof startRun>;
+    /** The resolved turn. Returned in its own right so a caller reads the plan
+     *  from here rather than re-narrowing `state.turn`, which stays optional
+     *  for the terminal callback that may run before it is assigned. */
+    turn: ChatTurn;
     modelMessages: ModelMessage[];
   }> {
     const { scope, input, sink } = params;
@@ -208,17 +212,16 @@ export class AgentRunner {
       throw err;
     }
 
-    const plan: ResolvedRunPlan = { resolved: state.turn.resolved };
+    const turn = state.turn;
+    const plan: ResolvedRunPlan = { resolved: turn.resolved };
     await sink.onResolved({ runId: input.runId, plan });
 
     // The conversation is converted once, here, and handed to whichever drive
     // the caller picks — `stream` for an HTTP client, `generate` for a headless
     // run. The drives own the model call and the terminal decision from there.
-    const modelMessages = await convertToModelMessages(
-      state.turn.stream.messages,
-    );
+    const modelMessages = await convertToModelMessages(turn.stream.messages);
 
-    return { state, run, modelMessages };
+    return { state, run, turn, modelMessages };
   }
 
   async stream(params: {
@@ -228,7 +231,7 @@ export class AgentRunner {
     options: StreamOptions;
   }): Promise<Response> {
     const { input, options } = params;
-    const { state, run, modelMessages } = await this.setup({
+    const { state, run, turn, modelMessages } = await this.setup({
       scope: params.scope,
       input,
       sink: params.sink,
@@ -238,7 +241,7 @@ export class AgentRunner {
     });
 
     logger.debug(
-      { systemPrompt: state.turn?.stream.system },
+      { systemPrompt: turn.stream.system },
       "System prompt for chat",
     );
 
@@ -248,23 +251,19 @@ export class AgentRunner {
     // never reach this callback and so carry no duration.
     const toolDurations = new Map<string, number>();
 
-    // The drive runs the model loop and folds the stream; this runner keeps
-    // only the teeing (one branch is the HTTP body, the other is drained to
-    // keep `state.messages` fresh for the sink's mid-run flush) and the
-    // response. Terminal status, the output-ceiling cutoff and the no-progress
-    // stop condition are all decided inside `runs/drive.ts`.
-    const drive = driveStreamed({
-      plan: state.turn!.stream,
+    // The drive runs the model loop, folds the stream and tees off the client
+    // branch; this runner keeps only the server-side drain (which keeps
+    // `state.messages` fresh for the sink's mid-run flush) and the response.
+    // Terminal status, the output-ceiling cutoff and the stop conditions are
+    // all decided inside `runs/drive.ts`.
+    const drive = driveChat({
+      plan: turn.stream,
       modelMessages,
       run,
       originalMessages: input.messages,
-      agentId: state.turn!.resolved.agentId,
+      agentId: turn.resolved.agentId,
       generateMessageId: createIdGenerator({ prefix: "msg", size: 16 }),
       toolDurations,
-      // An interactive Chat turn: no-progress left off (a human can stop
-      // those), a stream error rendered inline rather than failing the run,
-      // and a client stream split off.
-      mode: "chat",
       onToolExecutionEnd: ({ toolCall, toolExecutionMs }) => {
         toolDurations.set(toolCall.toolCallId, toolExecutionMs);
       },
@@ -278,9 +277,7 @@ export class AgentRunner {
     // Consume the snapshot branch server-side. The response body drives one
     // branch; we drain the other so a disconnected client (cancelling the
     // response branch) doesn't propagate back to the source — the run keeps
-    // pulling as long as the snapshot branch is being read. The drive stops
-    // yielding after the final handover, so this never overwrites the folded
-    // final with a duration-less snapshot.
+    // pulling as long as the snapshot branch is being read.
     void (async () => {
       try {
         for await (const message of drive.snapshots) {
@@ -303,7 +300,7 @@ export class AgentRunner {
       logger.error({ err, runId: input.runId }, "Chat drive background error"),
     );
 
-    return createUIMessageStreamResponse({ stream: drive.response! });
+    return createUIMessageStreamResponse({ stream: drive.response });
   }
 
   /**
@@ -319,7 +316,7 @@ export class AgentRunner {
     const { input } = params;
     const options = params.options ?? {};
     // No `origin`: headless callers don't have file URLs to inline.
-    const { state, run, modelMessages } = await this.setup({
+    const { run, turn, modelMessages } = await this.setup({
       scope: params.scope,
       input,
       sink: params.sink,
@@ -327,14 +324,12 @@ export class AgentRunner {
       timeouts: options.timeouts,
     });
 
-    // Headless runs are unattended → the drive enables no-progress detection.
     // The drive computes the stats, records the output-ceiling cutoff, decides
     // the terminal status and finishes the run — this entry point only returns.
     const { text, stats } = await driveOnce({
-      plan: state.turn!.stream,
+      plan: turn.stream,
       modelMessages,
       run,
-      unattended: true,
     });
 
     return { text, stats };

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -214,7 +214,9 @@ export class AgentRunner {
     // The conversation is converted once, here, and handed to whichever drive
     // the caller picks — `stream` for an HTTP client, `generate` for a headless
     // run. The drives own the model call and the terminal decision from there.
-    const modelMessages = await convertToModelMessages(state.turn.stream.messages);
+    const modelMessages = await convertToModelMessages(
+      state.turn.stream.messages,
+    );
 
     return { state, run, modelMessages };
   }

--- a/apps/backend/src/runs/drive.test.ts
+++ b/apps/backend/src/runs/drive.test.ts
@@ -33,7 +33,11 @@ const text = (id: string, ...deltas: string[]): LanguageModelV3StreamPart[] => [
   { type: "text-start", id },
   ...deltas.map((delta) => ({ type: "text-delta" as const, id, delta })),
   { type: "text-end", id },
-  { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage: USAGE },
+  {
+    type: "finish",
+    finishReason: { unified: "stop", raw: "stop" },
+    usage: USAGE,
+  },
 ];
 
 const modelOf = (...steps: LanguageModelV3StreamPart[][]) => {
@@ -116,7 +120,9 @@ describe("driveOnce", () => {
 
     const { stats } = await driveOnce({
       plan: planOf(
-        generatingModel({ finishReason: { unified: "length", raw: "max_tokens" } }),
+        generatingModel({
+          finishReason: { unified: "length", raw: "max_tokens" },
+        }),
       ),
       prompt: "hi",
       run,
@@ -263,7 +269,7 @@ describe("driveStreamed", () => {
 
   it("finishes as cancelled when the run is stopped mid-stream", async () => {
     const { run, outcome } = startRecordedRun();
-const drive = driveStreamed({
+    const drive = driveStreamed({
       plan: planOf(modelOf(text("t1", "gone in a flash"))),
       run,
       prompt: "hi",

--- a/apps/backend/src/runs/drive.test.ts
+++ b/apps/backend/src/runs/drive.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import type { Tool } from "ai";
 import type {
   LanguageModelV3GenerateResult,
   LanguageModelV3StreamPart,
 } from "@ai-sdk/provider";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { z } from "zod";
 import { startRun } from "./run-lifecycle.ts";
-import { runRegistry } from "./run-registry.ts";
-import { driveOnce, driveStreamed } from "./drive.ts";
+import { runRegistry, TimeoutError } from "./run-registry.ts";
+import { driveChat, driveDelegate, driveOnce } from "./drive.ts";
 import type { RunStatus } from "./types.ts";
 
 /**
@@ -14,8 +16,9 @@ import type { RunStatus } from "./types.ts";
  * These tests drive it with a *real* AI SDK pipeline and a mock model — no
  * `AgentRunner`, no delegate tool — to lock the unit: how a run ends
  * (succeeded / failed / cancelled), when the output-ceiling cutoff is
- * recorded, and how a streamed run reports its outcome. The `AgentRunner` and
- * sub-agent suites cover the wiring on top; this is the rule's floor.
+ * recorded, which stop conditions each entry point carries, and how a streamed
+ * run reports its outcome. The `AgentRunner` and sub-agent suites cover the
+ * wiring on top; this is the rule's floor.
  */
 
 const USAGE = {
@@ -74,12 +77,75 @@ const generatingModel = (
     } as LanguageModelV3GenerateResult,
   });
 
+const STUCK_TOOL = "probe";
+
+/**
+ * A model that re-issues the same tool call, with the same arguments, forever
+ * — the shape the no-progress detector exists to stop. Each call carries a
+ * fresh `toolCallId` (the SDK wants them unique); the detector keys on tool
+ * name + arguments + result, so the repeats still collide.
+ */
+const stuckStreamingModel = () => {
+  let index = 0;
+  return new MockLanguageModelV3({
+    doStream: () => {
+      const id = `tc${(index += 1)}`;
+      return Promise.resolve({
+        stream: simulateReadableStream({
+          chunks: [
+            { type: "stream-start", warnings: [] },
+            { type: "tool-input-start", id, toolName: STUCK_TOOL },
+            { type: "tool-input-end", id },
+            {
+              type: "tool-call",
+              toolCallId: id,
+              toolName: STUCK_TOOL,
+              input: "{}",
+            },
+            {
+              type: "finish",
+              finishReason: { unified: "tool-calls", raw: "tool_calls" },
+              usage: USAGE,
+            },
+          ],
+        }),
+      });
+    },
+  });
+};
+
+/** The same stuck loop on the `generateText` path. */
+const stuckGeneratingModel = () => {
+  let index = 0;
+  return new MockLanguageModelV3({
+    doGenerate: () => {
+      const id = `tc${(index += 1)}`;
+      return Promise.resolve({
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: id,
+            toolName: STUCK_TOOL,
+            input: "{}",
+          },
+        ],
+        finishReason: { unified: "tool-calls", raw: "tool_calls" },
+        usage: USAGE,
+      } as unknown as LanguageModelV3GenerateResult);
+    },
+  });
+};
+
 /** A run observed only by recording how it ended. */
-const startRecordedRun = () => {
+const startRecordedRun = (timeouts?: {
+  perStepTimeoutMs?: number;
+  perRunTimeoutMs?: number;
+}) => {
   const outcome: Array<{ status: RunStatus; error?: Error; stats: unknown }> =
     [];
   const run = startRun({
     runId: `drive-${Math.random().toString(36).slice(2)}`,
+    timeouts,
     onTerminate: ({ status, error, stats }) => {
       outcome.push({ status, error, stats });
     },
@@ -91,6 +157,21 @@ const planOf = (model: MockLanguageModelV3) => ({
   model,
   tools: {},
   maxSteps: 3,
+});
+
+/**
+ * The stuck plan's ceiling sits well above the detector's threshold (3 repeats)
+ * so a trip is unambiguously the detector's doing and not the step ceiling's.
+ */
+const stuckPlanOf = (model: MockLanguageModelV3) => ({
+  model,
+  tools: {
+    [STUCK_TOOL]: {
+      inputSchema: z.object({}),
+      execute: () => Promise.resolve("the same answer every time"),
+    },
+  } as unknown as Record<string, Tool>,
+  maxSteps: 12,
 });
 
 describe("driveOnce", () => {
@@ -105,7 +186,6 @@ describe("driveOnce", () => {
       plan: planOf(generatingModel()),
       run,
       prompt: "hi",
-      unattended: true,
     });
 
     expect(textOut).toBe("ok");
@@ -126,7 +206,6 @@ describe("driveOnce", () => {
       ),
       prompt: "hi",
       run,
-      unattended: true,
     });
 
     expect(stats.truncatedByTokenLimit).toBe(true);
@@ -142,7 +221,7 @@ describe("driveOnce", () => {
     });
 
     await expect(
-      driveOnce({ plan: planOf(model), run, prompt: "hi", unattended: true }),
+      driveOnce({ plan: planOf(model), run, prompt: "hi" }),
     ).rejects.toThrow("provider exploded");
 
     expect(outcome).toHaveLength(1);
@@ -161,28 +240,41 @@ describe("driveOnce", () => {
         }),
     });
 
-    const inflight = driveOnce({
-      plan: planOf(model),
-      run,
-      prompt: "hi",
-      unattended: true,
-    });
+    const inflight = driveOnce({ plan: planOf(model), run, prompt: "hi" });
     await new Promise((r) => setTimeout(r, 0));
     runRegistry.cancel(run.handle.runId);
 
     await expect(inflight).rejects.toThrow();
     expect(outcome[0].status).toBe("cancelled");
   });
+
+  // A headless run is unattended, so the stop condition that halts a model
+  // burning its step ceiling on a call that never changes is always on.
+  it("finishes as failed with a no-progress error when the model stops progressing", async () => {
+    const { run, outcome } = startRecordedRun();
+
+    await driveOnce({
+      plan: stuckPlanOf(stuckGeneratingModel()),
+      run,
+      prompt: "hi",
+    });
+
+    expect(outcome[0].status).toBe("failed");
+    expect(outcome[0].error?.name).toBe("NoProgressError");
+    expect(outcome[0].error?.message).toMatch(
+      new RegExp(`no_progress:.*${STUCK_TOOL}`),
+    );
+  });
 });
 
-describe("driveStreamed", () => {
+describe("driveDelegate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("consumes the stream, keeps the latest message and finishes succeeded", async () => {
     const { run, outcome } = startRecordedRun();
-    const drive = driveStreamed({
+    const drive = driveDelegate({
       plan: planOf(modelOf(text("t1", "Hello", " world"))),
       run,
       prompt: "hi",
@@ -202,6 +294,7 @@ describe("driveStreamed", () => {
       .join("");
     expect(textOut).toBe("Hello world");
     expect(result.failure).toBeUndefined();
+    expect(result.status).toBe("succeeded");
     expect(outcome[0].status).toBe("succeeded");
   });
 
@@ -225,11 +318,7 @@ describe("driveStreamed", () => {
           }),
         }),
     });
-    const drive = driveStreamed({
-      plan: planOf(model),
-      run,
-      prompt: "hi",
-    });
+    const drive = driveDelegate({ plan: planOf(model), run, prompt: "hi" });
     for await (const _ of drive.snapshots) void _;
     const result = await drive.done;
 
@@ -237,38 +326,24 @@ describe("driveStreamed", () => {
     expect(outcome[0].stats).toMatchObject({ truncatedByTokenLimit: true });
   });
 
-  it("fails the run and reports the failure when a fail-on-error drive hits a stream error", async () => {
+  it("fails the run and reports the failure when its stream hits an error", async () => {
     const { run, outcome } = startRecordedRun();
-    const model = new MockLanguageModelV3({
-      doStream: () =>
-        Promise.resolve({
-          stream: simulateReadableStream({
-            chunks: [
-              { type: "stream-start", warnings: [] },
-              { type: "text-start", id: "t1" },
-              { type: "text-delta", id: "t1", delta: "I'll try" },
-              { type: "text-end", id: "t1" },
-              { type: "error", error: new Error("upstream reset") },
-            ],
-          }),
-        }),
-    });
-    const drive = driveStreamed({
-      plan: planOf(model),
+    const drive = driveDelegate({
+      plan: planOf(errorAfterText("upstream reset")),
       run,
       prompt: "hi",
-      mode: "delegate",
     });
     for await (const _ of drive.snapshots) void _;
     const result = await drive.done;
 
     expect(result.failure).toMatch(/upstream reset/);
+    expect(result.status).toBe("failed");
     expect(outcome[0].status).toBe("failed");
   });
 
   it("finishes as cancelled when the run is stopped mid-stream", async () => {
     const { run, outcome } = startRecordedRun();
-    const drive = driveStreamed({
+    const drive = driveDelegate({
       plan: planOf(modelOf(text("t1", "gone in a flash"))),
       run,
       prompt: "hi",
@@ -279,7 +354,131 @@ describe("driveStreamed", () => {
     for await (const _ of drive.snapshots) void _;
 
     const result = await drive.done;
-    expect(result.failure).toBeUndefined();
+    // Reported, not re-derived: the delegate tool logs a cancellation
+    // differently from a fault and reads the status from here to tell them
+    // apart.
+    expect(result.status).toBe("cancelled");
+    expect(result.failure).toMatch(/Stopped before finishing/);
     expect(outcome[0].status).toBe("cancelled");
   });
+
+  // Issue #496: a delegated run is unattended, so it drives under the same
+  // no-progress stop condition a Trigger run has.
+  it("finishes as failed with a no-progress error when the model stops progressing", async () => {
+    const { run, outcome } = startRecordedRun();
+    const drive = driveDelegate({
+      plan: stuckPlanOf(stuckStreamingModel()),
+      run,
+      prompt: "hi",
+    });
+    for await (const _ of drive.snapshots) void _;
+    const result = await drive.done;
+
+    expect(result.status).toBe("failed");
+    expect(result.failure).toMatch(new RegExp(`no_progress:.*${STUCK_TOOL}`));
+    expect(outcome[0].error?.name).toBe("NoProgressError");
+  });
+
+  // A run that both timed out and reported a stream error is better explained
+  // by the error: the parent Agent is told what broke, while the run itself
+  // still records the `TimeoutError` naming the bound that was exceeded.
+  it("reports the stream error, not the stop reason, when a timed-out run also errored", async () => {
+    const { run, outcome } = startRecordedRun({
+      perRunTimeoutMs: 20,
+      perStepTimeoutMs: 60_000,
+    });
+    const drive = driveDelegate({
+      plan: planOf(errorThenEndOnAbort("upstream reset", run.handle.signal)),
+      run,
+      prompt: "hi",
+    });
+    for await (const _ of drive.snapshots) void _;
+    const result = await drive.done;
+
+    expect(result.failure).toMatch(/upstream reset/);
+    expect(result.failure).not.toMatch(/Stopped before finishing/);
+    expect(outcome[0].status).toBe("failed");
+    expect(outcome[0].error).toBeInstanceOf(TimeoutError);
+  });
 });
+
+describe("driveChat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hands back a client stream branch alongside the snapshots", async () => {
+    const { run } = startRecordedRun();
+    const drive = driveChat({
+      plan: planOf(modelOf(text("t1", "Hi"))),
+      run,
+      modelMessages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(drive.response).toBeInstanceOf(ReadableStream);
+    for await (const _ of drive.snapshots) void _;
+    await drive.done;
+    await drive.response.cancel();
+  });
+
+  // The interactive counterpart of the delegate rule above: a Chat turn renders
+  // a stream error inline (it is already in the folded message the client is
+  // watching), so the run itself is not failed and the caller is told nothing
+  // to throw on.
+  it("does not fail the run when its stream hits an error", async () => {
+    const { run, outcome } = startRecordedRun();
+    const drive = driveChat({
+      plan: planOf(errorAfterText("upstream reset")),
+      run,
+      modelMessages: [{ role: "user", content: "hi" }],
+    });
+    for await (const _ of drive.snapshots) void _;
+    const result = await drive.done;
+    await drive.response.cancel();
+
+    expect(result.failure).toBeUndefined();
+    expect(result.status).toBe("succeeded");
+    expect(outcome[0].status).toBe("succeeded");
+  });
+});
+
+const errorParts = (message: string): LanguageModelV3StreamPart[] => [
+  { type: "stream-start", warnings: [] },
+  { type: "text-start", id: "t1" },
+  { type: "text-delta", id: "t1", delta: "I'll try" },
+  { type: "text-end", id: "t1" },
+  { type: "error", error: new Error(message) },
+];
+
+/** A model that emits some text and then an error part mid-stream. */
+function errorAfterText(message: string) {
+  return new MockLanguageModelV3({
+    doStream: () =>
+      Promise.resolve({
+        stream: simulateReadableStream({ chunks: errorParts(message) }),
+      }),
+  });
+}
+
+/**
+ * The same error, on a stream that stays open until the run is aborted — so
+ * the run is still in flight when its per-run timeout fires, and the drive
+ * settles with both a stream error and a `TimeoutError` on the table. The race
+ * is real but narrow in production; pinning it here makes the precedence
+ * between the two explicit rather than incidental.
+ */
+function errorThenEndOnAbort(message: string, signal: AbortSignal) {
+  return new MockLanguageModelV3({
+    doStream: () =>
+      Promise.resolve({
+        stream: new ReadableStream<LanguageModelV3StreamPart>({
+          start(controller) {
+            for (const part of errorParts(message)) controller.enqueue(part);
+            signal.addEventListener("abort", () => controller.close(), {
+              once: true,
+            });
+          },
+        }),
+      }),
+  });
+}

--- a/apps/backend/src/runs/drive.test.ts
+++ b/apps/backend/src/runs/drive.test.ts
@@ -257,8 +257,7 @@ describe("driveStreamed", () => {
       plan: planOf(model),
       run,
       prompt: "hi",
-      failOnStreamError: true,
-      unattended: true,
+      mode: "delegate",
     });
     for await (const _ of drive.snapshots) void _;
     const result = await drive.done;

--- a/apps/backend/src/runs/drive.test.ts
+++ b/apps/backend/src/runs/drive.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type {
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamPart,
+} from "@ai-sdk/provider";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
+import { startRun } from "./run-lifecycle.ts";
+import { runRegistry } from "./run-registry.ts";
+import { driveOnce, driveStreamed } from "./drive.ts";
+import type { RunStatus } from "./types.ts";
+
+/**
+ * The drive is the seam that owns the model drill and the terminal decision.
+ * These tests drive it with a *real* AI SDK pipeline and a mock model — no
+ * `AgentRunner`, no delegate tool — to lock the unit: how a run ends
+ * (succeeded / failed / cancelled), when the output-ceiling cutoff is
+ * recorded, and how a streamed run reports its outcome. The `AgentRunner` and
+ * sub-agent suites cover the wiring on top; this is the rule's floor.
+ */
+
+const USAGE = {
+  inputTokens: {
+    total: 10,
+    noCache: 10,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: { total: 4, text: 4, reasoning: undefined },
+};
+
+const text = (id: string, ...deltas: string[]): LanguageModelV3StreamPart[] => [
+  { type: "stream-start", warnings: [] },
+  { type: "text-start", id },
+  ...deltas.map((delta) => ({ type: "text-delta" as const, id, delta })),
+  { type: "text-end", id },
+  { type: "finish", finishReason: { unified: "stop", raw: "stop" }, usage: USAGE },
+];
+
+const modelOf = (...steps: LanguageModelV3StreamPart[][]) => {
+  let index = 0;
+  return new MockLanguageModelV3({
+    doStream: () => {
+      const parts = steps[Math.min(index, steps.length - 1)];
+      index += 1;
+      return Promise.resolve({
+        stream: simulateReadableStream({ chunks: parts }),
+      });
+    },
+  });
+};
+
+/** A model backing the non-streamed `generateText` path. */
+const generatingModel = (
+  overrides: Partial<LanguageModelV3GenerateResult> = {},
+): MockLanguageModelV3 =>
+  new MockLanguageModelV3({
+    doGenerate: {
+      content: [{ type: "text", text: "ok" }],
+      finishReason: { unified: "stop", raw: "stop" },
+      usage: {
+        inputTokens: {
+          total: 10,
+          noCache: 10,
+          cacheRead: undefined,
+          cacheWrite: undefined,
+        },
+        outputTokens: { total: 4, text: 4, reasoning: undefined },
+      },
+      ...overrides,
+    } as LanguageModelV3GenerateResult,
+  });
+
+/** A run observed only by recording how it ended. */
+const startRecordedRun = () => {
+  const outcome: Array<{ status: RunStatus; error?: Error; stats: unknown }> =
+    [];
+  const run = startRun({
+    runId: `drive-${Math.random().toString(36).slice(2)}`,
+    onTerminate: ({ status, error, stats }) => {
+      outcome.push({ status, error, stats });
+    },
+  });
+  return { run, outcome };
+};
+
+const planOf = (model: MockLanguageModelV3) => ({
+  model,
+  tools: {},
+  maxSteps: 3,
+});
+
+describe("driveOnce", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the text and stats and finishes the run as succeeded", async () => {
+    const { run, outcome } = startRecordedRun();
+
+    const { text: textOut, stats } = await driveOnce({
+      plan: planOf(generatingModel()),
+      run,
+      prompt: "hi",
+      unattended: true,
+    });
+
+    expect(textOut).toBe("ok");
+    expect(stats.steps).toBe(1);
+    expect(outcome).toHaveLength(1);
+    expect(outcome[0].status).toBe("succeeded");
+    expect(runRegistry.has(run.handle.runId)).toBe(false);
+  });
+
+  it("records the output ceiling cutoff on the run's stats", async () => {
+    const { run, outcome } = startRecordedRun();
+
+    const { stats } = await driveOnce({
+      plan: planOf(
+        generatingModel({ finishReason: { unified: "length", raw: "max_tokens" } }),
+      ),
+      prompt: "hi",
+      run,
+      unattended: true,
+    });
+
+    expect(stats.truncatedByTokenLimit).toBe(true);
+    expect(outcome[0].stats).toMatchObject({ truncatedByTokenLimit: true });
+  });
+
+  it("finishes as failed and rethrows when the model call throws", async () => {
+    const { run, outcome } = startRecordedRun();
+    const model = new MockLanguageModelV3({
+      doGenerate: () => {
+        throw new Error("provider exploded");
+      },
+    });
+
+    await expect(
+      driveOnce({ plan: planOf(model), run, prompt: "hi", unattended: true }),
+    ).rejects.toThrow("provider exploded");
+
+    expect(outcome).toHaveLength(1);
+    expect(outcome[0].status).toBe("failed");
+    expect(outcome[0].error?.message).toBe("provider exploded");
+  });
+
+  it("finishes as cancelled when the run is stopped while generating", async () => {
+    const { run, outcome } = startRecordedRun();
+    const model = new MockLanguageModelV3({
+      doGenerate: () =>
+        new Promise<never>((_, reject) => {
+          run.handle.signal.addEventListener("abort", () =>
+            reject(run.handle.signal.reason ?? new Error("aborted")),
+          );
+        }),
+    });
+
+    const inflight = driveOnce({
+      plan: planOf(model),
+      run,
+      prompt: "hi",
+      unattended: true,
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    runRegistry.cancel(run.handle.runId);
+
+    await expect(inflight).rejects.toThrow();
+    expect(outcome[0].status).toBe("cancelled");
+  });
+});
+
+describe("driveStreamed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("consumes the stream, keeps the latest message and finishes succeeded", async () => {
+    const { run, outcome } = startRecordedRun();
+    const drive = driveStreamed({
+      plan: planOf(modelOf(text("t1", "Hello", " world"))),
+      run,
+      prompt: "hi",
+    });
+
+    const seen: unknown[] = [];
+    for await (const message of drive.snapshots) seen.push(message);
+    const result = await drive.done;
+
+    // readUIMessageStream re-emits the message as its parts accumulate, so a
+    // single answer lands as several progressive snapshots.
+    expect(seen.length).toBeGreaterThan(0);
+    const parts = result.latest?.parts ?? [];
+    const textOut = parts
+      .filter((p) => p.type === "text")
+      .map((p) => p.text)
+      .join("");
+    expect(textOut).toBe("Hello world");
+    expect(result.failure).toBeUndefined();
+    expect(outcome[0].status).toBe("succeeded");
+  });
+
+  it("flags the run when the terminal finish hit the output ceiling", async () => {
+    const { run, outcome } = startRecordedRun();
+    const model = new MockLanguageModelV3({
+      doStream: () =>
+        Promise.resolve({
+          stream: simulateReadableStream({
+            chunks: [
+              { type: "stream-start", warnings: [] },
+              { type: "text-start", id: "t1" },
+              { type: "text-delta", id: "t1", delta: "half" },
+              { type: "text-end", id: "t1" },
+              {
+                type: "finish",
+                finishReason: { unified: "length", raw: "max_tokens" },
+                usage: USAGE,
+              },
+            ],
+          }),
+        }),
+    });
+    const drive = driveStreamed({
+      plan: planOf(model),
+      run,
+      prompt: "hi",
+    });
+    for await (const _ of drive.snapshots) void _;
+    const result = await drive.done;
+
+    expect(result.truncated).toBe(true);
+    expect(outcome[0].stats).toMatchObject({ truncatedByTokenLimit: true });
+  });
+
+  it("fails the run and reports the failure when a fail-on-error drive hits a stream error", async () => {
+    const { run, outcome } = startRecordedRun();
+    const model = new MockLanguageModelV3({
+      doStream: () =>
+        Promise.resolve({
+          stream: simulateReadableStream({
+            chunks: [
+              { type: "stream-start", warnings: [] },
+              { type: "text-start", id: "t1" },
+              { type: "text-delta", id: "t1", delta: "I'll try" },
+              { type: "text-end", id: "t1" },
+              { type: "error", error: new Error("upstream reset") },
+            ],
+          }),
+        }),
+    });
+    const drive = driveStreamed({
+      plan: planOf(model),
+      run,
+      prompt: "hi",
+      failOnStreamError: true,
+      unattended: true,
+    });
+    for await (const _ of drive.snapshots) void _;
+    const result = await drive.done;
+
+    expect(result.failure).toMatch(/upstream reset/);
+    expect(outcome[0].status).toBe("failed");
+  });
+
+  it("finishes as cancelled when the run is stopped mid-stream", async () => {
+    const { run, outcome } = startRecordedRun();
+const drive = driveStreamed({
+      plan: planOf(modelOf(text("t1", "gone in a flash"))),
+      run,
+      prompt: "hi",
+    });
+    // Stopped before it is consumed: the model stream still completes, and the
+    // signal is the only record that the run was cancelled rather than finished.
+    runRegistry.cancel(run.handle.runId);
+    for await (const _ of drive.snapshots) void _;
+
+    const result = await drive.done;
+    expect(result.failure).toBeUndefined();
+    expect(outcome[0].status).toBe("cancelled");
+  });
+});

--- a/apps/backend/src/runs/drive.ts
+++ b/apps/backend/src/runs/drive.ts
@@ -28,106 +28,75 @@ import type { RunStats, RunStatus } from "./types.ts";
 /**
  * The model call inside a registered run.
  *
- * This module is the single place that *drives* a run to its terminal state —
- * every entry point that turns a prompt or a Chat history into a model answer
- * goes through one of these two functions. What used to be re-derived in three
- * places (two paths in `AgentRunner`, plus the delegate tool) now lives here:
+ * Every entry point that turns a prompt or a Chat history into a model answer
+ * drives it from here, so the rules that hold for all of them are stated once:
+ * how the invocation is assembled (step ceiling and stop conditions), which
+ * terminal status the run ends with, and when the output-ceiling cutoff is
+ * recorded on its stats.
  *
- * - building the model invocation (`buildModelInvocation`, step ceiling and
- *   the no-progress stop condition included),
- * - the terminal-status decision (succeeded / failed / cancelled),
- * - recording the output-ceiling cutoff (`truncatedByTokenLimit`) once, on
- *   the run's stats,
- * - ending the run.
+ * Three entry points, one per shape a caller needs:
  *
- * `driveStreamed` is for the `streamText` path — a Chat turn (which tees a
- * client stream) and a delegated sub-Agent (which folds the snapshots into an
- * activity log). It exposes the folded messages as an async iterable the
- * caller consumes, plus a `done` promise with the outcome, so a caller that
- * must *yield* per snapshot (the delegate tool) and one that must hand the
- * stream to a client immediately (the Chat route) each keep their own pacing.
+ * - `driveChat` — an interactive Chat turn. Splits off a client stream, renders
+ *   a stream error inline rather than failing the run, and stops yielding
+ *   snapshots once the terminal finish has handed its folded messages over.
+ * - `driveDelegate` — an unattended, delegated sub-Agent. Gains the no-progress
+ *   stop condition, fails when its stream reports an error (so a crash is never
+ *   read as the finding), and yields every snapshot into the caller's activity
+ *   log.
+ * - `driveOnce` — the headless `generateText` path (Triggers). Unattended by
+ *   construction; returns a single answer plus the computed stats.
  *
- * `driveOnce` is for the tail-free `generateText` path (Trigger runs), which
- * returns a single text answer and the computed stats.
+ * Both streamed drives expose the folded messages as an async iterable plus a
+ * `done` outcome, so a caller that must *yield* per snapshot and one that must
+ * hand a stream to a client immediately each keep their own pacing.
  */
 
 /**
- * Which shape a streamed drive takes. The two callers converge on two frozen
- * combinations of the pacing and failure knobs, so those are captured here as
- * a single intent instead of four independent flags a caller can scramble.
- *
- * - `"chat"` — an interactive Chat turn. Tolerates a stream error (renders it
- *   inline), splits off a client stream branch, and stops yielding snapshots
- *   once the terminal finish has handed its folded messages over.
- * - `"delegate"` — an unattended, delegated sub-Agent. Gains the no-progress
- *   stop condition, fails when its stream reports an error (so the generated
- *   answer is never read as the finding), and yields every snapshot into the
- *   caller's activity log.
+ * The conversation, in the one form its caller holds it: a delegated run has a
+ * single task `prompt`, a Chat turn has already-converted `modelMessages`. A
+ * union rather than two optionals, so a caller cannot pass both or neither.
  */
-export type StreamedDriveMode = "chat" | "delegate";
+export type DriveConversation =
+  | { prompt: string; modelMessages?: never }
+  | { prompt?: never; modelMessages: ModelMessage[] };
 
-type DriveModeBehavior = {
-  unattended: boolean;
-  failOnStreamError: boolean;
-  stopSnapshotsAfterFinal: boolean;
-  returnResponse: boolean;
-};
-
-const MODE_BEHAVIOR: Record<StreamedDriveMode, DriveModeBehavior> = {
-  chat: {
-    unattended: false,
-    failOnStreamError: false,
-    stopSnapshotsAfterFinal: true,
-    returnResponse: true,
-  },
-  delegate: {
-    unattended: true,
-    failOnStreamError: true,
-    stopSnapshotsAfterFinal: false,
-    returnResponse: false,
-  },
-};
-
-/**
- * A streamed drive's inputs. `plan` carries the generation settings plus, for
- * a Chat turn, the folded conversation under `messages`; a delegated run hands
- * the conversation as a single `prompt` instead. The two are mutually
- * exclusive.
- */
-export type StreamedDriveOptions = {
+/** What every drive needs, whichever shape it takes. */
+type DriveBase = {
   plan: RunPlan;
   run: RunLifecycle;
-  /** A single user prompt — the whole conversation of a delegated sub-Agent. */
-  prompt?: string;
-  /** A Chat turn's conversation, already converted to model messages. */
-  modelMessages?: ModelMessage[];
-  /** The opening messages a Chat turn folds its streamed answer onto. */
-  originalMessages?: PlatypusUIMessage[];
-  /** The resolved Agent id, stamped onto the streamed message. */
-  agentId?: string;
-  generateMessageId?: () => string;
-  /** The live map the caller fills from `onToolExecutionEnd`. */
-  toolDurations?: Map<string, number>;
-  /**
-   * Whether this is an interactive Chat turn or an unattended delegated
-   * sub-Agent. Defaults to `"chat"`.
-   */
-  mode?: StreamedDriveMode;
-  /** Hooked before the run folds the step, so the caller can read what it can't
-   *  otherwise recover (e.g. the provider's raw finish reason). */
-  onStepFinish?: (step: RunStep) => void;
-  onToolExecutionEnd?: (ctx: {
-    toolCall: { toolCallId: string };
-    toolExecutionMs: number;
-  }) => void;
-  /** The folded final messages (tool durations applied), right before the run
-   *  ends. The Chat turn persists these; the sink's terminal write observes
-   *  them. */
-  onFinal?: (messages: PlatypusUIMessage[]) => void;
 };
 
-/** What a `driveStreamed` run settled on. */
+/** The conversation as the SDK takes it — exactly one of the two keys. */
+const conversationArgs = (conversation: DriveConversation) =>
+  conversation.prompt !== undefined
+    ? { prompt: conversation.prompt }
+    : { messages: conversation.modelMessages };
+
+/**
+ * The arguments every drive hands the SDK: the shared assembly (model, tools,
+ * system, ceilings, sampling), this run's abort signal, the unattended stop
+ * condition when there is one, and the conversation.
+ */
+const modelArgs = (
+  opts: DriveBase & DriveConversation,
+  noProgress: NoProgressDetector | null,
+) => ({
+  ...buildModelInvocation(opts.plan, {
+    abortSignal: opts.run.handle.signal,
+    extraStopCondition: noProgress?.stopCondition,
+  }),
+  ...conversationArgs(opts),
+});
+
+/** An unattended run gets the no-progress detector; an attended one does not. */
+const detectorFor = (unattended: boolean): NoProgressDetector | null =>
+  unattended ? createNoProgressDetector() : null;
+
+/** What a streamed drive settled on. */
 export type StreamedDriveResult = {
+  /** The terminal status the run was finished with. Reported so a caller that
+   *  must tell a cancellation from a fault never re-derives one. */
+  status: RunStatus;
   /** The Chat turn's final folded messages (tool durations applied). */
   messages?: PlatypusUIMessage[];
   /** The last snapshot seen — the delegate's final assistant message. */
@@ -136,28 +105,9 @@ export type StreamedDriveResult = {
    *  clean finish. */
   failure?: string;
   /** The terminal finish hit the model's output ceiling. */
-  truncated?: boolean;
+  truncated: boolean;
 };
 
-type StreamedDrive = {
-  /** The folded assistant messages. Consuming this is what drains the run. */
-  snapshots: AsyncIterable<PlatypusUIMessage>;
-  /** A client stream branch, present in `"chat"` mode (a Chat turn). */
-  response?: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>>;
-  /** Resolves once the run has ended, with the drive's outcome. */
-  done: Promise<StreamedDriveResult>;
-};
-
-/**
- * The one terminal-status rule, in a registered run's terms.
- *
- * Shared by both drivers so neither re-derives "did we succeed?" from the
- * stream or result it happened to be driving. Decides the status (and, where a
- * failure is reported, the caller-facing sentence) an ended run should carry:
- * a single no-progress trip or, on a fail-on-error drive, a stream failure
- * ends the run as a failure; a run somebody stopped ends it as cancelled; a
- * timeout stays a failure with its `TimeoutError`; anything else is a success.
- */
 type TerminalDecision = {
   status: RunStatus;
   error?: Error;
@@ -165,6 +115,14 @@ type TerminalDecision = {
   failure?: string;
 };
 
+/**
+ * The one terminal-status rule, in a registered run's terms.
+ *
+ * Decides the status an ended run carries, the error it records, and — for a
+ * drive that treats a stream error as fatal — the sentence its caller is told.
+ * Every drive ends through this, so none re-derives "did we succeed?" from the
+ * stream or result it happened to be holding.
+ */
 const decideTerminalStatus = (
   run: RunLifecycle,
   opts: {
@@ -174,88 +132,128 @@ const decideTerminalStatus = (
   },
 ): TerminalDecision => {
   const trip = opts.noProgress?.tripped() ?? null;
-
   if (trip) {
     const err = new NoProgressError(trip.toolName, trip.count);
     return { status: "failed", error: err, failure: err.message };
   }
+
   const { status, error } = run.statusFromSignal();
-  // A timed-out run keeps its TimeoutError rather than whichever stream error
-  // also landed: the timeout names the bound that was exceeded.
-  if (opts.failOnStreamError && opts.failure && status !== "failed") {
-    const err = new Error(opts.failure);
-    return {
-      status: status === "cancelled" ? "cancelled" : "failed",
-      error: status === "cancelled" ? (error ?? err) : err,
-      failure: opts.failure,
-    };
-  }
-  // A fail-on-error drive that stopped mid-stream reports why it stopped, so
-  // the caller (a delegate's parent) can tell a stop from a finished answer.
-  const failure =
-    opts.failOnStreamError && run.handle.signal.aborted
-      ? run.abortReason()
-        ? `Stopped before finishing: ${run.abortReason()}`
-        : "Stopped before finishing."
-      : undefined;
-  return { status, error, failure };
+  if (!opts.failOnStreamError) return { status, error };
+
+  // What the stream reported outranks why we stopped: a run that both timed out
+  // and reported an error is better explained by the error. Absent one, a run
+  // that stopped mid-stream still owes its caller a reason it ended short — a
+  // delegate's parent has to tell a stop from a finished answer.
+  const stoppedShort = run.handle.signal.aborted
+    ? run.abortReason()
+      ? `Stopped before finishing: ${run.abortReason()}`
+      : "Stopped before finishing."
+    : undefined;
+  const failure = opts.failure ?? stoppedShort;
+  if (!failure) return { status, error };
+
+  // A timed-out or cancelled run keeps the signal's own error: the timeout
+  // names the bound that was exceeded, and a cancellation names who stopped it.
+  // A failure only the stream saw becomes the run's error.
+  return status === "succeeded"
+    ? { status: "failed", error: new Error(failure), failure }
+    : { status, error, failure };
 };
 
 /**
- * Ends a streamed run with the terminal-status decision and the caller-facing
- * reason for a non-clean end, computed once. The run's status and the returned
- * outcome stay consistent by construction: the failure the caller is told is
- * exactly the one the run was finished with.
+ * Ends a run that failed before any drive started — a delegate's tool setup
+ * throwing is the case that exists — under the terminal-status rule a drive
+ * would have applied, so that caller does not grow its own copy.
  */
-const endStreamedRun = async (
+export const failBeforeDrive = async (
   run: RunLifecycle,
-  opts: {
-    failure?: string;
-    noProgress: NoProgressDetector | null;
-    failOnStreamError: boolean;
-  },
-): Promise<TerminalDecision> => {
-  const decision = decideTerminalStatus(run, opts);
+  failure: string,
+): Promise<StreamedDriveResult> => {
+  const decision = decideTerminalStatus(run, {
+    failure,
+    noProgress: null,
+    failOnStreamError: true,
+  });
   await run.finish(decision.status, decision.error);
-  return decision;
+  return {
+    status: decision.status,
+    failure: decision.failure ?? failure,
+    truncated: false,
+  };
+};
+
+/** The knobs the two streamed shapes differ on, frozen per entry point. */
+type StreamedBehavior = {
+  unattended: boolean;
+  failOnStreamError: boolean;
+  stopSnapshotsAfterFinal: boolean;
+};
+
+/** An interactive Chat turn's drive — also the widest streamed shape, so it is
+ *  what the shared runner accepts. */
+export type ChatDriveOptions = DriveBase &
+  DriveConversation & {
+    /** The opening messages a Chat turn folds its streamed answer onto. */
+    originalMessages?: PlatypusUIMessage[];
+    /** The resolved Agent id, stamped onto the streamed message. */
+    agentId?: string;
+    generateMessageId?: () => string;
+    /** The live map the caller fills from `onToolExecutionEnd`. */
+    toolDurations?: Map<string, number>;
+    /** Hooked before the run folds the step, so the caller can read what it
+     *  can't otherwise recover (e.g. the provider's raw finish reason). */
+    onStepFinish?: (step: RunStep) => void;
+    onToolExecutionEnd?: (ctx: {
+      toolCall: { toolCallId: string };
+      toolExecutionMs: number;
+    }) => void;
+    /** The folded final messages (tool durations applied), right before the run
+     *  ends. The Chat turn persists these; the sink's terminal write observes
+     *  them. */
+    onFinal?: (messages: PlatypusUIMessage[]) => void;
+  };
+
+/** A delegated sub-Agent's drive: the same conversation and step hook, none of
+ *  the Chat turn's folding and client-stream machinery. */
+export type DelegateDriveOptions = DriveBase &
+  DriveConversation & {
+    onStepFinish?: (step: RunStep) => void;
+  };
+
+/** Where a drive's UI stream goes before it is consumed. A Chat turn tees off a
+ *  client branch here; a delegate consumes the stream whole. */
+type SplitStream = (
+  ui: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>>,
+) => ReadableStream<InferUIMessageChunk<PlatypusUIMessage>>;
+
+type StreamedCore = {
+  snapshots: AsyncIterable<PlatypusUIMessage>;
+  done: Promise<StreamedDriveResult>;
 };
 
 /**
- * Drives a `streamText` run inside its registered lifecycle.
- *
- * Runs the model loop, folds the streamed parts into `PlatypusUIMessage`s
- * (metadata, tool durations, stream errors and the terminal finish handled
- * here), and records the terminal status exactly once. Returns a handle the
- * caller paces: its `snapshots` feed a Chat route's client stream or a
- * delegate's activity log, and `done` reports the outcome after the run has
- * been finished.
+ * Runs a `streamText` model loop inside its registered lifecycle and folds the
+ * streamed parts into `PlatypusUIMessage`s — metadata, tool durations, stream
+ * errors and the terminal finish all handled here — then records the terminal
+ * status exactly once, when the snapshot stream drains.
  */
-export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
+const runStreamedDrive = (
+  opts: ChatDriveOptions,
+  behavior: StreamedBehavior,
+  split: SplitStream,
+): StreamedCore => {
   const {
-    plan,
     run,
-    prompt,
-    modelMessages,
     originalMessages = [],
     agentId,
     generateMessageId,
     toolDurations,
-    mode = "chat",
     onStepFinish,
     onToolExecutionEnd,
     onFinal,
   } = opts;
 
-  const {
-    unattended,
-    failOnStreamError,
-    stopSnapshotsAfterFinal,
-    returnResponse,
-  } = MODE_BEHAVIOR[mode];
-
-  const noProgress: NoProgressDetector | null = unattended
-    ? createNoProgressDetector()
-    : null;
+  const noProgress = detectorFor(behavior.unattended);
 
   let failure: string | undefined;
   let truncated = false;
@@ -268,11 +266,7 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
   });
 
   const result = streamText({
-    ...buildModelInvocation(plan, {
-      abortSignal: run.handle.signal,
-      extraStopCondition: noProgress?.stopCondition,
-    }),
-    ...(prompt !== undefined ? { prompt } : { messages: modelMessages ?? [] }),
+    ...modelArgs(opts, noProgress),
     onStepFinish: (step: RunStep) => {
       onStepFinish?.(step);
       run.onStep(step);
@@ -298,16 +292,7 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
     },
   });
 
-  let response:
-    ReadableStream<InferUIMessageChunk<PlatypusUIMessage>> | undefined;
-  let consume: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>>;
-  if (returnResponse) {
-    const [client, snapshot] = uiStream.tee();
-    response = client;
-    consume = snapshot;
-  } else {
-    consume = uiStream;
-  }
+  const consume = split(uiStream);
 
   const snapshots: AsyncIterable<PlatypusUIMessage> = (async function* () {
     try {
@@ -320,7 +305,7 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
         latest = message;
         // Drain past the handover but don't yield: a snapshot after the folded
         // final is no better than what it would overwrite (no durations).
-        if (stopSnapshotsAfterFinal && finalHandedOver) continue;
+        if (behavior.stopSnapshotsAfterFinal && finalHandedOver) continue;
         yield message;
       }
     } catch (error) {
@@ -343,14 +328,14 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
       if (truncated) {
         run.setStats({ ...run.stats, truncatedByTokenLimit: true });
       }
-      // The failure and the terminal decision come from the same place, and only
-      // that place — no caller re-derives "did it fail?" from the pieces here.
-      const decision = await endStreamedRun(run, {
+      const decision = decideTerminalStatus(run, {
         failure,
         noProgress,
-        failOnStreamError,
+        failOnStreamError: behavior.failOnStreamError,
       });
+      await run.finish(decision.status, decision.error);
       resolveDone({
+        status: decision.status,
         messages: handoverMessages,
         latest,
         failure: decision.failure,
@@ -359,48 +344,80 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
     }
   })();
 
-  return {
-    snapshots,
-    response,
-    done,
-  };
+  return { snapshots, done };
 };
 
-export type OnceDriveOptions = {
-  plan: RunPlan;
-  run: RunLifecycle;
-  prompt?: string;
-  modelMessages?: ModelMessage[];
-  /** Unattended (Trigger) runs enable no-progress detection. */
-  unattended?: boolean;
+export type ChatDrive = StreamedCore & {
+  /** The client stream branch. Always present: a Chat turn is the shape that
+   *  has one. */
+  response: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>>;
 };
+
+/**
+ * Drives an interactive Chat turn.
+ *
+ * A human is watching, so the no-progress condition is left off (they can stop
+ * it themselves) and a stream error is rendered inline rather than failing the
+ * run. The client branch is teed off before the server-side consumer drains the
+ * other, so a disconnected client never propagates back to the source.
+ */
+export const driveChat = (opts: ChatDriveOptions): ChatDrive => {
+  // Assigned by `split` below, which `runStreamedDrive` calls synchronously
+  // while constructing the drive — hence definite assignment before the return.
+  let response!: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>>;
+  const core = runStreamedDrive(
+    opts,
+    {
+      unattended: false,
+      failOnStreamError: false,
+      stopSnapshotsAfterFinal: true,
+    },
+    (ui) => {
+      const [client, serverSide] = ui.tee();
+      response = client;
+      return serverSide;
+    },
+  );
+  return { ...core, response };
+};
+
+/**
+ * Drives a delegated sub-Agent.
+ *
+ * Nobody is watching this run's steps, so it gains the no-progress stop
+ * condition (same call → same result, K times) and fails when its stream
+ * reports an error, rather than letting the parent read a crash as the
+ * delegate's finding. Every snapshot is yielded, for the caller's activity log.
+ */
+export const driveDelegate = (opts: DelegateDriveOptions): StreamedCore =>
+  runStreamedDrive(
+    opts,
+    {
+      unattended: true,
+      failOnStreamError: true,
+      stopSnapshotsAfterFinal: false,
+    },
+    (ui) => ui,
+  );
 
 /**
  * Drives a headless `generateText` run inside its registered lifecycle.
  *
- * Returns a single answer and the computed statistics. The terminal status and
- * output-ceiling cutoff are decided here — the same rules `driveStreamed`
- * applies — and the run is finished (succeeded, or failed with a `NoProgressError`
- * when the no-progress condition trips) before returning.
+ * Returns a single answer and the computed statistics. Headless means
+ * unattended, so the no-progress condition is always on. The terminal status
+ * and output-ceiling cutoff are decided by the same rules the streamed drives
+ * apply, and the run is finished before returning.
  */
 export const driveOnce = async (
-  opts: OnceDriveOptions,
+  opts: DriveBase & DriveConversation,
 ): Promise<{ text: string; stats: RunStats }> => {
-  const { plan, run, prompt, modelMessages, unattended = false } = opts;
-  const noProgress: NoProgressDetector | null = unattended
-    ? createNoProgressDetector()
-    : null;
+  const { run } = opts;
+  const noProgress = detectorFor(true);
   const startTime = Date.now();
 
   try {
     const result = await generateText({
-      ...buildModelInvocation(plan, {
-        abortSignal: run.handle.signal,
-        extraStopCondition: noProgress?.stopCondition,
-      }),
-      ...(prompt !== undefined
-        ? { prompt }
-        : { messages: modelMessages ?? [] }),
+      ...modelArgs(opts, noProgress),
       onStepFinish: (step: RunStep) => run.onStep(step),
     });
 
@@ -410,11 +427,9 @@ export const driveOnce = async (
     }
     run.setStats(stats);
 
-    // The terminal decision is the same one `driveStreamed` ends its runs with.
     // The no-progress stop condition halts the loop cleanly (the SDK resolves
     // normally), so a tripped detector surfaces here rather than in the catch.
     const decision = decideTerminalStatus(run, {
-      failure: undefined,
       noProgress,
       failOnStreamError: false,
     });
@@ -424,34 +439,19 @@ export const driveOnce = async (
         : null;
 
     // Nobody is watching an unattended run, so this log is the only record of
-    // how it ended. Carried here because the completion log is the one place
-    // the raw reason survives for an unattended run.
-    if (trip) {
-      logger.warn(
-        {
-          runId: run.handle.runId,
-          toolName: trip.toolName,
-          count: trip.count,
-          duration: Date.now() - startTime,
-          finishReason: result.finishReason,
-          rawFinishReason: result.rawFinishReason,
-          stats,
-        },
-        "Run aborted: no progress",
-      );
-    } else {
-      logger.info(
-        {
-          runId: run.handle.runId,
-          duration: Date.now() - startTime,
-          responseLength: result.text.length,
-          finishReason: result.finishReason,
-          rawFinishReason: result.rawFinishReason,
-          stats,
-        },
-        "Run generate completed",
-      );
-    }
+    // how it ended, and the one place the raw finish reason survives.
+    logger[trip ? "warn" : "info"](
+      {
+        runId: run.handle.runId,
+        ...(trip ? { toolName: trip.toolName, count: trip.count } : {}),
+        duration: Date.now() - startTime,
+        responseLength: result.text.length,
+        finishReason: result.finishReason,
+        rawFinishReason: result.rawFinishReason,
+        stats,
+      },
+      trip ? "Run aborted: no progress" : "Run generate completed",
+    );
 
     await run.finish(decision.status, decision.error);
     return { text: result.text, stats };
@@ -466,7 +466,6 @@ export const driveOnce = async (
     // choice is the shared one; only the error is the thrown one, not the
     // signal's (there is no `TimeoutError` for a run that merely threw).
     const decision = decideTerminalStatus(run, {
-      failure: undefined,
       noProgress,
       failOnStreamError: false,
     });

--- a/apps/backend/src/runs/drive.ts
+++ b/apps/backend/src/runs/drive.ts
@@ -122,8 +122,6 @@ type StreamedDrive = {
   snapshots: AsyncIterable<PlatypusUIMessage>;
   /** A client stream branch, present when `returnResponse` (a Chat turn). */
   response?: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>>;
-  /** True once the terminal `onFinish` has fired. */
-  finalHandedOver: () => boolean;
   /** Resolves once the run has ended, with the drive's outcome. */
   done: Promise<StreamedDriveResult>;
 };
@@ -155,7 +153,9 @@ const endStreamedRun = async (
   if (opts.failOnStreamError && opts.failure && status !== "failed") {
     await run.finish(
       status === "cancelled" ? "cancelled" : "failed",
-      status === "cancelled" ? (error ?? new Error(opts.failure)) : new Error(opts.failure),
+      status === "cancelled"
+        ? (error ?? new Error(opts.failure))
+        : new Error(opts.failure),
     );
     return;
   }
@@ -210,9 +210,7 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
       abortSignal: run.handle.signal,
       extraStopCondition: noProgress?.stopCondition,
     }),
-    ...(prompt !== undefined
-      ? { prompt }
-      : { messages: modelMessages ?? [] }),
+    ...(prompt !== undefined ? { prompt } : { messages: modelMessages ?? [] }),
     onStepFinish: (step: RunStep) => {
       onStepFinish?.(step);
       run.onStep(step);
@@ -245,7 +243,8 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
     },
   });
 
-  let response: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>> | undefined;
+  let response:
+    ReadableStream<InferUIMessageChunk<PlatypusUIMessage>> | undefined;
   let consume: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>>;
   if (returnResponse) {
     const [client, snapshot] = uiStream.tee();
@@ -277,17 +276,23 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
       failure ??= describeSdkError(error);
     } finally {
       await endStreamedRun(run, { failure, noProgress, failOnStreamError });
-      // The failure the caller should act on: the observed stream failure, or a
-      // no-progress trip, or (for a fail-on-error drive) an abort mid-stream.
+      // The failure the caller should act on — only a fail-on-error drive carries
+      // one: the observed stream failure, a no-progress trip, or an abort
+      // mid-stream. A Chat turn that tolerates a stream error records its run as
+      // succeeded, so it reports no failure here either. This keeps the seam's
+      // two answers — the run's status and the returned outcome — consistent.
       const trip = noProgress?.tripped() ?? null;
-      const terminalFailure =
-        failure ||
-        (trip ? new NoProgressError(trip.toolName, trip.count).message : undefined) ||
-        (failOnStreamError && run.handle.signal.aborted
-          ? run.abortReason()
-            ? `Stopped before finishing: ${run.abortReason()}`
-            : "Stopped before finishing."
-          : undefined);
+      const terminalFailure = failOnStreamError
+        ? failure ||
+          (trip
+            ? new NoProgressError(trip.toolName, trip.count).message
+            : undefined) ||
+          (run.handle.signal.aborted
+            ? run.abortReason()
+              ? `Stopped before finishing: ${run.abortReason()}`
+              : "Stopped before finishing."
+            : undefined)
+        : undefined;
       resolveDone({
         messages: handoverMessages,
         latest,
@@ -300,7 +305,6 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
   return {
     snapshots,
     response,
-    finalHandedOver: () => finalHandedOver,
     done,
   };
 };
@@ -337,13 +341,13 @@ export const driveOnce = async (
         abortSignal: run.handle.signal,
         extraStopCondition: noProgress?.stopCondition,
       }),
-      ...(prompt !== undefined ? { prompt } : { messages: modelMessages ?? [] }),
+      ...(prompt !== undefined
+        ? { prompt }
+        : { messages: modelMessages ?? [] }),
       onStepFinish: (step: RunStep) => run.onStep(step),
     });
 
-    const stats = computeStats(
-      result as Parameters<typeof computeStats>[0],
-    );
+    const stats = computeStats(result as Parameters<typeof computeStats>[0]);
     if (isTruncatedByTokenLimit(result.finishReason)) {
       stats.truncatedByTokenLimit = true;
     }

--- a/apps/backend/src/runs/drive.ts
+++ b/apps/backend/src/runs/drive.ts
@@ -23,7 +23,7 @@ import {
   isTruncatedByTokenLimit,
 } from "./stream-error.ts";
 import { applyToolDurations } from "./tool-durations.ts";
-import type { RunStats } from "./types.ts";
+import type { RunStats, RunStatus } from "./types.ts";
 
 /**
  * The model call inside a registered run.
@@ -52,6 +52,43 @@ import type { RunStats } from "./types.ts";
  */
 
 /**
+ * Which shape a streamed drive takes. The two callers converge on two frozen
+ * combinations of the pacing and failure knobs, so those are captured here as
+ * a single intent instead of four independent flags a caller can scramble.
+ *
+ * - `"chat"` — an interactive Chat turn. Tolerates a stream error (renders it
+ *   inline), splits off a client stream branch, and stops yielding snapshots
+ *   once the terminal finish has handed its folded messages over.
+ * - `"delegate"` — an unattended, delegated sub-Agent. Gains the no-progress
+ *   stop condition, fails when its stream reports an error (so the generated
+ *   answer is never read as the finding), and yields every snapshot into the
+ *   caller's activity log.
+ */
+export type StreamedDriveMode = "chat" | "delegate";
+
+type DriveModeBehavior = {
+  unattended: boolean;
+  failOnStreamError: boolean;
+  stopSnapshotsAfterFinal: boolean;
+  returnResponse: boolean;
+};
+
+const MODE_BEHAVIOR: Record<StreamedDriveMode, DriveModeBehavior> = {
+  chat: {
+    unattended: false,
+    failOnStreamError: false,
+    stopSnapshotsAfterFinal: true,
+    returnResponse: true,
+  },
+  delegate: {
+    unattended: true,
+    failOnStreamError: true,
+    stopSnapshotsAfterFinal: false,
+    returnResponse: false,
+  },
+};
+
+/**
  * A streamed drive's inputs. `plan` carries the generation settings plus, for
  * a Chat turn, the folded conversation under `messages`; a delegated run hands
  * the conversation as a single `prompt` instead. The two are mutually
@@ -72,25 +109,10 @@ export type StreamedDriveOptions = {
   /** The live map the caller fills from `onToolExecutionEnd`. */
   toolDurations?: Map<string, number>;
   /**
-   * Unattended runs (delegated sub-Agents) gain a no-progress stop condition
-   * alongside the step ceiling. Interactive Chat turns leave it off.
+   * Whether this is an interactive Chat turn or an unattended delegated
+   * sub-Agent. Defaults to `"chat"`.
    */
-  unattended?: boolean;
-  /**
-   * Whether the run fails when its stream reports an error. A delegated
-   * sub-Agent does (`failOnStreamError`), so the generated answer is never
-   * read as the finding; a Chat turn tolerates it and renders the error inline.
-   */
-  failOnStreamError?: boolean;
-  /**
-   * Once the terminal `onFinish` has handed over the folded final messages,
-   * keep draining the snapshot branch but stop yielding further snapshots.
-   * This is the Chat-turn teardown race: a snapshot landing during teardown
-   * carries no tool durations, so it must not overwrite the handover copy.
-   */
-  stopSnapshotsAfterFinal?: boolean;
-  /** Split the UI stream and hand back a client branch (only a Chat turn). */
-  returnResponse?: boolean;
+  mode?: StreamedDriveMode;
   /** Hooked before the run folds the step, so the caller can read what it can't
    *  otherwise recover (e.g. the provider's raw finish reason). */
   onStepFinish?: (step: RunStep) => void;
@@ -120,18 +142,70 @@ export type StreamedDriveResult = {
 type StreamedDrive = {
   /** The folded assistant messages. Consuming this is what drains the run. */
   snapshots: AsyncIterable<PlatypusUIMessage>;
-  /** A client stream branch, present when `returnResponse` (a Chat turn). */
+  /** A client stream branch, present in `"chat"` mode (a Chat turn). */
   response?: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>>;
   /** Resolves once the run has ended, with the drive's outcome. */
   done: Promise<StreamedDriveResult>;
 };
 
 /**
- * The one terminal-status rule. Decided here, in a registered run's terms, so
- * no caller re-derives "did we succeed?" from the stream it happened to be
- * driving. A single no-progress trip or stream failure ends the run as a
- * failure; a run somebody stopped ends it as cancelled; a timeout stays a
- * failure with its `TimeoutError`; anything else is a success.
+ * The one terminal-status rule, in a registered run's terms.
+ *
+ * Shared by both drivers so neither re-derives "did we succeed?" from the
+ * stream or result it happened to be driving. Decides the status (and, where a
+ * failure is reported, the caller-facing sentence) an ended run should carry:
+ * a single no-progress trip or, on a fail-on-error drive, a stream failure
+ * ends the run as a failure; a run somebody stopped ends it as cancelled; a
+ * timeout stays a failure with its `TimeoutError`; anything else is a success.
+ */
+type TerminalDecision = {
+  status: RunStatus;
+  error?: Error;
+  /** A caller-facing sentence for a non-clean end, when one is reported. */
+  failure?: string;
+};
+
+const decideTerminalStatus = (
+  run: RunLifecycle,
+  opts: {
+    failure?: string;
+    noProgress: NoProgressDetector | null;
+    failOnStreamError: boolean;
+  },
+): TerminalDecision => {
+  const trip = opts.noProgress?.tripped() ?? null;
+
+  if (trip) {
+    const err = new NoProgressError(trip.toolName, trip.count);
+    return { status: "failed", error: err, failure: err.message };
+  }
+  const { status, error } = run.statusFromSignal();
+  // A timed-out run keeps its TimeoutError rather than whichever stream error
+  // also landed: the timeout names the bound that was exceeded.
+  if (opts.failOnStreamError && opts.failure && status !== "failed") {
+    const err = new Error(opts.failure);
+    return {
+      status: status === "cancelled" ? "cancelled" : "failed",
+      error: status === "cancelled" ? (error ?? err) : err,
+      failure: opts.failure,
+    };
+  }
+  // A fail-on-error drive that stopped mid-stream reports why it stopped, so
+  // the caller (a delegate's parent) can tell a stop from a finished answer.
+  const failure =
+    opts.failOnStreamError && run.handle.signal.aborted
+      ? run.abortReason()
+        ? `Stopped before finishing: ${run.abortReason()}`
+        : "Stopped before finishing."
+      : undefined;
+  return { status, error, failure };
+};
+
+/**
+ * Ends a streamed run with the terminal-status decision and the caller-facing
+ * reason for a non-clean end, computed once. The run's status and the returned
+ * outcome stay consistent by construction: the failure the caller is told is
+ * exactly the one the run was finished with.
  */
 const endStreamedRun = async (
   run: RunLifecycle,
@@ -140,26 +214,10 @@ const endStreamedRun = async (
     noProgress: NoProgressDetector | null;
     failOnStreamError: boolean;
   },
-): Promise<void> => {
-  const { status, error } = run.statusFromSignal();
-  const trip = opts.noProgress?.tripped() ?? null;
-
-  if (trip) {
-    await run.finish("failed", new NoProgressError(trip.toolName, trip.count));
-    return;
-  }
-  // A timed-out run keeps its TimeoutError rather than whichever stream error
-  // also landed: the timeout names the bound that was exceeded.
-  if (opts.failOnStreamError && opts.failure && status !== "failed") {
-    await run.finish(
-      status === "cancelled" ? "cancelled" : "failed",
-      status === "cancelled"
-        ? (error ?? new Error(opts.failure))
-        : new Error(opts.failure),
-    );
-    return;
-  }
-  await run.finish(status, error);
+): Promise<TerminalDecision> => {
+  const decision = decideTerminalStatus(run, opts);
+  await run.finish(decision.status, decision.error);
+  return decision;
 };
 
 /**
@@ -182,14 +240,18 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
     agentId,
     generateMessageId,
     toolDurations,
-    unattended = false,
-    failOnStreamError = false,
-    stopSnapshotsAfterFinal = false,
-    returnResponse = false,
+    mode = "chat",
     onStepFinish,
     onToolExecutionEnd,
     onFinal,
   } = opts;
+
+  const {
+    unattended,
+    failOnStreamError,
+    stopSnapshotsAfterFinal,
+    returnResponse,
+  } = MODE_BEHAVIOR[mode];
 
   const noProgress: NoProgressDetector | null = unattended
     ? createNoProgressDetector()
@@ -232,13 +294,6 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
         toolDurations && toolDurations.size > 0
           ? applyToolDurations(finalMessages, toolDurations)
           : finalMessages;
-      truncated =
-        handoverMessages.some(
-          (m) => m.metadata?.truncatedByTokenLimit === true,
-        ) ?? false;
-      if (truncated) {
-        run.setStats({ ...run.stats, truncatedByTokenLimit: true });
-      }
       onFinal?.(handoverMessages);
     },
   });
@@ -275,28 +330,30 @@ export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
       );
       failure ??= describeSdkError(error);
     } finally {
-      await endStreamedRun(run, { failure, noProgress, failOnStreamError });
-      // The failure the caller should act on — only a fail-on-error drive carries
-      // one: the observed stream failure, a no-progress trip, or an abort
-      // mid-stream. A Chat turn that tolerates a stream error records its run as
-      // succeeded, so it reports no failure here either. This keeps the seam's
-      // two answers — the run's status and the returned outcome — consistent.
-      const trip = noProgress?.tripped() ?? null;
-      const terminalFailure = failOnStreamError
-        ? failure ||
-          (trip
-            ? new NoProgressError(trip.toolName, trip.count).message
-            : undefined) ||
-          (run.handle.signal.aborted
-            ? run.abortReason()
-              ? `Stopped before finishing: ${run.abortReason()}`
-              : "Stopped before finishing."
-            : undefined)
-        : undefined;
+      // The terminal finish attaches the cutoff marker to the folded messages it
+      // hands over; if that never fires (an abort before completion), the last
+      // snapshot still carries it. Either way it is recorded once, before the
+      // run's status is decided, so both the stats and the outcome agree.
+      truncated =
+        (handoverMessages?.some(
+          (m) => m.metadata?.truncatedByTokenLimit === true,
+        ) ??
+          false) ||
+        latest?.metadata?.truncatedByTokenLimit === true;
+      if (truncated) {
+        run.setStats({ ...run.stats, truncatedByTokenLimit: true });
+      }
+      // The failure and the terminal decision come from the same place, and only
+      // that place — no caller re-derives "did it fail?" from the pieces here.
+      const decision = await endStreamedRun(run, {
+        failure,
+        noProgress,
+        failOnStreamError,
+      });
       resolveDone({
         messages: handoverMessages,
         latest,
-        failure: terminalFailure,
+        failure: decision.failure,
         truncated,
       });
     }
@@ -353,11 +410,23 @@ export const driveOnce = async (
     }
     run.setStats(stats);
 
+    // The terminal decision is the same one `driveStreamed` ends its runs with.
     // The no-progress stop condition halts the loop cleanly (the SDK resolves
-    // normally), so the abort is surfaced here rather than via the catch path.
-    const trip = noProgress?.tripped() ?? null;
+    // normally), so a tripped detector surfaces here rather than in the catch.
+    const decision = decideTerminalStatus(run, {
+      failure: undefined,
+      noProgress,
+      failOnStreamError: false,
+    });
+    const trip =
+      decision.error instanceof NoProgressError
+        ? { toolName: decision.error.toolName, count: decision.error.count }
+        : null;
+
+    // Nobody is watching an unattended run, so this log is the only record of
+    // how it ended. Carried here because the completion log is the one place
+    // the raw reason survives for an unattended run.
     if (trip) {
-      const err = new NoProgressError(trip.toolName, trip.count);
       logger.warn(
         {
           runId: run.handle.runId,
@@ -370,26 +439,21 @@ export const driveOnce = async (
         },
         "Run aborted: no progress",
       );
-      await run.finish("failed", err);
-      return { text: result.text, stats };
+    } else {
+      logger.info(
+        {
+          runId: run.handle.runId,
+          duration: Date.now() - startTime,
+          responseLength: result.text.length,
+          finishReason: result.finishReason,
+          rawFinishReason: result.rawFinishReason,
+          stats,
+        },
+        "Run generate completed",
+      );
     }
 
-    // Nobody is watching an unattended run, so this log is the only record of
-    // how it ended. Carried here because the completion log is the one place
-    // the raw reason survives for an unattended run.
-    logger.info(
-      {
-        runId: run.handle.runId,
-        duration: Date.now() - startTime,
-        responseLength: result.text.length,
-        finishReason: result.finishReason,
-        rawFinishReason: result.rawFinishReason,
-        stats,
-      },
-      "Run generate completed",
-    );
-
-    await run.finish("succeeded");
+    await run.finish(decision.status, decision.error);
     return { text: result.text, stats };
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
@@ -398,10 +462,16 @@ export const driveOnce = async (
       "Run generate failed",
     );
     // A cancelled run is recorded as cancelled; a timed-out one stays a
-    // failure, and so does anything the model call threw on its own.
-    const aborted = run.statusFromSignal();
+    // failure, and so does anything the model call threw on its own. The status
+    // choice is the shared one; only the error is the thrown one, not the
+    // signal's (there is no `TimeoutError` for a run that merely threw).
+    const decision = decideTerminalStatus(run, {
+      failure: undefined,
+      noProgress,
+      failOnStreamError: false,
+    });
     await run.finish(
-      aborted.status === "cancelled" ? "cancelled" : "failed",
+      decision.status === "cancelled" ? "cancelled" : "failed",
       err,
     );
     throw err;

--- a/apps/backend/src/runs/drive.ts
+++ b/apps/backend/src/runs/drive.ts
@@ -1,0 +1,405 @@
+import {
+  generateText,
+  readUIMessageStream,
+  streamText,
+  type InferUIMessageChunk,
+  type ModelMessage,
+} from "ai";
+import { logger } from "../logger.ts";
+import type { PlatypusUIMessage } from "../types.ts";
+import { createMessageMetadata } from "./message-metadata.ts";
+import {
+  createNoProgressDetector,
+  NoProgressError,
+  type NoProgressDetector,
+} from "./no-progress.ts";
+import { buildModelInvocation, type RunPlan } from "./run-plan.ts";
+import type { RunLifecycle } from "./run-lifecycle.ts";
+import type { RunStep } from "./run-stats.ts";
+import { computeStats } from "./run-stats.ts";
+import {
+  describeSdkError,
+  formatStreamError,
+  isTruncatedByTokenLimit,
+} from "./stream-error.ts";
+import { applyToolDurations } from "./tool-durations.ts";
+import type { RunStats } from "./types.ts";
+
+/**
+ * The model call inside a registered run.
+ *
+ * This module is the single place that *drives* a run to its terminal state —
+ * every entry point that turns a prompt or a Chat history into a model answer
+ * goes through one of these two functions. What used to be re-derived in three
+ * places (two paths in `AgentRunner`, plus the delegate tool) now lives here:
+ *
+ * - building the model invocation (`buildModelInvocation`, step ceiling and
+ *   the no-progress stop condition included),
+ * - the terminal-status decision (succeeded / failed / cancelled),
+ * - recording the output-ceiling cutoff (`truncatedByTokenLimit`) once, on
+ *   the run's stats,
+ * - ending the run.
+ *
+ * `driveStreamed` is for the `streamText` path — a Chat turn (which tees a
+ * client stream) and a delegated sub-Agent (which folds the snapshots into an
+ * activity log). It exposes the folded messages as an async iterable the
+ * caller consumes, plus a `done` promise with the outcome, so a caller that
+ * must *yield* per snapshot (the delegate tool) and one that must hand the
+ * stream to a client immediately (the Chat route) each keep their own pacing.
+ *
+ * `driveOnce` is for the tail-free `generateText` path (Trigger runs), which
+ * returns a single text answer and the computed stats.
+ */
+
+/**
+ * A streamed drive's inputs. `plan` carries the generation settings plus, for
+ * a Chat turn, the folded conversation under `messages`; a delegated run hands
+ * the conversation as a single `prompt` instead. The two are mutually
+ * exclusive.
+ */
+export type StreamedDriveOptions = {
+  plan: RunPlan;
+  run: RunLifecycle;
+  /** A single user prompt — the whole conversation of a delegated sub-Agent. */
+  prompt?: string;
+  /** A Chat turn's conversation, already converted to model messages. */
+  modelMessages?: ModelMessage[];
+  /** The opening messages a Chat turn folds its streamed answer onto. */
+  originalMessages?: PlatypusUIMessage[];
+  /** The resolved Agent id, stamped onto the streamed message. */
+  agentId?: string;
+  generateMessageId?: () => string;
+  /** The live map the caller fills from `onToolExecutionEnd`. */
+  toolDurations?: Map<string, number>;
+  /**
+   * Unattended runs (delegated sub-Agents) gain a no-progress stop condition
+   * alongside the step ceiling. Interactive Chat turns leave it off.
+   */
+  unattended?: boolean;
+  /**
+   * Whether the run fails when its stream reports an error. A delegated
+   * sub-Agent does (`failOnStreamError`), so the generated answer is never
+   * read as the finding; a Chat turn tolerates it and renders the error inline.
+   */
+  failOnStreamError?: boolean;
+  /**
+   * Once the terminal `onFinish` has handed over the folded final messages,
+   * keep draining the snapshot branch but stop yielding further snapshots.
+   * This is the Chat-turn teardown race: a snapshot landing during teardown
+   * carries no tool durations, so it must not overwrite the handover copy.
+   */
+  stopSnapshotsAfterFinal?: boolean;
+  /** Split the UI stream and hand back a client branch (only a Chat turn). */
+  returnResponse?: boolean;
+  /** Hooked before the run folds the step, so the caller can read what it can't
+   *  otherwise recover (e.g. the provider's raw finish reason). */
+  onStepFinish?: (step: RunStep) => void;
+  onToolExecutionEnd?: (ctx: {
+    toolCall: { toolCallId: string };
+    toolExecutionMs: number;
+  }) => void;
+  /** The folded final messages (tool durations applied), right before the run
+   *  ends. The Chat turn persists these; the sink's terminal write observes
+   *  them. */
+  onFinal?: (messages: PlatypusUIMessage[]) => void;
+};
+
+/** What a `driveStreamed` run settled on. */
+export type StreamedDriveResult = {
+  /** The Chat turn's final folded messages (tool durations applied). */
+  messages?: PlatypusUIMessage[];
+  /** The last snapshot seen — the delegate's final assistant message. */
+  latest?: PlatypusUIMessage;
+  /** Why a non-clean drive ended, in a caller-facing sentence. Absent for a
+   *  clean finish. */
+  failure?: string;
+  /** The terminal finish hit the model's output ceiling. */
+  truncated?: boolean;
+};
+
+type StreamedDrive = {
+  /** The folded assistant messages. Consuming this is what drains the run. */
+  snapshots: AsyncIterable<PlatypusUIMessage>;
+  /** A client stream branch, present when `returnResponse` (a Chat turn). */
+  response?: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>>;
+  /** True once the terminal `onFinish` has fired. */
+  finalHandedOver: () => boolean;
+  /** Resolves once the run has ended, with the drive's outcome. */
+  done: Promise<StreamedDriveResult>;
+};
+
+/**
+ * The one terminal-status rule. Decided here, in a registered run's terms, so
+ * no caller re-derives "did we succeed?" from the stream it happened to be
+ * driving. A single no-progress trip or stream failure ends the run as a
+ * failure; a run somebody stopped ends it as cancelled; a timeout stays a
+ * failure with its `TimeoutError`; anything else is a success.
+ */
+const endStreamedRun = async (
+  run: RunLifecycle,
+  opts: {
+    failure?: string;
+    noProgress: NoProgressDetector | null;
+    failOnStreamError: boolean;
+  },
+): Promise<void> => {
+  const { status, error } = run.statusFromSignal();
+  const trip = opts.noProgress?.tripped() ?? null;
+
+  if (trip) {
+    await run.finish("failed", new NoProgressError(trip.toolName, trip.count));
+    return;
+  }
+  // A timed-out run keeps its TimeoutError rather than whichever stream error
+  // also landed: the timeout names the bound that was exceeded.
+  if (opts.failOnStreamError && opts.failure && status !== "failed") {
+    await run.finish(
+      status === "cancelled" ? "cancelled" : "failed",
+      status === "cancelled" ? (error ?? new Error(opts.failure)) : new Error(opts.failure),
+    );
+    return;
+  }
+  await run.finish(status, error);
+};
+
+/**
+ * Drives a `streamText` run inside its registered lifecycle.
+ *
+ * Runs the model loop, folds the streamed parts into `PlatypusUIMessage`s
+ * (metadata, tool durations, stream errors and the terminal finish handled
+ * here), and records the terminal status exactly once. Returns a handle the
+ * caller paces: its `snapshots` feed a Chat route's client stream or a
+ * delegate's activity log, and `done` reports the outcome after the run has
+ * been finished.
+ */
+export const driveStreamed = (opts: StreamedDriveOptions): StreamedDrive => {
+  const {
+    plan,
+    run,
+    prompt,
+    modelMessages,
+    originalMessages = [],
+    agentId,
+    generateMessageId,
+    toolDurations,
+    unattended = false,
+    failOnStreamError = false,
+    stopSnapshotsAfterFinal = false,
+    returnResponse = false,
+    onStepFinish,
+    onToolExecutionEnd,
+    onFinal,
+  } = opts;
+
+  const noProgress: NoProgressDetector | null = unattended
+    ? createNoProgressDetector()
+    : null;
+
+  let failure: string | undefined;
+  let truncated = false;
+  let finalHandedOver = false;
+  let latest: PlatypusUIMessage | undefined;
+  let handoverMessages: PlatypusUIMessage[] | undefined;
+  let resolveDone!: (result: StreamedDriveResult) => void;
+  const done = new Promise<StreamedDriveResult>((resolve) => {
+    resolveDone = resolve;
+  });
+
+  const result = streamText({
+    ...buildModelInvocation(plan, {
+      abortSignal: run.handle.signal,
+      extraStopCondition: noProgress?.stopCondition,
+    }),
+    ...(prompt !== undefined
+      ? { prompt }
+      : { messages: modelMessages ?? [] }),
+    onStepFinish: (step: RunStep) => {
+      onStepFinish?.(step);
+      run.onStep(step);
+    },
+    onToolExecutionEnd: (ctx) => {
+      onToolExecutionEnd?.(ctx);
+    },
+  });
+
+  const uiStream = result.toUIMessageStream<PlatypusUIMessage>({
+    originalMessages,
+    generateMessageId,
+    messageMetadata: createMessageMetadata(agentId, toolDurations),
+    onError: (error) => formatStreamError(error),
+    onFinish: ({ messages: finalMessages }) => {
+      finalHandedOver = true;
+      // The terminal finish, stamped with the locally-measured tool durations.
+      handoverMessages =
+        toolDurations && toolDurations.size > 0
+          ? applyToolDurations(finalMessages, toolDurations)
+          : finalMessages;
+      truncated =
+        handoverMessages.some(
+          (m) => m.metadata?.truncatedByTokenLimit === true,
+        ) ?? false;
+      if (truncated) {
+        run.setStats({ ...run.stats, truncatedByTokenLimit: true });
+      }
+      onFinal?.(handoverMessages);
+    },
+  });
+
+  let response: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>> | undefined;
+  let consume: ReadableStream<InferUIMessageChunk<PlatypusUIMessage>>;
+  if (returnResponse) {
+    const [client, snapshot] = uiStream.tee();
+    response = client;
+    consume = snapshot;
+  } else {
+    consume = uiStream;
+  }
+
+  const snapshots: AsyncIterable<PlatypusUIMessage> = (async function* () {
+    try {
+      for await (const message of readUIMessageStream<PlatypusUIMessage>({
+        stream: consume,
+        onError: (error) => {
+          failure ??= describeSdkError(error);
+        },
+      })) {
+        latest = message;
+        // Drain past the handover but don't yield: a snapshot after the folded
+        // final is no better than what it would overwrite (no durations).
+        if (stopSnapshotsAfterFinal && finalHandedOver) continue;
+        yield message;
+      }
+    } catch (error) {
+      logger.error(
+        { err: error, runId: run.handle.runId },
+        "Server-side UI stream consumer error",
+      );
+      failure ??= describeSdkError(error);
+    } finally {
+      await endStreamedRun(run, { failure, noProgress, failOnStreamError });
+      // The failure the caller should act on: the observed stream failure, or a
+      // no-progress trip, or (for a fail-on-error drive) an abort mid-stream.
+      const trip = noProgress?.tripped() ?? null;
+      const terminalFailure =
+        failure ||
+        (trip ? new NoProgressError(trip.toolName, trip.count).message : undefined) ||
+        (failOnStreamError && run.handle.signal.aborted
+          ? run.abortReason()
+            ? `Stopped before finishing: ${run.abortReason()}`
+            : "Stopped before finishing."
+          : undefined);
+      resolveDone({
+        messages: handoverMessages,
+        latest,
+        failure: terminalFailure,
+        truncated,
+      });
+    }
+  })();
+
+  return {
+    snapshots,
+    response,
+    finalHandedOver: () => finalHandedOver,
+    done,
+  };
+};
+
+export type OnceDriveOptions = {
+  plan: RunPlan;
+  run: RunLifecycle;
+  prompt?: string;
+  modelMessages?: ModelMessage[];
+  /** Unattended (Trigger) runs enable no-progress detection. */
+  unattended?: boolean;
+};
+
+/**
+ * Drives a headless `generateText` run inside its registered lifecycle.
+ *
+ * Returns a single answer and the computed statistics. The terminal status and
+ * output-ceiling cutoff are decided here — the same rules `driveStreamed`
+ * applies — and the run is finished (succeeded, or failed with a `NoProgressError`
+ * when the no-progress condition trips) before returning.
+ */
+export const driveOnce = async (
+  opts: OnceDriveOptions,
+): Promise<{ text: string; stats: RunStats }> => {
+  const { plan, run, prompt, modelMessages, unattended = false } = opts;
+  const noProgress: NoProgressDetector | null = unattended
+    ? createNoProgressDetector()
+    : null;
+  const startTime = Date.now();
+
+  try {
+    const result = await generateText({
+      ...buildModelInvocation(plan, {
+        abortSignal: run.handle.signal,
+        extraStopCondition: noProgress?.stopCondition,
+      }),
+      ...(prompt !== undefined ? { prompt } : { messages: modelMessages ?? [] }),
+      onStepFinish: (step: RunStep) => run.onStep(step),
+    });
+
+    const stats = computeStats(
+      result as Parameters<typeof computeStats>[0],
+    );
+    if (isTruncatedByTokenLimit(result.finishReason)) {
+      stats.truncatedByTokenLimit = true;
+    }
+    run.setStats(stats);
+
+    // The no-progress stop condition halts the loop cleanly (the SDK resolves
+    // normally), so the abort is surfaced here rather than via the catch path.
+    const trip = noProgress?.tripped() ?? null;
+    if (trip) {
+      const err = new NoProgressError(trip.toolName, trip.count);
+      logger.warn(
+        {
+          runId: run.handle.runId,
+          toolName: trip.toolName,
+          count: trip.count,
+          duration: Date.now() - startTime,
+          finishReason: result.finishReason,
+          rawFinishReason: result.rawFinishReason,
+          stats,
+        },
+        "Run aborted: no progress",
+      );
+      await run.finish("failed", err);
+      return { text: result.text, stats };
+    }
+
+    // Nobody is watching an unattended run, so this log is the only record of
+    // how it ended. Carried here because the completion log is the one place
+    // the raw reason survives for an unattended run.
+    logger.info(
+      {
+        runId: run.handle.runId,
+        duration: Date.now() - startTime,
+        responseLength: result.text.length,
+        finishReason: result.finishReason,
+        rawFinishReason: result.rawFinishReason,
+        stats,
+      },
+      "Run generate completed",
+    );
+
+    await run.finish("succeeded");
+    return { text: result.text, stats };
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.error(
+      { error, runId: run.handle.runId, duration: Date.now() - startTime },
+      "Run generate failed",
+    );
+    // A cancelled run is recorded as cancelled; a timed-out one stays a
+    // failure, and so does anything the model call threw on its own.
+    const aborted = run.statusFromSignal();
+    await run.finish(
+      aborted.status === "cancelled" ? "cancelled" : "failed",
+      err,
+    );
+    throw err;
+  }
+};

--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -622,6 +622,18 @@ describe("createSubAgentTool", () => {
       register.mockRestore();
     });
 
+    // Issue #496: a delegated run is unattended, so it drives under the same
+    // no-progress stop condition a Trigger run has — a stuck model re-issuing
+    // the same call for the same result is aborted rather than burning compute
+    // up to the step ceiling. An interactive Chat turn leaves that off.
+    it("drives the delegated run with the no-progress stop condition", async () => {
+      await delegate({});
+
+      const { stopWhen } = streamArgs();
+      // Step ceiling (stepCountIs) + the no-progress detector.
+      expect(stopWhen).toHaveLength(2);
+    });
+
     // The generator body doesn't start until the consumer pulls, so a parent
     // cancelled between dispatch and the first tick would never fire the abort
     // listener and the delegation would run on regardless.

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -1,10 +1,5 @@
 import { randomUUID } from "node:crypto";
-import {
-  getToolOrDynamicToolName,
-  isToolUIPart,
-  tool,
-  type Tool,
-} from "ai";
+import { getToolOrDynamicToolName, isToolUIPart, tool, type Tool } from "ai";
 import { z } from "zod";
 import { logger } from "../logger.ts";
 import { startRun } from "../runs/run-lifecycle.ts";

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -3,7 +3,7 @@ import { getToolOrDynamicToolName, isToolUIPart, tool, type Tool } from "ai";
 import { z } from "zod";
 import { logger } from "../logger.ts";
 import { startRun } from "../runs/run-lifecycle.ts";
-import { driveStreamed } from "../runs/drive.ts";
+import { driveDelegate, failBeforeDrive } from "../runs/drive.ts";
 import type { RunPlan } from "../runs/run-plan.ts";
 import { runRegistry } from "../runs/run-registry.ts";
 import { describeSdkError } from "../runs/stream-error.ts";
@@ -312,21 +312,25 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
         // the terminal callback and unregisters. `finish` is once-only, so the
         // explicit outcomes below win over the fallback in the `finally`.
         try {
-          // Set when the sub-agent's own stream reports a failure. The stream
-          // ENDS NORMALLY after an error, so without this the generator would
-          // return whatever text had accumulated — typically the model's opening
-          // preamble — and the parent would read a crash as an answer.
+          // The last snapshot seen, which is where the delegate's answer is
+          // read from. Whether that answer is safe to hand the parent is the
+          // drive's call, not this loop's: a stream that errored ENDS NORMALLY,
+          // so `latest` on its own cannot tell a finished answer from the
+          // model's opening preamble before a crash. `outcome.failure` can.
           let latest: PlatypusUIMessage | undefined;
           let entries: SubAgentActivityEntry[] = [];
-          let drive: ReturnType<typeof driveStreamed> | null = null;
-          let setupError: string | undefined;
+          // Either the drive started or it didn't — one or the other, never
+          // neither, so the outcome below needs no fallback for the gap.
+          let started:
+            | { drive: ReturnType<typeof driveDelegate> }
+            | { setupError: string };
 
           try {
             // Inside the try: opening this delegate's own tools can fail the
             // same way its stream can, and it reaches the parent as a tool error
             // either way rather than an unattributed throw.
             const tools = await loadTools();
-            drive = driveStreamed({
+            const drive = driveDelegate({
               // A Sub-Agent invocation receives Instructions plus guardrails and
               // nothing else — no workspace context, no memories, no user
               // identity (ADR-0016). The exception is expressed here, in what is
@@ -343,18 +347,13 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
               },
               prompt: task,
               run,
-              // A delegated sub-Agent is the unattended half of the streamed
-              // drive: it gains the no-progress stop condition (same call →
-              // same result, K times) that an interactive Chat leaves off, and
-              // fails when its stream reports an error rather than reading the
-              // crash as the finding.
-              mode: "delegate",
               onStepFinish: (step) => {
                 rawFinishReason = step.rawFinishReason;
               },
             });
+            started = { drive };
           } catch (error) {
-            setupError = describeSdkError(error);
+            started = { setupError: describeSdkError(error) };
           }
 
           // The drive folds the stream; this generator only projects it onto the
@@ -362,9 +361,9 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
           // yield: text deltas and growing tool inputs change the message on
           // nearly every chunk but leave the activity log alone, and yielding for
           // those would spam the parent's SSE stream.
-          if (drive) {
+          if ("drive" in started) {
             let lastYielded = "";
-            for await (const message of drive.snapshots) {
+            for await (const message of started.drive.snapshots) {
               latest = message;
               entries = activityEntries(message);
               const rendered = JSON.stringify(entries);
@@ -374,12 +373,16 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
             }
           }
 
-          const outcome = setupError
-            ? { failure: setupError, truncated: false as const }
-            : await drive!.done;
+          // Either the drive ended the run and reported how, or it never
+          // started and `failBeforeDrive` ends it under the same rule. Both
+          // hand back a decided status, so this tool never derives one.
+          const outcome =
+            "drive" in started
+              ? await started.drive.done
+              : await failBeforeDrive(run, started.setupError);
 
           const aggregatedText = assistantText(latest);
-          const truncatedByTokenLimit = outcome.truncated === true;
+          const truncatedByTokenLimit = outcome.truncated;
 
           // Throw rather than return: a failed delegation must reach the parent
           // as a tool error, not as a short answer it might summarize and pass
@@ -387,17 +390,9 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
           // along in the message so the work isn't lost.
           if (outcome.failure) {
             // A delegation stopped because someone cancelled the parent is a
-            // normal outcome, not a fault of this sub-agent — record and log it
-            // as the cancellation it is. `run.finish` is once-only: when the
-            // drive already ended the run (its terminal decision) this is a
-            // no-op; when stream setup failed before the drive started, this is
-            // the run's only finish.
-            const { status, error } = run.statusFromSignal();
-            const cancelled = status === "cancelled";
-            await run.finish(
-              cancelled ? "cancelled" : "failed",
-              error ?? new Error(outcome.failure),
-            );
+            // normal outcome, not a fault of this sub-agent — log it as the
+            // cancellation it is.
+            const cancelled = outcome.status === "cancelled";
             logger[cancelled ? "warn" : "error"](
               { runId, subAgentName: name, error: outcome.failure },
               `Sub-agent "${name}" did not finish`,

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -2,18 +2,16 @@ import { randomUUID } from "node:crypto";
 import {
   getToolOrDynamicToolName,
   isToolUIPart,
-  readUIMessageStream,
-  streamText,
   tool,
   type Tool,
 } from "ai";
 import { z } from "zod";
 import { logger } from "../logger.ts";
-import { createMessageMetadata } from "../runs/message-metadata.ts";
 import { startRun } from "../runs/run-lifecycle.ts";
-import { buildModelInvocation, type RunPlan } from "../runs/run-plan.ts";
+import { driveStreamed } from "../runs/drive.ts";
+import type { RunPlan } from "../runs/run-plan.ts";
 import { runRegistry } from "../runs/run-registry.ts";
-import { describeSdkError, formatStreamError } from "../runs/stream-error.ts";
+import { describeSdkError } from "../runs/stream-error.ts";
 import type { ParentRunContext } from "../runs/types.ts";
 import { renderSecurityGuardrails } from "../security-prompt.ts";
 import { actorUserId, workspaceScopeForSubAgent } from "../scope.ts";
@@ -323,60 +321,55 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
           // ENDS NORMALLY after an error, so without this the generator would
           // return whatever text had accumulated — typically the model's opening
           // preamble — and the parent would read a crash as an answer.
-          let streamFailure: string | undefined;
           let latest: PlatypusUIMessage | undefined;
           let entries: SubAgentActivityEntry[] = [];
+          let drive: ReturnType<typeof driveStreamed> | null = null;
+          let setupError: string | undefined;
 
           try {
             // Inside the try: opening this delegate's own tools can fail the
             // same way its stream can, and it reaches the parent as a tool error
             // either way rather than an unattributed throw.
             const tools = await loadTools();
-            const result = streamText({
-              ...buildModelInvocation(
-                {
-                  ...plan,
-                  // A Sub-Agent invocation receives Instructions plus
-                  // guardrails and nothing else — no workspace context, no
-                  // memories, no user identity (ADR-0016). The exception is
-                  // expressed here, in what is handed to the shared assembly,
-                  // rather than as a mode inside the system-prompt renderer.
-                  system: composedInstructions,
-                  // Wrapped per invocation: the wrapper holds THIS run's
-                  // per-step stall timer down for the duration of each tool
-                  // call. Results arrive already normalized — the Tool session
-                  // that loaded them owns that (#321 one level down).
-                  tools: wrapToolsWithActivity(tools, run.onActivity),
-                },
-                { abortSignal: run.handle.signal },
-              ),
+            drive = driveStreamed({
+              // A Sub-Agent invocation receives Instructions plus guardrails and
+              // nothing else — no workspace context, no memories, no user
+              // identity (ADR-0016). The exception is expressed here, in what is
+              // handed to the shared drive, rather than as a mode inside the
+              // system-prompt renderer.
+              plan: {
+                ...plan,
+                system: composedInstructions,
+                // Wrapped per invocation: the wrapper holds THIS run's per-step
+                // stall timer down for the duration of each tool call. Results
+                // arrive already normalized — the Tool session that loaded them
+                // owns that (#321 one level down).
+                tools: wrapToolsWithActivity(tools, run.onActivity),
+              },
               prompt: task,
+              run,
+              // A delegated run is unattended: it gains the no-progress stop
+              // condition (same call → same result, K times) that an interactive
+              // Chat leaves off, and fails the run when its stream reports an
+              // error rather than reading the crash as the finding.
+              unattended: true,
+              failOnStreamError: true,
               onStepFinish: (step) => {
                 rawFinishReason = step.rawFinishReason;
-                run.onStep(step);
               },
             });
+          } catch (error) {
+            setupError = describeSdkError(error);
+          }
 
-            // The same consumption the run path uses: stream parts folded into a
-            // `UIMessage` by the SDK, errors rendered by `stream-error.ts`, and
-            // the output-ceiling cutoff carried on message metadata.
-            const uiStream = result.toUIMessageStream<PlatypusUIMessage>({
-              messageMetadata: createMessageMetadata(undefined),
-              onError: (error) => formatStreamError(error),
-            });
-
-            // Serialized entries of the last yield. Text deltas and growing tool
-            // inputs change the message on nearly every chunk but leave the
-            // activity log alone, and yielding for those would spam the parent's
-            // SSE stream.
+          // The drive folds the stream; this generator only projects it onto the
+          // activity log the parent's UI renders. Serialized entries of the last
+          // yield: text deltas and growing tool inputs change the message on
+          // nearly every chunk but leave the activity log alone, and yielding for
+          // those would spam the parent's SSE stream.
+          if (drive) {
             let lastYielded = "";
-
-            for await (const message of readUIMessageStream<PlatypusUIMessage>({
-              stream: uiStream,
-              onError: (error) => {
-                streamFailure ??= describeSdkError(error);
-              },
-            })) {
+            for await (const message of drive.snapshots) {
               latest = message;
               entries = activityEntries(message);
               const rendered = JSON.stringify(entries);
@@ -384,39 +377,34 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
               lastYielded = rendered;
               yield { entries } satisfies SubAgentActivity;
             }
-
-            // An abort ends the stream normally, so the signal is the only record
-            // that the run was stopped rather than finished.
-            if (!streamFailure && run.handle.signal.aborted) {
-              const reason = run.abortReason();
-              streamFailure = reason
-                ? `Stopped before finishing: ${reason}`
-                : "Stopped before finishing.";
-            }
-          } catch (error) {
-            streamFailure ??= describeSdkError(error);
           }
 
+          const outcome = setupError
+            ? { failure: setupError, truncated: false as const }
+            : await drive!.done;
+
           const aggregatedText = assistantText(latest);
-          const truncatedByTokenLimit =
-            latest?.metadata?.truncatedByTokenLimit === true;
+          const truncatedByTokenLimit = outcome.truncated === true;
 
           // Throw rather than return: a failed delegation must reach the parent
           // as a tool error, not as a short answer it might summarize and pass
           // off to the user as the sub-agent's finding. Any partial text rides
           // along in the message so the work isn't lost.
-          if (streamFailure) {
+          if (outcome.failure) {
             // A delegation stopped because someone cancelled the parent is a
             // normal outcome, not a fault of this sub-agent — record and log it
-            // as the cancellation it is.
+            // as the cancellation it is. `run.finish` is once-only: when the
+            // drive already ended the run (its terminal decision) this is a
+            // no-op; when stream setup failed before the drive started, this is
+            // the run's only finish.
             const { status, error } = run.statusFromSignal();
             const cancelled = status === "cancelled";
             await run.finish(
               cancelled ? "cancelled" : "failed",
-              error ?? new Error(streamFailure),
+              error ?? new Error(outcome.failure),
             );
             logger[cancelled ? "warn" : "error"](
-              { runId, subAgentName: name, error: streamFailure },
+              { runId, subAgentName: name, error: outcome.failure },
               `Sub-agent "${name}" did not finish`,
             );
             // The failure is a step of the work as the parent's UI reads it, so
@@ -424,11 +412,15 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
             yield {
               entries: [
                 ...entries,
-                { type: "failed", status: "error", error: streamFailure },
+                {
+                  type: "failed",
+                  status: "error",
+                  error: outcome.failure,
+                },
               ],
             } satisfies SubAgentActivity;
             throw new Error(
-              `Sub-agent "${name}" did not complete: ${streamFailure}` +
+              `Sub-agent "${name}" did not complete: ${outcome.failure}` +
                 (aggregatedText
                   ? `\n\nPartial output before the failure:\n${aggregatedText}`
                   : ""),
@@ -436,14 +428,11 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
           }
 
           if (truncatedByTokenLimit) {
-            run.setStats({ ...run.stats, truncatedByTokenLimit: true });
             logger.warn(
               { runId, subAgentId: id, subAgentName: name, rawFinishReason },
               `Sub-agent "${name}" answer truncated at the output token limit`,
             );
           }
-
-          await run.finish("succeeded");
 
           const text =
             aggregatedText || summarizeToolResult(finalToolResult(latest));

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -343,12 +343,12 @@ export const createSubAgentTool = (options: SubAgentToolOptions) => {
               },
               prompt: task,
               run,
-              // A delegated run is unattended: it gains the no-progress stop
-              // condition (same call → same result, K times) that an interactive
-              // Chat leaves off, and fails the run when its stream reports an
-              // error rather than reading the crash as the finding.
-              unattended: true,
-              failOnStreamError: true,
+              // A delegated sub-Agent is the unattended half of the streamed
+              // drive: it gains the no-progress stop condition (same call →
+              // same result, K times) that an interactive Chat leaves off, and
+              // fails when its stream reports an error rather than reading the
+              // crash as the finding.
+              mode: "delegate",
               onStepFinish: (step) => {
                 rawFinishReason = step.rawFinishReason;
               },


### PR DESCRIPTION
Closes #496.

## What

Extracts the model drill from the three places that re-derived it — the Chat `stream` and headless `generate` paths in `AgentRunner`, and the delegate tool's `execute` — into `apps/backend/src/runs/drive.ts`.

The seam now owns what used to be copied three ways:
- building the model invocation (step ceiling and the no-progress stop condition included),
- the terminal-status decision (succeeded / failed / cancelled),
- recording the output-ceiling cutoff on the run's stats,
- ending the run.

`driveStreamed` serves `streamText` runs (a Chat turn tees a client stream; a delegated sub-Agent folds the snapshots into its activity log) and `driveOnce` serves `generateText` runs (Triggers).

A delegated sub-Agent run is unattended, so it now drives under the same no-progress condition a Trigger has — a stuck model that re-issues the same call for the same result is aborted instead of running to the step ceiling (previously wired to `generate` only, so Trigger-delegated runs silently got none).

## Callers keep only their shape

- `AgentRunner.stream` — the tee + `Response`
- `AgentRunner.generate` — `{ text, stats }`
- delegate tool — the activity projection + the throw-on-failure rule

## Tests

- New `runs/drive.test.ts` at the seam (real AI SDK pipeline, mock model)
- Full backend suite, typecheck, ESLint and Prettier all green (1884 tests)

## ADR
None.