### PR TITLE
feat(frontend): resolve a Chat turn's model once, behind one interface

### DIFF
--- a/apps/docs/content/building-with-platypus/agents.mdx
+++ b/apps/docs/content/building-with-platypus/agents.mdx
@@ -54,6 +54,11 @@ been given a [Model alias](/concepts/providers#model-aliases). Pick it and the
 Agent follows whatever model that alias points at, so an Org Admin can upgrade
 the Agent later without you editing it.
 
+If the model you pick doesn't natively accept file attachments, the form warns
+you right there — the same capability check the Chat composer runs once
+someone actually attaches a file, surfaced earlier, before anyone sends this
+Agent something it can't read.
+
 </Steps>
 
 <Callout type="info">

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -139,7 +139,9 @@ is stored with the message, so it is still there when you reload the Chat.
 The ceiling itself is **Max output tokens** on the Provider's model, which an
 Org Admin sets — see
 [Capping a single reply](/self-hosting/providers-and-auth#capping-a-single-reply)
-if replies keep stopping short of what the model can write.
+if replies keep stopping short of what the model can write. Where one is set,
+hovering the model picker shows it ahead of time, so you don't have to hit the
+limit once to learn it exists.
 
 <Callout type="warning">
   **Nothing resumes a cut-short reply.** **Regenerate** re-runs the whole turn

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -656,9 +656,7 @@ const AgentForm = ({
               : undefined;
             const resolvedModel = resolveModel({
               providers,
-              agents: [],
               selection: {
-                agentId: "",
                 providerId: formData.providerId,
                 modelId: formData.modelId,
               },

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -56,6 +56,12 @@ import {
   joinUrl,
 } from "@/lib/utils";
 import { findModelOption, getModelOptions } from "@/lib/model-config";
+import { resolveModel } from "@/lib/resolve-model";
+import {
+  decodeSelectionReference,
+  encodeProviderSelection,
+} from "@/lib/selection-reference";
+import { ModelCapabilityNotice } from "@/components/model-capability-notice";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -302,17 +308,14 @@ const AgentForm = ({
   }, [setAvatarFromFile]);
 
   const handleModelChange = (value: string) => {
-    if (value.startsWith("provider:")) {
-      // Provider/model selected
-      const [, newProviderId, ...modelIdParts] = value.split(":");
-      const newModelId = modelIdParts.join(":");
-      clearValidationErrors("providerId", "modelId");
-      setFormData((prevData) => ({
-        ...prevData,
-        providerId: newProviderId,
-        modelId: newModelId,
-      }));
-    }
+    const decoded = decodeSelectionReference(value);
+    if (decoded?.type !== "provider") return;
+    clearValidationErrors("providerId", "modelId");
+    setFormData((prevData) => ({
+      ...prevData,
+      providerId: decoded.providerId,
+      modelId: decoded.modelReference,
+    }));
   };
 
   const handleSubmit = async () => {
@@ -649,8 +652,17 @@ const AgentForm = ({
                 ? findModelOption(provider, formData.modelId)
                 : undefined;
             const selectedModelValue = option
-              ? `provider:${formData.providerId}:${option.value}`
+              ? encodeProviderSelection(formData.providerId, option.value)
               : undefined;
+            const resolvedModel = resolveModel({
+              providers,
+              agents: [],
+              selection: {
+                agentId: "",
+                providerId: formData.providerId,
+                modelId: formData.modelId,
+              },
+            });
             return (
               <Field data-invalid={!!modelError}>
                 <FieldLabel htmlFor="modelId">Model</FieldLabel>
@@ -672,8 +684,14 @@ const AgentForm = ({
                         <SelectLabel>{provider.name}</SelectLabel>
                         {getModelOptions(provider).map((model) => (
                           <SelectItem
-                            key={`provider:${provider.id}:${model.value}`}
-                            value={`provider:${provider.id}:${model.value}`}
+                            key={encodeProviderSelection(
+                              provider.id,
+                              model.value,
+                            )}
+                            value={encodeProviderSelection(
+                              provider.id,
+                              model.value,
+                            )}
                           >
                             {model.label}
                           </SelectItem>
@@ -683,6 +701,11 @@ const AgentForm = ({
                   </SelectContent>
                 </Select>
                 {modelError && <FieldError>{modelError}</FieldError>}
+                {resolvedModel && (
+                  <ModelCapabilityNotice
+                    passthroughFileTypes={resolvedModel.passthroughFileTypes}
+                  />
+                )}
               </Field>
             );
           })()}

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -32,9 +32,6 @@ import {
   Agent,
   ToolSet,
   Skill,
-  providerHasNativeSearch,
-  SEARCH_SOURCE_NATIVE,
-  SEARCH_SOURCE_NONE,
 } from "@platypus/schemas";
 import { type PlatypusUIMessage } from "@platypus/backend/src/types";
 import useSWR from "swr";
@@ -42,11 +39,7 @@ import { fetcher, joinUrl } from "@/lib/utils";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useChatSettings } from "@/hooks/use-chat-settings";
 import { useModelSelection } from "@/hooks/use-model-selection";
-import {
-  getContextWindow,
-  getPassthroughFileTypes,
-  resolveModelId,
-} from "@/lib/model-config";
+import { resolveModel } from "@/lib/resolve-model";
 import { ContextMeter } from "./context-meter";
 import { FileCompatibilityWarning } from "./file-compatibility-warning";
 import { useMessageEditing } from "@/hooks/use-message-editing";
@@ -406,62 +399,23 @@ export const Chat = ({
   }
 
   const selectedAgent = agentId ? agents.find((a) => a.id === agentId) : null;
-  // Resolve the provider backing the current selection, whether that's a raw
-  // model (providerId) or an agent (which carries its own providerId). Used to
-  // decide whether the chat search toggle is shown.
-  const resolvedProviderId = agentId ? selectedAgent?.providerId : providerId;
-  const resolvedProvider = resolvedProviderId
-    ? providers.find((p) => p.id === resolvedProviderId)
-    : null;
-  // Show the search toggle only when a searching turn would actually serve
-  // tools. Hidden when nothing is resolved yet — we can't search without a
-  // model. (#167)
-  //
-  // Mirrors `resolveSearchMode`'s own precedence: `searchSource` of "none"
-  // serves nothing, a value naming a Web-search backend (ADR-0014) serves that
-  // backend, and "native" serves the provider's own search if it has one. So a
-  // vLLM or Bedrock Provider — no native search of any kind — gains the toggle
-  // as soon as a backend is selected on it.
-  //
-  // The capability test is `providerHasNativeSearch`, shared with the backend's
-  // injection gate, rather than a local `!== "Bedrock"`: the gate is the
-  // authority over what a turn actually serves (see `resolveSearchMode`), so a
-  // second copy of the table here would show a toggle that resolves to no
-  // tools. Bedrock is not the only case — OpenAI's search is Responses-API
-  // only, so a chat-completions endpoint (vLLM, llama.cpp) has none either.
-  //
-  // A configured backend is trusted on the stored id alone: no catalog fetch, no
-  // liveness check. An id whose plugin has since been dropped degrades to no
-  // tools server-side with a warn line, which is the documented posture.
-  const canSearch =
-    !!resolvedProvider &&
-    resolvedProvider.searchSource !== SEARCH_SOURCE_NONE &&
-    (resolvedProvider.searchSource === SEARCH_SOURCE_NATIVE
-      ? providerHasNativeSearch(resolvedProvider)
-      : Boolean(resolvedProvider.searchSource));
 
-  // The media types the currently-selected model ingests natively (issue #328),
-  // used to warn about incompatible attachments. Empty when nothing resolves yet.
-  //
-  // The Agent's / selection's stored value is a REFERENCE and may be an alias,
-  // so it is resolved to a concrete id first — matching it against entry ids
-  // directly would silently fall back to the provider-type defaults for every
-  // aliased model (ADR-0017).
-  const modelReference = agentId ? selectedAgent?.modelId : modelId;
-  const concreteModelId =
-    resolvedProvider && modelReference
-      ? resolveModelId(resolvedProvider, modelReference)
-      : undefined;
-  const passthroughFileTypes =
-    resolvedProvider && concreteModelId
-      ? getPassthroughFileTypes(resolvedProvider, concreteModelId)
-      : [];
+  // One entry point for "what model will this Chat turn use, and what can it
+  // do?" — replaces separately resolving the provider, the concrete model id,
+  // passthrough file types, context window and search capability by hand.
+  // `null` means nothing resolves yet: no selection made, or the selected
+  // Agent/Provider/model reference no longer exists.
+  const resolvedModel = resolveModel({
+    providers,
+    agents,
+    selection: { agentId, modelId, providerId },
+  });
 
   // Context occupancy (ADR-0018): the capacity comes from the Org Admin's
-  // declaration on the resolved model, the reading from the latest assistant
-  // message that CARRIES one. It rides in the message metadata, so it survives a
-  // reload rather than staying blank until the next send, and a cancelled turn
-  // keeps whatever the run reported.
+  // declaration on the resolved model (`resolvedModel.contextWindow`), the
+  // reading from the latest assistant message that CARRIES one. It rides in
+  // the message metadata, so it survives a reload rather than staying blank
+  // until the next send, and a cancelled turn keeps whatever the run reported.
   //
   // Latest-that-carries-one rather than simply the latest: a turn in flight has
   // no reading until its first step finishes, and blanking the meter over that
@@ -471,10 +425,6 @@ export const Chat = ({
   // presence is the test rather than its value.
   //
   // Either number missing hides the meter; `ContextMeter` owns that decision.
-  const contextWindow =
-    resolvedProvider && concreteModelId
-      ? getContextWindow(resolvedProvider, concreteModelId)
-      : undefined;
   const contextOccupancy = messages
     .filter(
       (m) => m.role === "assistant" && "contextOccupancy" in (m.metadata ?? {}),
@@ -601,7 +551,9 @@ export const Chat = ({
                   {(attachment) => <PromptInputAttachment data={attachment} />}
                 </PromptInputAttachments>
                 <FileCompatibilityWarning
-                  passthroughFileTypes={passthroughFileTypes}
+                  passthroughFileTypes={
+                    resolvedModel?.passthroughFileTypes ?? []
+                  }
                 />
                 <PromptInputBody>
                   <PromptInputTextarea
@@ -638,7 +590,7 @@ export const Chat = ({
                       </TooltipTrigger>
                       <TooltipContent>Microphone</TooltipContent>
                     </Tooltip>
-                    {canSearch && (
+                    {resolvedModel?.canSearch && (
                       <Tooltip delayDuration={1000}>
                         <TooltipTrigger asChild>
                           <PromptInputButton
@@ -738,7 +690,7 @@ export const Chat = ({
                   <ContextMeter
                     className="order-last -mx-3 -mb-3 mt-1.5 w-[calc(100%+1.5rem)] justify-center rounded-b-md bg-foreground/5 px-3 py-1.5 sm:order-none sm:mx-0 sm:mt-0 sm:mb-0 sm:w-auto sm:justify-start sm:rounded-none sm:bg-transparent sm:p-0 sm:mr-auto"
                     occupancy={contextOccupancy?.inputTokens}
-                    contextWindow={contextWindow}
+                    contextWindow={resolvedModel?.contextWindow}
                   />
                   <PromptInputSubmit status={effectiveStatus} />
                 </PromptInputFooter>

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -618,6 +618,7 @@ export const Chat = ({
                         }
                       }}
                       onModelChange={handleModelChange}
+                      maxOutputTokens={resolvedModel?.maxOutputTokens}
                     />
                     {agentId && selectedAgent && (
                       <Dialog

--- a/apps/frontend/components/model-capability-notice.test.tsx
+++ b/apps/frontend/components/model-capability-notice.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ModelCapabilityNotice } from "./model-capability-notice";
+
+describe("ModelCapabilityNotice", () => {
+  it("warns when the model accepts no file types natively", () => {
+    render(<ModelCapabilityNotice passthroughFileTypes={[]} />);
+    expect(
+      screen.getByText(/doesn't natively accept file attachments/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when the model accepts at least one file type natively", () => {
+    const { container } = render(
+      <ModelCapabilityNotice passthroughFileTypes={["image/*"]} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/frontend/components/model-capability-notice.tsx
+++ b/apps/frontend/components/model-capability-notice.tsx
@@ -1,0 +1,32 @@
+import { TriangleAlert } from "lucide-react";
+import { FieldDescription } from "@/components/ui/field";
+
+/**
+ * Proactive capability info for a picked model, shown where the picker has no
+ * attachments to check against (the Agent form configures a model ahead of
+ * any Chat that will use it). Mirrors `FileCompatibilityWarning`'s posture —
+ * a heads-up about what this `(Provider, model)` pair can and can't ingest,
+ * not a block — but at the general capability level rather than per-file,
+ * since there is nothing attached yet to classify (issue #328).
+ */
+export const ModelCapabilityNotice = ({
+  passthroughFileTypes,
+}: {
+  passthroughFileTypes: string[];
+}) => {
+  if (passthroughFileTypes.length > 0) return null;
+
+  return (
+    <FieldDescription
+      role="status"
+      className="flex items-start gap-1.5 text-amber-700 dark:text-amber-400"
+    >
+      <TriangleAlert className="mt-0.5 size-3.5 shrink-0" />
+      <span>
+        This model doesn&apos;t natively accept file attachments. Non-text files
+        sent to this Agent in Chat will be rejected — PDFs and DOCX are still
+        readable, sent as extracted text.
+      </span>
+    </FieldDescription>
+  );
+};

--- a/apps/frontend/components/model-selector-dialog.tsx
+++ b/apps/frontend/components/model-selector-dialog.tsx
@@ -12,6 +12,10 @@ import {
 import { AgentAvatar } from "./agent-avatar";
 import { Button } from "./ui/button";
 import { findModelOption, getModelOptions } from "@/lib/model-config";
+import {
+  encodeAgentSelection,
+  encodeProviderSelection,
+} from "@/lib/selection-reference";
 
 const filterByKeywords = (
   _value: string,
@@ -83,11 +87,11 @@ export const ModelSelectorDialog = ({
               {agents.map((agent) => (
                 <ModelSelectorItem
                   key={agent.id}
-                  value={`agent:${agent.id}`}
+                  value={encodeAgentSelection(agent.id)}
                   keywords={[agent.name]}
                   className="cursor-pointer"
                   onSelect={() => {
-                    onModelChange(`agent:${agent.id}`);
+                    onModelChange(encodeAgentSelection(agent.id));
                     onOpenChange(false);
                   }}
                 >
@@ -103,12 +107,14 @@ export const ModelSelectorDialog = ({
             <ModelSelectorGroup key={provider.id} heading={provider.name}>
               {getModelOptions(provider).map((model) => (
                 <ModelSelectorItem
-                  key={`provider:${provider.id}:${model.value}`}
+                  key={encodeProviderSelection(provider.id, model.value)}
                   className="cursor-pointer"
-                  value={`provider:${provider.id}:${model.value}`}
+                  value={encodeProviderSelection(provider.id, model.value)}
                   keywords={[model.label, provider.name]}
                   onSelect={() => {
-                    onModelChange(`provider:${provider.id}:${model.value}`);
+                    onModelChange(
+                      encodeProviderSelection(provider.id, model.value),
+                    );
                     onOpenChange(false);
                   }}
                 >

--- a/apps/frontend/components/model-selector-dialog.tsx
+++ b/apps/frontend/components/model-selector-dialog.tsx
@@ -16,6 +16,8 @@ import {
   encodeAgentSelection,
   encodeProviderSelection,
 } from "@/lib/selection-reference";
+import { formatTokens } from "@/lib/context-window";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 const filterByKeywords = (
   _value: string,
@@ -35,6 +37,12 @@ interface ModelSelectorDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   onModelChange: (value: string) => void;
+  /**
+   * The resolved model's Output ceiling (issue #454), shown as a tooltip on
+   * the trigger — the only reader this figure has today, so an Org Admin's
+   * declaration is visible before a reply is cut short, not only after.
+   */
+  maxOutputTokens?: number;
 }
 
 export const ModelSelectorDialog = ({
@@ -46,6 +54,7 @@ export const ModelSelectorDialog = ({
   isOpen,
   onOpenChange,
   onModelChange,
+  maxOutputTokens,
 }: ModelSelectorDialogProps) => {
   const selectedAgent = agentId ? agents.find((a) => a.id === agentId) : null;
 
@@ -59,24 +68,37 @@ export const ModelSelectorDialog = ({
       ? findModelOption(selectedProvider, modelId)?.label
       : undefined;
 
+  const trigger = (
+    <Button
+      variant="outline"
+      size="sm"
+      className="max-w-40 overflow-hidden sm:max-w-none"
+    >
+      {selectedAgent && (
+        <AgentAvatar agent={selectedAgent} className="size-4" />
+      )}
+      <span className="truncate">
+        {agentId
+          ? selectedAgent?.name || "Select model"
+          : selectedModelLabel || "Select model"}
+      </span>
+    </Button>
+  );
+
   return (
     <ModelSelector open={isOpen} onOpenChange={onOpenChange}>
-      <ModelSelectorTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          className="max-w-40 overflow-hidden sm:max-w-none"
-        >
-          {selectedAgent && (
-            <AgentAvatar agent={selectedAgent} className="size-4" />
-          )}
-          <span className="truncate">
-            {agentId
-              ? selectedAgent?.name || "Select model"
-              : selectedModelLabel || "Select model"}
-          </span>
-        </Button>
-      </ModelSelectorTrigger>
+      {maxOutputTokens ? (
+        <Tooltip delayDuration={1000}>
+          <ModelSelectorTrigger asChild>
+            <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          </ModelSelectorTrigger>
+          <TooltipContent>
+            Max reply length: {formatTokens(maxOutputTokens)} tokens
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        <ModelSelectorTrigger asChild>{trigger}</ModelSelectorTrigger>
+      )}
       <ModelSelectorContent filter={filterByKeywords}>
         <ModelSelectorInput placeholder="Search agents and models..." />
         <ModelSelectorList>

--- a/apps/frontend/hooks/use-model-selection.ts
+++ b/apps/frontend/hooks/use-model-selection.ts
@@ -1,7 +1,11 @@
 import { useState, useEffect } from "react";
 import { Provider, Agent, Chat } from "@platypus/schemas";
 import { setWithExpiry, getWithExpiry } from "@/lib/local-storage";
-import { findModelOption, getModelOptions } from "@/lib/model-config";
+import { decodeSelectionReference } from "@/lib/selection-reference";
+import {
+  resolveRestoredSelection,
+  type StoredSelection,
+} from "@/lib/restore-selection";
 
 export interface ModelSelection {
   agentId: string;
@@ -23,27 +27,26 @@ export const useModelSelection = (
   const STORAGE_KEY = `platypus:workspace:${workspaceId}:lastSelection`;
 
   const handleModelChange = (value: string) => {
-    if (value.startsWith("agent:")) {
-      // Agent selected
-      const newAgentId = value.replace("agent:", "");
-      setAgentId(newAgentId);
+    const decoded = decodeSelectionReference(value);
+    if (!decoded) return;
+    if (decoded.type === "agent") {
+      setAgentId(decoded.agentId);
       setProviderId(""); // Clear provider/model
       setModelId("");
-    } else if (value.startsWith("provider:")) {
-      // Provider/model selected
-      const [, newProviderId, ...modelIdParts] = value.split(":");
-      const newModelId = modelIdParts.join(":");
-      setProviderId(newProviderId);
-      setModelId(newModelId);
+    } else {
+      setProviderId(decoded.providerId);
+      setModelId(decoded.modelReference);
       setAgentId(""); // Clear agent
     }
   };
 
-  // Restore persisted agent/provider/model from chat data or localStorage, with
-  // validation and fallback. This runs once the async providers/agents/chat
-  // data are available (and only while nothing is selected), reading
-  // client-only localStorage — work that belongs in an effect, so the
-  // restoring setState calls below are intentional.
+  // Restore persisted agent/provider/model from chat data or localStorage.
+  // This runs once the async providers/agents/chat data are available (and
+  // only while nothing is selected), reading client-only localStorage — work
+  // that belongs in an effect, so the restoring setState calls below are
+  // intentional. The three-priority ladder itself (chatData → localStorage →
+  // first provider's first model) is `resolveRestoredSelection`, a pure
+  // function tested on its own without a DOM or storage stub.
   useEffect(() => {
     /* eslint-disable react-hooks/set-state-in-effect */
     if (isLoading || providers.length === 0) return;
@@ -51,98 +54,19 @@ export const useModelSelection = (
     // If we already have a selection, do nothing
     if (modelId || providerId || agentId) return;
 
-    // PRIORITY 1: Restore from chatData (existing chat)
-    if (chatData) {
-      // Check if chat has an agent
-      if (chatData.agentId && agents.length > 0) {
-        const agent = agents.find((a) => a.id === chatData.agentId);
-        if (agent) {
-          // Agent still exists, restore it
-          setAgentId(chatData.agentId);
-          return;
-        } else {
-          // Agent was deleted, fall back to provider/model
-          console.warn(`Agent '${chatData.agentId}' no longer exists`);
-        }
-      }
+    const restored = resolveRestoredSelection({
+      chatData,
+      storedSelection: chatData
+        ? null
+        : getWithExpiry<StoredSelection>(STORAGE_KEY),
+      providers,
+      agents,
+    });
+    if (!restored) return;
 
-      // Restore provider/model from chatData
-      const persistedProviderId = chatData.providerId;
-      const persistedModelId = chatData.modelId;
-
-      if (persistedProviderId && persistedModelId) {
-        // Check if the persisted provider still exists
-        const provider = providers.find((p) => p.id === persistedProviderId);
-        if (provider) {
-          // Resolve the persisted value to a model ENTRY rather than testing
-          // string membership: once a model is given an alias its option value
-          // becomes `alias:<name>`, so a stored bare id would fail the check
-          // and silently fall through to a DIFFERENT model (ADR-0017).
-          const option = findModelOption(provider, persistedModelId);
-          if (option) {
-            setProviderId(persistedProviderId);
-            setModelId(option.value);
-            return;
-          } else {
-            // Provider exists but model is no longer available, use provider's first model
-            console.warn(
-              `Model '${persistedModelId}' no longer available for provider '${persistedProviderId}', falling back to first model`,
-            );
-            setProviderId(persistedProviderId);
-            setModelId(getModelOptions(provider)[0]?.value ?? "");
-            return;
-          }
-        } else {
-          // Provider no longer exists, fall back to first available provider
-          console.warn(
-            `Provider '${persistedProviderId}' no longer exists, falling back to first available provider`,
-          );
-        }
-      }
-    }
-
-    // PRIORITY 2: Try to restore from localStorage (for NEW chats only)
-    if (!chatData) {
-      const lastSelection = getWithExpiry<{
-        type: "agent" | "provider";
-        id?: string;
-        providerId?: string;
-        modelId?: string;
-      }>(STORAGE_KEY);
-
-      if (lastSelection) {
-        if (lastSelection.type === "agent" && lastSelection.id) {
-          const agent = agents.find((a) => a.id === lastSelection.id);
-          if (agent) {
-            setAgentId(lastSelection.id);
-            return;
-          }
-          console.warn(
-            `Agent '${lastSelection.id}' from localStorage no longer exists`,
-          );
-        } else if (
-          lastSelection.type === "provider" &&
-          lastSelection.providerId &&
-          lastSelection.modelId
-        ) {
-          const provider = providers.find(
-            (p) => p.id === lastSelection.providerId,
-          );
-          const option =
-            provider && findModelOption(provider, lastSelection.modelId);
-          if (option) {
-            setProviderId(lastSelection.providerId);
-            setModelId(option.value);
-            return;
-          }
-          console.warn(`Provider/model from localStorage no longer valid`);
-        }
-      }
-    }
-
-    // PRIORITY 3: Fall back to first provider's first model (for new chats, invalid persisted data, or missing chatData)
-    setModelId(getModelOptions(providers[0])[0]?.value ?? "");
-    setProviderId(providers[0].id);
+    setAgentId(restored.agentId);
+    setModelId(restored.modelId);
+    setProviderId(restored.providerId);
     /* eslint-enable react-hooks/set-state-in-effect */
   }, [
     chatData,

--- a/apps/frontend/lib/model-config.test.ts
+++ b/apps/frontend/lib/model-config.test.ts
@@ -7,6 +7,8 @@ import {
   resolveModelId,
   getPassthroughFileTypes,
   getContextWindow,
+  getMaxOutputTokens,
+  getSearchCapability,
 } from "./model-config";
 
 const provider = (modelIds: unknown, over: Partial<Provider> = {}) =>
@@ -164,5 +166,71 @@ describe("getContextWindow", () => {
     expect(
       getContextWindow(legacy, resolveModelId(legacy, "legacy-model")!),
     ).toBeUndefined();
+  });
+});
+
+describe("getMaxOutputTokens", () => {
+  it("returns the declared ceiling for an aliased model", () => {
+    const p = provider([
+      {
+        id: "claude-sonnet",
+        passthroughFileTypes: [],
+        alias: "flagship",
+        maxOutputTokens: 64_000,
+      },
+    ]);
+    const resolved = resolveModelId(p, "alias:flagship")!;
+    expect(getMaxOutputTokens(p, resolved)).toBe(64_000);
+  });
+
+  it("returns undefined when undeclared or unknown", () => {
+    const declaredNone = provider([{ id: "gpt-4", passthroughFileTypes: [] }]);
+    expect(
+      getMaxOutputTokens(declaredNone, resolveModelId(declaredNone, "gpt-4")!),
+    ).toBeUndefined();
+    expect(
+      getMaxOutputTokens(declaredNone, "ghost" as ConcreteModelId),
+    ).toBeUndefined();
+  });
+});
+
+describe("getSearchCapability", () => {
+  it("is false when searchSource is none", () => {
+    expect(
+      getSearchCapability(provider(["gpt-4"], { searchSource: "none" })),
+    ).toBe(false);
+  });
+
+  it("is true for native search on a capable provider", () => {
+    expect(
+      getSearchCapability(
+        provider(["gpt-4"], {
+          providerType: "Anthropic" as Provider["providerType"],
+          searchSource: "native",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for native search on a provider with no native tool (e.g. Bedrock)", () => {
+    expect(
+      getSearchCapability(
+        provider(["gpt-4"], {
+          providerType: "Bedrock" as Provider["providerType"],
+          searchSource: "native",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("is true when a Web-search backend is configured, regardless of native support", () => {
+    expect(
+      getSearchCapability(
+        provider(["gpt-4"], {
+          providerType: "Bedrock" as Provider["providerType"],
+          searchSource: "some-plugin.backend",
+        }),
+      ),
+    ).toBe(true);
   });
 });

--- a/apps/frontend/lib/model-config.ts
+++ b/apps/frontend/lib/model-config.ts
@@ -4,7 +4,10 @@ import {
   findModelEntry,
   modelLabelFor,
   modelReferenceFor,
+  providerHasNativeSearch,
   resolveModelReference,
+  SEARCH_SOURCE_NATIVE,
+  SEARCH_SOURCE_NONE,
   type ConcreteModelId,
   type Provider,
 } from "@platypus/schemas";
@@ -142,6 +145,35 @@ export const getContextWindow = (
   modelId: ConcreteModelId,
 ): number | undefined =>
   getModelConfigs(provider).find((m) => m.id === modelId)?.contextWindow;
+
+/**
+ * The output-token ceiling declared for a model, or `undefined` where the
+ * Provider declares none (issue #454) — which leaves the vendor's own default
+ * in force. Mirrors the backend's `maxOutputTokensForModel`.
+ */
+export const getMaxOutputTokens = (
+  provider: Pick<Provider, "modelIds">,
+  modelId: ConcreteModelId,
+): number | undefined =>
+  getModelConfigs(provider).find((m) => m.id === modelId)?.maxOutputTokens;
+
+/**
+ * Whether a searching turn against this Provider would actually serve search
+ * tools — Provider-scoped rather than per-model, since `searchSource` is a
+ * Provider setting (ADR-0014). `"none"` serves nothing; a value naming a
+ * Web-search backend serves that backend regardless of native support;
+ * `"native"` serves the Provider's own tool only where `providerHasNativeSearch`
+ * says the (providerType, apiMode) pair actually exposes one — a Bedrock or
+ * chat-completions OpenAI Provider has none, so setting `searchSource` to
+ * `"native"` there resolves to no capability at all.
+ */
+export const getSearchCapability = (
+  provider: Pick<Provider, "providerType" | "apiMode" | "searchSource">,
+): boolean =>
+  provider.searchSource !== SEARCH_SOURCE_NONE &&
+  (provider.searchSource === SEARCH_SOURCE_NATIVE
+    ? providerHasNativeSearch(provider)
+    : Boolean(provider.searchSource));
 
 /**
  * Classify an attachment against a model's passthrough set — the metadata-only

--- a/apps/frontend/lib/resolve-model.test.ts
+++ b/apps/frontend/lib/resolve-model.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import type { Agent, Provider } from "@platypus/schemas";
+import { resolveModel } from "./resolve-model";
+
+const provider = (over: Partial<Provider> = {}): Provider =>
+  ({
+    id: "p1",
+    name: "Test",
+    providerType: "Anthropic",
+    apiMode: "chat",
+    searchSource: "native",
+    modelIds: [
+      {
+        id: "gpt-4",
+        alias: "flagship",
+        passthroughFileTypes: ["image/*"],
+        contextWindow: 128_000,
+        maxOutputTokens: 8_192,
+      },
+    ],
+    ...over,
+  }) as unknown as Provider;
+
+const agent = (over: Partial<Agent> = {}): Agent =>
+  ({
+    id: "a1",
+    providerId: "p1",
+    modelId: "alias:flagship",
+    ...over,
+  }) as unknown as Agent;
+
+describe("resolveModel", () => {
+  it("resolves a direct provider/model selection", () => {
+    const p = provider();
+    const resolved = resolveModel({
+      providers: [p],
+      agents: [],
+      selection: { agentId: "", modelId: "alias:flagship", providerId: "p1" },
+    });
+    expect(resolved).toEqual({
+      label: "flagship",
+      concreteId: "gpt-4",
+      contextWindow: 128_000,
+      maxOutputTokens: 8_192,
+      passthroughFileTypes: ["image/*"],
+      canSearch: true,
+    });
+  });
+
+  it("resolves through an Agent's own provider and model", () => {
+    const p = provider();
+    const resolved = resolveModel({
+      providers: [p],
+      agents: [agent()],
+      selection: { agentId: "a1", modelId: "", providerId: "" },
+    });
+    expect(resolved?.concreteId).toBe("gpt-4");
+    expect(resolved?.label).toBe("flagship");
+  });
+
+  it("returns null when nothing is selected yet", () => {
+    expect(
+      resolveModel({
+        providers: [provider()],
+        agents: [],
+        selection: { agentId: "", modelId: "", providerId: "" },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the selected Agent no longer exists", () => {
+    expect(
+      resolveModel({
+        providers: [provider()],
+        agents: [],
+        selection: { agentId: "ghost", modelId: "", providerId: "" },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the selected Provider no longer exists", () => {
+    expect(
+      resolveModel({
+        providers: [],
+        agents: [],
+        selection: { agentId: "", modelId: "gpt-4", providerId: "ghost" },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when the model reference resolves to nothing (dangling id)", () => {
+    expect(
+      resolveModel({
+        providers: [provider()],
+        agents: [],
+        selection: { agentId: "", modelId: "removed-model", providerId: "p1" },
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to the concrete id as the label when the model has no alias", () => {
+    const p = provider({
+      modelIds: [{ id: "gpt-4o-mini", passthroughFileTypes: [] }],
+    });
+    const resolved = resolveModel({
+      providers: [p],
+      agents: [],
+      selection: { agentId: "", modelId: "gpt-4o-mini", providerId: "p1" },
+    });
+    expect(resolved?.label).toBe("gpt-4o-mini");
+  });
+
+  it("leaves contextWindow and maxOutputTokens undefined when undeclared", () => {
+    const p = provider({
+      modelIds: [{ id: "gpt-4o-mini", passthroughFileTypes: [] }],
+    });
+    const resolved = resolveModel({
+      providers: [p],
+      agents: [],
+      selection: { agentId: "", modelId: "gpt-4o-mini", providerId: "p1" },
+    });
+    expect(resolved?.contextWindow).toBeUndefined();
+    expect(resolved?.maxOutputTokens).toBeUndefined();
+  });
+
+  it("resolves canSearch false when the Provider's searchSource is none", () => {
+    const p = provider({ searchSource: "none" });
+    const resolved = resolveModel({
+      providers: [p],
+      agents: [],
+      selection: { agentId: "", modelId: "alias:flagship", providerId: "p1" },
+    });
+    expect(resolved?.canSearch).toBe(false);
+  });
+
+  it("falls back to the provider's default passthrough types when the model declares none", () => {
+    const p = provider({
+      providerType: "Anthropic" as Provider["providerType"],
+      modelIds: [{ id: "claude", passthroughFileTypes: [] }],
+    });
+    const resolved = resolveModel({
+      providers: [p],
+      agents: [],
+      selection: { agentId: "", modelId: "claude", providerId: "p1" },
+    });
+    expect(resolved?.passthroughFileTypes).toEqual([
+      "image/*",
+      "application/pdf",
+    ]);
+  });
+});

--- a/apps/frontend/lib/resolve-model.ts
+++ b/apps/frontend/lib/resolve-model.ts
@@ -9,7 +9,8 @@ import {
 } from "./model-config";
 
 export type ModelSelectionInput = {
-  agentId: string;
+  /** Omit entirely for a caller (like the Agent form) that never selects by Agent. */
+  agentId?: string;
   modelId: string;
   providerId: string;
 };
@@ -44,10 +45,11 @@ export type ResolvedModel = {
  */
 export const resolveModel = (input: {
   providers: Provider[];
-  agents: Agent[];
+  /** Omit for a caller (like the Agent form) that never selects by Agent. */
+  agents?: Agent[];
   selection: ModelSelectionInput;
 }): ResolvedModel | null => {
-  const { providers, agents, selection } = input;
+  const { providers, agents = [], selection } = input;
 
   let provider: Provider | undefined;
   let modelReference: string | undefined;

--- a/apps/frontend/lib/resolve-model.ts
+++ b/apps/frontend/lib/resolve-model.ts
@@ -1,0 +1,80 @@
+import type { Agent, ConcreteModelId, Provider } from "@platypus/schemas";
+import {
+  findModelOption,
+  getContextWindow,
+  getMaxOutputTokens,
+  getPassthroughFileTypes,
+  getSearchCapability,
+  resolveModelId,
+} from "./model-config";
+
+export type ModelSelectionInput = {
+  agentId: string;
+  modelId: string;
+  providerId: string;
+};
+
+export type ResolvedModel = {
+  /** What a picker shows for this model — never the storage `alias:` prefix. */
+  label: string;
+  concreteId: ConcreteModelId;
+  /** The vendor's published total token capacity, or undefined if undeclared (ADR-0018). */
+  contextWindow: number | undefined;
+  /** The ceiling on a single reply, or undefined if undeclared (issue #454). */
+  maxOutputTokens: number | undefined;
+  /** The media types this model ingests natively (issue #328). */
+  passthroughFileTypes: string[];
+  /** Whether a searching turn against this model would serve search tools. */
+  canSearch: boolean;
+};
+
+/**
+ * The single entry point for "what model will this Chat turn use, and what
+ * can it do?" Resolves the current selection — an Agent, or a direct
+ * Provider/model pair — to one object carrying every capability a turn cares
+ * about, so callers stop composing `resolveModelId` +
+ * `getPassthroughFileTypes` + `getContextWindow` + … by hand at each call
+ * site.
+ *
+ * Returns `null` whenever nothing resolves: no selection made yet, a
+ * selected Agent or Provider that no longer exists, or a model reference
+ * that names nothing on the resolved Provider (a dangling id, or an alias
+ * that was removed). There is no partial result — a Chat turn either has a
+ * model or it doesn't.
+ */
+export const resolveModel = (input: {
+  providers: Provider[];
+  agents: Agent[];
+  selection: ModelSelectionInput;
+}): ResolvedModel | null => {
+  const { providers, agents, selection } = input;
+
+  let provider: Provider | undefined;
+  let modelReference: string | undefined;
+
+  if (selection.agentId) {
+    const agent = agents.find((a) => a.id === selection.agentId);
+    if (!agent) return null;
+    provider = providers.find((p) => p.id === agent.providerId);
+    modelReference = agent.modelId;
+  } else {
+    provider = providers.find((p) => p.id === selection.providerId);
+    modelReference = selection.modelId;
+  }
+
+  if (!provider || !modelReference) return null;
+
+  const concreteId = resolveModelId(provider, modelReference);
+  if (!concreteId) return null;
+
+  const option = findModelOption(provider, modelReference);
+
+  return {
+    label: option?.label ?? concreteId,
+    concreteId,
+    contextWindow: getContextWindow(provider, concreteId),
+    maxOutputTokens: getMaxOutputTokens(provider, concreteId),
+    passthroughFileTypes: getPassthroughFileTypes(provider, concreteId),
+    canSearch: getSearchCapability(provider),
+  };
+};

--- a/apps/frontend/lib/restore-selection.test.ts
+++ b/apps/frontend/lib/restore-selection.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Agent, Chat, Provider } from "@platypus/schemas";
+import { resolveRestoredSelection } from "./restore-selection";
+
+const provider = (over: Partial<Provider> = {}): Provider =>
+  ({
+    id: "p1",
+    name: "Test",
+    modelIds: [{ id: "gpt-4", passthroughFileTypes: [] }],
+    ...over,
+  }) as unknown as Provider;
+
+const agent = (over: Partial<Agent> = {}): Agent =>
+  ({
+    id: "a1",
+    providerId: "p1",
+    modelId: "gpt-4",
+    ...over,
+  }) as unknown as Agent;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolveRestoredSelection — priority 1 (existing chat)", () => {
+  it("restores the chat's Agent when it still exists", () => {
+    const result = resolveRestoredSelection({
+      chatData: { agentId: "a1" } as Chat,
+      storedSelection: null,
+      providers: [provider()],
+      agents: [agent()],
+    });
+    expect(result).toEqual({ agentId: "a1", modelId: "", providerId: "" });
+  });
+
+  it("falls through to provider/model when the chat's Agent was deleted", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = resolveRestoredSelection({
+      chatData: {
+        agentId: "deleted-agent",
+        providerId: "p1",
+        modelId: "gpt-4",
+      } as Chat,
+      storedSelection: null,
+      providers: [provider()],
+      agents: [], // Agent no longer exists
+    });
+    expect(result).toEqual({
+      agentId: "",
+      modelId: "gpt-4",
+      providerId: "p1",
+    });
+  });
+
+  it("restores a bare model id to its aliased option (ADR-0017)", () => {
+    const result = resolveRestoredSelection({
+      chatData: { providerId: "p1", modelId: "gpt-4" } as Chat,
+      storedSelection: null,
+      providers: [
+        provider({
+          modelIds: [
+            { id: "gpt-4", alias: "flagship", passthroughFileTypes: [] },
+          ],
+        }),
+      ],
+      agents: [],
+    });
+    expect(result).toEqual({
+      agentId: "",
+      modelId: "alias:flagship",
+      providerId: "p1",
+    });
+  });
+
+  it("falls back to the provider's first model when the persisted model is gone", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = resolveRestoredSelection({
+      chatData: { providerId: "p1", modelId: "removed-model" } as Chat,
+      storedSelection: null,
+      providers: [provider()],
+      agents: [],
+    });
+    expect(result).toEqual({
+      agentId: "",
+      modelId: "gpt-4",
+      providerId: "p1",
+    });
+  });
+
+  it("falls back to the first available provider when the persisted Provider was removed", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fallbackProvider = provider({
+      id: "p2",
+      modelIds: [{ id: "claude", passthroughFileTypes: [] }],
+    });
+    const result = resolveRestoredSelection({
+      chatData: { providerId: "removed-provider", modelId: "gpt-4" } as Chat,
+      storedSelection: null,
+      providers: [fallbackProvider],
+      agents: [],
+    });
+    expect(result).toEqual({
+      agentId: "",
+      modelId: "claude",
+      providerId: "p2",
+    });
+  });
+});
+
+describe("resolveRestoredSelection — priority 2 (localStorage, new chats only)", () => {
+  it("restores a stored Agent selection", () => {
+    const result = resolveRestoredSelection({
+      chatData: undefined,
+      storedSelection: { type: "agent", id: "a1" },
+      providers: [provider()],
+      agents: [agent()],
+    });
+    expect(result).toEqual({ agentId: "a1", modelId: "", providerId: "" });
+  });
+
+  it("restores a stored provider/model selection", () => {
+    const result = resolveRestoredSelection({
+      chatData: undefined,
+      storedSelection: { type: "provider", providerId: "p1", modelId: "gpt-4" },
+      providers: [provider()],
+      agents: [],
+    });
+    expect(result).toEqual({
+      agentId: "",
+      modelId: "gpt-4",
+      providerId: "p1",
+    });
+  });
+
+  it("is never consulted when a chat already exists", () => {
+    // A chat exists but has neither agentId nor providerId/modelId set — an
+    // edge case, but localStorage still must not leak into a real chat, so
+    // this should fall through to priority 3 rather than the stored value.
+    const result = resolveRestoredSelection({
+      chatData: {} as Chat,
+      storedSelection: { type: "agent", id: "a1" },
+      providers: [provider()],
+      agents: [agent()],
+    });
+    expect(result).toEqual({
+      agentId: "",
+      modelId: "gpt-4",
+      providerId: "p1",
+    });
+  });
+
+  it("falls through to priority 3 when the stored value names an empty/absent selection", () => {
+    const result = resolveRestoredSelection({
+      chatData: undefined,
+      storedSelection: null,
+      providers: [provider()],
+      agents: [],
+    });
+    expect(result).toEqual({
+      agentId: "",
+      modelId: "gpt-4",
+      providerId: "p1",
+    });
+  });
+});
+
+describe("resolveRestoredSelection — priority 3 (fallback)", () => {
+  it("falls back to the first provider's first model for a brand-new chat with empty storage", () => {
+    const result = resolveRestoredSelection({
+      chatData: undefined,
+      storedSelection: null,
+      providers: [provider(), provider({ id: "p2" })],
+      agents: [],
+    });
+    expect(result).toEqual({
+      agentId: "",
+      modelId: "gpt-4",
+      providerId: "p1",
+    });
+  });
+
+  it("returns null when there are no providers to fall back to", () => {
+    const result = resolveRestoredSelection({
+      chatData: undefined,
+      storedSelection: null,
+      providers: [],
+      agents: [],
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/apps/frontend/lib/restore-selection.test.ts
+++ b/apps/frontend/lib/restore-selection.test.ts
@@ -43,8 +43,35 @@ describe("resolveRestoredSelection — priority 1 (existing chat)", () => {
       } as Chat,
       storedSelection: null,
       providers: [provider()],
-      agents: [], // Agent no longer exists
+      // A non-empty list missing the target id — genuinely deleted, as
+      // opposed to merely not having loaded yet (see the next test).
+      agents: [agent({ id: "some-other-agent" })],
     });
+    expect(result).toEqual({
+      agentId: "",
+      modelId: "gpt-4",
+      providerId: "p1",
+    });
+  });
+
+  it("does not judge the Agent reference before `agents` has loaded", () => {
+    // agents.length === 0 here means "still loading", not "deleted" — treating
+    // it as deleted would commit to Priority 3 before the Agent ever gets a
+    // chance to match once the real list arrives (a regression this guards).
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = resolveRestoredSelection({
+      chatData: {
+        agentId: "a1",
+        providerId: "p1",
+        modelId: "gpt-4",
+      } as Chat,
+      storedSelection: null,
+      providers: [provider()],
+      agents: [],
+    });
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("no longer exists"),
+    );
     expect(result).toEqual({
       agentId: "",
       modelId: "gpt-4",

--- a/apps/frontend/lib/restore-selection.ts
+++ b/apps/frontend/lib/restore-selection.ts
@@ -1,0 +1,117 @@
+import type { Agent, Chat, Provider } from "@platypus/schemas";
+import { findModelOption, getModelOptions } from "./model-config";
+
+/** The shape a Chat's last selection is persisted as under its localStorage key. */
+export type StoredSelection =
+  | { type: "agent"; id: string }
+  | { type: "provider"; providerId: string; modelId: string };
+
+export type RestoreLadderInput = {
+  /** Present when restoring an existing Chat; absent for a brand-new one. */
+  chatData: Pick<Chat, "agentId" | "providerId" | "modelId"> | undefined;
+  /** The Chat's last selection read from localStorage, or `null` if none/expired. */
+  storedSelection: StoredSelection | null;
+  providers: Provider[];
+  agents: Agent[];
+};
+
+export type RestoredSelection = {
+  agentId: string;
+  modelId: string;
+  providerId: string;
+};
+
+/**
+ * The three-priority restore ladder that decides which model a Chat opens
+ * against: an existing Chat's own selection, then a new Chat's last-used
+ * localStorage selection, then the first available Provider's first model.
+ * Pure — takes the already-read localStorage value rather than reading it
+ * itself — so every fallback (a deleted Agent, a removed Provider, an aliased
+ * model, empty storage) is testable without a DOM or storage stub.
+ *
+ * Returns `null` only when there is no Provider to fall back to, meaning
+ * nothing can be resolved yet — the caller should leave its state as-is
+ * rather than committing an empty selection.
+ */
+export const resolveRestoredSelection = (
+  input: RestoreLadderInput,
+): RestoredSelection | null => {
+  const { chatData, storedSelection, providers, agents } = input;
+
+  if (providers.length === 0) return null;
+
+  // PRIORITY 1: restore from chatData (existing chat).
+  if (chatData) {
+    if (chatData.agentId) {
+      const agent = agents.find((a) => a.id === chatData.agentId);
+      if (agent) {
+        return { agentId: chatData.agentId, modelId: "", providerId: "" };
+      }
+      console.warn(`Agent '${chatData.agentId}' no longer exists`);
+    }
+
+    if (chatData.providerId && chatData.modelId) {
+      const provider = providers.find((p) => p.id === chatData.providerId);
+      if (provider) {
+        // Resolve to a model ENTRY rather than testing string membership: once
+        // a model is given an alias its option value becomes `alias:<name>`,
+        // so a stored bare id would fail a plain equality check and silently
+        // fall through to a different model (ADR-0017).
+        const option = findModelOption(provider, chatData.modelId);
+        if (option) {
+          return {
+            agentId: "",
+            modelId: option.value,
+            providerId: chatData.providerId,
+          };
+        }
+        console.warn(
+          `Model '${chatData.modelId}' no longer available for provider '${chatData.providerId}', falling back to first model`,
+        );
+        return {
+          agentId: "",
+          providerId: chatData.providerId,
+          modelId: getModelOptions(provider)[0]?.value ?? "",
+        };
+      }
+      console.warn(
+        `Provider '${chatData.providerId}' no longer exists, falling back to first available provider`,
+      );
+    }
+  }
+
+  // PRIORITY 2: restore from localStorage (new chats only).
+  if (!chatData && storedSelection) {
+    if (storedSelection.type === "agent") {
+      const agent = agents.find((a) => a.id === storedSelection.id);
+      if (agent) {
+        return { agentId: storedSelection.id, modelId: "", providerId: "" };
+      }
+      console.warn(
+        `Agent '${storedSelection.id}' from localStorage no longer exists`,
+      );
+    } else {
+      const provider = providers.find(
+        (p) => p.id === storedSelection.providerId,
+      );
+      const option =
+        provider && findModelOption(provider, storedSelection.modelId);
+      if (option) {
+        return {
+          agentId: "",
+          providerId: storedSelection.providerId,
+          modelId: option.value,
+        };
+      }
+      console.warn("Provider/model from localStorage no longer valid");
+    }
+  }
+
+  // PRIORITY 3: fall back to the first provider's first model.
+  const fallbackProvider = providers[0];
+  return {
+    agentId: "",
+    providerId: fallbackProvider.id,
+    modelId: getModelOptions(fallbackProvider)[0]?.value ?? "",
+  };
+};

--- a/apps/frontend/lib/restore-selection.ts
+++ b/apps/frontend/lib/restore-selection.ts
@@ -42,7 +42,11 @@ export const resolveRestoredSelection = (
 
   // PRIORITY 1: restore from chatData (existing chat).
   if (chatData) {
-    if (chatData.agentId) {
+    // Only judge the Agent reference once `agents` has actually loaded —
+    // agents.length === 0 while data is still in flight looks identical to a
+    // genuinely empty list, and treating it as "deleted" would fall through to
+    // Priority 3 before the real Agent ever gets a chance to match.
+    if (chatData.agentId && agents.length > 0) {
       const agent = agents.find((a) => a.id === chatData.agentId);
       if (agent) {
         return { agentId: chatData.agentId, modelId: "", providerId: "" };

--- a/apps/frontend/lib/selection-reference.test.ts
+++ b/apps/frontend/lib/selection-reference.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  encodeAgentSelection,
+  encodeProviderSelection,
+  decodeSelectionReference,
+} from "./selection-reference";
+
+describe("encodeAgentSelection", () => {
+  it("prefixes the agent id", () => {
+    expect(encodeAgentSelection("a1")).toBe("agent:a1");
+  });
+});
+
+describe("encodeProviderSelection", () => {
+  it("joins provider id and model reference", () => {
+    expect(encodeProviderSelection("p1", "gpt-4o")).toBe("provider:p1:gpt-4o");
+  });
+
+  it("round-trips a model reference that itself contains a colon (a Model alias)", () => {
+    expect(encodeProviderSelection("p1", "alias:flagship")).toBe(
+      "provider:p1:alias:flagship",
+    );
+  });
+});
+
+describe("decodeSelectionReference", () => {
+  it("decodes an agent reference", () => {
+    expect(decodeSelectionReference("agent:a1")).toEqual({
+      type: "agent",
+      agentId: "a1",
+    });
+  });
+
+  it("decodes a provider reference", () => {
+    expect(decodeSelectionReference("provider:p1:gpt-4o")).toEqual({
+      type: "provider",
+      providerId: "p1",
+      modelReference: "gpt-4o",
+    });
+  });
+
+  it("keeps the alias prefix inside the model reference rather than splitting on every colon", () => {
+    expect(decodeSelectionReference("provider:p1:alias:flagship")).toEqual({
+      type: "provider",
+      providerId: "p1",
+      modelReference: "alias:flagship",
+    });
+  });
+
+  it("round-trips encodeProviderSelection for an aliased model", () => {
+    const encoded = encodeProviderSelection("p1", "alias:flagship");
+    expect(decodeSelectionReference(encoded)).toEqual({
+      type: "provider",
+      providerId: "p1",
+      modelReference: "alias:flagship",
+    });
+  });
+
+  it("returns null for a value naming neither shape", () => {
+    expect(decodeSelectionReference("")).toBeNull();
+    expect(decodeSelectionReference("gpt-4o")).toBeNull();
+  });
+});

--- a/apps/frontend/lib/selection-reference.ts
+++ b/apps/frontend/lib/selection-reference.ts
@@ -1,0 +1,43 @@
+/**
+ * The composite value the model picker (chat composer, Agent form) submits:
+ * either an Agent by id, or a Provider paired with the model reference it
+ * resolves through (which may itself be a Model alias reference, e.g.
+ * `alias:flagship` — see ADR-0017). One codec, so the encode/decode pair is
+ * defined once instead of reassembled at each call site.
+ */
+export type SelectionReference =
+  | { type: "agent"; agentId: string }
+  | { type: "provider"; providerId: string; modelReference: string };
+
+export const encodeAgentSelection = (agentId: string): string =>
+  `agent:${agentId}`;
+
+export const encodeProviderSelection = (
+  providerId: string,
+  modelReference: string,
+): string => `provider:${providerId}:${modelReference}`;
+
+/**
+ * Parses a value built by `encodeAgentSelection` / `encodeProviderSelection`.
+ *
+ * A provider reference splits on `:` with a rest element rather than a fixed
+ * split(":")[n] — a Model alias reference is itself `alias:<name>`, so the
+ * model segment can contain its own colon. Anything not matching either shape
+ * (an empty string, a bare model id with no prefix) decodes to `null`.
+ */
+export const decodeSelectionReference = (
+  value: string,
+): SelectionReference | null => {
+  if (value.startsWith("agent:")) {
+    return { type: "agent", agentId: value.slice("agent:".length) };
+  }
+  if (value.startsWith("provider:")) {
+    const [, providerId, ...modelReferenceParts] = value.split(":");
+    return {
+      type: "provider",
+      providerId,
+      modelReference: modelReferenceParts.join(":"),
+    };
+  }
+  return null;
+};


### PR DESCRIPTION
## Summary

- Adds `resolveModel` (`apps/frontend/lib/resolve-model.ts`) as the single entry point for a Chat turn's model: label, concrete id, Context window, Output ceiling, Passthrough file types, and search capability — replacing the five separate derivations that sat above `chat.tsx`'s render body.
- Extracts the picker's selection-reference codec (`apps/frontend/lib/selection-reference.ts`) — `encodeAgentSelection` / `encodeProviderSelection` / `decodeSelectionReference` — deleting the duplicated `split(":")` parse from `agent-form.tsx` and `use-model-selection.ts`.
- Extracts the three-priority restore ladder out of `use-model-selection.ts`'s effect into a pure, unit-tested function (`apps/frontend/lib/restore-selection.ts`), covering the deleted-Agent, removed-Provider, aliased-model, and empty-storage fallbacks — plus a regression test for a race where an Agent list not yet loaded could be mistaken for a deleted Agent.
- The Agent form now warns about model capability the way the Chat composer does (`ModelCapabilityNotice`), and shows the Output ceiling as a tooltip on the model picker so it has a reader before a reply is cut short, not only after.
- Docs updated in the same PR: `building-with-platypus/agents.mdx` and `building-with-platypus/chat.mdx`.

Closes #573.

## Test plan

- [x] `pnpm typecheck` (all packages)
- [x] `pnpm test` (backend 1901, frontend 234, docs 28 — all green)
- [x] `pnpm lint` (no new warnings/errors)
- [x] New unit tests for `resolveModel`, the selection-reference codec, `resolveRestoredSelection`'s fallback ladder, and `ModelCapabilityNotice`
- [x] Two-axis code review (standards + spec) run against the diff; findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)