### PR TITLE
chore: record the invitation-redemption design decisions

### DIFF
--- a/.out-of-scope/org-email-domain-admission.md
+++ b/.out-of-scope/org-email-domain-admission.md
@@ -1,0 +1,86 @@
+# Org-Scoped Email-Domain Admission
+
+Platypus does **not** let an Organization hold a list of allowed email domains that
+admits people to the deployment. There is no `allowedEmailDomains` on the
+`organization` row, no deployment-wide `SIGNUP_ALLOWED_EMAIL_DOMAINS` env
+allowlist, and no `DEFAULT_ORGANIZATION_ID` auto-attach hook. More broadly, this
+rejects **admission by address pattern** — the idea that holding an address
+matching some rule is sufficient grounds to be given an account.
+
+This rejects the _admission mechanism_, not the underlying want. "Everyone at
+this company should be able to get in without me clicking a button per person"
+is a reasonable thing to want, and the zero-per-person-admin-work property is
+genuinely the thing the other options don't have. What is out of scope is
+spending the Organization row, or an env allowlist, to buy it.
+
+## Why domain admission is out of scope
+
+### It inverts the authority tiering
+
+`CONTEXT.md` states the tiering plainly: authority over configuration runs
+**Operator → Org Admin → Workspace Owner**, each tier bounded by the tier above
+it. Holding an account sits *above* the top of that chain — only a Super Admin
+creates an Organization, and an Org Admin's entire authority is scoped to the
+Organization they were given.
+
+A domain list on the Organization row would hand an Org Admin a text field that
+decides **who may register on the deployment**. That is Operator authority,
+exercised by editing an org-scoped setting. An Org Admin who typed `gmail.com`
+into that field would open the deployment to everyone on the internet with a
+Gmail address, and the Operator — who owns the deployment's exposure — would have
+no say and no signal.
+
+The request's own framing is the tell: the setting "does both jobs — it gates who
+may register _and_ answers which Organization they belong to." Those two jobs
+belong to two different tiers. Collapsing them into one field is precisely what
+makes the field attractive and precisely what makes it wrong.
+
+### An address is not evidence
+
+Platypus does not verify email addresses — `requireEmailVerification` is off and
+there is no mail transport to turn it on with. So a domain rule tests a *claim*,
+not a fact: nothing establishes that the person registering as
+`someone@example.com` controls that mailbox, or exists.
+
+Domain admission therefore reads as "anyone who asserts an address on this
+domain is admitted." For a rule whose whole purpose is to decide who gets in,
+resting it on an unverified self-assertion is not a strong enough foundation, and
+the fix — actually verifying addresses — is a mail-delivery feature Platypus
+deliberately does not have.
+
+### The problem it solves is already solved
+
+The request reached the org-scoped design by merging two weaker ideas, and was
+explicit that neither is worth having alone: a bare env allowlist still drops
+people into the orphaned no-Organization state, and a bare default-org
+auto-attach widens exposure because sign-up stays open. That reasoning is sound.
+
+But the thing both halves were reaching for — a person who is admitted **and**
+lands somewhere useful — is what an **Invitation** already is. An invitation
+names the person, names the Organization, carries an ordered set of Blueprints,
+and provisions a Workspace on acceptance. It is the deployment's record of the
+decision "this person should have an account here." A domain rule would be a
+second, weaker admission record standing beside it, disagreeing about who
+decides.
+
+## What to do instead
+
+Send invitations, and redeem them into accounts by link. An invitation link is
+one admin action per person: create the invitation, paste the link into whatever
+channel you already use. That is not the zero-per-person-work property a domain
+list would give, and this is an honest cost of the rejection — a hundred-person
+rollout is a hundred invitations.
+
+What you get in exchange is that every account on the deployment traces to a
+decision somebody made, and the Operator keeps control of admission while Org
+Admins keep control of their Organization.
+
+If the per-person work is genuinely the blocker at your scale, the shape worth
+proposing is **Operator-level** — a deployment-wide allowlist owned by whoever
+owns the deployment's exposure, set at deploy time, not an org-scoped field an
+Org Admin can edit. That is a different request from this one and it is not
+rejected here; it simply has not been made.
+
+## Prior requests
+
+- #462 — "Feature: application-level control over who can sign up" (option D)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -132,6 +132,14 @@ The Org-Admin action that re-scopes a Workspace-private resource to Organization
 A named, Organization-scoped macro that, applied to a Workspace, both creates the Attachments for a chosen set of Shared resources (Tier 1) and sets the Workspace's pointer-settings — task/memory Providers and a default Context (Tier 2) — in one step. Run once at provisioning (or re-run on demand), never a live link. A Tier 2 Provider must also be one the Blueprint attaches. Editing a Blueprint affects only later applications; already-provisioned Workspaces are unchanged. The primary tool for provisioning a ready-to-use Workspace during onboarding.
 _Avoid_: template, policy, group.
 
+**Invitation**:
+An Organization's record of the decision that one named person may hold an account and join it, carrying an optional Workspace name and an ordered set of Blueprints. Redeemable exactly once, before it expires; redemption or acceptance joins the person to the Organization and provisions their Workspace.
+_Avoid_: invite request, membership request, allowlist entry.
+
+**Invitation link**:
+The single-use URL that redeems an Invitation, bearing a token minted with it. Held by whoever the Invitation's sender passes it to — the link, not the address on the Invitation, is what binds a redemption to it.
+_Avoid_: magic link, signup link, activation link.
+
 **Gateway** (Messaging gateway):
 A decoupled, stateful app — deployed alongside the frontend and backend — that bridges external chat Surfaces to Platypus, relaying messages both ways. Holds the long-lived per-Surface connections and hosts Gateway adapters; the backend itself stays messaging-agnostic. Platypus, not the Gateway, is the identity authority.
 _Avoid_: bot, bridge, connector.
@@ -172,6 +180,7 @@ The record binding a Conversation locus to a Chat (which carries the Workspace +
 - An **Agent**, **Skill**, **MCP**, or **Provider** is a **Scoped resource**: its row carries either an `organizationId` or a `workspaceId`, never both. Resolved relative to a **Workspace**, an Organization-scoped one is a **Shared resource**, visible only through an **Attachment**; a Sandbox-backed **Tool set** instead rebinds to the invoking **Workspace**'s **Sandbox** at Chat-turn time.
 - A **Blueprint** names a set of **Shared resources** and, applied to a **Workspace**, creates their **Attachments** in one step.
 - **Workspaces** are created only by **Org Admins** — directly, or auto-provisioned for a member when they accept an invitation. An invitation carries an ordered set of zero-or-more **Blueprints**; on accept they are applied to the new Workspace in order (Attachments union; later Blueprints win on any single-valued pointer-setting). Members do not create their own Workspaces.
+- An **Invitation** is redeemed through its **Invitation link**, which creates the account and joins the Organization in one act; a person who already holds an account instead accepts the Invitation in-app. Where the Operator requires invitations, redemption is the only way an account comes into existence — admission is the **Operator**'s to constrain, never an **Org Admin**'s to widen.
 - Authority over configuration runs **Operator** → **Org Admin** → **Workspace Owner**; each tier is bounded by the tier above it.
 - A **Gateway** hosts many **Gateway adapters**, one per **Surface**. A message on a **Surface** carries a **Sender** and arrives at a **Conversation locus**.
 - A **Sender** resolves to a **User** through an **Identity link** (authorizes); a **Conversation locus** resolves to a **Chat** through a **Conversation binding** (routes). The two are separate because in a shared room "who spoke" and "where it happened" diverge; a direct message collapses them 1:1.

--- a/docs/adr/0019-invitations-are-redeemable-into-accounts.md
+++ b/docs/adr/0019-invitations-are-redeemable-into-accounts.md
@@ -1,0 +1,94 @@
+---
+status: accepted
+---
+
+# Invitations are redeemable into accounts
+
+Extends ADR-0008 and ADR-0009. Those ADRs treat an invitation as a row matched to an
+_existing_ account by email address, which makes the invitation useless as an admission
+control: the invitee must already hold an account before the invitation is visible to them,
+so open self-service registration is a prerequisite of the invitation flow rather than an
+oversight in it. We therefore give an invitation a **token** and make it **redeemable into an
+account**: an invitation link creates the account, signs the person in, and accepts the
+invitation in one act. An Operator may then require invitations, at which point the
+invitation row is the only thing in the system that can produce a `user`. Everything
+ADR-0008 and ADR-0009 establish about what an invitation _carries_ — the optional Workspace
+name, the ordered Blueprint set, snapshot-not-binding application, the deletion guard — is
+unchanged.
+
+## Decisions
+
+- **The invitation is the admission record, and nothing restates it.** The alternative
+  considered first was an Operator-created account: close registration and have the Super
+  Admin mint `user` rows from the platform Users screen. Rejected because it produces _two_
+  records of one decision — an invitation saying a person may join, and a hand-made account
+  saying they may hold an account — and a two-step process where the second step can be
+  skipped, leaving exactly the orphaned accountless-Organization state this work exists to
+  eliminate. One record, one action.
+
+- **The token binds the redemption, not the address.** An email-match gate — reject
+  registration unless a pending invitation exists for the submitted address — was the
+  originally proposed mechanism and is rejected. Platypus verifies no addresses
+  (`requireEmailVerification` is off and there is no mail transport), so such a gate tests
+  whether an address is _on a list_, never whether the person at the keyboard is its owner.
+  Company addresses follow guessable conventions, so the gate would narrow the set of
+  registerable addresses to precisely the invited — and therefore valuable — ones. A
+  server-minted token is not guessable. The invitee's address is read off the invitation
+  rather than typed.
+
+- **This trades guessability for transmission, deliberately.** Under address matching an
+  invitation is worthless to anyone not already controlling that mailbox. Under token
+  redemption, whoever holds the link can redeem it: forwarded to the wrong person, they get
+  the account and the Organization membership. This is a real and accepted regression in one
+  axis, taken because the transmission channel is the sender's to choose and is the same
+  channel that already had to carry "an invitation is waiting for you", whereas
+  guessability is under nobody's control. Single-use and expiry — already carried by
+  `status` and `expiresAt` — bound the exposure; there is no revocation action beyond
+  deleting the invitation and creating a new one.
+
+- **The token is stored in plaintext and re-copyable.** Hashing it would confine the
+  plaintext to the creation response, making the link show-once and a lost link
+  unrecoverable. Rejected: Platypus has no email, so the one channel that could re-send a
+  show-once secret does not exist, and the threat this design addresses is a stranger
+  reaching the registration page, not an attacker holding `SELECT` on the database. An
+  Organization's Invitations surface therefore offers the link on any pending row.
+
+- **Requiring invitations disables registration rather than gating it.** With redemption
+  performing account creation server-side, the auth library's own `disableSignUp` option
+  closes the public registration endpoint outright when the Operator requires invitations. A
+  `hooks.before` middleware that inspected registration requests for a valid token was
+  rejected: it leaves the endpoint live and makes the middleware the security boundary, so
+  every upgrade of the auth library is an opportunity for the fence to stop lining up with
+  the door it fences. Closing the door with a supported option and minting users only
+  through a route we own is the stronger shape.
+
+- **Admission is Operator-scoped.** Requiring invitations is a deploy-time Operator
+  decision, defaulted to off so existing deployments are unaffected. Admission rules owned
+  by an Organization — notably an org-held allowed-email-domain list — are rejected on
+  authority grounds; see `.out-of-scope/org-email-domain-admission.md`.
+
+## Consequences
+
+- **Redemption may leave an account behind.** Redemption creates the account, signs the
+  person in, then joins the Organization and provisions the Workspace with its Blueprints.
+  Account creation happens outside the accept transaction — the hazard `seed.ts` already
+  documents and hand-compensates for — so a Blueprint failure can leave a usable account
+  with the invitation still pending. This is the deliberate answer: the account survives and
+  the in-app acceptance path is still available, which is strictly better than a link that
+  lands someone on an empty shell.
+
+- **In-app acceptance remains, and the link serves both audiences.** Someone who already
+  holds an account has nothing to redeem into, so the existing notification and
+  Settings-based acceptance path is unchanged. The link also works for a signed-in holder of
+  the invited address, and refuses explicitly when a _different_ account is signed in rather
+  than silently binding to the wrong one.
+
+- **Self-service registration survives.** Requiring invitations does not make account
+  creation an administrative act: the invitee still chooses their own name and password, and
+  no initial password is ever transmitted or known to an administrator. Only the entrance
+  changes.
+
+- **The self-hosting documentation now describes two admission modes.** With the requirement
+  defaulted off, the deployment's admission posture depends on configuration and can no
+  longer be stated as one flat claim. The default is expected to flip at the next major
+  version, at which point the documentation returns to stating one thing.


### PR DESCRIPTION
Records the design settled during triage of #462, ahead of the implementation in #549 and #550. Documentation and records only — no code, no behaviour change.

## What was decided

An **Invitation** becomes redeemable. It carries a token, and its link creates the account, signs the person in, and accepts the invitation in one act. An Operator may then require invitations, at which point the invitation row is the only thing in the system that can produce a user.

Self-service registration survives. The invitee still chooses their own name and password, and no initial password is ever set by, transmitted through, or known to an administrator. Only the entrance changes.

## Files

**`docs/adr/0019-invitations-are-redeemable-into-accounts.md`** — extends ADR-0008 and ADR-0009 without modifying them. Records the trade-off actually taken: binding redemption to a server-minted token rather than to an email address gives up "an invitation is worthless to anyone not already controlling that mailbox" in exchange for an address no longer being sufficient to claim one. Also records why the rejected alternatives were rejected — an administrator hand-minting accounts (two records of one decision, and a second step that can be skipped), and a `hooks.before` gate on the registration endpoint (leaves the door open and makes the middleware the security boundary, so every auth-library upgrade is a chance for the fence to stop lining up with the door).

**`CONTEXT.md`** — adds **Invitation** and **Invitation link**, plus a relationship line. Invitation had no glossary entry at all despite being referenced in Relationships and owning ADR-0009; this work makes it a first-class concept, so it needed defining.

**`.out-of-scope/org-email-domain-admission.md`** — records the rejection of an Organization holding a list of allowed email domains, on authority grounds: it would hand an Org Admin a text field deciding who may register on the *deployment*, inverting the Operator → Org Admin → Workspace Owner tiering that `CONTEXT.md` states. The note is explicit that the underlying want is not rejected — an Operator-scoped allowlist is a different request and has not been refused.

## Docs

No `apps/docs/content` change belongs here. Per the table in `CLAUDE.md`, none of these paths trigger a documentation update — the user-facing rewrite of `self-hosting/users-and-access.mdx` for two admission modes is a deliverable of #550, where the configuration it describes actually lands.

## Review notes

The ADR is the part worth reading closely — it commits to a security posture change, and the trade-off in the third decision is the one to push back on if you read it differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
