### PR TITLE
feat(frontend): add a typed-outcome request module for API writes

### DIFF
--- a/apps/frontend/lib/api-write.test.ts
+++ b/apps/frontend/lib/api-write.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { writeEntity } from "./api-write";
+
+function mockResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "",
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const BACKEND_URL = "http://localhost:4000";
+
+describe("writeEntity — transport", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("POSTs to the org-scoped collection path when creating with no workspace scope", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(mockResponse(201, { id: "a1" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        data: { name: "Bot" },
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4000/organizations/org1/agents",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Bot" }),
+      }),
+    );
+  });
+
+  it("POSTs to the workspace-scoped collection path when a workspaceId is present", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(201, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1", workspaceId: "ws1" },
+      { data: { name: "Bot" } },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4000/organizations/org1/workspaces/ws1/agents",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("PUTs to the item path when an id and data are both given (update)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1", workspaceId: "ws1" },
+      { id: "a1", data: { name: "Renamed" } },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4000/organizations/org1/workspaces/ws1/agents/a1",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ name: "Renamed" }),
+      }),
+    );
+  });
+
+  it("DELETEs the item path with no body when an id is given without data", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1", workspaceId: "ws1" },
+      { id: "a1" },
+    );
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("DELETE");
+    expect(init.credentials).toBe("include");
+    expect(init.body).toBeUndefined();
+    expect(init.headers).toBeUndefined();
+  });
+
+  it("always sends credentials: include", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        id: "a1",
+      },
+    );
+
+    expect(fetchMock.mock.calls[0][1].credentials).toBe("include");
+  });
+});
+
+describe("writeEntity — outcomes", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("maps a 2xx response to a success outcome carrying the parsed body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockResponse(201, { id: "a1", name: "Bot" })),
+    );
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        data: { name: "Bot" },
+      },
+    );
+
+    expect(result).toEqual({
+      outcome: "success",
+      data: { id: "a1", name: "Bot" },
+      revalidateKeys: ["http://localhost:4000/organizations/org1/agents"],
+    });
+  });
+
+  it("declares both the collection and item keys to revalidate after an update", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(200, {})));
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        id: "a1",
+        data: { name: "Renamed" },
+      },
+    );
+
+    expect(result.outcome).toBe("success");
+    if (result.outcome === "success") {
+      expect(result.revalidateKeys).toEqual([
+        "http://localhost:4000/organizations/org1/agents",
+        "http://localhost:4000/organizations/org1/agents/a1",
+      ]);
+    }
+  });
+
+  it("declares only the collection key to revalidate after a delete", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(200, {})));
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        id: "a1",
+      },
+    );
+
+    expect(result.outcome).toBe("success");
+    if (result.outcome === "success") {
+      expect(result.revalidateKeys).toEqual([
+        "http://localhost:4000/organizations/org1/agents",
+      ]);
+    }
+  });
+
+  it("maps 404 (NotFoundError) to a notFound outcome", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(mockResponse(404, { error: "Agent not found" })),
+    );
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        id: "missing",
+        data: { name: "x" },
+      },
+    );
+
+    expect(result).toEqual({ outcome: "notFound", message: "Agent not found" });
+  });
+
+  it("falls back to a default message when a 404 body carries none", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(404, {})));
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        id: "missing",
+        data: {},
+      },
+    );
+
+    expect(result).toEqual({ outcome: "notFound", message: "Not found" });
+  });
+
+  it("maps 403 (LockedError) to a locked outcome", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse(403, {
+          error: "This resource is managed at the organization level",
+        }),
+      ),
+    );
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        id: "a1",
+        data: { name: "x" },
+      },
+    );
+
+    expect(result).toEqual({
+      outcome: "locked",
+      message: "This resource is managed at the organization level",
+    });
+  });
+
+  it("maps 409 (ConflictError / unique violation) to a conflict outcome", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse(409, {
+          error: "A resource with that name already exists",
+        }),
+      ),
+    );
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        data: { name: "dup" },
+      },
+    );
+
+    expect(result).toEqual({
+      outcome: "conflict",
+      message: "A resource with that name already exists",
+    });
+  });
+
+  it("maps a 400 with sValidator's issue-array shape to invalid with dot-path field errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse(400, {
+          data: {},
+          success: false,
+          error: [
+            {
+              path: ["modelIds", 1, "alias"],
+              message: "Alias 'dup' duplicates",
+            },
+            { path: ["name"], message: "Name is required" },
+          ],
+        }),
+      ),
+    );
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "providers",
+      { orgId: "org1" },
+      {
+        data: {},
+      },
+    );
+
+    expect(result.outcome).toBe("invalid");
+    if (result.outcome === "invalid") {
+      expect(result.fieldErrors).toEqual({
+        "modelIds.1.alias": "Alias 'dup' duplicates",
+        modelIds: "Alias 'dup' duplicates",
+        name: "Name is required",
+      });
+      expect(result.message).toBe("Alias 'dup' duplicates");
+    }
+  });
+
+  it("maps a 400 with a files array (FileValidationError) to invalid, carrying the offending files", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse(400, {
+          error: "Some files could not be processed: scan.pdf",
+          files: ["scan.pdf"],
+        }),
+      ),
+    );
+
+    const result = await writeEntity(BACKEND_URL, "attachments", {
+      orgId: "org1",
+    });
+
+    expect(result).toEqual({
+      outcome: "invalid",
+      message: "Some files could not be processed: scan.pdf",
+      fieldErrors: {},
+      files: ["scan.pdf"],
+    });
+  });
+
+  it("maps a 400 with a plain string error (ValidationError) to invalid with no field errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(mockResponse(400, { error: "Invalid label ID" })),
+    );
+
+    const result = await writeEntity(BACKEND_URL, "boards", {
+      orgId: "org1",
+      workspaceId: "ws1",
+    });
+
+    expect(result).toEqual({
+      outcome: "invalid",
+      message: "Invalid label ID",
+      fieldErrors: {},
+    });
+  });
+
+  it("maps an unmapped status to a generic error outcome carrying the HTTP status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          mockResponse(500, { error: "Internal Server Error" }),
+        ),
+    );
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        data: {},
+      },
+    );
+
+    expect(result).toEqual({
+      outcome: "error",
+      message: "Internal Server Error",
+      httpStatus: 500,
+    });
+  });
+
+  it("maps a network failure to an error outcome instead of throwing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new TypeError("Failed to fetch")),
+    );
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        data: {},
+      },
+    );
+
+    expect(result).toEqual({
+      outcome: "error",
+      message: "Network request failed",
+    });
+  });
+
+  it("tolerates a response body that isn't valid JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "",
+        json: async () => {
+          throw new SyntaxError("Unexpected end of input");
+        },
+      } as unknown as Response),
+    );
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        id: "a1",
+      },
+    );
+
+    expect(result.outcome).toBe("success");
+    if (result.outcome === "success") {
+      expect(result.data).toBeNull();
+    }
+  });
+});

--- a/apps/frontend/lib/api-write.ts
+++ b/apps/frontend/lib/api-write.ts
@@ -1,0 +1,168 @@
+import { joinUrl, parseValidationErrors } from "./utils";
+
+/**
+ * A write's target scope (ADR-0007): an Organization-level (Shared) resource,
+ * or a resource inside one Workspace. Presence of `workspaceId` is what
+ * distinguishes the two — there is deliberately no separate discriminant to
+ * get out of sync with it.
+ */
+export type Scope =
+  | { readonly orgId: string; readonly workspaceId?: undefined }
+  | { readonly orgId: string; readonly workspaceId: string };
+
+export interface WriteOptions<TData> {
+  /** Omit to create; provide to update or delete an existing entity. */
+  readonly id?: string;
+  /** Omit only when `id` is set and the write is a delete. */
+  readonly data?: TData;
+}
+
+/**
+ * The outcomes the backend's central `onError` (ADR-0010) can produce for a
+ * write, plus the field-level shape `sValidator` returns for a 400 before it
+ * ever reaches that seam. A caller destructures `outcome` and TypeScript
+ * won't let it skip a case, so the four failure modes this ticket exists to
+ * stop callers from re-deriving from a raw status code can't be missed.
+ */
+export type WriteOutcome<TResult> =
+  | {
+      readonly outcome: "success";
+      readonly data: TResult;
+      /** SWR keys this write should invalidate — the caller still calls `mutate`. */
+      readonly revalidateKeys: readonly string[];
+    }
+  | { readonly outcome: "notFound"; readonly message: string }
+  | { readonly outcome: "locked"; readonly message: string }
+  | { readonly outcome: "conflict"; readonly message: string }
+  | {
+      readonly outcome: "invalid";
+      readonly message: string;
+      /** Dot-path keyed, same convention as `parseValidationErrors`. */
+      readonly fieldErrors: Record<string, string>;
+      /** Present only for a `FileValidationError` 400 — the offending files. */
+      readonly files?: string[];
+    }
+  | {
+      readonly outcome: "error";
+      readonly message: string;
+      readonly httpStatus?: number;
+    };
+
+const DEFAULT_MESSAGES = {
+  notFound: "Not found",
+  locked: "This resource is managed at the organization level",
+  conflict: "This operation conflicts with an existing resource",
+  invalid: "Validation failed",
+  error: "Request failed",
+} as const;
+
+function scopedPath(entity: string, scope: Scope): string {
+  return scope.workspaceId
+    ? `/organizations/${scope.orgId}/workspaces/${scope.workspaceId}/${entity}`
+    : `/organizations/${scope.orgId}/${entity}`;
+}
+
+function errorMessage(body: unknown): string | undefined {
+  if (body && typeof body === "object" && "error" in body) {
+    const { error } = body as { error: unknown };
+    if (typeof error === "string") return error;
+  }
+  return undefined;
+}
+
+function errorFiles(body: unknown): string[] | undefined {
+  if (body && typeof body === "object" && "files" in body) {
+    const { files } = body as { files: unknown };
+    if (Array.isArray(files) && files.every((f) => typeof f === "string")) {
+      return files;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Owns a single write (create, update, or delete) to the Platypus API: the
+ * base URL, the Organization-vs-Workspace path shape, credentials, the HTTP
+ * method, and the outcome mapping that mirrors the backend's ADR-0010 error
+ * seam. Callers pass `id`/`data` rather than a method: `id` absent means
+ * create (POST), `id` present with `data` means update (PUT), `id` present
+ * without `data` means delete (DELETE).
+ */
+export async function writeEntity<TResult = unknown, TData = unknown>(
+  backendUrl: string,
+  entity: string,
+  scope: Scope,
+  options: WriteOptions<TData> = {},
+): Promise<WriteOutcome<TResult>> {
+  const { id, data } = options;
+  const method: "POST" | "PUT" | "DELETE" =
+    id === undefined ? "POST" : data === undefined ? "DELETE" : "PUT";
+
+  const path = scopedPath(entity, scope);
+  const collectionUrl = joinUrl(backendUrl, path);
+  const url =
+    id === undefined ? collectionUrl : joinUrl(backendUrl, `${path}/${id}`);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method,
+      credentials: "include",
+      ...(method !== "DELETE"
+        ? {
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(data),
+          }
+        : {}),
+    });
+  } catch {
+    return { outcome: "error", message: "Network request failed" };
+  }
+
+  const body: unknown = await response.json().catch(() => null);
+
+  if (response.ok) {
+    const revalidateKeys =
+      method === "PUT" ? [collectionUrl, url] : [collectionUrl];
+    return { outcome: "success", data: body as TResult, revalidateKeys };
+  }
+
+  switch (response.status) {
+    case 404:
+      return {
+        outcome: "notFound",
+        message: errorMessage(body) ?? DEFAULT_MESSAGES.notFound,
+      };
+    case 403:
+      return {
+        outcome: "locked",
+        message: errorMessage(body) ?? DEFAULT_MESSAGES.locked,
+      };
+    case 409:
+      return {
+        outcome: "conflict",
+        message: errorMessage(body) ?? DEFAULT_MESSAGES.conflict,
+      };
+    case 400: {
+      const fieldErrors = parseValidationErrors(body);
+      const message =
+        errorMessage(body) ??
+        Object.values(fieldErrors)[0] ??
+        DEFAULT_MESSAGES.invalid;
+      const files = errorFiles(body);
+      return {
+        outcome: "invalid",
+        message,
+        fieldErrors,
+        ...(files ? { files } : {}),
+      };
+    }
+    default:
+      return {
+        outcome: "error",
+        message:
+          (errorMessage(body) ?? response.statusText) || DEFAULT_MESSAGES.error,
+        httpStatus: response.status,
+      };
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `apps/frontend/lib/api-write.ts`, a single module (`writeEntity`) that owns a write to the Platypus API: it resolves the base URL and the Organization-vs-Workspace path shape, always sends credentials, and infers the HTTP method (create → POST, update → PUT, delete → DELETE) from whether `id`/`data` are present — so callers stop re-deriving the transport for themselves.
- The return value is a typed `WriteOutcome` discriminated union (`success | notFound | locked | conflict | invalid | error`) mirroring the backend's central error seam (ADR-0010): `NotFoundError → 404`, `LockedError → 403`, `ConflictError → 409`, `ValidationError → 400`, plus the field-issue-array shape `sValidator` returns on 400 and the `files` payload `FileValidationError` attaches. Callers must branch on `outcome` and can't skip a case.
- Field-level errors reuse the existing `parseValidationErrors` from `lib/utils.ts`, so they're keyed exactly the way forms already consume them — full dot paths (`modelIds.1.alias`), with a top-level fallback.
- A successful write declares which SWR keys should be invalidated (`revalidateKeys`: collection key for create/delete, collection + item key for update) rather than performing the `mutate` itself, keeping the module framework-agnostic.
- No existing call site is touched — this ticket only adds the module; migration happens in follow-up batches.

Closes #563

## Test plan

- [x] `pnpm --filter @platypus/frontend test` — 18 new unit tests in `apps/frontend/lib/api-write.test.ts` covering transport (org/workspace path shapes, method inference, credentials, no-body deletes) and every outcome against the exact statuses `apps/backend/src/errors.test.ts` already pins (404, 403, 409, 400 with both the sValidator array shape and a plain string message, 400 with `files`, an unmapped 500, a network failure, and an unparsable success body)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (full monorepo: 1901 backend + 214 frontend tests)
- [x] Reviewed via `/code-review` (standards + spec axes) — no hard violations; fixed the one real gap found (the `files` array wasn't threaded through) and corrected an overclaiming doc comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)