### PR TITLE
chore(frontend): move the Chat cluster onto the request module

### DIFF
--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -34,8 +34,9 @@ import {
   Skill,
 } from "@platypus/schemas";
 import { type PlatypusUIMessage } from "@platypus/backend/src/types";
-import useSWR from "swr";
-import { fetcher, joinUrl } from "@/lib/utils";
+import { joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
+import { useScopedSWR } from "@/hooks/use-scoped-swr";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useChatSettings } from "@/hooks/use-chat-settings";
 import { useModelSelection } from "@/hooks/use-model-selection";
@@ -72,23 +73,18 @@ export const Chat = ({
   chatId: string;
   initialAgentId?: string;
 }) => {
-  const { user, isWorkspaceOwner } = useAuth();
+  const { isWorkspaceOwner } = useAuth();
   const backendUrl = useBackendUrl();
+  const scope = useMemo(() => ({ orgId, workspaceId }), [orgId, workspaceId]);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [search, setSearch] = useState(false);
   const [inputValue, setInputValue] = useState("");
 
   // Fetch providers
-  const { data: providersData, isLoading } = useSWR<{ results: Provider[] }>(
-    backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/providers`,
-        )
-      : null,
-    fetcher,
-  );
+  const { data: providersData, isLoading } = useScopedSWR<{
+    results: Provider[];
+  }>("providers", scope);
 
   // Memoize providers to prevent unnecessary re-renders
   const providers = useMemo(
@@ -97,14 +93,9 @@ export const Chat = ({
   );
 
   // Fetch agents
-  const { data: agentsData } = useSWR<{ results: Agent[] }>(
-    backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/agents`,
-        )
-      : null,
-    fetcher,
+  const { data: agentsData } = useScopedSWR<{ results: Agent[] }>(
+    "agents",
+    scope,
   );
 
   // Memoize agents to prevent unnecessary re-renders
@@ -114,14 +105,9 @@ export const Chat = ({
   );
 
   // Fetch tool sets
-  const { data: toolSetsData } = useSWR<{ results: ToolSet[] }>(
-    backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/tools`,
-        )
-      : null,
-    fetcher,
+  const { data: toolSetsData } = useScopedSWR<{ results: ToolSet[] }>(
+    "tools",
+    scope,
   );
 
   // Memoize tool sets to prevent unnecessary re-renders
@@ -131,14 +117,9 @@ export const Chat = ({
   );
 
   // Fetch skills
-  const { data: skillsData } = useSWR<{ results: Skill[] }>(
-    backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/skills`,
-        )
-      : null,
-    fetcher,
+  const { data: skillsData } = useScopedSWR<{ results: Skill[] }>(
+    "skills",
+    scope,
   );
   // Memoize skills to prevent unnecessary re-renders
   const skills = useMemo(
@@ -150,14 +131,9 @@ export const Chat = ({
   // still in progress so users who reconnect mid-run see partial messages
   // land without manually reloading. Stop polling once the run reaches a
   // terminal status.
-  const { data: chatData, isLoading: isChatLoading } = useSWR<ChatType>(
-    backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/chat/${chatId}`,
-        )
-      : null,
-    fetcher,
+  const { data: chatData, isLoading: isChatLoading } = useScopedSWR<ChatType>(
+    `chat/${chatId}`,
+    scope,
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
@@ -446,16 +422,19 @@ export const Chat = ({
       // aborting the local fetch (what `stop()` does) no longer cancels
       // the run. Send an explicit cancel POST so the server stops billing
       // tokens and persists the partial result with status="cancelled".
-      void fetch(
-        joinUrl(
-          backendUrl || "",
-          `/organizations/${orgId}/workspaces/${workspaceId}/chat/${chatId}/cancel`,
-        ),
-        { method: "POST", credentials: "include" },
-      ).catch(() => {
-        // Swallow: the user can retry by pressing stop again, and the
-        // server treats repeated cancels as idempotent no-ops.
-      });
+      // Fire-and-forget (not awaited) so `stop()` below isn't held up by
+      // the round trip, but a failure still surfaces — the user can retry
+      // by pressing stop again, and the server treats repeated cancels as
+      // idempotent no-ops, but silently swallowing a real failure (e.g. a
+      // network error) would leave them thinking the run was cancelled
+      // when it wasn't.
+      void writeEntity(backendUrl || "", `chat/${chatId}/cancel`, scope).then(
+        (outcome) => {
+          if (outcome.outcome !== "success") {
+            toast.error(outcome.message);
+          }
+        },
+      );
       return stop();
     }
 

--- a/apps/frontend/hooks/use-scoped-swr.test.tsx
+++ b/apps/frontend/hooks/use-scoped-swr.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+const authState: { user: { id: string } | null } = { user: { id: "u1" } };
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => authState,
+}));
+
+let capturedKey: unknown;
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: (key: unknown) => {
+    capturedKey = key;
+    return { data: undefined, isLoading: false };
+  },
+}));
+
+import { useScopedSWR } from "./use-scoped-swr";
+
+describe("useScopedSWR", () => {
+  afterEach(() => {
+    authState.user = { id: "u1" };
+  });
+
+  it("resolves the workspace-scoped URL as the SWR key", () => {
+    renderHook(() =>
+      useScopedSWR("providers", { orgId: "org1", workspaceId: "ws1" }),
+    );
+    expect(capturedKey).toBe(
+      "http://test/organizations/org1/workspaces/ws1/providers",
+    );
+  });
+
+  it("resolves the org-scoped URL when no workspace is given", () => {
+    renderHook(() => useScopedSWR("agents", { orgId: "org1" }));
+    expect(capturedKey).toBe("http://test/organizations/org1/agents");
+  });
+
+  it("withholds the key — rather than passing a falsy string SWR might still treat as a cache key — when scope is null", () => {
+    renderHook(() => useScopedSWR("providers", null));
+    expect(capturedKey).toBeNull();
+  });
+
+  it("withholds the key when there is no signed-in user", () => {
+    authState.user = null;
+    renderHook(() =>
+      useScopedSWR("providers", { orgId: "org1", workspaceId: "ws1" }),
+    );
+    expect(capturedKey).toBeNull();
+  });
+});

--- a/apps/frontend/hooks/use-scoped-swr.ts
+++ b/apps/frontend/hooks/use-scoped-swr.ts
@@ -1,0 +1,26 @@
+import useSWR, { type SWRConfiguration, type SWRResponse } from "swr";
+import { useAuth } from "@/components/auth-provider";
+import { useBackendUrl } from "@/app/client-context";
+import { fetcher } from "@/lib/utils";
+import { scopedUrl, type Scope } from "@/lib/api-write";
+
+/**
+ * A GET through the request module: the same base-URL-and-signed-in-user
+ * gate and Organization-vs-Workspace path shape `writeEntity` already owns
+ * for writes, resolved once instead of as a repeated
+ * `backendUrl && user ? joinUrl(...) : null` at every read call site.
+ * `scope: null` (rather than a boolean `enabled`) lets a caller withhold the
+ * fetch for the same reason it can't yet name a scope — e.g. a dialog that
+ * hasn't opened, or an id that hasn't resolved.
+ */
+export function useScopedSWR<T>(
+  entity: string,
+  scope: Scope | null,
+  config?: SWRConfiguration<T>,
+): SWRResponse<T> {
+  const { user } = useAuth();
+  const backendUrl = useBackendUrl();
+  const key =
+    backendUrl && user && scope ? scopedUrl(backendUrl, entity, scope) : null;
+  return useSWR<T>(key, fetcher, config);
+}

--- a/apps/frontend/lib/api-write.test.ts
+++ b/apps/frontend/lib/api-write.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { writeEntity } from "./api-write";
+import { writeEntity, scopedUrl } from "./api-write";
 
 function mockResponse(status: number, body: unknown) {
   return {
@@ -112,6 +112,23 @@ describe("writeEntity — transport", () => {
     );
 
     expect(fetchMock.mock.calls[0][1].credentials).toBe("include");
+  });
+});
+
+describe("scopedUrl — the read-side path shape", () => {
+  it("builds the workspace-scoped URL when a workspaceId is present", () => {
+    expect(
+      scopedUrl(BACKEND_URL, "providers", {
+        orgId: "org1",
+        workspaceId: "ws1",
+      }),
+    ).toBe("http://localhost:4000/organizations/org1/workspaces/ws1/providers");
+  });
+
+  it("builds the org-scoped URL when no workspaceId is given", () => {
+    expect(scopedUrl(BACKEND_URL, "agents", { orgId: "org1" })).toBe(
+      "http://localhost:4000/organizations/org1/agents",
+    );
   });
 });
 

--- a/apps/frontend/lib/api-write.ts
+++ b/apps/frontend/lib/api-write.ts
@@ -62,6 +62,20 @@ function scopedPath(entity: string, scope: Scope): string {
     : `/organizations/${scope.orgId}/${entity}`;
 }
 
+/**
+ * The read-side counterpart to `writeEntity`'s path resolution: the same
+ * base URL and Organization-vs-Workspace path shape, for a caller that only
+ * needs a key to fetch (typically as an SWR key via `useScopedSWR`) rather
+ * than a full write outcome.
+ */
+export function scopedUrl(
+  backendUrl: string,
+  entity: string,
+  scope: Scope,
+): string {
+  return joinUrl(backendUrl, scopedPath(entity, scope));
+}
+
 function errorMessage(body: unknown): string | undefined {
   if (body && typeof body === "object" && "error" in body) {
     const { error } = body as { error: unknown };


### PR DESCRIPTION
## Summary
- Chat's 5 SWR reads (providers, agents, tools, skills, the chat record) and the run-cancel write now go through the request module (`lib/api-write.ts`) instead of each hand-rolling the base-URL-and-signed-in-user gate and URL construction.
- New `hooks/use-scoped-swr.ts` resolves that gate once for reads; new `scopedUrl` export on `lib/api-write.ts` is its read-side counterpart to `writeEntity`'s path resolution.
- The cancel-run path now reports a failure via `toast.error` instead of silently swallowing it.
- Streaming, attachments and tool rendering are untouched.

Closes #566

## Test plan
- [x] `pnpm test` (apps/frontend) — 317 passed
- [x] `pnpm typecheck` (apps/frontend) — clean
- [x] `pnpm lint` (apps/frontend) — clean (pre-existing unrelated warnings only)
- [x] Reviewed via `/code-review` against issue #566 (Standards + Spec axes, both clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)