### PR TITLE
chore(frontend): delete unreferenced prompt-input exports and split out speech driver

### DIFF
--- a/apps/frontend/components/ai-elements/prompt-input.test.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  PromptInput,
+  PromptInputAttachment,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputTextarea,
+} from "./prompt-input";
+
+beforeEach(() => {
+  // jsdom has no matchMedia; PromptInputTextarea subscribes to it via useIsMobile.
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }) as unknown as typeof window.matchMedia;
+});
+
+function getFileInput() {
+  return screen.getByLabelText("Upload files") as HTMLInputElement;
+}
+
+function fireFileChange(input: HTMLInputElement, files: File[]) {
+  Object.defineProperty(input, "files", {
+    value: files,
+    configurable: true,
+  });
+  fireEvent.change(input);
+}
+
+describe("PromptInput accept filtering", () => {
+  it("accepts a file matching an extension pattern and rejects one that doesn't", () => {
+    const onError = vi.fn();
+    render(
+      <PromptInput accept=".pdf" onError={onError} onSubmit={vi.fn()}>
+        <PromptInputAttachments className="w-full">
+          {(attachment) => <PromptInputAttachment data={attachment} />}
+        </PromptInputAttachments>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+      </PromptInput>,
+    );
+
+    const input = getFileInput();
+    const txtFile = new File(["hello"], "notes.txt", { type: "text/plain" });
+    fireFileChange(input, [txtFile]);
+
+    expect(onError).toHaveBeenCalledWith({
+      code: "accept",
+      message: "No files match the accepted types.",
+    });
+    expect(screen.queryByText("notes.txt")).not.toBeInTheDocument();
+
+    const pdfFile = new File(["%PDF"], "report.pdf", {
+      type: "application/pdf",
+    });
+    fireFileChange(input, [pdfFile]);
+
+    expect(screen.getByText("report.pdf")).toBeInTheDocument();
+  });
+
+  it("accepts a file matching an explicit mime type beyond image/*", () => {
+    const onError = vi.fn();
+    render(
+      <PromptInput
+        accept="application/json"
+        onError={onError}
+        onSubmit={vi.fn()}
+      >
+        <PromptInputAttachments className="w-full">
+          {(attachment) => <PromptInputAttachment data={attachment} />}
+        </PromptInputAttachments>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+      </PromptInput>,
+    );
+
+    const input = getFileInput();
+    const jsonFile = new File(["{}"], "data.json", {
+      type: "application/json",
+    });
+    fireFileChange(input, [jsonFile]);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(screen.getByText("data.json")).toBeInTheDocument();
+  });
+});
+
+describe("PromptInput attachments", () => {
+  it("adds and removes an attachment", () => {
+    render(
+      <PromptInput onSubmit={vi.fn()}>
+        <PromptInputAttachments className="w-full">
+          {(attachment) => <PromptInputAttachment data={attachment} />}
+        </PromptInputAttachments>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+      </PromptInput>,
+    );
+
+    const input = getFileInput();
+    const file = new File(["hi"], "photo.png", { type: "image/png" });
+    fireFileChange(input, [file]);
+
+    expect(screen.getByText("photo.png")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove attachment" }));
+
+    expect(screen.queryByText("photo.png")).not.toBeInTheDocument();
+  });
+
+  it("enforces maxFiles and maxFileSize", () => {
+    const onError = vi.fn();
+    render(
+      <PromptInput
+        maxFiles={1}
+        maxFileSize={10}
+        onError={onError}
+        onSubmit={vi.fn()}
+      >
+        <PromptInputAttachments className="w-full">
+          {(attachment) => <PromptInputAttachment data={attachment} />}
+        </PromptInputAttachments>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+      </PromptInput>,
+    );
+
+    const input = getFileInput();
+    const tooBig = new File(["x".repeat(20)], "big.txt", {
+      type: "text/plain",
+    });
+    fireFileChange(input, [tooBig]);
+    expect(onError).toHaveBeenCalledWith({
+      code: "max_file_size",
+      message: "All files exceed the maximum size.",
+    });
+
+    const small1 = new File(["a"], "a.txt", { type: "text/plain" });
+    const small2 = new File(["b"], "b.txt", { type: "text/plain" });
+    fireFileChange(input, [small1, small2]);
+
+    expect(onError).toHaveBeenCalledWith({
+      code: "max_files",
+      message: "Too many files. Some were not added.",
+    });
+    expect(screen.getByText("a.txt")).toBeInTheDocument();
+    expect(screen.queryByText("b.txt")).not.toBeInTheDocument();
+  });
+
+  it("adds files dropped anywhere on the document when globalDrop is set", () => {
+    render(
+      <PromptInput globalDrop onSubmit={vi.fn()}>
+        <PromptInputAttachments className="w-full">
+          {(attachment) => <PromptInputAttachment data={attachment} />}
+        </PromptInputAttachments>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+      </PromptInput>,
+    );
+
+    const file = new File(["hi"], "dropped.png", { type: "image/png" });
+
+    fireEvent.drop(document, {
+      dataTransfer: {
+        types: ["Files"],
+        files: [file],
+      },
+    });
+
+    expect(screen.getByText("dropped.png")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/ai-elements/prompt-input.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.tsx
@@ -2,15 +2,6 @@
 
 import { Button } from "@/components/ui/button";
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-} from "@/components/ui/command";
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -27,14 +18,8 @@ import {
   InputGroupButton,
   InputGroupTextarea,
 } from "@/components/ui/input-group";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useSpeechToText } from "@/hooks/use-speech-to-text";
 import { cn } from "@/lib/utils";
 import type { ChatStatus, FileUIPart } from "ai";
 import {
@@ -49,8 +34,6 @@ import {
 } from "lucide-react";
 import { nanoid } from "nanoid";
 import {
-  type ChangeEvent,
-  type ChangeEventHandler,
   Children,
   type ClipboardEventHandler,
   type ComponentProps,
@@ -60,9 +43,9 @@ import {
   Fragment,
   type HTMLAttributes,
   type KeyboardEventHandler,
-  type PropsWithChildren,
   type ReactNode,
   type RefObject,
+  type ChangeEventHandler,
   useCallback,
   useContext,
   useEffect,
@@ -71,11 +54,7 @@ import {
   useState,
 } from "react";
 
-// ============================================================================
-// Provider Context & Types
-// ============================================================================
-
-export type AttachmentsContext = {
+type AttachmentsContext = {
   files: (FileUIPart & { id: string })[];
   add: (files: File[] | FileList) => void;
   remove: (id: string) => void;
@@ -84,183 +63,40 @@ export type AttachmentsContext = {
   fileInputRef: RefObject<HTMLInputElement | null>;
 };
 
-export type TextInputContext = {
-  value: string;
-  setInput: (v: string) => void;
-  clear: () => void;
-};
-
-export type PromptInputControllerProps = {
-  textInput: TextInputContext;
-  attachments: AttachmentsContext;
-  /** INTERNAL: Allows PromptInput to register its file textInput + "open" callback */
-  __registerFileInput: (
-    ref: RefObject<HTMLInputElement | null>,
-    open: () => void,
-  ) => void;
-};
-
-const PromptInputController = createContext<PromptInputControllerProps | null>(
+const PromptInputAttachmentsContext = createContext<AttachmentsContext | null>(
   null,
 );
-const ProviderAttachmentsContext = createContext<AttachmentsContext | null>(
-  null,
-);
-
-export const usePromptInputController = () => {
-  const ctx = useContext(PromptInputController);
-  if (!ctx) {
-    throw new Error(
-      "Wrap your component inside <PromptInputProvider> to use usePromptInputController().",
-    );
-  }
-  return ctx;
-};
-
-// Optional variants (do NOT throw). Useful for dual-mode components.
-const useOptionalPromptInputController = () =>
-  useContext(PromptInputController);
-
-export const useProviderAttachments = () => {
-  const ctx = useContext(ProviderAttachmentsContext);
-  if (!ctx) {
-    throw new Error(
-      "Wrap your component inside <PromptInputProvider> to use useProviderAttachments().",
-    );
-  }
-  return ctx;
-};
-
-const useOptionalProviderAttachments = () =>
-  useContext(ProviderAttachmentsContext);
-
-export type PromptInputProviderProps = PropsWithChildren<{
-  initialInput?: string;
-}>;
-
-/**
- * Optional global provider that lifts PromptInput state outside of PromptInput.
- * If you don't use it, PromptInput stays fully self-managed.
- */
-export function PromptInputProvider({
-  initialInput: initialTextInput = "",
-  children,
-}: PromptInputProviderProps) {
-  // ----- textInput state
-  const [textInput, setTextInput] = useState(initialTextInput);
-  const clearInput = useCallback(() => setTextInput(""), []);
-
-  // ----- attachments state (global when wrapped)
-  const [attachements, setAttachements] = useState<
-    (FileUIPart & { id: string })[]
-  >([]);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const openRef = useRef<() => void>(() => {});
-
-  const add = useCallback((files: File[] | FileList) => {
-    const incoming = Array.from(files);
-    if (incoming.length === 0) {
-      return;
-    }
-
-    setAttachements((prev) =>
-      prev.concat(
-        incoming.map((file) => ({
-          id: nanoid(),
-          type: "file" as const,
-          url: URL.createObjectURL(file),
-          mediaType: file.type,
-          filename: file.name,
-        })),
-      ),
-    );
-  }, []);
-
-  const remove = useCallback((id: string) => {
-    setAttachements((prev) => {
-      const found = prev.find((f) => f.id === id);
-      if (found?.url) {
-        URL.revokeObjectURL(found.url);
-      }
-      return prev.filter((f) => f.id !== id);
-    });
-  }, []);
-
-  const clear = useCallback(() => {
-    setAttachements((prev) => {
-      for (const f of prev) {
-        if (f.url) {
-          URL.revokeObjectURL(f.url);
-        }
-      }
-      return [];
-    });
-  }, []);
-
-  const openFileDialog = useCallback(() => {
-    openRef.current?.();
-  }, []);
-
-  const attachments = useMemo<AttachmentsContext>(
-    () => ({
-      files: attachements,
-      add,
-      remove,
-      clear,
-      openFileDialog,
-      fileInputRef,
-    }),
-    [attachements, add, remove, clear, openFileDialog],
-  );
-
-  const __registerFileInput = useCallback(
-    (ref: RefObject<HTMLInputElement | null>, open: () => void) => {
-      fileInputRef.current = ref.current;
-      openRef.current = open;
-    },
-    [],
-  );
-
-  const controller = useMemo<PromptInputControllerProps>(
-    () => ({
-      textInput: {
-        value: textInput,
-        setInput: setTextInput,
-        clear: clearInput,
-      },
-      attachments,
-      __registerFileInput,
-    }),
-    [textInput, clearInput, attachments, __registerFileInput],
-  );
-
-  return (
-    <PromptInputController.Provider value={controller}>
-      <ProviderAttachmentsContext.Provider value={attachments}>
-        {children}
-      </ProviderAttachmentsContext.Provider>
-    </PromptInputController.Provider>
-  );
-}
-
-// ============================================================================
-// Component Context & Hooks
-// ============================================================================
-
-const LocalAttachmentsContext = createContext<AttachmentsContext | null>(null);
 
 export const usePromptInputAttachments = () => {
-  // Dual-mode: prefer provider if present, otherwise use local
-  const provider = useOptionalProviderAttachments();
-  const local = useContext(LocalAttachmentsContext);
-  const context = provider ?? local;
+  const context = useContext(PromptInputAttachmentsContext);
   if (!context) {
     throw new Error(
-      "usePromptInputAttachments must be used within a PromptInput or PromptInputProvider",
+      "usePromptInputAttachments must be used within a PromptInput",
     );
   }
   return context;
 };
+
+function fileMatchesAccept(file: File, accept: string): boolean {
+  const patterns = accept
+    .split(",")
+    .map((pattern) => pattern.trim())
+    .filter(Boolean);
+
+  if (patterns.length === 0) {
+    return true;
+  }
+
+  return patterns.some((pattern) => {
+    if (pattern.startsWith(".")) {
+      return file.name.toLowerCase().endsWith(pattern.toLowerCase());
+    }
+    if (pattern.endsWith("/*")) {
+      return file.type.startsWith(pattern.slice(0, -1));
+    }
+    return file.type === pattern;
+  });
+}
 
 export type PromptInputAttachmentProps = HTMLAttributes<HTMLDivElement> & {
   data: FileUIPart & { id: string };
@@ -283,7 +119,7 @@ export function PromptInputAttachment({
   const attachmentLabel = filename || (isImage ? "Image" : "Attachment");
 
   return (
-    <PromptInputHoverCard>
+    <HoverCard closeDelay={0} openDelay={0}>
       <HoverCardTrigger asChild>
         <div
           className={cn(
@@ -330,7 +166,7 @@ export function PromptInputAttachment({
           <span className="flex-1 truncate">{attachmentLabel}</span>
         </div>
       </HoverCardTrigger>
-      <PromptInputHoverCardContent className="w-auto p-2">
+      <HoverCardContent align="start" className="w-auto p-2">
         <div className="w-auto space-y-3">
           {isImage && (
             <div className="flex max-h-96 w-96 items-center justify-center overflow-hidden rounded-md border">
@@ -359,8 +195,8 @@ export function PromptInputAttachment({
             </div>
           </div>
         </div>
-      </PromptInputHoverCardContent>
-    </PromptInputHoverCard>
+      </HoverCardContent>
+    </HoverCard>
   );
 }
 
@@ -428,12 +264,10 @@ export type PromptInputProps = Omit<
   HTMLAttributes<HTMLFormElement>,
   "onSubmit" | "onError"
 > & {
-  accept?: string; // e.g., "image/*" or leave undefined for any
+  accept?: string; // e.g., "image/*", ".pdf", or a comma-separated list of either
   multiple?: boolean;
   // When true, accepts drops anywhere on document. Default false (opt-in).
   globalDrop?: boolean;
-  // Render a hidden input with given name and keep it in sync for native form posts. Default false.
-  syncHiddenInput?: boolean;
   // Minimal constraints
   maxFiles?: number;
   maxFileSize?: number; // bytes
@@ -452,7 +286,6 @@ export const PromptInput = ({
   accept,
   multiple,
   globalDrop,
-  syncHiddenInput,
   maxFiles,
   maxFileSize,
   onError,
@@ -460,10 +293,6 @@ export const PromptInput = ({
   children,
   ...props
 }: PromptInputProps) => {
-  // Try to use a provider controller if present
-  const controller = useOptionalPromptInputController();
-  const usingProvider = !!controller;
-
   // Refs
   const inputRef = useRef<HTMLInputElement | null>(null);
   const anchorRef = useRef<HTMLSpanElement>(null);
@@ -477,11 +306,9 @@ export const PromptInput = ({
     }
   }, []);
 
-  // ----- Local attachments (only used when no provider)
-  const [items, setItems] = useState<(FileUIPart & { id: string })[]>([]);
-  const files = usingProvider ? controller.attachments.files : items;
+  const [files, setItems] = useState<(FileUIPart & { id: string })[]>([]);
 
-  const openFileDialogLocal = useCallback(() => {
+  const openFileDialog = useCallback(() => {
     inputRef.current?.click();
   }, []);
 
@@ -490,16 +317,12 @@ export const PromptInput = ({
       if (!accept || accept.trim() === "") {
         return true;
       }
-      if (accept.includes("image/*")) {
-        return f.type.startsWith("image/");
-      }
-      // NOTE: keep simple; expand as needed
-      return true;
+      return fileMatchesAccept(f, accept);
     },
     [accept],
   );
 
-  const addLocal = useCallback(
+  const add = useCallback(
     (fileList: File[] | FileList) => {
       const incoming = Array.from(fileList);
       const accepted = incoming.filter((f) => matchesAccept(f));
@@ -550,34 +373,17 @@ export const PromptInput = ({
     [matchesAccept, maxFiles, maxFileSize, onError],
   );
 
-  const add = useCallback(
-    (files: File[] | FileList) =>
-      usingProvider ? controller.attachments.add(files) : addLocal(files),
-    [usingProvider, controller, addLocal],
-  );
-
-  const remove = useCallback(
-    (id: string) => {
-      if (usingProvider) {
-        controller.attachments.remove(id);
-        return;
+  const remove = useCallback((id: string) => {
+    setItems((prev) => {
+      const found = prev.find((file) => file.id === id);
+      if (found?.url) {
+        URL.revokeObjectURL(found.url);
       }
-      setItems((prev) => {
-        const found = prev.find((file) => file.id === id);
-        if (found?.url) {
-          URL.revokeObjectURL(found.url);
-        }
-        return prev.filter((file) => file.id !== id);
-      });
-    },
-    [usingProvider, controller],
-  );
+      return prev.filter((file) => file.id !== id);
+    });
+  }, []);
 
   const clear = useCallback(() => {
-    if (usingProvider) {
-      controller.attachments.clear();
-      return;
-    }
     setItems((prev) => {
       for (const file of prev) {
         if (file.url) {
@@ -586,29 +392,7 @@ export const PromptInput = ({
       }
       return [];
     });
-  }, [usingProvider, controller]);
-
-  const openFileDialog = useCallback(
-    () =>
-      usingProvider
-        ? controller.attachments.openFileDialog()
-        : openFileDialogLocal(),
-    [usingProvider, controller, openFileDialogLocal],
-  );
-
-  // Let provider know about our hidden file input so external menus can call openFileDialog()
-  useEffect(() => {
-    if (!usingProvider) return;
-    controller.__registerFileInput(inputRef, () => inputRef.current?.click());
-  }, [usingProvider, controller]);
-
-  // Note: File input cannot be programmatically set for security reasons
-  // The syncHiddenInput prop is no longer functional
-  useEffect(() => {
-    if (syncHiddenInput && inputRef.current && files.length === 0) {
-      inputRef.current.value = "";
-    }
-  }, [files, syncHiddenInput]);
+  }, []);
 
   // Attach drop handlers on nearest form and document (opt-in)
   useEffect(() => {
@@ -662,13 +446,11 @@ export const PromptInput = ({
 
   useEffect(
     () => () => {
-      if (!usingProvider) {
-        for (const f of files) {
-          if (f.url) URL.revokeObjectURL(f.url);
-        }
+      for (const f of files) {
+        if (f.url) URL.revokeObjectURL(f.url);
       }
     },
-    [usingProvider, files],
+    [files],
   );
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (event) => {
@@ -704,18 +486,12 @@ export const PromptInput = ({
     event.preventDefault();
 
     const form = event.currentTarget;
-    const text = usingProvider
-      ? controller.textInput.value
-      : (() => {
-          const formData = new FormData(form);
-          return (formData.get("message") as string) || "";
-        })();
+    const formData = new FormData(form);
+    const text = (formData.get("message") as string) || "";
 
     // Reset form immediately after capturing text to avoid race condition
     // where user input during async blob conversion would be lost
-    if (!usingProvider) {
-      form.reset();
-    }
+    form.reset();
 
     // Convert blob URLs to data URLs asynchronously
     Promise.all(
@@ -734,22 +510,12 @@ export const PromptInput = ({
 
         // Handle both sync and async onSubmit
         if (result instanceof Promise) {
-          result
-            .then(() => {
-              clear();
-              if (usingProvider) {
-                controller.textInput.clear();
-              }
-            })
-            .catch(() => {
-              // Don't clear on error - user may want to retry
-            });
+          result.then(clear).catch(() => {
+            // Don't clear on error - user may want to retry
+          });
         } else {
           // Sync function completed without throwing, clear attachments
           clear();
-          if (usingProvider) {
-            controller.textInput.clear();
-          }
         }
       } catch {
         // Don't clear on error - user may want to retry
@@ -757,9 +523,8 @@ export const PromptInput = ({
     });
   };
 
-  // Render with or without local provider
-  const inner = (
-    <>
+  return (
+    <PromptInputAttachmentsContext.Provider value={ctx}>
       <span aria-hidden="true" className="hidden" ref={anchorRef} />
       <input
         accept={accept}
@@ -778,15 +543,7 @@ export const PromptInput = ({
       >
         <InputGroup className="overflow-hidden">{children}</InputGroup>
       </form>
-    </>
-  );
-
-  return usingProvider ? (
-    inner
-  ) : (
-    <LocalAttachmentsContext.Provider value={ctx}>
-      {inner}
-    </LocalAttachmentsContext.Provider>
+    </PromptInputAttachmentsContext.Provider>
   );
 };
 
@@ -806,13 +563,11 @@ export type PromptInputTextareaProps = ComponentProps<
 };
 
 export const PromptInputTextarea = ({
-  onChange,
   className,
   placeholder = "What would you like to know?",
   status,
   ...props
 }: PromptInputTextareaProps) => {
-  const controller = useOptionalPromptInputController();
   const attachments = usePromptInputAttachments();
   const [isComposing, setIsComposing] = useState(false);
   const isMobile = useIsMobile();
@@ -885,18 +640,6 @@ export const PromptInputTextarea = ({
     }
   };
 
-  const controlledProps = controller
-    ? {
-        value: controller.textInput.value,
-        onChange: (e: ChangeEvent<HTMLTextAreaElement>) => {
-          controller.textInput.setInput(e.currentTarget.value);
-          onChange?.(e);
-        },
-      }
-    : {
-        onChange,
-      };
-
   return (
     <InputGroupTextarea
       className={cn("field-sizing-content max-h-48 min-h-16", className)}
@@ -907,26 +650,9 @@ export const PromptInputTextarea = ({
       onPaste={handlePaste}
       placeholder={placeholder}
       {...props}
-      {...controlledProps}
     />
   );
 };
-
-export type PromptInputHeaderProps = Omit<
-  ComponentProps<typeof InputGroupAddon>,
-  "align"
->;
-
-export const PromptInputHeader = ({
-  className,
-  ...props
-}: PromptInputHeaderProps) => (
-  <InputGroupAddon
-    align="block-end"
-    className={cn("order-first flex-wrap gap-1", className)}
-    {...props}
-  />
-);
 
 export type PromptInputFooterProps = Omit<
   ComponentProps<typeof InputGroupAddon>,
@@ -1004,19 +730,6 @@ export const PromptInputActionMenuContent = ({
   <DropdownMenuContent align="start" className={cn(className)} {...props} />
 );
 
-export type PromptInputActionMenuItemProps = ComponentProps<
-  typeof DropdownMenuItem
->;
-export const PromptInputActionMenuItem = ({
-  className,
-  ...props
-}: PromptInputActionMenuItemProps) => (
-  <DropdownMenuItem className={cn(className)} {...props} />
-);
-
-// Note: Actions that perform side-effects (like opening a file dialog)
-// are provided in opt-in modules (e.g., prompt-input-attachments).
-
 export type PromptInputSubmitProps = ComponentProps<typeof InputGroupButton> & {
   status?: ChatStatus;
 };
@@ -1053,58 +766,6 @@ export const PromptInputSubmit = ({
   );
 };
 
-interface SpeechRecognition extends EventTarget {
-  continuous: boolean;
-  interimResults: boolean;
-  lang: string;
-  start(): void;
-  stop(): void;
-  onstart: ((this: SpeechRecognition, ev: Event) => void) | null;
-  onend: ((this: SpeechRecognition, ev: Event) => void) | null;
-  onresult:
-    ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null;
-  onerror:
-    ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null;
-}
-
-interface SpeechRecognitionEvent extends Event {
-  results: SpeechRecognitionResultList;
-  resultIndex: number;
-}
-
-type SpeechRecognitionResultList = {
-  readonly length: number;
-  item(index: number): SpeechRecognitionResult;
-  [index: number]: SpeechRecognitionResult;
-};
-
-type SpeechRecognitionResult = {
-  readonly length: number;
-  item(index: number): SpeechRecognitionAlternative;
-  [index: number]: SpeechRecognitionAlternative;
-  isFinal: boolean;
-};
-
-type SpeechRecognitionAlternative = {
-  transcript: string;
-  confidence: number;
-};
-
-interface SpeechRecognitionErrorEvent extends Event {
-  error: string;
-}
-
-declare global {
-  interface Window {
-    SpeechRecognition: {
-      new (): SpeechRecognition;
-    };
-    webkitSpeechRecognition: {
-      new (): SpeechRecognition;
-    };
-  }
-}
-
 export type PromptInputSpeechButtonProps = ComponentProps<
   typeof PromptInputButton
 > & {
@@ -1118,86 +779,10 @@ export const PromptInputSpeechButton = ({
   onTranscriptionChange,
   ...props
 }: PromptInputSpeechButtonProps) => {
-  const [isListening, setIsListening] = useState(false);
-  const [recognition, setRecognition] = useState<SpeechRecognition | null>(
-    null,
-  );
-  const recognitionRef = useRef<SpeechRecognition | null>(null);
-
-  useEffect(() => {
-    if (
-      typeof window !== "undefined" &&
-      ("SpeechRecognition" in window || "webkitSpeechRecognition" in window)
-    ) {
-      const SpeechRecognition =
-        window.SpeechRecognition || window.webkitSpeechRecognition;
-      const speechRecognition = new SpeechRecognition();
-
-      speechRecognition.continuous = true;
-      speechRecognition.interimResults = true;
-      speechRecognition.lang = "en-US";
-
-      speechRecognition.onstart = () => {
-        setIsListening(true);
-      };
-
-      speechRecognition.onend = () => {
-        setIsListening(false);
-      };
-
-      speechRecognition.onresult = (event) => {
-        let finalTranscript = "";
-
-        for (let i = event.resultIndex; i < event.results.length; i++) {
-          const result = event.results[i];
-          if (result.isFinal) {
-            finalTranscript += result[0]?.transcript ?? "";
-          }
-        }
-
-        if (finalTranscript && textareaRef?.current) {
-          const textarea = textareaRef.current;
-          const currentValue = textarea.value;
-          const newValue =
-            currentValue + (currentValue ? " " : "") + finalTranscript;
-
-          textarea.value = newValue;
-          textarea.dispatchEvent(new Event("input", { bubbles: true }));
-          onTranscriptionChange?.(newValue);
-        }
-      };
-
-      speechRecognition.onerror = (event) => {
-        console.error("Speech recognition error:", event.error);
-        setIsListening(false);
-      };
-
-      recognitionRef.current = speechRecognition;
-      // Expose the constructed SpeechRecognition (an external browser API,
-      // only available after mount) to render so the mic button can enable;
-      // the setState here is part of initialising that external system.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setRecognition(speechRecognition);
-    }
-
-    return () => {
-      if (recognitionRef.current) {
-        recognitionRef.current.stop();
-      }
-    };
-  }, [textareaRef, onTranscriptionChange]);
-
-  const toggleListening = useCallback(() => {
-    if (!recognition) {
-      return;
-    }
-
-    if (isListening) {
-      recognition.stop();
-    } else {
-      recognition.start();
-    }
-  }, [recognition, isListening]);
+  const { isListening, isSupported, toggleListening } = useSpeechToText({
+    textareaRef,
+    onTranscriptionChange,
+  });
 
   return (
     <PromptInputButton
@@ -1206,7 +791,7 @@ export const PromptInputSpeechButton = ({
         isListening && "animate-pulse bg-accent text-accent-foreground",
         className,
       )}
-      disabled={!recognition}
+      disabled={!isSupported}
       onClick={toggleListening}
       {...props}
     >
@@ -1214,201 +799,3 @@ export const PromptInputSpeechButton = ({
     </PromptInputButton>
   );
 };
-
-export type PromptInputSelectProps = ComponentProps<typeof Select>;
-
-export const PromptInputSelect = (props: PromptInputSelectProps) => (
-  <Select {...props} />
-);
-
-export type PromptInputSelectTriggerProps = ComponentProps<
-  typeof SelectTrigger
->;
-
-export const PromptInputSelectTrigger = ({
-  className,
-  ...props
-}: PromptInputSelectTriggerProps) => (
-  <SelectTrigger
-    className={cn(
-      "border-none bg-transparent font-medium text-muted-foreground shadow-none transition-colors",
-      "hover:bg-accent hover:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground",
-      className,
-    )}
-    {...props}
-  />
-);
-
-export type PromptInputSelectContentProps = ComponentProps<
-  typeof SelectContent
->;
-
-export const PromptInputSelectContent = ({
-  className,
-  ...props
-}: PromptInputSelectContentProps) => (
-  <SelectContent className={cn(className)} {...props} />
-);
-
-export type PromptInputSelectItemProps = ComponentProps<typeof SelectItem>;
-
-export const PromptInputSelectItem = ({
-  className,
-  ...props
-}: PromptInputSelectItemProps) => (
-  <SelectItem className={cn(className)} {...props} />
-);
-
-export type PromptInputSelectValueProps = ComponentProps<typeof SelectValue>;
-
-export const PromptInputSelectValue = ({
-  className,
-  ...props
-}: PromptInputSelectValueProps) => (
-  <SelectValue className={cn(className)} {...props} />
-);
-
-export type PromptInputHoverCardProps = ComponentProps<typeof HoverCard>;
-
-export const PromptInputHoverCard = ({
-  openDelay = 0,
-  closeDelay = 0,
-  ...props
-}: PromptInputHoverCardProps) => (
-  <HoverCard closeDelay={closeDelay} openDelay={openDelay} {...props} />
-);
-
-export type PromptInputHoverCardTriggerProps = ComponentProps<
-  typeof HoverCardTrigger
->;
-
-export const PromptInputHoverCardTrigger = (
-  props: PromptInputHoverCardTriggerProps,
-) => <HoverCardTrigger {...props} />;
-
-export type PromptInputHoverCardContentProps = ComponentProps<
-  typeof HoverCardContent
->;
-
-export const PromptInputHoverCardContent = ({
-  align = "start",
-  ...props
-}: PromptInputHoverCardContentProps) => (
-  <HoverCardContent align={align} {...props} />
-);
-
-export type PromptInputTabsListProps = HTMLAttributes<HTMLDivElement>;
-
-export const PromptInputTabsList = ({
-  className,
-  ...props
-}: PromptInputTabsListProps) => <div className={cn(className)} {...props} />;
-
-export type PromptInputTabProps = HTMLAttributes<HTMLDivElement>;
-
-export const PromptInputTab = ({
-  className,
-  ...props
-}: PromptInputTabProps) => <div className={cn(className)} {...props} />;
-
-export type PromptInputTabLabelProps = HTMLAttributes<HTMLHeadingElement>;
-
-export const PromptInputTabLabel = ({
-  className,
-  ...props
-}: PromptInputTabLabelProps) => (
-  <h3
-    className={cn(
-      "mb-2 px-3 font-medium text-muted-foreground text-xs",
-      className,
-    )}
-    {...props}
-  />
-);
-
-export type PromptInputTabBodyProps = HTMLAttributes<HTMLDivElement>;
-
-export const PromptInputTabBody = ({
-  className,
-  ...props
-}: PromptInputTabBodyProps) => (
-  <div className={cn("space-y-1", className)} {...props} />
-);
-
-export type PromptInputTabItemProps = HTMLAttributes<HTMLDivElement>;
-
-export const PromptInputTabItem = ({
-  className,
-  ...props
-}: PromptInputTabItemProps) => (
-  <div
-    className={cn(
-      "flex items-center gap-2 px-3 py-2 text-xs hover:bg-accent",
-      className,
-    )}
-    {...props}
-  />
-);
-
-export type PromptInputCommandProps = ComponentProps<typeof Command>;
-
-export const PromptInputCommand = ({
-  className,
-  ...props
-}: PromptInputCommandProps) => <Command className={cn(className)} {...props} />;
-
-export type PromptInputCommandInputProps = ComponentProps<typeof CommandInput>;
-
-export const PromptInputCommandInput = ({
-  className,
-  ...props
-}: PromptInputCommandInputProps) => (
-  <CommandInput className={cn(className)} {...props} />
-);
-
-export type PromptInputCommandListProps = ComponentProps<typeof CommandList>;
-
-export const PromptInputCommandList = ({
-  className,
-  ...props
-}: PromptInputCommandListProps) => (
-  <CommandList className={cn(className)} {...props} />
-);
-
-export type PromptInputCommandEmptyProps = ComponentProps<typeof CommandEmpty>;
-
-export const PromptInputCommandEmpty = ({
-  className,
-  ...props
-}: PromptInputCommandEmptyProps) => (
-  <CommandEmpty className={cn(className)} {...props} />
-);
-
-export type PromptInputCommandGroupProps = ComponentProps<typeof CommandGroup>;
-
-export const PromptInputCommandGroup = ({
-  className,
-  ...props
-}: PromptInputCommandGroupProps) => (
-  <CommandGroup className={cn(className)} {...props} />
-);
-
-export type PromptInputCommandItemProps = ComponentProps<typeof CommandItem>;
-
-export const PromptInputCommandItem = ({
-  className,
-  ...props
-}: PromptInputCommandItemProps) => (
-  <CommandItem className={cn(className)} {...props} />
-);
-
-export type PromptInputCommandSeparatorProps = ComponentProps<
-  typeof CommandSeparator
->;
-
-export const PromptInputCommandSeparator = ({
-  className,
-  ...props
-}: PromptInputCommandSeparatorProps) => (
-  <CommandSeparator className={cn(className)} {...props} />
-);

--- a/apps/frontend/hooks/use-speech-to-text.test.tsx
+++ b/apps/frontend/hooks/use-speech-to-text.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useSpeechToText } from "./use-speech-to-text";
+
+class FakeSpeechRecognition extends EventTarget {
+  continuous = false;
+  interimResults = false;
+  lang = "";
+  start = vi.fn(() => {
+    this.onstart?.(new Event("start"));
+  });
+  stop = vi.fn(() => {
+    this.onend?.(new Event("end"));
+  });
+  onstart: ((ev: Event) => void) | null = null;
+  onend: ((ev: Event) => void) | null = null;
+  onresult: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+
+  emitFinalResult(transcript: string) {
+    this.onresult?.({
+      resultIndex: 0,
+      results: {
+        length: 1,
+        0: {
+          isFinal: true,
+          length: 1,
+          0: { transcript, confidence: 1 },
+        },
+      },
+    });
+  }
+}
+
+describe("useSpeechToText", () => {
+  let lastInstance: FakeSpeechRecognition | null = null;
+  const registerInstance = (instance: FakeSpeechRecognition) => {
+    lastInstance = instance;
+  };
+
+  class TrackingSpeechRecognition extends FakeSpeechRecognition {
+    constructor() {
+      super();
+      registerInstance(this);
+    }
+  }
+
+  beforeEach(() => {
+    lastInstance = null;
+    window.SpeechRecognition =
+      TrackingSpeechRecognition as unknown as Window["SpeechRecognition"];
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, "SpeechRecognition");
+    Reflect.deleteProperty(window, "webkitSpeechRecognition");
+  });
+
+  it("reports unsupported when no Web Speech API is present", () => {
+    Reflect.deleteProperty(window, "SpeechRecognition");
+    const { result } = renderHook(() => useSpeechToText());
+    expect(result.current.isSupported).toBe(false);
+  });
+
+  it("reports supported and toggles listening state via start/stop", () => {
+    const { result } = renderHook(() => useSpeechToText());
+    expect(result.current.isSupported).toBe(true);
+    expect(result.current.isListening).toBe(false);
+
+    act(() => result.current.toggleListening());
+    expect(result.current.isListening).toBe(true);
+    expect(lastInstance?.start).toHaveBeenCalledTimes(1);
+
+    act(() => result.current.toggleListening());
+    expect(result.current.isListening).toBe(false);
+    expect(lastInstance?.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("appends a final transcript onto the textarea and dispatches input", () => {
+    const textarea = document.createElement("textarea");
+    textarea.value = "hello";
+    const textareaRef = { current: textarea };
+    const onTranscriptionChange = vi.fn();
+    const inputHandler = vi.fn();
+    textarea.addEventListener("input", inputHandler);
+
+    const { result } = renderHook(() =>
+      useSpeechToText({ textareaRef, onTranscriptionChange }),
+    );
+
+    act(() => lastInstance?.emitFinalResult("world"));
+
+    expect(textarea.value).toBe("hello world");
+    expect(inputHandler).toHaveBeenCalledTimes(1);
+    expect(onTranscriptionChange).toHaveBeenCalledWith("hello world");
+    expect(result.current.transcript).toBe("hello world");
+  });
+
+  it("stops recognition on unmount", () => {
+    const { unmount } = renderHook(() => useSpeechToText());
+    unmount();
+    expect(lastInstance?.stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/hooks/use-speech-to-text.ts
+++ b/apps/frontend/hooks/use-speech-to-text.ts
@@ -1,0 +1,160 @@
+"use client";
+
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start(): void;
+  stop(): void;
+  onstart: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onend: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onresult:
+    ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null;
+  onerror:
+    ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => void) | null;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  results: SpeechRecognitionResultList;
+  resultIndex: number;
+}
+
+type SpeechRecognitionResultList = {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+};
+
+type SpeechRecognitionResult = {
+  readonly length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+  isFinal: boolean;
+};
+
+type SpeechRecognitionAlternative = {
+  transcript: string;
+  confidence: number;
+};
+
+interface SpeechRecognitionErrorEvent extends Event {
+  error: string;
+}
+
+declare global {
+  interface Window {
+    SpeechRecognition: {
+      new (): SpeechRecognition;
+    };
+    webkitSpeechRecognition: {
+      new (): SpeechRecognition;
+    };
+  }
+}
+
+export type UseSpeechToTextOptions = {
+  textareaRef?: RefObject<HTMLTextAreaElement | null>;
+  onTranscriptionChange?: (text: string) => void;
+};
+
+/**
+ * Drives the browser's Web Speech API and appends finalized transcripts
+ * onto the given textarea, dispatching a native "input" event so any
+ * uncontrolled/controlled listeners on it stay in sync.
+ */
+export function useSpeechToText({
+  textareaRef,
+  onTranscriptionChange,
+}: UseSpeechToTextOptions = {}) {
+  const [isListening, setIsListening] = useState(false);
+  const [isSupported, setIsSupported] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+
+  useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      !("SpeechRecognition" in window || "webkitSpeechRecognition" in window)
+    ) {
+      return;
+    }
+
+    const SpeechRecognitionCtor =
+      window.SpeechRecognition || window.webkitSpeechRecognition;
+    const recognition = new SpeechRecognitionCtor();
+
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = "en-US";
+
+    recognition.onstart = () => {
+      setIsListening(true);
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+    };
+
+    recognition.onresult = (event) => {
+      let finalTranscript = "";
+
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        if (result.isFinal) {
+          finalTranscript += result[0]?.transcript ?? "";
+        }
+      }
+
+      if (finalTranscript && textareaRef?.current) {
+        const textarea = textareaRef.current;
+        const currentValue = textarea.value;
+        const newValue =
+          currentValue + (currentValue ? " " : "") + finalTranscript;
+
+        textarea.value = newValue;
+        textarea.dispatchEvent(new Event("input", { bubbles: true }));
+        setTranscript(newValue);
+        onTranscriptionChange?.(newValue);
+      }
+    };
+
+    recognition.onerror = (event) => {
+      console.error("Speech recognition error:", event.error);
+      setIsListening(false);
+    };
+
+    recognitionRef.current = recognition;
+    // Expose support for the Web Speech API (only knowable after mount) to
+    // render so the mic button can enable; this setState is part of
+    // initialising that external system.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIsSupported(true);
+
+    return () => {
+      recognition.stop();
+    };
+  }, [textareaRef, onTranscriptionChange]);
+
+  const toggleListening = useCallback(() => {
+    const recognition = recognitionRef.current;
+    if (!recognition) {
+      return;
+    }
+
+    if (isListening) {
+      recognition.stop();
+    } else {
+      recognition.start();
+    }
+  }, [isListening]);
+
+  return { isListening, isSupported, toggleListening, transcript };
+}


### PR DESCRIPTION
## Summary
- Deletes 21 unreferenced exports from `prompt-input.tsx` (the `Select`/`Command`/`Tab` pass-through wrappers, `PromptInputHeader`, `PromptInputActionMenuItem`, and the `PromptInputHoverCard*` wrappers), inlining `HoverCard`/`HoverCardContent` directly where still needed.
- Removes the unreachable `PromptInputProvider` dual attachment-ownership mode and its reconciliation branching — nothing selected it, so `PromptInput` is now single-mode/self-managed.
- Extracts the Web Speech Recognition driver into its own hook, `hooks/use-speech-to-text.ts`, decoupling it from the attachment machinery.
- Removes the non-functional `syncHiddenInput` prop and fixes the `accept` filter to honour any extension/mime/wildcard pattern instead of only ever matching `image/*`.
- Adds tests covering attach/remove, drag-and-drop, count/size limits, accept filtering, and the extracted speech hook.

Closes #562