### PR TITLE
fix(frontend): correct sub-Agents to Sub-Agents in Instructions text

### DIFF
--- a/.agents/skills/docs-audit/VOICE.md
+++ b/.agents/skills/docs-audit/VOICE.md
@@ -56,9 +56,9 @@ usual home for it. Do not soften it into "note that".
 
 ## Conventions
 
-- **Domain nouns are capitalised**: Agent, Workspace, Organization, Chat, Skill,
-  Trigger, Board, Webhook, Sandbox, Plugin, Tool, Provider, Operator. Ordinary
-  words are not — a "card" on a Board is a card.
+- **Domain nouns are capitalised**: Agent, Sub-Agent, Workspace, Organization,
+  Chat, Skill, Trigger, Board, Webhook, Sandbox, Plugin, Tool, Provider,
+  Operator. Ordinary words are not — a "card" on a Board is a card.
 - **UI labels are bold**, and menu paths use an arrow: **Settings → Webhooks**.
   Bold the label exactly as it appears on screen.
 - **Code spans** for env vars, values, fields, and event names: `BACKEND_URL`,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,7 +29,7 @@ The plain text pulled out of a binary document (PDF, DOCX) that the target model
 _Avoid_: parsed text, converted file, OCR (Platypus does not OCR).
 
 **Agent**:
-A configurable preset that pins a Provider, model, Instructions, generation parameters, Tools, Skills, and sub-Agents. Selecting an Agent on a Chat turn replaces direct Provider/model selection.
+A configurable preset that pins a Provider, model, Instructions, generation parameters, Tools, Skills, and Sub-Agents. Selecting an Agent on a Chat turn replaces direct Provider/model selection.
 
 **Sub-Agent**:
 An Agent referenced by a parent Agent and exposed to it as a delegate Tool. Invoking it starts a run in its own right — bounded by the same per-step and per-run timeouts the parent turn was started under, and cancelled when the parent is — but never a Chat: nothing about a delegated run is persisted.

--- a/apps/docs/content/building-with-platypus/agents.mdx
+++ b/apps/docs/content/building-with-platypus/agents.mdx
@@ -37,7 +37,7 @@ optional, but it's the single biggest lever on behaviour — e.g. _"You are a
 concise research assistant. Cite sources and prefer primary documents."_
 
 Platypus builds the full system prompt around what you write, adding the
-Workspace and user context, Memories, the Skills and sub-agent catalogues, and
+Workspace and user context, Memories, the Skills and Sub-Agent catalogues, and
 your Provider's security guardrails. [The system
 prompt](/concepts/system-prompt) lists every part in order — check it before
 writing anything long, so you don't restate what Platypus already supplies.

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -629,7 +629,7 @@ const AgentForm = ({
             <FieldDescription>
               How this Agent should behave. Platypus builds the full system
               prompt around it, adding workspace and user context, memories,
-              Skills, sub-Agents, and your Provider&apos;s security guardrails.
+              Skills, Sub-Agents, and your Provider&apos;s security guardrails.
             </FieldDescription>
           </Field>
           {/* Provider and model are chosen from one control, so surface either

--- a/apps/frontend/components/chat-settings-dialog.tsx
+++ b/apps/frontend/components/chat-settings-dialog.tsx
@@ -76,7 +76,7 @@ export const ChatSettingsDialog = ({
           <FieldDescription>
             How the assistant should behave in this chat. Platypus builds the
             full system prompt around it, adding workspace and user context,
-            memories, Skills, sub-Agents, and your Provider&apos;s security
+            memories, Skills, Sub-Agents, and your Provider&apos;s security
             guardrails.
           </FieldDescription>
         </div>


### PR DESCRIPTION
## Summary
Correct mid-word capital 'sub-Agents' to 'Sub-Agents' in user-facing Instructions text, matching the domain term defined in CONTEXT.md.

## Files changed
- `apps/frontend/components/chat-settings-dialog.tsx:79`
- `apps/frontend/components/agent-form.tsx:632`
- `CONTEXT.md:32`

## Rationale
CONTEXT.md defines **Sub-Agent** as a domain term, and the codebase uses 'Sub-Agents' (capital S) consistently elsewhere (e.g., `agent-form.tsx:828` and `CONTEXT.md:168,183`). Only these three locations had the incorrect mid-word capital 'sub-Agents'.

Fixes #544.