### PR TITLE
feat(frontend): have the auth module answer capabilities, not role booleans

### DIFF
--- a/apps/frontend/components/agents-list.tsx
+++ b/apps/frontend/components/agents-list.tsx
@@ -61,6 +61,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
+import { canManageSharedResource } from "@/lib/authorization";
 import { NoProvidersEmptyState } from "@/components/no-providers-empty-state";
 import { AttachSharedResourceDialog } from "@/components/attach-shared-resource-dialog";
 
@@ -89,7 +90,7 @@ export const AgentsList = ({
   orgId: string;
   workspaceId: string;
 }) => {
-  const { user, isOrgAdmin } = useAuth();
+  const { user, isOrgAdmin, actor } = useAuth();
   const backendUrl = useBackendUrl();
   const router = useRouter();
   const [cloneDialogOpen, setCloneDialogOpen] = useState(false);
@@ -168,8 +169,9 @@ export const AgentsList = ({
   const toolSets = toolSetsData?.results || [];
   const skills = skillsData?.results || [];
 
-  // Promote and attach are Org Admin actions (ADR-0007).
-  const canManageShared = isOrgAdmin;
+  // Attach, detach, and Promote a Shared resource are the same rule
+  // (ADR-0007), asked of the auth module instead of re-derived here.
+  const canManageShared = canManageSharedResource(actor, workspaceId).allowed;
   const attachedOrgIds = agents
     .filter((a) => a.scope === "organization")
     .map((a) => a.id);

--- a/apps/frontend/components/auth-provider.tsx
+++ b/apps/frontend/components/auth-provider.tsx
@@ -10,7 +10,11 @@ import {
 } from "react";
 import { createAuthClient } from "better-auth/react";
 import { useParams } from "next/navigation";
-import { type Actor, resolveActor } from "@/lib/authorization";
+import {
+  type Actor,
+  type WorkspaceDelegationFlags,
+  resolveActor,
+} from "@/lib/authorization";
 
 interface OrgMembership {
   id: string;
@@ -18,10 +22,8 @@ interface OrgMembership {
   role: "admin" | "member";
 }
 
-interface WorkspaceData {
+interface WorkspaceData extends WorkspaceDelegationFlags {
   ownerId: string;
-  providerSelfManagement: boolean;
-  mcpSelfManagement: boolean;
 }
 
 interface User {
@@ -63,10 +65,7 @@ interface AuthContextType {
   /** The named actor for this request — see `lib/authorization.ts`. */
   actor: Actor;
   /** ADR-0006 delegation flags for the Workspace in scope, if any. */
-  workspaceDelegation: {
-    providerSelfManagement: boolean;
-    mcpSelfManagement: boolean;
-  } | null;
+  workspaceDelegation: WorkspaceDelegationFlags | null;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -192,12 +191,7 @@ export function AuthProvider({
     orgRole: orgMembership?.role ?? null,
     isWorkspaceOwner,
   });
-  const workspaceDelegation = workspaceData
-    ? {
-        providerSelfManagement: workspaceData.providerSelfManagement,
-        mcpSelfManagement: workspaceData.mcpSelfManagement,
-      }
-    : null;
+  const workspaceDelegation: WorkspaceDelegationFlags | null = workspaceData;
 
   return (
     <AuthContext.Provider

--- a/apps/frontend/components/auth-provider.tsx
+++ b/apps/frontend/components/auth-provider.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { createAuthClient } from "better-auth/react";
 import { useParams } from "next/navigation";
+import { type Actor, resolveActor } from "@/lib/authorization";
 
 interface OrgMembership {
   id: string;
@@ -19,6 +20,8 @@ interface OrgMembership {
 
 interface WorkspaceData {
   ownerId: string;
+  providerSelfManagement: boolean;
+  mcpSelfManagement: boolean;
 }
 
 interface User {
@@ -57,6 +60,13 @@ interface AuthContextType {
   isOrgAdmin: boolean;
   isWorkspaceOwner: boolean;
   hasWorkspaceAccess: boolean;
+  /** The named actor for this request — see `lib/authorization.ts`. */
+  actor: Actor;
+  /** ADR-0006 delegation flags for the Workspace in scope, if any. */
+  workspaceDelegation: {
+    providerSelfManagement: boolean;
+    mcpSelfManagement: boolean;
+  } | null;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -152,7 +162,15 @@ export function AuthProvider({
     })
       .then((res) => (res.ok ? res.json() : null))
       .then((ws) => {
-        setWorkspaceData(ws ? { ownerId: ws.ownerId } : null);
+        setWorkspaceData(
+          ws
+            ? {
+                ownerId: ws.ownerId,
+                providerSelfManagement: ws.providerSelfManagement === true,
+                mcpSelfManagement: ws.mcpSelfManagement === true,
+              }
+            : null,
+        );
         setIsWorkspaceLoading(false);
         setHasFetchedWorkspace(true);
       })
@@ -169,6 +187,17 @@ export function AuthProvider({
     (data?.user as unknown as User | undefined)?.role === "admin";
   const isWorkspaceOwner = workspaceData?.ownerId === data?.user?.id;
   const hasWorkspaceAccess = isSuperAdmin || isOrgAdmin || isWorkspaceOwner;
+  const actor = resolveActor({
+    isOperator: isSuperAdmin,
+    orgRole: orgMembership?.role ?? null,
+    isWorkspaceOwner,
+  });
+  const workspaceDelegation = workspaceData
+    ? {
+        providerSelfManagement: workspaceData.providerSelfManagement,
+        mcpSelfManagement: workspaceData.mcpSelfManagement,
+      }
+    : null;
 
   return (
     <AuthContext.Provider
@@ -187,6 +216,8 @@ export function AuthProvider({
         isOrgAdmin,
         isWorkspaceOwner,
         hasWorkspaceAccess,
+        actor,
+        workspaceDelegation,
       }}
     >
       {children}

--- a/apps/frontend/components/mcp-list.tsx
+++ b/apps/frontend/components/mcp-list.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { MCP, type Workspace } from "@platypus/schemas";
+import { MCP } from "@platypus/schemas";
 import { Item, ItemActions, ItemContent, ItemTitle } from "./ui/item";
 import useSWR from "swr";
 import { cn, fetcher, joinUrl } from "../lib/utils";
 import { useAuth } from "@/components/auth-provider";
+import {
+  canConfigureWorkspaceResource,
+  canManageSharedResource,
+} from "@/lib/authorization";
 import {
   Building,
   ExternalLink,
@@ -40,7 +44,7 @@ const McpList = ({
   // Add scope to the MCP type for this component
   type McpWithScope = MCP & { scope?: "organization" | "workspace" };
 
-  const { user, isOrgAdmin } = useAuth();
+  const { user, isOrgAdmin, actor, workspaceDelegation } = useAuth();
   const backendUrl = useBackendUrl();
   const [selectedOrgMcp, setSelectedOrgMcp] = useState<McpWithScope | null>(
     null,
@@ -62,9 +66,9 @@ const McpList = ({
     results: McpWithScope[];
   }>(fetchUrl, fetcher);
 
-  // Attaching/detaching org-scoped Shared resources is an Org Admin action,
-  // available only inside a workspace (ADR-0007 / #154).
-  const canAttach = Boolean(workspaceId) && isOrgAdmin;
+  // Attach, detach, and Promote a Shared resource are the same rule
+  // (ADR-0007 / #154), asked of the auth module instead of re-derived here.
+  const canAttach = canManageSharedResource(actor, workspaceId).allowed;
 
   const detachOrgMcp = async (mcpId: string) => {
     if (!backendUrl || !workspaceId) return;
@@ -85,17 +89,16 @@ const McpList = ({
   };
 
   // Workspace-scoped MCP config is admin-only unless the workspace delegates
-  // it (ADR-0006). Org-level MCP management lives behind an admin-only route
-  // (the org settings layout already requires admin), so it is always
-  // manageable here.
-  const { data: workspace } = useSWR<Workspace>(
-    backendUrl && user && workspaceId
-      ? joinUrl(backendUrl, `/organizations/${orgId}/workspaces/${workspaceId}`)
-      : null,
-    fetcher,
-  );
+  // it (ADR-0006), resolved once by the auth module off the Workspace's own
+  // delegation flags — no separate fetch needed. Org-level MCP management
+  // lives behind an admin-only route (the org settings layout already
+  // requires admin), so it is always manageable here.
   const canManage = workspaceId
-    ? isOrgAdmin || workspace?.mcpSelfManagement === true
+    ? canConfigureWorkspaceResource(
+        actor,
+        "mcp",
+        workspaceDelegation?.mcpSelfManagement === true,
+      ).allowed
     : true;
 
   if (isLoading) {

--- a/apps/frontend/components/protected-route.tsx
+++ b/apps/frontend/components/protected-route.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { useAuth } from "@/components/auth-provider";
+import {
+  canAccessOrganization,
+  canAccessWorkspace,
+  isOperator,
+  type OrgRole,
+} from "@/lib/authorization";
 import { useRouter, useParams } from "next/navigation";
 import { useEffect } from "react";
 import {
@@ -15,20 +21,13 @@ import { Button } from "@/components/ui/button";
 import { OctagonX, Home, Building } from "lucide-react";
 import Link from "next/link";
 
-type RequiredOrgRole = "member" | "admin";
-
 interface ProtectedRouteProps {
   children: React.ReactNode;
-  requiredOrgRole?: RequiredOrgRole;
+  requiredOrgRole?: OrgRole;
   requireOrgAccess?: boolean;
   requireWorkspaceAccess?: boolean;
   requireSuperAdmin?: boolean;
 }
-
-const orgRoleHierarchy: Record<RequiredOrgRole, number> = {
-  member: 1,
-  admin: 2,
-};
 
 interface AccessDeniedProps {
   title: string;
@@ -75,7 +74,7 @@ export function ProtectedRoute({
   requireWorkspaceAccess = false,
   requireSuperAdmin = false,
 }: ProtectedRouteProps) {
-  const { user, isAuthLoading, orgMembership, hasWorkspaceAccess } = useAuth();
+  const { user, isAuthLoading, orgMembership, actor } = useAuth();
   const router = useRouter();
   const params = useParams();
 
@@ -93,7 +92,7 @@ export function ProtectedRoute({
     return null;
   }
 
-  if (requireSuperAdmin && user?.role !== "admin") {
+  if (requireSuperAdmin && !isOperator(actor)) {
     return (
       <AccessDenied
         title="Super Admin Access Required"
@@ -102,19 +101,21 @@ export function ProtectedRoute({
     );
   }
 
-  if (requireOrgAccess && !orgMembership) {
-    return (
-      <AccessDenied
-        title="Organization Access Required"
-        description="You do not have permission to access this organization. Please contact your administrator or switch to an organization you have access to."
-      />
+  if (requireOrgAccess) {
+    const orgAccess = canAccessOrganization(
+      actor,
+      orgMembership?.role ?? null,
+      requiredOrgRole,
     );
-  }
-
-  if (requireOrgAccess && orgMembership) {
-    const hasRole =
-      orgRoleHierarchy[orgMembership.role] >= orgRoleHierarchy[requiredOrgRole];
-    if (!hasRole) {
+    if (!orgAccess.allowed && orgAccess.reason === "not-a-member") {
+      return (
+        <AccessDenied
+          title="Organization Access Required"
+          description="You do not have permission to access this organization. Please contact your administrator or switch to an organization you have access to."
+        />
+      );
+    }
+    if (!orgAccess.allowed && orgAccess.reason === "insufficient-role") {
       return (
         <AccessDenied
           title="Insufficient Organization Permissions"
@@ -123,7 +124,7 @@ export function ProtectedRoute({
               You need <span className="font-semibold">{requiredOrgRole}</span>{" "}
               permissions to access this page. Your current role in this
               organization is{" "}
-              <span className="font-semibold">{orgMembership.role}</span>.
+              <span className="font-semibold">{orgMembership?.role}</span>.
             </>
           }
         />
@@ -131,7 +132,7 @@ export function ProtectedRoute({
     }
   }
 
-  if (requireWorkspaceAccess && !hasWorkspaceAccess) {
+  if (requireWorkspaceAccess && !canAccessWorkspace(actor)) {
     return (
       <AccessDenied
         title="Workspace Access Required"

--- a/apps/frontend/components/providers-list.test.tsx
+++ b/apps/frontend/components/providers-list.test.tsx
@@ -9,7 +9,12 @@ vi.mock("@/app/client-context", () => ({
 }));
 
 vi.mock("@/components/auth-provider", () => ({
-  useAuth: () => ({ user: { id: "u1" }, isOrgAdmin: true }),
+  useAuth: () => ({
+    user: { id: "u1" },
+    isOrgAdmin: true,
+    actor: "org-admin",
+    workspaceDelegation: null,
+  }),
 }));
 
 type ProviderWithScope = Provider & { scope: "organization" | "workspace" };

--- a/apps/frontend/components/providers-list.tsx
+++ b/apps/frontend/components/providers-list.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { Provider, type Workspace } from "@platypus/schemas";
+import { Provider } from "@platypus/schemas";
 import { Item, ItemActions, ItemContent, ItemTitle } from "./ui/item";
 import useSWR from "swr";
 import { cn, fetcher, joinUrl } from "../lib/utils";
 import { useAuth } from "@/components/auth-provider";
+import {
+  canConfigureWorkspaceResource,
+  canManageSharedResource,
+} from "@/lib/authorization";
 import {
   Building,
   ExternalLink,
@@ -40,7 +44,7 @@ const ProvidersList = ({
   // Add scope to Provider type for this component
   type ProviderWithScope = Provider & { scope: "organization" | "workspace" };
 
-  const { user, isOrgAdmin } = useAuth();
+  const { user, isOrgAdmin, actor, workspaceDelegation } = useAuth();
   const backendUrl = useBackendUrl();
   const [selectedOrgProvider, setSelectedOrgProvider] =
     useState<ProviderWithScope | null>(null);
@@ -61,9 +65,9 @@ const ProvidersList = ({
     results: ProviderWithScope[];
   }>(fetchUrl, fetcher);
 
-  // Attaching/detaching org-scoped Shared resources is an Org Admin action,
-  // available only inside a workspace (ADR-0007 / #154).
-  const canAttach = Boolean(workspaceId) && isOrgAdmin;
+  // Attach, detach, and Promote a Shared resource are the same rule
+  // (ADR-0007 / #154), asked of the auth module instead of re-derived here.
+  const canAttach = canManageSharedResource(actor, workspaceId).allowed;
 
   const detachOrgProvider = async (providerId: string) => {
     if (!backendUrl || !workspaceId) return;
@@ -84,16 +88,16 @@ const ProvidersList = ({
   };
 
   // Workspace-scoped provider config is admin-only unless the workspace
-  // delegates it (ADR-0006). Org-level provider management lives behind an
-  // admin-only route, so it is always manageable here.
-  const { data: workspace } = useSWR<Workspace>(
-    backendUrl && user && workspaceId
-      ? joinUrl(backendUrl, `/organizations/${orgId}/workspaces/${workspaceId}`)
-      : null,
-    fetcher,
-  );
+  // delegates it (ADR-0006), resolved once by the auth module off the
+  // Workspace's own delegation flags — no separate fetch needed. Org-level
+  // provider management lives behind an admin-only route, so it is always
+  // manageable here.
   const canManage = workspaceId
-    ? isOrgAdmin || workspace?.providerSelfManagement === true
+    ? canConfigureWorkspaceResource(
+        actor,
+        "provider",
+        workspaceDelegation?.providerSelfManagement === true,
+      ).allowed
     : true;
 
   if (isLoading || error) return null; // FIXME

--- a/apps/frontend/components/skills-list.tsx
+++ b/apps/frontend/components/skills-list.tsx
@@ -50,6 +50,7 @@ import { fetcher, joinUrl } from "@/lib/utils";
 import Link from "next/link";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
+import { canManageSharedResource } from "@/lib/authorization";
 import { AttachSharedResourceDialog } from "@/components/attach-shared-resource-dialog";
 import {
   ManageAttachmentsDialog,
@@ -103,7 +104,7 @@ export const SkillsList = ({
   orgId: string;
   workspaceId?: string;
 }) => {
-  const { user, isOrgAdmin } = useAuth();
+  const { user, isOrgAdmin, actor } = useAuth();
   const backendUrl = useBackendUrl();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [skillToDelete, setSkillToDelete] = useState<SkillWithScope | null>(
@@ -162,10 +163,9 @@ export const SkillsList = ({
     a.name.localeCompare(b.name),
   );
 
-  // Attaching/detaching org-scoped Shared resources is an Org Admin action,
-  // available only inside a workspace (ADR-0007 / #154).
-  const canAttach = Boolean(workspaceId) && isOrgAdmin;
-  // Promote is an Org Admin action on a workspace-scoped Skill (ADR-0007).
+  // Attach, detach, and Promote a Shared resource are the same rule
+  // (ADR-0007 / #154), asked of the auth module instead of re-derived here.
+  const canAttach = canManageSharedResource(actor, workspaceId).allowed;
   const canPromote = canAttach;
 
   const attachedOrgIds = skills

--- a/apps/frontend/lib/authorization.test.ts
+++ b/apps/frontend/lib/authorization.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import {
+  type Actor,
+  canAccessOrganization,
+  canAccessWorkspace,
+  canConfigureWorkspaceResource,
+  canManageSharedResource,
+  isOperator,
+  resolveActor,
+} from "./authorization";
+
+const ACTORS: Actor[] = [
+  "operator",
+  "org-admin",
+  "workspace-owner",
+  "org-member",
+];
+
+describe("resolveActor", () => {
+  it("names the Operator regardless of any other signal", () => {
+    expect(
+      resolveActor({
+        isOperator: true,
+        orgRole: "member",
+        isWorkspaceOwner: false,
+      }),
+    ).toBe("operator");
+  });
+
+  it("names the Org Admin when not the Operator", () => {
+    expect(
+      resolveActor({
+        isOperator: false,
+        orgRole: "admin",
+        isWorkspaceOwner: false,
+      }),
+    ).toBe("org-admin");
+  });
+
+  it("names the Workspace Owner when neither Operator nor Org Admin", () => {
+    expect(
+      resolveActor({
+        isOperator: false,
+        orgRole: "member",
+        isWorkspaceOwner: true,
+      }),
+    ).toBe("workspace-owner");
+  });
+
+  it("falls back to a plain Org member", () => {
+    expect(
+      resolveActor({
+        isOperator: false,
+        orgRole: "member",
+        isWorkspaceOwner: false,
+      }),
+    ).toBe("org-member");
+  });
+
+  it("falls back to a plain Org member outside any Organization", () => {
+    expect(
+      resolveActor({
+        isOperator: false,
+        orgRole: null,
+        isWorkspaceOwner: false,
+      }),
+    ).toBe("org-member");
+  });
+});
+
+describe("canManageSharedResource — attach/detach/Promote (ADR-0007)", () => {
+  it.each(ACTORS)("%s outside a Workspace is refused", (actor) => {
+    expect(canManageSharedResource(actor, undefined)).toEqual({
+      allowed: false,
+      reason: "no-workspace-context",
+    });
+  });
+
+  it("Operator inside a Workspace is allowed", () => {
+    expect(canManageSharedResource("operator", "ws-1")).toEqual({
+      allowed: true,
+    });
+  });
+
+  it("Org Admin inside a Workspace is allowed", () => {
+    expect(canManageSharedResource("org-admin", "ws-1")).toEqual({
+      allowed: true,
+    });
+  });
+
+  it("Workspace Owner inside their own Workspace is refused", () => {
+    expect(canManageSharedResource("workspace-owner", "ws-1")).toEqual({
+      allowed: false,
+      reason: "not-org-admin",
+    });
+  });
+
+  it("a plain Org member inside a Workspace is refused", () => {
+    expect(canManageSharedResource("org-member", "ws-1")).toEqual({
+      allowed: false,
+      reason: "not-org-admin",
+    });
+  });
+});
+
+describe("canConfigureWorkspaceResource — credential delegation (ADR-0006)", () => {
+  for (const type of ["provider", "mcp"] as const) {
+    it(`Operator always may configure a ${type}`, () => {
+      expect(canConfigureWorkspaceResource("operator", type, false)).toEqual({
+        allowed: true,
+      });
+    });
+
+    it(`Org Admin always may configure a ${type}`, () => {
+      expect(canConfigureWorkspaceResource("org-admin", type, false)).toEqual({
+        allowed: true,
+      });
+    });
+
+    it(`Workspace Owner may configure a delegated ${type}`, () => {
+      expect(
+        canConfigureWorkspaceResource("workspace-owner", type, true),
+      ).toEqual({ allowed: true });
+    });
+
+    it(`Workspace Owner may not configure a non-delegated ${type}`, () => {
+      expect(
+        canConfigureWorkspaceResource("workspace-owner", type, false),
+      ).toEqual({ allowed: false, reason: "not-delegated" });
+    });
+
+    it(`a plain Org member may never configure a ${type}`, () => {
+      expect(canConfigureWorkspaceResource("org-member", type, true)).toEqual({
+        allowed: false,
+        reason: "not-owner",
+      });
+    });
+  }
+
+  it("a Sandbox is never delegatable, even to its Workspace Owner", () => {
+    expect(
+      canConfigureWorkspaceResource("workspace-owner", "sandbox", true),
+    ).toEqual({ allowed: false, reason: "not-delegatable" });
+  });
+
+  it("Operator and Org Admin still configure a Sandbox", () => {
+    expect(canConfigureWorkspaceResource("operator", "sandbox", false)).toEqual(
+      { allowed: true },
+    );
+    expect(
+      canConfigureWorkspaceResource("org-admin", "sandbox", false),
+    ).toEqual({ allowed: true });
+  });
+});
+
+describe("canAccessOrganization", () => {
+  it("the Operator reaches an Organization with no membership at all", () => {
+    expect(canAccessOrganization("operator", null)).toEqual({
+      allowed: true,
+    });
+    expect(canAccessOrganization("operator", null, "admin")).toEqual({
+      allowed: true,
+    });
+  });
+
+  it("a non-member is refused", () => {
+    expect(canAccessOrganization("org-admin", null)).toEqual({
+      allowed: false,
+      reason: "not-a-member",
+    });
+  });
+
+  it("a member meets the default 'member' requirement", () => {
+    expect(canAccessOrganization("org-member", "member")).toEqual({
+      allowed: true,
+    });
+  });
+
+  it("a member is refused an admin-only Organization surface", () => {
+    expect(canAccessOrganization("org-member", "member", "admin")).toEqual({
+      allowed: false,
+      reason: "insufficient-role",
+    });
+  });
+
+  it("an admin meets an admin-only requirement", () => {
+    expect(canAccessOrganization("org-admin", "admin", "admin")).toEqual({
+      allowed: true,
+    });
+  });
+});
+
+describe("canAccessWorkspace", () => {
+  it("the Operator reaches every Workspace", () => {
+    expect(canAccessWorkspace("operator")).toBe(true);
+  });
+
+  it("the Org Admin reaches every Workspace", () => {
+    expect(canAccessWorkspace("org-admin")).toBe(true);
+  });
+
+  it("the Workspace Owner reaches their own Workspace", () => {
+    expect(canAccessWorkspace("workspace-owner")).toBe(true);
+  });
+
+  it("a plain Org member reaches no Workspace", () => {
+    expect(canAccessWorkspace("org-member")).toBe(false);
+  });
+});
+
+describe("isOperator", () => {
+  it.each(ACTORS)("names the Operator case for %s", (actor) => {
+    expect(isOperator(actor)).toBe(actor === "operator");
+  });
+});

--- a/apps/frontend/lib/authorization.ts
+++ b/apps/frontend/lib/authorization.ts
@@ -38,8 +38,7 @@ const isOrgAdminOrAbove = (actor: Actor): boolean =>
 
 export type SharedResourceDenial = "no-workspace-context" | "not-org-admin";
 
-export type SharedResourceAccess =
-  { allowed: true } | { allowed: false; reason: SharedResourceDenial };
+export type SharedResourceAccess = Access<SharedResourceDenial>;
 
 /**
  * Attach, detach, and Promote a Shared resource are the same rule (ADR-0007)
@@ -63,11 +62,19 @@ export function canManageSharedResource(
 export type DelegatableResourceType = "provider" | "mcp";
 export type CredentialResourceType = DelegatableResourceType | "sandbox";
 
+/** A Workspace's own ADR-0006 delegation flags, as stored on its row. */
+export interface WorkspaceDelegationFlags {
+  providerSelfManagement: boolean;
+  mcpSelfManagement: boolean;
+}
+
 export type ConfigAccessDenial =
   "not-owner" | "not-delegatable" | "not-delegated";
 
-export type WorkspaceConfigAccess =
-  { allowed: true } | { allowed: false; reason: ConfigAccessDenial };
+export type Access<Reason> =
+  { allowed: true } | { allowed: false; reason: Reason };
+
+export type WorkspaceConfigAccess = Access<ConfigAccessDenial>;
 
 /**
  * ADR-0006: may this actor configure a credential- and reach-bearing
@@ -94,8 +101,7 @@ export function canConfigureWorkspaceResource(
 
 export type OrgAccessDenial = "not-a-member" | "insufficient-role";
 
-export type OrgAccess =
-  { allowed: true } | { allowed: false; reason: OrgAccessDenial };
+export type OrgAccess = Access<OrgAccessDenial>;
 
 /** Authority tiers, ordered so a higher role satisfies a lower requirement. */
 const ORG_ROLE_RANK: Record<OrgRole, number> = { member: 1, admin: 2 };

--- a/apps/frontend/lib/authorization.ts
+++ b/apps/frontend/lib/authorization.ts
@@ -1,0 +1,134 @@
+/**
+ * Frontend counterpart to the backend's authorization module
+ * (`apps/backend/src/middleware/authorization.ts`): the actor is a named
+ * value — never a role boolean a caller reconstructs into policy — and each
+ * function answers whether that actor may perform one action, returning a
+ * typed denial reason rather than throwing (ADR-0010).
+ */
+
+export type OrgRole = "admin" | "member";
+
+/**
+ * The three actors named in CONTEXT.md, ranked by the authority tier they
+ * hold: Operator > Org Admin > Workspace Owner > plain Org member. A caller
+ * cleared for a higher tier is always cleared for what a lower tier can do.
+ */
+export type Actor = "operator" | "org-admin" | "workspace-owner" | "org-member";
+
+export interface ActorContext {
+  /** The platform super-admin, i.e. `user.role === "admin"`. */
+  isOperator: boolean;
+  /** The caller's role in the Organization in scope, or null outside one. */
+  orgRole: OrgRole | null;
+  /** Whether the caller owns the Workspace in scope. */
+  isWorkspaceOwner: boolean;
+}
+
+export function resolveActor(context: ActorContext): Actor {
+  if (context.isOperator) return "operator";
+  if (context.orgRole === "admin") return "org-admin";
+  if (context.isWorkspaceOwner) return "workspace-owner";
+  return "org-member";
+}
+
+const isOrgAdminOrAbove = (actor: Actor): boolean =>
+  actor === "operator" || actor === "org-admin";
+
+// ---- Shared resources: attach / detach / Promote (ADR-0007) ----
+
+export type SharedResourceDenial = "no-workspace-context" | "not-org-admin";
+
+export type SharedResourceAccess =
+  { allowed: true } | { allowed: false; reason: SharedResourceDenial };
+
+/**
+ * Attach, detach, and Promote a Shared resource are the same rule (ADR-0007)
+ * — an Org Admin action, available only inside a Workspace — collapsed to
+ * one decision instead of five independent spellings.
+ */
+export function canManageSharedResource(
+  actor: Actor,
+  workspaceId: string | undefined,
+): SharedResourceAccess {
+  if (!workspaceId) return { allowed: false, reason: "no-workspace-context" };
+  if (!isOrgAdminOrAbove(actor)) {
+    return { allowed: false, reason: "not-org-admin" };
+  }
+  return { allowed: true };
+}
+
+// ---- Credential/reach-bearing config delegation (ADR-0006) ----
+
+/** Scoped resources ADR-0006 allows an Org Admin to delegate to the Owner. */
+export type DelegatableResourceType = "provider" | "mcp";
+export type CredentialResourceType = DelegatableResourceType | "sandbox";
+
+export type ConfigAccessDenial =
+  "not-owner" | "not-delegatable" | "not-delegated";
+
+export type WorkspaceConfigAccess =
+  { allowed: true } | { allowed: false; reason: ConfigAccessDenial };
+
+/**
+ * ADR-0006: may this actor configure a credential- and reach-bearing
+ * Workspace resource? Sandboxes are never delegatable; Providers and MCPs
+ * delegate to the Workspace Owner only when the workspace's own delegation
+ * flag is set. Resolved once here so a read path (credential redaction) and
+ * a write path can't drift onto two different rules.
+ */
+export function canConfigureWorkspaceResource(
+  actor: Actor,
+  type: CredentialResourceType,
+  delegated: boolean,
+): WorkspaceConfigAccess {
+  if (isOrgAdminOrAbove(actor)) return { allowed: true };
+  if (actor !== "workspace-owner") {
+    return { allowed: false, reason: "not-owner" };
+  }
+  if (type === "sandbox") return { allowed: false, reason: "not-delegatable" };
+  if (!delegated) return { allowed: false, reason: "not-delegated" };
+  return { allowed: true };
+}
+
+// ---- Route-level access ----
+
+export type OrgAccessDenial = "not-a-member" | "insufficient-role";
+
+export type OrgAccess =
+  { allowed: true } | { allowed: false; reason: OrgAccessDenial };
+
+/** Authority tiers, ordered so a higher role satisfies a lower requirement. */
+const ORG_ROLE_RANK: Record<OrgRole, number> = { member: 1, admin: 2 };
+
+/**
+ * May this actor reach an Organization, optionally requiring at least
+ * `requiredRole`? The Operator bypasses membership entirely, mirroring the
+ * backend's `requireOrgAccess`.
+ */
+export function canAccessOrganization(
+  actor: Actor,
+  orgRole: OrgRole | null,
+  requiredRole: OrgRole = "member",
+): OrgAccess {
+  if (actor === "operator") return { allowed: true };
+  if (!orgRole) return { allowed: false, reason: "not-a-member" };
+  if (ORG_ROLE_RANK[orgRole] < ORG_ROLE_RANK[requiredRole]) {
+    return { allowed: false, reason: "insufficient-role" };
+  }
+  return { allowed: true };
+}
+
+/**
+ * May this actor reach a Workspace at all? Operator and Org Admin reach
+ * every Workspace in the Organization; a Workspace Owner reaches their own
+ * (the only one `resolveActor` would have classified them as owning); a
+ * plain Org member reaches none.
+ */
+export function canAccessWorkspace(actor: Actor): boolean {
+  return actor !== "org-member";
+}
+
+/** May this actor reach a platform-level, Operator-only surface? */
+export function isOperator(actor: Actor): boolean {
+  return actor === "operator";
+}


### PR DESCRIPTION
## Summary

- Adds `apps/frontend/lib/authorization.ts`: a frontend counterpart to the backend's authorization module, naming the actor (Operator/Org Admin/Workspace Owner/Org member) as a value and answering capability questions (`canManageSharedResource`, `canConfigureWorkspaceResource`, `canAccessOrganization`, `canAccessWorkspace`, `isOperator`) with typed denial reasons instead of exposing role booleans for callers to re-derive policy from.
- Collapses the five spellings of the attach-and-promote rule (ADR-0007) across `providers-list.tsx`, `mcp-list.tsx`, `skills-list.tsx`, and `agents-list.tsx` into one call to `canManageSharedResource` — fixing a real bug in `agents-list.tsx` where the workspace guard was silently dropped.
- Resolves the ADR-0006 delegation rule once via `canConfigureWorkspaceResource`, sourced from the Workspace row `auth-provider.tsx` already fetches, deleting the redundant per-component Workspace fetches in `providers-list.tsx` and `mcp-list.tsx`.
- `protected-route.tsx` now asks the same module instead of keeping its own `orgRoleHierarchy` table.
- Exposes the Operator as a first-class `actor` value on the auth context, instead of being folded into `hasWorkspaceAccess` and discarded.

Closes #572

## Test plan

- [x] `pnpm typecheck` (whole monorepo)
- [x] `pnpm lint` (whole monorepo, pre-existing warnings only)
- [x] `pnpm test` (whole monorepo — 2135 tests pass, including 38 new unit tests in `lib/authorization.test.ts` covering every actor × action, including the Operator case)
- [x] Reviewed via `/code-review` (Standards + Spec axes) — all 6 acceptance criteria confirmed met, no scope creep; flagged duplication cleaned up in a follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)