### PR TITLE
fix: mixed-case invitation visibility

### DIFF
--- a/apps/backend/drizzle/0052_lowercase_invitation_emails.sql
+++ b/apps/backend/drizzle/0052_lowercase_invitation_emails.sql
@@ -1,0 +1,3 @@
+UPDATE "invitation"
+SET "email" = lower("email")
+WHERE "email" <> lower("email");

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1786734053558,
       "tag": "0051_jazzy_kid_colt",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1787140800000,
+      "tag": "0052_lowercase_invitation_emails",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/routes/invitation.test.ts
+++ b/apps/backend/src/routes/invitation.test.ts
@@ -45,6 +45,32 @@ describe("Invitation Routes", () => {
       expect(await res.json()).toEqual({ ...mockInvitation, blueprintIds: [] });
     });
 
+    it("normalizes a mixed-case invitation email before persistence", async () => {
+      mockSession({ id: "admin-1", email: "admin@example.com", role: "user" });
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "inv-1", email: "user@example.com" },
+      ]);
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({
+          email: "User@Example.COM",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(201);
+      const insertedValues = mockDb.values.mock.calls.find(
+        ([value]) =>
+          typeof value === "object" &&
+          value !== null &&
+          "organizationId" in value,
+      )?.[0];
+      expect(insertedValues).toMatchObject({ email: "user@example.com" });
+      expect(await res.json()).toMatchObject({ email: "user@example.com" });
+    });
+
     // ADR-0009: an invitation carries an ordered set of Blueprints, stored in
     // the invitation_blueprint junction with `position`.
     it("persists an ordered set of blueprints", async () => {
@@ -163,7 +189,7 @@ describe("Invitation Routes", () => {
       const res = await app.request(baseUrl, {
         method: "POST",
         body: JSON.stringify({
-          email: "admin@example.com",
+          email: "Admin@Example.COM",
           workspaceId: "ws-1",
           role: "editor",
         }),

--- a/apps/backend/src/routes/invitation.ts
+++ b/apps/backend/src/routes/invitation.ts
@@ -31,8 +31,9 @@ invitation.post(
     const { orgId } = orgScopeOf(c);
     const data = c.req.valid("json");
     const user = c.get("user")!;
+    const normalizedEmail = data.email.toLowerCase();
 
-    if (data.email.toLowerCase() === user.email.toLowerCase()) {
+    if (normalizedEmail === user.email.toLowerCase()) {
       return c.json({ error: "You cannot invite yourself" }, 400);
     }
 
@@ -73,7 +74,7 @@ invitation.post(
           .insert(invitationTable)
           .values({
             id: invitationId,
-            email: data.email,
+            email: normalizedEmail,
             organizationId: orgId,
             invitedBy: user.id,
             status: "pending",

--- a/apps/backend/src/routes/user-invitation.test.ts
+++ b/apps/backend/src/routes/user-invitation.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mockDb, mockSession, resetMockDb } from "../test-utils.ts";
+import { eq } from "drizzle-orm";
+import { invitation as invitationTable } from "../db/schema.ts";
 import app from "../server.ts";
 
 describe("User Invitation Routes", () => {
@@ -36,6 +38,34 @@ describe("User Invitation Routes", () => {
       const res = await app.request(baseUrl);
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ results: mockInvitations });
+    });
+
+    it("lists an invitation normalized from a mixed-case invite email", async () => {
+      mockSession({ id: "u1", email: "User@Example.COM", role: "user" });
+
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 7);
+
+      const normalizedInvitation = {
+        id: "inv-1",
+        email: "user@example.com",
+        status: "pending",
+        expiresAt: futureDate.toISOString(),
+        organizationName: "Org 1",
+        workspaceName: "WS 1",
+        invitedByName: "Admin",
+      };
+
+      mockDb.where.mockResolvedValueOnce([normalizedInvitation]);
+
+      const res = await app.request(baseUrl);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ results: [normalizedInvitation] });
+      expect(eq).toHaveBeenCalledWith(
+        invitationTable.email,
+        "user@example.com",
+      );
     });
   });
 
@@ -85,6 +115,42 @@ describe("User Invitation Routes", () => {
         ownerId: "u1",
         name: "Contractor Sandbox",
       });
+    });
+
+    it("accepts an invitation normalized from a mixed-case invite email", async () => {
+      mockSession({
+        id: "u1",
+        email: "User@Example.COM",
+        name: "Jane",
+        role: "user",
+      });
+
+      const futureDate = new Date();
+      futureDate.setDate(futureDate.getDate() + 7);
+
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "inv-1",
+          email: "user@example.com",
+          status: "pending",
+          expiresAt: futureDate.toISOString(),
+          organizationId: "org-1",
+          workspaceName: "Contractor Sandbox",
+        },
+      ]);
+      mockDb.limit.mockResolvedValueOnce([]);
+      mockDb.orderBy.mockResolvedValueOnce([]);
+
+      const res = await app.request(`${baseUrl}/inv-1/accept`, {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ message: "Invitation accepted" });
+      expect(eq).toHaveBeenCalledWith(
+        invitationTable.email,
+        "user@example.com",
+      );
     });
 
     // ADR-0008: a blueprint-less / unnamed invite yields an empty workspace
@@ -381,6 +447,25 @@ describe("User Invitation Routes", () => {
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ message: "Invitation declined" });
+    });
+
+    it("declines an invitation normalized from a mixed-case invite email", async () => {
+      mockSession({ id: "u1", email: "User@Example.COM", role: "user" });
+
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "inv-1", email: "user@example.com", status: "declined" },
+      ]);
+
+      const res = await app.request(`${baseUrl}/inv-1/decline`, {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ message: "Invitation declined" });
+      expect(eq).toHaveBeenCalledWith(
+        invitationTable.email,
+        "user@example.com",
+      );
     });
   });
 });

--- a/apps/backend/src/routes/user-invitation.ts
+++ b/apps/backend/src/routes/user-invitation.ts
@@ -39,6 +39,7 @@ const defaultWorkspaceName = (name: string): string => {
 /** List pending invitations for the current user */
 userInvitation.get("/", requireAuth, async (c) => {
   const user = c.get("user")!;
+  const userEmail = user.email.toLowerCase();
   const now = new Date();
 
   const results = await db
@@ -62,7 +63,7 @@ userInvitation.get("/", requireAuth, async (c) => {
     .innerJoin(userTable, eq(invitationTable.invitedBy, userTable.id))
     .where(
       and(
-        eq(invitationTable.email, user.email),
+        eq(invitationTable.email, userEmail),
         eq(invitationTable.status, "pending"),
       ),
     );
@@ -75,6 +76,7 @@ userInvitation.get("/", requireAuth, async (c) => {
 /** Accept an invitation */
 userInvitation.post("/:invitationId/accept", requireAuth, async (c) => {
   const user = c.get("user")!;
+  const userEmail = user.email.toLowerCase();
   const invitationId = c.req.param("invitationId");
   const now = new Date();
 
@@ -84,7 +86,7 @@ userInvitation.post("/:invitationId/accept", requireAuth, async (c) => {
     .where(
       and(
         eq(invitationTable.id, invitationId),
-        eq(invitationTable.email, user.email),
+        eq(invitationTable.email, userEmail),
         eq(invitationTable.status, "pending"),
       ),
     )
@@ -166,6 +168,7 @@ userInvitation.post("/:invitationId/accept", requireAuth, async (c) => {
 /** Decline an invitation */
 userInvitation.post("/:invitationId/decline", requireAuth, async (c) => {
   const user = c.get("user")!;
+  const userEmail = user.email.toLowerCase();
   const invitationId = c.req.param("invitationId");
 
   const result = await db
@@ -174,7 +177,7 @@ userInvitation.post("/:invitationId/decline", requireAuth, async (c) => {
     .where(
       and(
         eq(invitationTable.id, invitationId),
-        eq(invitationTable.email, user.email),
+        eq(invitationTable.email, userEmail),
         eq(invitationTable.status, "pending"),
       ),
     )


### PR DESCRIPTION
## Summary

- Normalize invitation emails to lowercase before storing them.
- Compare self-invite emails case-insensitively.
- Add a migration to lowercase existing invitation emails.
- Add regression coverage for mixed-case invitation creation, listing, acceptance, and decline flows.

## Validation

- Passed: `pnpm --filter @platypus/backend exec vitest run src/routes/invitation.test.ts src/routes/user-invitation.test.ts`
- Caveat: `pnpm test --filter @platypus/backend` exits 1 locally because unrelated `src/services/file-gate.test.ts` timed out.
- Caveat: `pnpm test` exits 1 locally because unrelated docs-contract internal heading links are currently failing.
- Caveat: The production migration path against a seeded mixed-case invitation row was not run locally because this environment has no PostgreSQL `DATABASE_URL`, Docker, or `psql`.