### PR TITLE
fix(frontend): a refused detach of a Shared resource reports success

### DIFF
--- a/apps/frontend/components/agents-list.tsx
+++ b/apps/frontend/components/agents-list.tsx
@@ -102,6 +102,7 @@ export const AgentsList = ({
   const [selectedOrgAgent, setSelectedOrgAgent] =
     useState<AgentWithScope | null>(null);
   const [detaching, setDetaching] = useState(false);
+  const [detachError, setDetachError] = useState<string | null>(null);
   const [agentToPromote, setAgentToPromote] = useState<AgentWithScope | null>(
     null,
   );
@@ -323,16 +324,22 @@ export const AgentsList = ({
   const detachOrgAgent = async (agentId: string) => {
     if (!backendUrl) return;
     setDetaching(true);
+    setDetachError(null);
     try {
-      await fetch(
+      const response = await fetch(
         joinUrl(
           backendUrl,
           `/organizations/${orgId}/workspaces/${workspaceId}/attachments/agent/${agentId}`,
         ),
         { method: "DELETE", credentials: "include" },
       );
-      setSelectedOrgAgent(null);
-      await mutate();
+      if (response.ok) {
+        setSelectedOrgAgent(null);
+        await mutate();
+      } else {
+        const info = await response.json().catch(() => ({}));
+        setDetachError(info.error || "Failed to detach agent.");
+      }
     } finally {
       setDetaching(false);
     }
@@ -371,7 +378,10 @@ export const AgentsList = ({
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="cursor-pointer"
-                onSelect={() => setSelectedOrgAgent(agent)}
+                onSelect={() => {
+                  setDetachError(null);
+                  setSelectedOrgAgent(agent);
+                }}
               >
                 <Unlink /> Detach
               </DropdownMenuItem>
@@ -623,7 +633,12 @@ export const AgentsList = ({
 
       <Dialog
         open={!!selectedOrgAgent}
-        onOpenChange={(open) => !open && setSelectedOrgAgent(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedOrgAgent(null);
+            setDetachError(null);
+          }
+        }}
       >
         <DialogContent>
           <DialogHeader>
@@ -634,8 +649,17 @@ export const AgentsList = ({
               appearing here.
             </DialogDescription>
           </DialogHeader>
+          {detachError && (
+            <p className="text-sm text-destructive">{detachError}</p>
+          )}
           <DialogFooter>
-            <Button variant="outline" onClick={() => setSelectedOrgAgent(null)}>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setSelectedOrgAgent(null);
+                setDetachError(null);
+              }}
+            >
               Close
             </Button>
             {isOrgAdmin && selectedOrgAgent && (

--- a/apps/frontend/components/mcp-list.tsx
+++ b/apps/frontend/components/mcp-list.tsx
@@ -47,6 +47,7 @@ const McpList = ({
   );
   const [attachOpen, setAttachOpen] = useState(false);
   const [detaching, setDetaching] = useState(false);
+  const [detachError, setDetachError] = useState<string | null>(null);
 
   const fetchUrl =
     backendUrl && user
@@ -69,16 +70,22 @@ const McpList = ({
   const detachOrgMcp = async (mcpId: string) => {
     if (!backendUrl || !workspaceId) return;
     setDetaching(true);
+    setDetachError(null);
     try {
-      await fetch(
+      const response = await fetch(
         joinUrl(
           backendUrl,
           `/organizations/${orgId}/workspaces/${workspaceId}/attachments/mcp/${mcpId}`,
         ),
         { method: "DELETE", credentials: "include" },
       );
-      setSelectedOrgMcp(null);
-      await mutate();
+      if (response.ok) {
+        setSelectedOrgMcp(null);
+        await mutate();
+      } else {
+        const info = await response.json().catch(() => ({}));
+        setDetachError(info.error || "Failed to detach MCP.");
+      }
     } finally {
       setDetaching(false);
     }
@@ -144,7 +151,10 @@ const McpList = ({
                 asChild={!isOrgScopedInWorkspace}
                 onClick={
                   isOrgScopedInWorkspace
-                    ? () => setSelectedOrgMcp(mcp)
+                    ? () => {
+                        setDetachError(null);
+                        setSelectedOrgMcp(mcp);
+                      }
                     : undefined
                 }
                 className={cn(isOrgScopedInWorkspace && "cursor-pointer")}
@@ -229,7 +239,12 @@ const McpList = ({
       )}
       <Dialog
         open={!!selectedOrgMcp}
-        onOpenChange={(open) => !open && setSelectedOrgMcp(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedOrgMcp(null);
+            setDetachError(null);
+          }
+        }}
       >
         <DialogContent>
           <DialogHeader>
@@ -240,8 +255,17 @@ const McpList = ({
               organization settings.
             </DialogDescription>
           </DialogHeader>
+          {detachError && (
+            <p className="text-sm text-destructive">{detachError}</p>
+          )}
           <DialogFooter>
-            <Button variant="outline" onClick={() => setSelectedOrgMcp(null)}>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setSelectedOrgMcp(null);
+                setDetachError(null);
+              }}
+            >
               Close
             </Button>
             {canAttach && selectedOrgMcp && (

--- a/apps/frontend/components/providers-list.test.tsx
+++ b/apps/frontend/components/providers-list.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { Provider } from "@platypus/schemas";
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "u1" }, isOrgAdmin: true }),
+}));
+
+type ProviderWithScope = Provider & { scope: "organization" | "workspace" };
+
+// The `GET .../providers` list this component renders. Set per test.
+let providers: ProviderWithScope[] = [];
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (key?.includes("/providers")) {
+      return {
+        data: { results: providers },
+        error: undefined,
+        isLoading: false,
+        mutate: mutateSpy,
+      };
+    }
+    // Workspace lookup (providerSelfManagement) — unused by these tests.
+    return {
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    };
+  },
+}));
+
+const mutateSpy = vi.fn();
+
+import { ProvidersList } from "./providers-list";
+
+// --- Helpers -----------------------------------------------------------------
+
+const orgProvider: ProviderWithScope = {
+  id: "p1",
+  name: "Shared OpenAI",
+  providerType: "OpenAI",
+  scope: "organization",
+} as unknown as ProviderWithScope;
+
+/** A refused detach, carrying the reason the backend gave. */
+function mockRefusedDetach(reason: string) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status: 409,
+    json: async () => ({ error: reason }),
+  } as unknown as Response);
+}
+
+function openDetachDialog() {
+  fireEvent.click(screen.getByText("Shared OpenAI"));
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe("ProvidersList detach", () => {
+  afterEach(() => {
+    providers = [];
+    mutateSpy.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces the backend's reason and keeps the row when detach is refused", async () => {
+    providers = [orgProvider];
+    const fetchMock = mockRefusedDetach(
+      "This provider is in use by an agent in this workspace",
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProvidersList orgId="org1" workspaceId="ws1" />);
+    openDetachDialog();
+    fireEvent.click(screen.getByRole("button", { name: /Detach/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "This provider is in use by an agent in this workspace",
+        ),
+      ).toBeInTheDocument(),
+    );
+
+    // A refused detach must not revalidate the list.
+    expect(mutateSpy).not.toHaveBeenCalled();
+    // The dialog stays open on the same provider rather than silently closing.
+    expect(screen.getByText("Organization Provider")).toBeInTheDocument();
+  });
+
+  it("revalidates and closes the dialog when detach succeeds", async () => {
+    providers = [orgProvider];
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ message: "Detached" }),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProvidersList orgId="org1" workspaceId="ws1" />);
+    openDetachDialog();
+    fireEvent.click(screen.getByRole("button", { name: /Detach/ }));
+
+    await waitFor(() => expect(mutateSpy).toHaveBeenCalled());
+    expect(screen.queryByText("Organization Provider")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/providers-list.tsx
+++ b/apps/frontend/components/providers-list.tsx
@@ -46,6 +46,7 @@ const ProvidersList = ({
     useState<ProviderWithScope | null>(null);
   const [attachOpen, setAttachOpen] = useState(false);
   const [detaching, setDetaching] = useState(false);
+  const [detachError, setDetachError] = useState<string | null>(null);
 
   const fetchUrl =
     backendUrl && user
@@ -68,16 +69,22 @@ const ProvidersList = ({
   const detachOrgProvider = async (providerId: string) => {
     if (!backendUrl || !workspaceId) return;
     setDetaching(true);
+    setDetachError(null);
     try {
-      await fetch(
+      const response = await fetch(
         joinUrl(
           backendUrl,
           `/organizations/${orgId}/workspaces/${workspaceId}/attachments/provider/${providerId}`,
         ),
         { method: "DELETE", credentials: "include" },
       );
-      setSelectedOrgProvider(null);
-      await mutate();
+      if (response.ok) {
+        setSelectedOrgProvider(null);
+        await mutate();
+      } else {
+        const info = await response.json().catch(() => ({}));
+        setDetachError(info.error || "Failed to detach provider.");
+      }
     } finally {
       setDetaching(false);
     }
@@ -128,7 +135,10 @@ const ProvidersList = ({
                 asChild={!isOrgScopedInWorkspace}
                 onClick={
                   isOrgScopedInWorkspace
-                    ? () => setSelectedOrgProvider(provider)
+                    ? () => {
+                        setDetachError(null);
+                        setSelectedOrgProvider(provider);
+                      }
                     : undefined
                 }
                 className={cn(isOrgScopedInWorkspace && "cursor-pointer")}
@@ -213,7 +223,12 @@ const ProvidersList = ({
       )}
       <Dialog
         open={!!selectedOrgProvider}
-        onOpenChange={(open) => !open && setSelectedOrgProvider(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedOrgProvider(null);
+            setDetachError(null);
+          }
+        }}
       >
         <DialogContent>
           <DialogHeader>
@@ -224,10 +239,16 @@ const ProvidersList = ({
               organization settings.
             </DialogDescription>
           </DialogHeader>
+          {detachError && (
+            <p className="text-sm text-destructive">{detachError}</p>
+          )}
           <DialogFooter>
             <Button
               variant="outline"
-              onClick={() => setSelectedOrgProvider(null)}
+              onClick={() => {
+                setSelectedOrgProvider(null);
+                setDetachError(null);
+              }}
             >
               Close
             </Button>

--- a/apps/frontend/components/skills-list.tsx
+++ b/apps/frontend/components/skills-list.tsx
@@ -114,6 +114,7 @@ export const SkillsList = ({
   const [selectedOrgSkill, setSelectedOrgSkill] =
     useState<SkillWithScope | null>(null);
   const [detaching, setDetaching] = useState(false);
+  const [detachError, setDetachError] = useState<string | null>(null);
   const [attachOpen, setAttachOpen] = useState(false);
   const [skillToPromote, setSkillToPromote] = useState<SkillWithScope | null>(
     null,
@@ -234,16 +235,22 @@ export const SkillsList = ({
   const detachOrgSkill = async (skillId: string) => {
     if (!backendUrl || !workspaceId) return;
     setDetaching(true);
+    setDetachError(null);
     try {
-      await fetch(
+      const response = await fetch(
         joinUrl(
           backendUrl,
           `/organizations/${orgId}/workspaces/${workspaceId}/attachments/skill/${skillId}`,
         ),
         { method: "DELETE", credentials: "include" },
       );
-      setSelectedOrgSkill(null);
-      await mutate();
+      if (response.ok) {
+        setSelectedOrgSkill(null);
+        await mutate();
+      } else {
+        const info = await response.json().catch(() => ({}));
+        setDetachError(info.error || "Failed to detach skill.");
+      }
     } finally {
       setDetaching(false);
     }
@@ -295,7 +302,10 @@ export const SkillsList = ({
                 <Item
                   variant="outline"
                   className="h-full cursor-pointer"
-                  onClick={() => setSelectedOrgSkill(skill)}
+                  onClick={() => {
+                    setDetachError(null);
+                    setSelectedOrgSkill(skill);
+                  }}
                 >
                   <ItemContent>
                     <div className="flex items-center gap-2">
@@ -444,7 +454,12 @@ export const SkillsList = ({
 
       <Dialog
         open={!!selectedOrgSkill}
-        onOpenChange={(open) => !open && setSelectedOrgSkill(null)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedOrgSkill(null);
+            setDetachError(null);
+          }
+        }}
       >
         <DialogContent>
           <DialogHeader>
@@ -455,8 +470,17 @@ export const SkillsList = ({
               organization settings.
             </DialogDescription>
           </DialogHeader>
+          {detachError && (
+            <p className="text-sm text-destructive">{detachError}</p>
+          )}
           <DialogFooter>
-            <Button variant="outline" onClick={() => setSelectedOrgSkill(null)}>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setSelectedOrgSkill(null);
+                setDetachError(null);
+              }}
+            >
               Close
             </Button>
             {canAttach && selectedOrgSkill && (


### PR DESCRIPTION
## Summary
- Each of the four detach paths (Agent, Skill, MCP, Provider) now checks `response.ok` before treating the detach as done, instead of firing the DELETE and ignoring the result.
- A refused detach surfaces the reason the backend gave (`info.error`), falling back to a generic message only when the response body is empty or not JSON.
- The workspace list is only revalidated (`mutate()`) on success, and the confirm dialog stays open on a failed detach instead of silently closing.

Closes #560

## Test plan
- [x] `pnpm --filter frontend test` — 198/198 passing, including new coverage in `providers-list.test.tsx` for both the refused-detach path (error shown, list not revalidated, dialog stays open) and the success path
- [x] `pnpm typecheck`
- [x] `pnpm --filter frontend lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)