### PR TITLE
docs: tell contributors which issues are ready to pick up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ Please be respectful and constructive in all interactions. We are committed to p
 
 Looking for something to work on? Browse our [good first issues](https://github.com/willdady/platypus/contribute) — scoped, newcomer-friendly tasks that are a great starting point.
 
+### Picking an issue
+
+Issues labelled `ready-for-agent` or `ready-for-human` have an agreed approach — go ahead and start. Issues labelled `needs-triage` haven't been decided yet. Some describe a real bug but leave the fix open; drop a comment before you start and we'll help you work out the direction.
+
 1. **Fork the repository** and clone your fork locally.
 2. **Set up your development environment** by following [Local Development](#local-development) below.
 3. **Create a branch** from `main` for your changes (see [Branch Naming](#branch-naming) below).


### PR DESCRIPTION
Closes #531

## What

Adds a short **"Picking an issue"** subsection to `CONTRIBUTING.md` under **Getting Started**, right after the "good first issues" line. It explains that issues labelled `ready-for-agent` or `ready-for-human` have an agreed approach (go ahead and start), while `needs-triage` issues haven't been decided yet and contributors should drop a comment first.

## Why

From the outside there is no way to tell a decided issue from an undecided one. This surfaced on #515, where a contributor picked up #467 — a `needs-triage` issue with an open direction call — and, with clean code, settled three questions that were still open. Nothing told them to check in first, so this is a documentation gap rather than a contributor mistake.

These two clauses were kept as required by the issue:
- The check-in reads as an offer to help ("we'll help you work out the direction"), not a permission request.
- It stays to a few sentences — a signpost, not a process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)