### PR TITLE
fix(backend): make the chat idle timeout measure silence, not step duration

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -55,6 +55,11 @@ STORAGE_DISK_PATH=./data/files
 # STORAGE_S3_ACCESS_KEY_ID=
 # STORAGE_S3_SECRET_ACCESS_KEY=
 
+# Idle timeout for a Chat turn: how long with no streamed output before the run is stopped.
+CHAT_PER_STEP_TIMEOUT_MS=120000
+# Wall-clock timeout for an entire Chat turn.
+CHAT_PER_RUN_TIMEOUT_MS=1800000
+
 # Trigger run timeouts (unattended Agent runs)
 TRIGGER_PER_STEP_TIMEOUT_MS=600000  # idle timeout between steps (10 min)
 TRIGGER_PER_RUN_TIMEOUT_MS=3600000  # wall-clock timeout per run (60 min)

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -26,6 +26,36 @@ import { agentRunner } from "../runs/agent-runner.ts";
 import { ChatSink } from "../runs/sinks/chat-sink.ts";
 import type { RunInput } from "../runs/types.ts";
 
+/**
+ * The bounds an interactive Chat run is given.
+ *
+ * Chat used to take the registry's own defaults, which are deliberately tight
+ * because they are what an unbounded caller falls back to. That gave a watched
+ * conversation a 10-minute ceiling — shorter than a long agentic turn — and no
+ * way for an Operator to raise it (issue #552).
+ *
+ * The per-step bound is an idle timeout: time with no streamed chunk at all,
+ * not time spent on one step. Two minutes of complete silence from a provider
+ * is a stall worth acting on; a long answer is not, and no longer trips it.
+ *
+ * Override via env:
+ *  - `CHAT_PER_STEP_TIMEOUT_MS` (default 2 min)
+ *  - `CHAT_PER_RUN_TIMEOUT_MS` (default 30 min)
+ */
+const DEFAULT_CHAT_PER_STEP_TIMEOUT_MS = 2 * 60 * 1000;
+const DEFAULT_CHAT_PER_RUN_TIMEOUT_MS = 30 * 60 * 1000;
+
+const chatTimeouts = () => ({
+  perStepTimeoutMs: parseInt(
+    process.env.CHAT_PER_STEP_TIMEOUT_MS ??
+      String(DEFAULT_CHAT_PER_STEP_TIMEOUT_MS),
+  ),
+  perRunTimeoutMs: parseInt(
+    process.env.CHAT_PER_RUN_TIMEOUT_MS ??
+      String(DEFAULT_CHAT_PER_RUN_TIMEOUT_MS),
+  ),
+});
+
 // --- Routes ---
 
 const chat = new Hono<{ Variables: Variables }>();
@@ -152,6 +182,7 @@ chat.post(
         // The client cancels via POST /chat/:chatId/cancel.
         origin: getOrigin(c),
         frontendUrl: process.env.FRONTEND_URL,
+        timeouts: chatTimeouts(),
       },
     });
   },

--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -1538,8 +1538,9 @@ describe("model output ceiling", () => {
 // Smoke test the TimeoutError export so the type stays public-importable
 describe("AgentRunner timeout types", () => {
   it("TimeoutError remains an Error subclass", () => {
-    const e = new TimeoutError("x", "run");
+    const e = new TimeoutError("x", "run", 1000);
     expect(e).toBeInstanceOf(Error);
     expect(e.kind).toBe("run");
+    expect(e.limitMs).toBe(1000);
   });
 });

--- a/apps/backend/src/runs/drive.test.ts
+++ b/apps/backend/src/runs/drive.test.ts
@@ -440,7 +440,127 @@ describe("driveChat", () => {
     expect(result.status).toBe("succeeded");
     expect(outcome[0].status).toBe("succeeded");
   });
+
+  // The regression from issue #552. An abort closes the SDK's stream rather
+  // than failing it, so `onError` never fires and the client's branch used to
+  // end clean: the answer stopped mid-word and the composer simply reset, with
+  // nothing anywhere saying a bound had been hit.
+  it("tells the client why a timed-out run stopped", async () => {
+    const { run } = startRecordedRun({
+      perRunTimeoutMs: 20,
+      perStepTimeoutMs: 60_000,
+    });
+    const drive = driveChat({
+      plan: planOf(textThenEndOnAbort(run.handle.signal)),
+      run,
+      modelMessages: [{ role: "user", content: "hi" }],
+    });
+
+    const chunks = await collect(drive.response);
+    for await (const _ of drive.snapshots) void _;
+    await drive.done;
+
+    const errors = chunks.filter((c) => c.type === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].errorText).toMatch(/time limit/);
+    // The partial answer is still delivered — the notice is appended to it,
+    // not substituted for it.
+    expect(chunks.some((c) => c.type === "text-delta")).toBe(true);
+  });
+
+  it("names the idle bound when it was the per-step timeout that fired", async () => {
+    const { run } = startRecordedRun({
+      perStepTimeoutMs: 20,
+      perRunTimeoutMs: 60_000,
+    });
+    const drive = driveChat({
+      plan: planOf(textThenEndOnAbort(run.handle.signal)),
+      run,
+      modelMessages: [{ role: "user", content: "hi" }],
+    });
+
+    const chunks = await collect(drive.response);
+    for await (const _ of drive.snapshots) void _;
+    await drive.done;
+
+    const errors = chunks.filter((c) => c.type === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].errorText).toMatch(/stopped sending output/);
+  });
+
+  // A user who pressed stop knows why it stopped. Telling them again would
+  // dress their own action up as a failure.
+  it("stays silent when the run was cancelled rather than timed out", async () => {
+    const { run } = startRecordedRun({
+      perStepTimeoutMs: 60_000,
+      perRunTimeoutMs: 60_000,
+    });
+    const drive = driveChat({
+      plan: planOf(textThenEndOnAbort(run.handle.signal)),
+      run,
+      modelMessages: [{ role: "user", content: "hi" }],
+    });
+    setTimeout(() => runRegistry.cancel(run.handle.runId), 20);
+
+    const chunks = await collect(drive.response);
+    for await (const _ of drive.snapshots) void _;
+    const result = await drive.done;
+
+    expect(chunks.some((c) => c.type === "error")).toBe(false);
+    expect(result.status).toBe("cancelled");
+  });
+
+  it("adds nothing to a run that finished normally", async () => {
+    const { run } = startRecordedRun();
+    const drive = driveChat({
+      plan: planOf(modelOf(text("t1", "Hi"))),
+      run,
+      modelMessages: [{ role: "user", content: "hi" }],
+    });
+
+    const chunks = await collect(drive.response);
+    for await (const _ of drive.snapshots) void _;
+    await drive.done;
+
+    expect(chunks.some((c) => c.type === "error")).toBe(false);
+  });
 });
+
+/** Drain a UI message stream branch into an array of its chunks. */
+const collect = async <T>(stream: ReadableStream<T>): Promise<T[]> => {
+  const out: T[] = [];
+  for await (const chunk of stream as unknown as AsyncIterable<T>) {
+    out.push(chunk);
+  }
+  return out;
+};
+
+/**
+ * A model that streams a partial answer and then goes quiet until the run is
+ * aborted — a provider that stalls mid-answer, which is the shape both
+ * timeouts exist to catch.
+ */
+function textThenEndOnAbort(signal: AbortSignal) {
+  return new MockLanguageModelV3({
+    doStream: () =>
+      Promise.resolve({
+        stream: new ReadableStream<LanguageModelV3StreamPart>({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] });
+            controller.enqueue({ type: "text-start", id: "t1" });
+            controller.enqueue({
+              type: "text-delta",
+              id: "t1",
+              delta: "Partial",
+            });
+            signal.addEventListener("abort", () => controller.close(), {
+              once: true,
+            });
+          },
+        }),
+      }),
+  });
+}
 
 const errorParts = (message: string): LanguageModelV3StreamPart[] => [
   { type: "stream-start", warnings: [] },

--- a/apps/backend/src/runs/drive.ts
+++ b/apps/backend/src/runs/drive.ts
@@ -15,6 +15,7 @@ import {
 } from "./no-progress.ts";
 import { buildModelInvocation, type RunPlan } from "./run-plan.ts";
 import type { RunLifecycle } from "./run-lifecycle.ts";
+import { describeTimeout, TimeoutError } from "./run-registry.ts";
 import type { RunStep } from "./run-stats.ts";
 import { computeStats } from "./run-stats.ts";
 import {
@@ -271,6 +272,11 @@ const runStreamedDrive = (
       onStepFinish?.(step);
       run.onStep(step);
     },
+    // The only thing that proves a long-running step is still alive. Without
+    // it the idle timer sees a silent gap for the whole of a long answer.
+    onChunk: () => {
+      run.onStreamChunk();
+    },
     onToolExecutionEnd: (ctx) => {
       onToolExecutionEnd?.(ctx);
     },
@@ -347,6 +353,43 @@ const runStreamedDrive = (
   return { snapshots, done };
 };
 
+/**
+ * Appends the reason an aborted run stopped to the client's branch of the
+ * stream.
+ *
+ * An abort is not an error as far as the SDK is concerned: `streamText` closes
+ * the stream on `isAbortError` rather than failing it, so `onError` never runs
+ * and no error part is written. The client sees a clean end — the answer stops
+ * mid-word, the submit button comes back, and nothing says why. That is how a
+ * per-step timeout looked like no failure at all (issue #552).
+ *
+ * Only a timeout is reported. A cancellation reaches here the same way, but the
+ * user pressed stop themselves and does not need to be told.
+ */
+const withAbortNotice = (
+  run: RunLifecycle,
+): TransformStream<
+  InferUIMessageChunk<PlatypusUIMessage>,
+  InferUIMessageChunk<PlatypusUIMessage>
+> =>
+  new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+    },
+    flush(controller) {
+      const reason: unknown = run.handle.signal.reason;
+      if (!(reason instanceof TimeoutError)) return;
+      logger.warn(
+        { runId: run.handle.runId, kind: reason.kind },
+        "Reporting run timeout to the client",
+      );
+      controller.enqueue({
+        type: "error",
+        errorText: describeTimeout(reason),
+      });
+    },
+  });
+
 export type ChatDrive = StreamedCore & {
   /** The client stream branch. Always present: a Chat turn is the shape that
    *  has one. */
@@ -374,7 +417,10 @@ export const driveChat = (opts: ChatDriveOptions): ChatDrive => {
     },
     (ui) => {
       const [client, serverSide] = ui.tee();
-      response = client;
+      // Only the client branch carries the notice: the run itself already
+      // records the timeout through `statusFromSignal`, so adding it to the
+      // server-side drain would report the same failure twice.
+      response = client.pipeThrough(withAbortNotice(opts.run));
       return serverSide;
     },
   );

--- a/apps/backend/src/runs/run-lifecycle.ts
+++ b/apps/backend/src/runs/run-lifecycle.ts
@@ -33,6 +33,13 @@ export type RunLifecycle = {
   setStats: (next: RunStats) => void;
   /** `onStepFinish` for `streamText` / `generateText`. */
   onStep: (step: RunStep) => void;
+  /**
+   * `onChunk` for `streamText`. Tells the idle timer the provider is still
+   * talking, so a step that streams for longer than the per-step bound is not
+   * mistaken for a stall (issue #552). Nothing is logged or accumulated here:
+   * it runs once per streamed chunk.
+   */
+  onStreamChunk: () => void;
   /** Tool-call boundary handler for `wrapToolsWithActivity`. */
   onActivity: (event: ToolActivityEvent) => void;
   /** Terminate once, with the outcome. Repeat calls are no-ops. */
@@ -180,6 +187,7 @@ export const startRun = (params: {
       stats = next;
     },
     onStep,
+    onStreamChunk: () => handle.noteActivity(),
     onActivity,
     finish,
     statusFromSignal,

--- a/apps/backend/src/runs/run-registry.test.ts
+++ b/apps/backend/src/runs/run-registry.test.ts
@@ -4,6 +4,7 @@ import {
   TimeoutError,
   DEFAULT_PER_STEP_TIMEOUT_MS,
   DEFAULT_PER_RUN_TIMEOUT_MS,
+  describeTimeout,
 } from "./run-registry.ts";
 
 describe("RunRegistry", () => {
@@ -221,5 +222,107 @@ describe("RunRegistry", () => {
     expect(registry.has("x")).toBe(true);
     registry.unregister("x");
     expect(registry.has("x")).toBe(false);
+  });
+
+  // The per-step bound measures silence, not elapsed time. A step that streams
+  // for longer than the bound is still working; only one that goes quiet for
+  // the whole window is a stall. This is the regression from issue #552, where
+  // a single long answer was aborted mid-stream at exactly the bound.
+  describe("per-step timeout as an idle timeout", () => {
+    it("noteActivity keeps a step alive far past the per-step bound", () => {
+      const onTimeout = vi.fn();
+      const handle = registry.register("idle-1", {
+        perStepTimeoutMs: 1000,
+        perRunTimeoutMs: 1_000_000,
+        onTimeout,
+      });
+
+      // Ten times the bound, streaming steadily throughout, with no step ever
+      // finishing — exactly the shape of one long answer.
+      for (let i = 0; i < 20; i++) {
+        vi.advanceTimersByTime(500);
+        handle.noteActivity();
+      }
+
+      expect(onTimeout).not.toHaveBeenCalled();
+      expect(handle.signal.aborted).toBe(false);
+    });
+
+    it("still fires once activity stops for the whole window", () => {
+      const onTimeout = vi.fn();
+      const handle = registry.register("idle-2", {
+        perStepTimeoutMs: 1000,
+        perRunTimeoutMs: 1_000_000,
+        onTimeout,
+      });
+
+      vi.advanceTimersByTime(900);
+      handle.noteActivity();
+      // Silence from here. The timer that was armed at registration wakes at
+      // 1000ms, finds 100ms of idle, and re-arms for the remaining 900ms.
+      vi.advanceTimersByTime(1000);
+
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+      expect((onTimeout.mock.calls[0][0] as TimeoutError).kind).toBe("step");
+      expect(handle.signal.aborted).toBe(true);
+    });
+
+    it("noteActivity does not defer the per-run bound", () => {
+      const onTimeout = vi.fn();
+      const handle = registry.register("idle-3", {
+        perStepTimeoutMs: 1000,
+        perRunTimeoutMs: 5000,
+        onTimeout,
+      });
+      for (let i = 0; i < 12; i++) {
+        vi.advanceTimersByTime(500);
+        handle.noteActivity();
+      }
+
+      // A run that streams forever is still bounded — that is the whole point
+      // of keeping the two timers independent.
+      expect(
+        onTimeout.mock.calls.some(
+          (call) => (call[0] as TimeoutError).kind === "run",
+        ),
+      ).toBe(true);
+    });
+
+    it("noteActivity on an unknown or finished run is a no-op", () => {
+      const handle = registry.register("idle-4", { perStepTimeoutMs: 1000 });
+      registry.unregister("idle-4");
+      expect(() => handle.noteActivity()).not.toThrow();
+    });
+  });
+
+  describe("describeTimeout", () => {
+    it("names the idle window for a step timeout", () => {
+      const text = describeTimeout(
+        new TimeoutError("internal wording", "step", 2 * 60 * 1000),
+      );
+      expect(text).toContain("2 minutes");
+      expect(text).toContain("stopped sending output");
+      // The internal message names a run id and a millisecond figure; neither
+      // belongs in front of a user.
+      expect(text).not.toContain("internal wording");
+      expect(text).not.toContain("120000");
+    });
+
+    it("names the wall-clock bound for a run timeout", () => {
+      const text = describeTimeout(
+        new TimeoutError("internal", "run", 30 * 60 * 1000),
+      );
+      expect(text).toContain("30 minutes");
+      expect(text).toContain("time limit");
+    });
+
+    it("uses seconds below the two-minute mark", () => {
+      expect(describeTimeout(new TimeoutError("i", "step", 45_000))).toContain(
+        "45 seconds",
+      );
+      expect(describeTimeout(new TimeoutError("i", "step", 1000))).toContain(
+        "1 second",
+      );
+    });
   });
 });

--- a/apps/backend/src/runs/run-registry.ts
+++ b/apps/backend/src/runs/run-registry.ts
@@ -13,16 +13,47 @@ import type { RunId } from "./types.ts";
  */
 export class TimeoutError extends Error {
   readonly kind: "step" | "run";
+  /** The bound that was exceeded, so a caller can say it without re-reading
+   *  the configuration that set it. */
+  readonly limitMs: number;
 
-  constructor(message: string, kind: "step" | "run") {
+  constructor(message: string, kind: "step" | "run", limitMs: number) {
     super(message);
     this.name = "TimeoutError";
     this.kind = kind;
+    this.limitMs = limitMs;
   }
 }
 
+/** A duration as a reader would say it: "90 seconds", "2 minutes". */
+const humanizeMs = (ms: number): string => {
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 120) return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  const minutes = Math.round(seconds / 60);
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+};
+
+/**
+ * A timeout in the terms the person who was waiting understands.
+ *
+ * `TimeoutError.message` names the run id and a millisecond bound — right for a
+ * log line, wrong for the one sentence a user gets when their answer stops
+ * mid-word. Both timeouts are reported, because a user cannot tell them apart
+ * from the outside and the remedy differs: a stalled provider versus a run that
+ * was simply too long.
+ */
+export const describeTimeout = (error: TimeoutError): string =>
+  error.kind === "step"
+    ? `The model stopped sending output for ${humanizeMs(error.limitMs)}, so the run was stopped. Anything it had already written is kept above.`
+    : `The run hit its ${humanizeMs(error.limitMs)} time limit and was stopped. Anything already written is kept above.`;
+
 export type RegisterOptions = {
-  /** Per-step (between-step) idle timeout. Defaults to 2 minutes. */
+  /**
+   * Idle timeout: how long the run may show no sign of life at all — no
+   * streamed chunk, no step boundary, no tool-call edge — before it is
+   * aborted. Not a ceiling on how long one step may take. Defaults to 2
+   * minutes.
+   */
   perStepTimeoutMs?: number;
   /** Wall-clock timeout for the whole run. Defaults to 10 minutes. */
   perRunTimeoutMs?: number;
@@ -49,10 +80,24 @@ export type RunHandle = {
   /** Reset the per-step timer (e.g. when a step makes progress). */
   bumpStep(): void;
   /**
+   * Record a sign of life from the model mid-step — one streamed chunk.
+   *
+   * The per-step bound is an IDLE timeout: "has the provider stopped talking to
+   * us?", not "has this step taken too long?". Only `bumpStep` fires at step
+   * boundaries, so without this a single step that streams for longer than the
+   * bound is aborted while it is still producing output. That is what cut long
+   * answers and long tool-call arguments off mid-stream (issue #552).
+   *
+   * Deliberately does not touch the timer. This is called once per streamed
+   * chunk — thousands of times in a long answer — so it only stamps a
+   * timestamp, and the timer re-arms itself from that stamp when it fires.
+   */
+  noteActivity(): void;
+  /**
    * Suspend the per-step stall timer for the duration of a tool call.
    *
-   * The per-step timeout answers "has the model stopped making progress
-   * between steps?", and a tool that is still executing is not that. Holds
+   * The per-step timeout answers "has anything happened lately?", and a tool
+   * that is still executing produces no chunks to say so. Holds
    * nest, so parallel tool calls are counted; the timer re-arms when the last
    * one releases. The per-RUN timeout is deliberately untouched, so a tool that
    * never returns is still bounded.
@@ -74,6 +119,9 @@ type Entry = {
   finished: boolean;
   /** Tool calls currently in flight; the step timer is off while this is > 0. */
   holds: number;
+  /** When this run last showed a sign of life — a step boundary, a tool-call
+   *  edge, or a streamed chunk. The per-step bound is measured from here. */
+  lastActivityAt: number;
 };
 
 export class RunRegistry {
@@ -97,16 +145,32 @@ export class RunRegistry {
       onTimeout: options.onTimeout,
       finished: false,
       holds: 0,
+      lastActivityAt: Date.now(),
     };
 
     const fireTimeout = (kind: "step" | "run") => {
       if (entry.finished) return;
+      // A step timer that wakes to find recent activity is not looking at a
+      // stall: re-arm for the remainder of the idle window instead of aborting
+      // a run that is still streaming. Re-arming here rather than on every
+      // chunk keeps the hot path to one timestamp write.
+      if (kind === "step") {
+        const idleMs = Date.now() - entry.lastActivityAt;
+        if (idleMs < entry.perStepTimeoutMs) {
+          entry.stepTimer = setTimeout(
+            () => fireTimeout("step"),
+            entry.perStepTimeoutMs - idleMs,
+          );
+          return;
+        }
+      }
       entry.finished = true;
       const error = new TimeoutError(
         kind === "step"
           ? `Run '${runId}' exceeded per-step timeout of ${perStepTimeoutMs}ms`
           : `Run '${runId}' exceeded per-run timeout of ${perRunTimeoutMs}ms`,
         kind,
+        kind === "step" ? perStepTimeoutMs : perRunTimeoutMs,
       );
       if (entry.stepTimer) clearTimeout(entry.stepTimer);
       if (entry.runTimer) clearTimeout(entry.runTimer);
@@ -125,6 +189,9 @@ export class RunRegistry {
     const armStep = (e: Entry) => {
       if (e.stepTimer) clearTimeout(e.stepTimer);
       e.stepTimer = undefined;
+      // Every path through here is itself a sign of life (a step finished, a
+      // tool call started or returned), so the idle window restarts from now.
+      e.lastActivityAt = Date.now();
       if (e.holds > 0) return;
       e.stepTimer = setTimeout(() => fireTimeout("step"), e.perStepTimeoutMs);
     };
@@ -136,6 +203,11 @@ export class RunRegistry {
         const e = this.entries.get(runId);
         if (!e || e.finished) return;
         armStep(e);
+      },
+      noteActivity: () => {
+        const e = this.entries.get(runId);
+        if (!e || e.finished) return;
+        e.lastActivityAt = Date.now();
       },
       holdStep: () => {
         const e = this.entries.get(runId);

--- a/apps/docs/content/reference/backend-configuration.mdx
+++ b/apps/docs/content/reference/backend-configuration.mdx
@@ -105,6 +105,22 @@ run sooner.
 | `TRIGGER_PER_STEP_TIMEOUT_MS` | Idle timeout between steps of a Trigger run; a step that makes no progress aborts it. | `600000` (10 minutes)  | No       |
 | `TRIGGER_PER_RUN_TIMEOUT_MS`  | Wall-clock timeout for an entire Trigger run.                                         | `3600000` (60 minutes) | No       |
 
+## Chat
+
+Timeouts that bound an interactive Chat turn. The idle timeout measures silence
+from the provider — no streamed output of any kind — so a long answer or a long
+tool call never trips it; only a provider that stops responding does. Raise the
+wall-clock timeout if your Agents run long multi-step turns that people wait
+through.
+
+| Variable                   | Purpose                                                                                                 | Default                | Required |
+| -------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------- | -------- |
+| `CHAT_PER_STEP_TIMEOUT_MS` | Idle timeout for a Chat turn; the run is stopped after this long with no streamed output from the model. | `120000` (2 minutes)   | No       |
+| `CHAT_PER_RUN_TIMEOUT_MS`  | Wall-clock timeout for an entire Chat turn.                                                             | `1800000` (30 minutes) | No       |
+
+When either bound stops a turn, the reason is shown in the chat rather than the
+answer simply ending.
+
 ## Tools
 
 | Variable                        | Purpose                                                                                                                                   | Default                 | Required |

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -323,7 +323,9 @@ These rarely need changing but exist when you need them — see the
   affect Trigger schedules, which carry their own per-Trigger timezone chosen in
   the Trigger form, and it does not affect log timestamps.
 - **Schedulers & runs** — concurrency caps and per-run / per-step timeouts for
-  scheduled and triggered agent executions.
+  scheduled and triggered agent executions, and for interactive Chat turns. The
+  per-step bound is an idle timeout: it measures how long the model has sent
+  nothing at all, so a slow-but-working answer never trips it.
 
 ## Where the exhaustive lists live
 


### PR DESCRIPTION
Closes #552.

A Chat turn stopped mid-stream after two minutes with nothing said about why: the answer ended mid-word, the composer's submit button reverted as though the turn had finished, and the truncation sat far below the Provider's configured **Max output tokens**. Two independent faults produced that, and both are fixed here.

## The bound was not the idle timeout it claimed to be

`RunRegistry`'s per-step timeout is documented as an idle timeout, but was only ever reset by `RunHandle.bumpStep()` — which `RunLifecycle.onStep` calls from the SDK's `onStepFinish`, a *step boundary*. Streamed chunks never touched it, and `holdStep`/`releaseStep` only suspend it while a tool executes, not while the model generates. So it measured wall-clock since the last completed step. Any single step taking longer than the bound to generate — a long answer, a large tool-call argument, reasoning plus output — was aborted mid-stream regardless of how much output it was producing.

`RunHandle.noteActivity()` is now wired to `streamText`'s `onChunk` through a thin `RunLifecycle.onStreamChunk`. It only stamps a timestamp: it runs once per streamed chunk, so touching the timer there would mean thousands of `clearTimeout`/`setTimeout` pairs per answer. The timer re-arms itself instead — on firing it checks idle time and, if there has been recent activity, re-arms for the remainder. `armStep` refreshes the same stamp, so step boundaries and tool-call edges count as activity too.

The per-run timer is deliberately untouched, so a run that streams forever is still bounded.

Interactive Chat also passed no timeouts at all and took the registry's conservative fallbacks (2 min / 10 min), with no way for an Operator to raise them. It now has its own, mirroring how `trigger-execution.ts` does it: `CHAT_PER_STEP_TIMEOUT_MS` (2 min, now genuinely idle) and `CHAT_PER_RUN_TIMEOUT_MS` (30 min). Sub-agents inherit them through `parentRun.timeouts`.

## The abort was invisible to the client

An abort is not an error as far as the AI SDK is concerned: `streamText` closes the stream on `isAbortError` rather than failing it, so `toUIMessageStream`'s `onError` — which `formatStreamError` is wired to — never ran and no error part was written. Server-side the run was recorded correctly, with `decideTerminalStatus` reading the `TimeoutError` off the signal and persisting it. The information existed; it just never crossed to the browser. This would equally have hidden any future cause of a mid-stream abort.

A `withAbortNotice` transform now sits on the client branch of the teed stream and, on flush, appends an error part carrying the reason. `useChat` surfaces it through the existing `ErrorDialog`, so no frontend change was needed. The partial answer is kept — the notice is appended, not substituted. Only the client branch carries it, since the run already records the timeout itself. A user-initiated cancellation stays silent.

`TimeoutError` gained `limitMs`, and `describeTimeout` renders the user-facing sentence: the internal message names a run id and a millisecond figure, which is right for a log line and wrong in front of a user.

## Testing

`typecheck`, `lint`, and the full suite pass — 2263 tests across 8 packages, 11 of them new. The drive tests are load-bearing: they assert exactly one error part reaches the client branch, which is zero without the transform. The registry tests cover streaming past 10x the bound without tripping, still tripping on genuine silence, and the per-run bound staying independent of stream activity.

Docs ship with the code: the two variables are in `reference/backend-configuration.mdx` and `.env.example`, and `self-hosting/configuration.mdx` now says what the per-step bound actually measures.

## Worth a reviewer's judgement

`CHAT_PER_RUN_TIMEOUT_MS` defaults to 30 minutes. That is an estimate of what a long agentic Chat turn needs, not a measurement — worth checking against real traffic, and a one-line change in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)