### PR TITLE
chore: publish a floating major tag for Docker Hub images

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -23,6 +23,26 @@ jobs:
         id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
+      # The floating major tag (`:2`) moves forward with every release in its
+      # line, so a deployment can pin a major and still take minors and patches.
+      # A prerelease never claims one: `:2` must not resolve to 2.0.0-rc.1. The
+      # outputs are empty in that case, and an empty tag line is dropped by
+      # build-push-action.
+      - name: Derive floating major tag
+        id: tags
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [[ "$VERSION" == *-* ]]; then
+            echo "Prerelease $VERSION — no floating major tag."
+            echo "frontend_major=" >> "$GITHUB_OUTPUT"
+            echo "backend_major=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          major="${VERSION%%.*}"
+          echo "frontend_major=willdady/platypus-frontend:$major" >> "$GITHUB_OUTPUT"
+          echo "backend_major=willdady/platypus-backend:$major" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
@@ -45,6 +65,7 @@ jobs:
           tags: |
             willdady/platypus-frontend:latest
             willdady/platypus-frontend:${{ steps.version.outputs.version }}
+            ${{ steps.tags.outputs.frontend_major }}
 
       - name: Build and push backend image
         uses: docker/build-push-action@v7
@@ -56,3 +77,4 @@ jobs:
           tags: |
             willdady/platypus-backend:latest
             willdady/platypus-backend:${{ steps.version.outputs.version }}
+            ${{ steps.tags.outputs.backend_major }}

--- a/apps/docs/content/docs-contract.test.ts
+++ b/apps/docs/content/docs-contract.test.ts
@@ -860,6 +860,110 @@ describe("field limits", () => {
   });
 });
 
+// --- docker image tags -------------------------------------------------------
+
+/**
+ * The Compose page tells Operators to pin a tag. Nothing but the release
+ * workflow makes those tags exist, so the page's three-way choice — `latest`,
+ * the floating major, an exact version — is pinned against the workflow that
+ * pushes them and against the version line the repository is actually on.
+ */
+const RELEASE_WORKFLOW = ".github/workflows/build-and-push.yml";
+const COMPOSE_PAGE = "self-hosting/docker-compose.mdx";
+const IMAGES = ["frontend", "backend"] as const;
+
+const currentMajor = (): string => {
+  const { version } = JSON.parse(readRepoFile("package.json")) as {
+    version?: string;
+  };
+  const major = version?.match(/^(\d+)\./)?.[1];
+  if (!major) {
+    throw new Error(
+      `No \`x.y.z\` version in the root package.json (read \`${version}\`). ` +
+        `The release workflow derives every image tag from it; update this test if the scheme changed.`,
+    );
+  }
+  return major;
+};
+
+describe("docker image tags", () => {
+  const workflow = readRepoFile(RELEASE_WORKFLOW);
+  const major = currentMajor();
+
+  it("pushes latest, the exact version, and a floating major for both images", () => {
+    const violations: string[] = [];
+
+    for (const image of IMAGES) {
+      const expected = [
+        `willdady/platypus-${image}:latest`,
+        `willdady/platypus-${image}:\${{ steps.version.outputs.version }}`,
+        `\${{ steps.tags.outputs.${image}_major }}`,
+      ];
+      for (const tag of expected) {
+        if (!workflow.includes(tag)) {
+          violations.push(
+            `${RELEASE_WORKFLOW} no longer tags the ${image} image with \`${tag}\`.\n` +
+              `${COMPOSE_PAGE} tells Operators all three tags exist; either restore the tag or rewrite that page.`,
+          );
+        }
+      }
+    }
+
+    expectNoViolations(violations);
+  });
+
+  /**
+   * The page promises `:2` tracks the newest `2.x.y`. A major written into the
+   * workflow by hand keeps resolving long after the repository has moved on, so
+   * the claim fails silently rather than loudly. This checks the shape of the
+   * tag, not the shell that builds it — how the major gets derived is the
+   * workflow's business.
+   */
+  it("hardcodes no major in the release workflow", () => {
+    const hardcoded = [
+      ...workflow.matchAll(
+        /willdady\/platypus-(?:frontend|backend):(\d[\w.]*)/g,
+      ),
+    ];
+
+    expectNoViolations(
+      hardcoded.map(
+        ([full]) =>
+          `${RELEASE_WORKFLOW} pushes \`${full}\`, a version literal.\n` +
+          `Every version-bearing tag has to come from the workflow's own version output, or it stops moving with the release.`,
+      ),
+    );
+  });
+
+  it("shows only tags that exist, on the major line the repository is on", () => {
+    const page = readDoc(COMPOSE_PAGE);
+    const tags = [
+      ...page.matchAll(/willdady\/platypus-(?:frontend|backend):([\w.-]+)/g),
+    ];
+
+    expect(
+      tags.length,
+      `Matched no image tags in ${COMPOSE_PAGE} — the page stopped naming them, or the matcher broke.`,
+    ).toBeGreaterThan(0);
+
+    const violations: string[] = [];
+    for (const [full, tag] of tags) {
+      const onCurrentLine =
+        tag === "latest" ||
+        tag === major ||
+        new RegExp(String.raw`^${major}\.\d+\.\d+$`).test(tag);
+      if (!onCurrentLine) {
+        violations.push(
+          `${COMPOSE_PAGE} shows \`${full}\`, which is not \`:latest\`, the floating \`:${major}\`, or an exact \`${major}.y.z\`.\n` +
+            `Source of truth: the root package.json version. A major bump is meant to fail here — update the page's examples with it.`,
+        );
+      }
+    }
+
+    expectNoViolations(violations);
+  });
+});
+
 // --- internal links and heading anchors --------------------------------------
 
 /** `content/index.mdx` → `/`, `content/foo/index.mdx` → `/foo`. */

--- a/apps/docs/content/self-hosting/docker-compose.mdx
+++ b/apps/docs/content/self-hosting/docker-compose.mdx
@@ -36,25 +36,45 @@ report status.
 ### Image tags
 
 The compose file ships pointing at `:latest` for both application images. Every
-release also publishes a version tag — `willdady/platypus-backend:2.2.1`,
-`willdady/platypus-frontend:2.2.1` — matching the release's version number.
+release publishes three tags per image, and which one you pin decides how much
+moves under you on the next `docker compose pull`:
 
-**Pin those tags.** `:latest` moves under you: the next `docker compose pull`
-fetches whatever the newest release happens to be, and you have no way to state
-which version a deployment is running. Override the images in a
-`compose.override.yaml` alongside `compose.yaml`:
+| Tag           | Example                            | What a pull fetches                     |
+| ------------- | ---------------------------------- | --------------------------------------- |
+| Latest        | `willdady/platypus-backend:latest` | The newest release, major bump included |
+| Major line    | `willdady/platypus-backend:2`      | The newest `2.x.y`, never `3.0.0`       |
+| Exact version | `willdady/platypus-backend:2.7.1`  | That release and nothing else           |
+
+**Pin something other than `:latest`.** It is the only tag that can carry a
+breaking major change into a running deployment, and it leaves you unable to say
+which version you are on.
+
+Pin the **major line** for a deployment you want to keep current without
+watching every release. Pin the **exact version** for one you upgrade
+deliberately — it is the only tag that makes an upgrade a change you made rather
+than a pull you ran.
+
+Override the images in a `compose.override.yaml` alongside `compose.yaml`:
 
 ```yaml
 services:
   backend:
-    image: willdady/platypus-backend:2.2.1
+    image: willdady/platypus-backend:2.7.1
   frontend:
-    image: willdady/platypus-frontend:2.2.1
+    image: willdady/platypus-frontend:2.7.1
 ```
 
 Compose merges `compose.override.yaml` automatically, so `docker compose up -d`
 picks it up with no extra flags. Bump both together — the two images are
 released as a pair and are only tested against each other.
+
+<Callout type="warning">
+  A major-line pin is not a record of what you deployed. Two hosts that pulled
+  `:2` a month apart run different builds from identical compose files, so
+  "we're both on 2" is not a statement anyone can act on during an incident.
+  Read `docker compose images` for the digest a host actually has, and pin exact
+  versions where that matters.
+</Callout>
 
 ### Ports
 
@@ -241,7 +261,9 @@ release — and rolls nothing back, because the shipped compose file doesn't pin
 version.
 
 Edit the pinned tags in your `compose.override.yaml` back to the version you
-were on, and bring the stack up again:
+were on, and bring the stack up again. Use exact versions here even if you
+normally pin the major line — `:2` has no way to express "the release before
+this one":
 
 ```bash
 docker compose up -d

--- a/apps/docs/turbo.json
+++ b/apps/docs/turbo.json
@@ -8,7 +8,9 @@
         "$TURBO_ROOT$/.env.example",
         "$TURBO_ROOT$/apps/backend/.env.example",
         "$TURBO_ROOT$/apps/frontend/.env.example",
-        "$TURBO_ROOT$/apps/backend/src/plugins/builtin.ts"
+        "$TURBO_ROOT$/apps/backend/src/plugins/builtin.ts",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/.github/workflows/build-and-push.yml"
       ]
     }
   }


### PR DESCRIPTION
Closes #503

## Problem

Every release pushed exactly two tags per image: `:latest` and the exact version. That left self-hosters choosing between an unannounced major bump on the next `docker pull` and hand-editing compose for every patch.

## Change

Each release now also pushes a floating major tag per image — `willdady/platypus-backend:2`, `willdady/platypus-frontend:2` — always pointing at the newest `2.x.y`. `:latest` and the exact-version tags are untouched.

The major is derived from the workflow's existing `version` output rather than hardcoded, so the two can't drift. A prerelease publishes no floating tag: `:2` must never resolve to a `2.0.0-rc.1`. The step emits empty outputs in that case, which `build-push-action` drops from the tag list.

The compose docs now explain the three-way choice — `:latest`, the major line, an exact version — with guidance on which to pin, and a note that rolling back needs an exact version because `:2` can't express "the release before this one".

Three cases in the docs contract test pin that the workflow pushes all three tags per image, that no version literal is hardcoded, and that the page shows no tag outside the current major line.

## Verification

Full suite green (2247 tests), typecheck and lint clean.

The shipped shell was extracted verbatim and run under `set -eo pipefail` against `2.7.1`, `2.8.0`, `3.0.0`, `10.1.4`, `2.0.0-rc.1` and `3.0.0-beta.2` — correct major, empty on prereleases, exit 0 throughout. The "empty tag line is dropped" claim was confirmed against actions-toolkit's `getList` (`skipEmptyLines: true` plus `.filter(item => item)`) rather than assumed. Each new assertion was checked by breaking the thing it pins and watching it fail.

## Decisions and known gaps

**No floating minor tag.** The issue left this open. The docs requirement frames the reader's choice as three options, and a fourth tag buys a narrow "patches only" case at the cost of the page's clarity.

**`:latest` still moves on a prerelease.** Changing `:latest` is out of scope for this issue, so it was left alone. If a prerelease were ever published, `:latest` would follow it while `:2` correctly would not. Worth revisiting only if prereleases become real.

**A `3.0.0` bump will fail the docs contract test** until the compose page's examples are updated. That tripwire is intentional and the failure message says so, but a major release PR carries one extra hand-edit.

**Not addressed:** the `willdady/platypus-*` image name is hardcoded across this workflow, `compose.yaml`, both Docker build scripts and the docs — real shotgun surgery, but outside this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
