### PR TITLE
chore(frontend): delete the unreachable blob-to-data conversion in the chat surface

### DIFF
--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -520,30 +520,12 @@ export const Chat = ({
       return;
     }
 
-    // Convert blob: URLs to data: URLs so the backend can access the file
-    // content. blob: URLs are browser-only references that can't be resolved
-    // server-side.
-    const files = await Promise.all(
-      (message.files ?? []).map(async (file) => {
-        if (!file.url.startsWith("blob:")) return file;
-        const res = await fetch(file.url);
-        const blob = await res.blob();
-        const dataUrl = await new Promise<string>((resolve, reject) => {
-          const reader = new FileReader();
-          reader.onload = () => resolve(reader.result as string);
-          reader.onerror = reject;
-          reader.readAsDataURL(blob);
-        });
-        return { ...file, url: dataUrl };
-      }),
-    );
-
     const body = getRequestBody();
 
     sendMessage(
       {
         text: message.text || "Sent with attachments",
-        files,
+        files: message.files,
       },
       { body },
     );


### PR DESCRIPTION
Closes #574

Delete a block of unreachable code in the chat surface. Before sending a message, it used to walk the attached files converting any blob URL into a data URL. However, the composer already does exactly that conversion before handing the files over, so the guard that skips already-converted files is always true and the loop never does anything.

**Note:** As mentioned in the issue, the underlying cause is that the type the composer hands over does not record that its URLs are already data URLs, so the caller defends against a state the producer had already excluded. This PR does not change that type, it only deletes the dead loop.