### PR TITLE
chore(frontend): move the resource-list modules onto the request module

### DIFF
--- a/apps/frontend/components/agents-list.test.tsx
+++ b/apps/frontend/components/agents-list.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { Agent, Provider } from "@platypus/schemas";
+import {
+  installRadixPointerPolyfills,
+  openDropdownMenu as openMenu,
+} from "@/lib/test-utils";
+
+beforeAll(installRadixPointerPolyfills);
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({
+    user: { id: "u1" },
+    isOrgAdmin: true,
+    actor: "org-admin",
+  }),
+}));
+
+const pushSpy = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushSpy }),
+}));
+
+type AgentWithScope = Agent & { scope?: "organization" | "workspace" };
+
+// The `GET .../agents` list this component renders. Set per test.
+let agents: AgentWithScope[] = [];
+const provider: Provider = { id: "p1", name: "OpenAI" } as unknown as Provider;
+
+const mutateSpy = vi.fn();
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (key?.includes("/agents")) {
+      return {
+        data: { results: agents },
+        isLoading: false,
+        mutate: mutateSpy,
+      };
+    }
+    if (key?.includes("/providers")) {
+      return { data: { results: [provider] }, isLoading: false };
+    }
+    return { data: { results: [] }, isLoading: false };
+  },
+}));
+
+import { AgentsList } from "./agents-list";
+
+// --- Helpers -----------------------------------------------------------------
+
+const orgAgent: AgentWithScope = {
+  id: "a1",
+  name: "Shared Agent",
+  description: "desc",
+  scope: "organization",
+} as unknown as AgentWithScope;
+
+const workspaceAgent: AgentWithScope = {
+  id: "a2",
+  name: "Workspace Agent",
+  description: "desc",
+  scope: "workspace",
+} as unknown as AgentWithScope;
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  agents = [];
+  mutateSpy.mockClear();
+  pushSpy.mockClear();
+  vi.restoreAllMocks();
+});
+
+// --- Tests -------------------------------------------------------------------
+
+describe("AgentsList detach", () => {
+  it("surfaces the backend's reason and keeps the row when detach is refused", async () => {
+    agents = [orgAgent];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(409, { error: "This agent is a sub-agent elsewhere" }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Detach"));
+    fireEvent.click(screen.getByRole("button", { name: /Detach/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("This agent is a sub-agent elsewhere"),
+      ).toBeInTheDocument(),
+    );
+    expect(mutateSpy).not.toHaveBeenCalled();
+    expect(screen.getByText("Detach shared agent")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/workspaces/ws1/attachments/agent/a1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("revalidates and closes the dialog when detach succeeds", async () => {
+    agents = [orgAgent];
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Detach"));
+    fireEvent.click(screen.getByRole("button", { name: /Detach/ }));
+
+    await waitFor(() => expect(mutateSpy).toHaveBeenCalled());
+    expect(screen.queryByText("Detach shared agent")).not.toBeInTheDocument();
+  });
+});
+
+describe("AgentsList delete", () => {
+  it("deletes the workspace-scoped agent through the request module", async () => {
+    agents = [workspaceAgent];
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(mutateSpy).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/workspaces/ws1/agents/a2",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});
+
+describe("AgentsList clone", () => {
+  it("navigates to the new agent on success", async () => {
+    agents = [workspaceAgent];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(201, { id: "a3", name: "Cloned" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Clone"));
+    fireEvent.click(screen.getByRole("button", { name: "Clone" }));
+
+    await waitFor(() =>
+      expect(pushSpy).toHaveBeenCalledWith("/org1/workspace/ws1/agents/a3"),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/workspaces/ws1/agents",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("surfaces the backend's reason when clone fails", async () => {
+    agents = [workspaceAgent];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(409, { error: "Name already in use" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Clone"));
+    fireEvent.click(screen.getByRole("button", { name: "Clone" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Name already in use")).toBeInTheDocument(),
+    );
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentsList promote", () => {
+  it("surfaces blockers from a refused promote", async () => {
+    agents = [workspaceAgent];
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(422, {
+        error: "Promote blocked",
+        blockers: [{ type: "skill", id: "s1", name: "Private Skill" }],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Promote to organization"));
+    fireEvent.click(screen.getByRole("button", { name: "Promote" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Private Skill")).toBeInTheDocument(),
+    );
+    expect(mutateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/workspaces/ws1/agents/a2/promote",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/apps/frontend/components/agents-list.tsx
+++ b/apps/frontend/components/agents-list.tsx
@@ -64,6 +64,7 @@ import { useAuth } from "@/components/auth-provider";
 import { canManageSharedResource } from "@/lib/authorization";
 import { NoProvidersEmptyState } from "@/components/no-providers-empty-state";
 import { AttachSharedResourceDialog } from "@/components/attach-shared-resource-dialog";
+import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
 
 // The Agent is shown either in a Workspace, where it may be a workspace-scoped
 // Agent or an attached org-scoped (Shared) Agent rendered with an Organization
@@ -111,6 +112,11 @@ export const AgentsList = ({
   const [promoteError, setPromoteError] = useState<string | null>(null);
   const [promoteBlockers, setPromoteBlockers] = useState<PromoteBlocker[]>([]);
 
+  // Resolved once per render and reused for the list's reads and every write
+  // below, rather than re-deriving the Organization-vs-Workspace branch at
+  // each call site.
+  const scope: Scope = { orgId, workspaceId };
+
   const {
     data: agentsData,
     isLoading: isLoadingAgents,
@@ -119,10 +125,7 @@ export const AgentsList = ({
     results: AgentWithScope[];
   }>(
     backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/agents`,
-        )
+      ? joinUrl(backendUrl, scopedPath("agents", scope))
       : null,
     fetcher,
   );
@@ -131,10 +134,7 @@ export const AgentsList = ({
     results: Provider[];
   }>(
     backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/providers`,
-        )
+      ? joinUrl(backendUrl, scopedPath("providers", scope))
       : null,
     fetcher,
   );
@@ -142,12 +142,7 @@ export const AgentsList = ({
   const { data: toolSetsData } = useSWR<{
     results: ToolSet[];
   }>(
-    backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/tools`,
-        )
-      : null,
+    backendUrl && user ? joinUrl(backendUrl, scopedPath("tools", scope)) : null,
     fetcher,
   );
 
@@ -155,10 +150,7 @@ export const AgentsList = ({
     results: Skill[];
   }>(
     backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/skills`,
-        )
+      ? joinUrl(backendUrl, scopedPath("skills", scope))
       : null,
     fetcher,
   );
@@ -213,25 +205,13 @@ export const AgentsList = ({
   const handleDeleteConfirm = async () => {
     if (!agentToDelete || !backendUrl) return;
 
-    try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/agents/${agentToDelete.id}`,
-        ),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
-      );
-
-      if (response.ok) {
-        mutate();
-        setDeleteDialogOpen(false);
-        setAgentToDelete(null);
-      }
-    } catch (error) {
-      console.error("Failed to delete agent:", error);
+    const outcome = await writeEntity(backendUrl, "agents", scope, {
+      id: agentToDelete.id,
+    });
+    if (outcome.outcome === "success") {
+      mutate();
+      setDeleteDialogOpen(false);
+      setAgentToDelete(null);
     }
   };
 
@@ -245,7 +225,7 @@ export const AgentsList = ({
       createdAt,
       updatedAt,
       avatarUrl,
-      scope,
+      scope: agentScope,
       organizationId,
       ...cloneData
     } = agentToClone as AgentWithScope;
@@ -258,43 +238,26 @@ export const AgentsList = ({
       }).map(([key, value]) => [key, value === null ? undefined : value]),
     );
 
-    try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/agents`,
-        ),
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          credentials: "include",
-          body: JSON.stringify(sanitizedData),
-        },
-      );
+    const outcome = await writeEntity<Agent>(backendUrl, "agents", scope, {
+      data: sanitizedData,
+    });
 
-      if (response.ok) {
-        const newAgent = await response.json();
-        mutate();
-        setCloneDialogOpen(false);
-        setAgentToClone(null);
-        setCloneName("");
-        router.push(`/${orgId}/workspace/${workspaceId}/agents/${newAgent.id}`);
-      } else {
-        const errorData = await response.json();
-        if (errorData.error && Array.isArray(errorData.error)) {
-          setCloneError(errorData.error[0]?.message || "Failed to clone agent");
-        } else {
-          setCloneError("Failed to clone agent");
-        }
-      }
-    } catch (error) {
-      console.error("Failed to clone agent:", error);
-      setCloneError("Failed to clone agent");
+    if (outcome.outcome === "success") {
+      mutate();
+      setCloneDialogOpen(false);
+      setAgentToClone(null);
+      setCloneName("");
+      router.push(
+        `/${orgId}/workspace/${workspaceId}/agents/${outcome.data.id}`,
+      );
+    } else {
+      setCloneError(outcome.message);
     }
   };
 
+  // The backend blocks Promote with a 422 fix-this checklist (ADR-0007's
+  // no-cascade rule) whose `blockers` array is outside the outcomes the
+  // request module maps, so this write stays raw rather than losing it.
   const handlePromoteConfirm = async () => {
     if (!agentToPromote || !backendUrl) return;
     setPromoting(true);
@@ -304,7 +267,7 @@ export const AgentsList = ({
       const response = await fetch(
         joinUrl(
           backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/agents/${agentToPromote.id}/promote`,
+          `${scopedPath("agents", scope)}/${agentToPromote.id}/promote`,
         ),
         { method: "POST", credentials: "include" },
       );
@@ -328,19 +291,19 @@ export const AgentsList = ({
     setDetaching(true);
     setDetachError(null);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/attachments/agent/${agentId}`,
-        ),
-        { method: "DELETE", credentials: "include" },
+      const outcome = await writeEntity(
+        backendUrl,
+        "attachments/agent",
+        scope,
+        {
+          id: agentId,
+        },
       );
-      if (response.ok) {
+      if (outcome.outcome === "success") {
         setSelectedOrgAgent(null);
         await mutate();
       } else {
-        const info = await response.json().catch(() => ({}));
-        setDetachError(info.error || "Failed to detach agent.");
+        setDetachError(outcome.message);
       }
     } finally {
       setDetaching(false);

--- a/apps/frontend/components/mcp-list.test.tsx
+++ b/apps/frontend/components/mcp-list.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { MCP } from "@platypus/schemas";
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({
+    user: { id: "u1" },
+    isOrgAdmin: true,
+    actor: "org-admin",
+    workspaceDelegation: null,
+  }),
+}));
+
+type McpWithScope = MCP & { scope?: "organization" | "workspace" };
+
+// The `GET .../mcps` list this component renders. Set per test.
+let mcps: McpWithScope[] = [];
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (key?.includes("/mcps")) {
+      return {
+        data: { results: mcps },
+        error: undefined,
+        isLoading: false,
+        mutate: mutateSpy,
+      };
+    }
+    return {
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    };
+  },
+}));
+
+const mutateSpy = vi.fn();
+
+import { McpList } from "./mcp-list";
+
+// --- Helpers -----------------------------------------------------------------
+
+const orgMcp: McpWithScope = {
+  id: "m1",
+  name: "Shared MCP",
+  scope: "organization",
+} as unknown as McpWithScope;
+
+/** A refused detach, carrying the reason the backend gave. */
+function mockRefusedDetach(reason: string) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status: 409,
+    json: async () => ({ error: reason }),
+  } as unknown as Response);
+}
+
+function openDetachDialog() {
+  fireEvent.click(screen.getByText("Shared MCP"));
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe("McpList detach", () => {
+  afterEach(() => {
+    mcps = [];
+    mutateSpy.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces the backend's reason and keeps the row when detach is refused", async () => {
+    mcps = [orgMcp];
+    const fetchMock = mockRefusedDetach(
+      "This MCP server is in use by an agent in this workspace",
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<McpList orgId="org1" workspaceId="ws1" />);
+    openDetachDialog();
+    fireEvent.click(screen.getByRole("button", { name: /Detach/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "This MCP server is in use by an agent in this workspace",
+        ),
+      ).toBeInTheDocument(),
+    );
+
+    // A refused detach must not revalidate the list.
+    expect(mutateSpy).not.toHaveBeenCalled();
+    // The dialog stays open on the same MCP rather than silently closing.
+    expect(screen.getByText("Organization MCP")).toBeInTheDocument();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/workspaces/ws1/attachments/mcp/m1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("revalidates and closes the dialog when detach succeeds", async () => {
+    mcps = [orgMcp];
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ message: "Detached" }),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<McpList orgId="org1" workspaceId="ws1" />);
+    openDetachDialog();
+    fireEvent.click(screen.getByRole("button", { name: /Detach/ }));
+
+    await waitFor(() => expect(mutateSpy).toHaveBeenCalled());
+    expect(screen.queryByText("Organization MCP")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/mcp-list.tsx
+++ b/apps/frontend/components/mcp-list.tsx
@@ -31,6 +31,7 @@ import {
 } from "./ui/dialog";
 import { AttachSharedResourceDialog } from "./attach-shared-resource-dialog";
 import { useState } from "react";
+import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
 
 const McpList = ({
   className,
@@ -53,15 +54,13 @@ const McpList = ({
   const [detaching, setDetaching] = useState(false);
   const [detachError, setDetachError] = useState<string | null>(null);
 
+  // Resolved once per render and reused for the list's read and every write
+  // below, rather than re-deriving the Organization-vs-Workspace branch at
+  // each call site.
+  const scope: Scope = workspaceId ? { orgId, workspaceId } : { orgId };
+
   const fetchUrl =
-    backendUrl && user
-      ? workspaceId
-        ? joinUrl(
-            backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}/mcps`,
-          )
-        : joinUrl(backendUrl, `/organizations/${orgId}/mcps`)
-      : null;
+    backendUrl && user ? joinUrl(backendUrl, scopedPath("mcps", scope)) : null;
 
   const { data, error, isLoading, mutate } = useSWR<{
     results: McpWithScope[];
@@ -76,19 +75,14 @@ const McpList = ({
     setDetaching(true);
     setDetachError(null);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/attachments/mcp/${mcpId}`,
-        ),
-        { method: "DELETE", credentials: "include" },
-      );
-      if (response.ok) {
+      const outcome = await writeEntity(backendUrl, "attachments/mcp", scope, {
+        id: mcpId,
+      });
+      if (outcome.outcome === "success") {
         setSelectedOrgMcp(null);
         await mutate();
       } else {
-        const info = await response.json().catch(() => ({}));
-        setDetachError(info.error || "Failed to detach MCP.");
+        setDetachError(outcome.message);
       }
     } finally {
       setDetaching(false);

--- a/apps/frontend/components/org-agents-list.test.tsx
+++ b/apps/frontend/components/org-agents-list.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { Agent } from "@platypus/schemas";
+import {
+  installRadixPointerPolyfills,
+  openDropdownMenu as openMenu,
+} from "@/lib/test-utils";
+
+beforeAll(installRadixPointerPolyfills);
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({
+    user: { id: "u1" },
+    isOrgAdmin: true,
+  }),
+}));
+
+// The `GET .../agents` list this component renders. Set per test.
+let agents: Agent[] = [];
+const mutateSpy = vi.fn();
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: () => ({
+    data: { results: agents },
+    isLoading: false,
+    mutate: mutateSpy,
+  }),
+}));
+
+import { OrgAgentsList } from "./org-agents-list";
+
+// --- Helpers -----------------------------------------------------------------
+
+const sharedAgent: Agent = {
+  id: "a1",
+  name: "Shared Agent",
+  description: "desc",
+} as unknown as Agent;
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  agents = [];
+  mutateSpy.mockClear();
+  vi.restoreAllMocks();
+});
+
+// --- Tests -------------------------------------------------------------------
+
+describe("OrgAgentsList delete", () => {
+  it("blocks delete and reports the attachment count when the agent is still attached", async () => {
+    agents = [sharedAgent];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { results: [{ id: "att1" }] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<OrgAgentsList orgId="org1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+
+    await waitFor(() =>
+      expect(screen.getByText("Can't delete shared agent")).toBeInTheDocument(),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/attachments?resourceType=agent&resourceId=a1",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  it("surfaces the backend's reason and keeps the agent when delete fails", async () => {
+    agents = [sharedAgent];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, { results: [] }))
+      .mockResolvedValueOnce(jsonResponse(409, { error: "Still referenced" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<OrgAgentsList orgId="org1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+
+    const deleteButton = await screen.findByRole("button", { name: "Delete" });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() =>
+      expect(screen.getByText("Still referenced")).toBeInTheDocument(),
+    );
+    expect(mutateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/agents/a1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("revalidates when delete succeeds", async () => {
+    agents = [sharedAgent];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(200, { results: [] }))
+      .mockResolvedValueOnce(jsonResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<OrgAgentsList orgId="org1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+
+    const deleteButton = await screen.findByRole("button", { name: "Delete" });
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(mutateSpy).toHaveBeenCalled());
+  });
+});

--- a/apps/frontend/components/org-agents-list.tsx
+++ b/apps/frontend/components/org-agents-list.tsx
@@ -28,6 +28,7 @@ import {
   SharedWithBadge,
 } from "@/components/manage-sharing";
 import Link from "next/link";
+import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
 
 // The Organization surface for Shared Agents (ADR-0007): Org Admins see and
 // manage every Shared Agent, attached or not. Promotion (from a Workspace) is
@@ -45,9 +46,14 @@ export const OrgAgentsList = ({ orgId }: { orgId: string }) => {
     count: number;
   } | null>(null);
 
+  // Resolved once per render and reused for the list's read and every write
+  // below, rather than re-deriving the Organization-vs-Workspace branch at
+  // each call site.
+  const scope: Scope = { orgId };
+
   const { data, isLoading, mutate } = useSWR<{ results: Agent[] }>(
     backendUrl && user
-      ? joinUrl(backendUrl, `/organizations/${orgId}/agents`)
+      ? joinUrl(backendUrl, scopedPath("agents", scope))
       : null,
     fetcher,
   );
@@ -65,7 +71,7 @@ export const OrgAgentsList = ({ orgId }: { orgId: string }) => {
       const res = await fetch(
         joinUrl(
           backendUrl,
-          `/organizations/${orgId}/attachments?resourceType=agent&resourceId=${agent.id}`,
+          `${scopedPath("attachments", scope)}?resourceType=agent&resourceId=${agent.id}`,
         ),
         { credentials: "include" },
       );
@@ -87,19 +93,14 @@ export const OrgAgentsList = ({ orgId }: { orgId: string }) => {
     setDeleting(true);
     setDeleteError(null);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/agents/${agentToDelete.id}`,
-        ),
-        { method: "DELETE", credentials: "include" },
-      );
-      if (response.ok) {
+      const outcome = await writeEntity(backendUrl, "agents", scope, {
+        id: agentToDelete.id,
+      });
+      if (outcome.outcome === "success") {
         await mutate();
         setAgentToDelete(null);
       } else {
-        const info = await response.json().catch(() => ({}));
-        setDeleteError(info.error || "Failed to delete agent.");
+        setDeleteError(outcome.message);
       }
     } finally {
       setDeleting(false);

--- a/apps/frontend/components/providers-list.tsx
+++ b/apps/frontend/components/providers-list.tsx
@@ -31,6 +31,7 @@ import {
 } from "./ui/dialog";
 import { AttachSharedResourceDialog } from "./attach-shared-resource-dialog";
 import { useState } from "react";
+import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
 
 const ProvidersList = ({
   className,
@@ -52,14 +53,14 @@ const ProvidersList = ({
   const [detaching, setDetaching] = useState(false);
   const [detachError, setDetachError] = useState<string | null>(null);
 
+  // Resolved once per render and reused for the list's read and every write
+  // below, rather than re-deriving the Organization-vs-Workspace branch at
+  // each call site.
+  const scope: Scope = workspaceId ? { orgId, workspaceId } : { orgId };
+
   const fetchUrl =
     backendUrl && user
-      ? workspaceId
-        ? joinUrl(
-            backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}/providers`,
-          )
-        : joinUrl(backendUrl, `/organizations/${orgId}/providers`)
+      ? joinUrl(backendUrl, scopedPath("providers", scope))
       : null;
 
   const { data, error, isLoading, mutate } = useSWR<{
@@ -75,19 +76,19 @@ const ProvidersList = ({
     setDetaching(true);
     setDetachError(null);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/attachments/provider/${providerId}`,
-        ),
-        { method: "DELETE", credentials: "include" },
+      const outcome = await writeEntity(
+        backendUrl,
+        "attachments/provider",
+        scope,
+        {
+          id: providerId,
+        },
       );
-      if (response.ok) {
+      if (outcome.outcome === "success") {
         setSelectedOrgProvider(null);
         await mutate();
       } else {
-        const info = await response.json().catch(() => ({}));
-        setDetachError(info.error || "Failed to detach provider.");
+        setDetachError(outcome.message);
       }
     } finally {
       setDetaching(false);

--- a/apps/frontend/components/skills-list.test.tsx
+++ b/apps/frontend/components/skills-list.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { Skill } from "@platypus/schemas";
+import {
+  installRadixPointerPolyfills,
+  openDropdownMenu as openMenu,
+} from "@/lib/test-utils";
+
+beforeAll(installRadixPointerPolyfills);
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({
+    user: { id: "u1" },
+    isOrgAdmin: true,
+    actor: "org-admin",
+  }),
+}));
+
+type SkillWithScope = Skill & { scope?: "organization" | "workspace" };
+
+// The `GET .../skills` list this component renders. Set per test.
+let skills: SkillWithScope[] = [];
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (key?.includes("/skills")) {
+      return {
+        data: { results: skills },
+        error: undefined,
+        isLoading: false,
+        mutate: mutateSpy,
+      };
+    }
+    // Agent-association lookup — unused by these tests.
+    return {
+      data: { results: [] },
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    };
+  },
+}));
+
+const mutateSpy = vi.fn();
+
+import { SkillsList } from "./skills-list";
+
+// --- Helpers -----------------------------------------------------------------
+
+const orgSkill: SkillWithScope = {
+  id: "s1",
+  name: "Shared Skill",
+  description: "desc",
+  scope: "organization",
+} as unknown as SkillWithScope;
+
+const workspaceSkill: SkillWithScope = {
+  id: "s2",
+  name: "Workspace Skill",
+  description: "desc",
+  scope: "workspace",
+} as unknown as SkillWithScope;
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function openDetachDialog() {
+  fireEvent.click(screen.getByText("Shared Skill"));
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe("SkillsList detach", () => {
+  afterEach(() => {
+    skills = [];
+    mutateSpy.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces the backend's reason and keeps the row when detach is refused", async () => {
+    skills = [orgSkill];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(409, { error: "This skill is in use by an agent" }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillsList orgId="org1" workspaceId="ws1" />);
+    openDetachDialog();
+    fireEvent.click(screen.getByRole("button", { name: /Detach/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("This skill is in use by an agent"),
+      ).toBeInTheDocument(),
+    );
+
+    expect(mutateSpy).not.toHaveBeenCalled();
+    expect(screen.getByText("Organization Skill")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/workspaces/ws1/attachments/skill/s1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("revalidates and closes the dialog when detach succeeds", async () => {
+    skills = [orgSkill];
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillsList orgId="org1" workspaceId="ws1" />);
+    openDetachDialog();
+    fireEvent.click(screen.getByRole("button", { name: /Detach/ }));
+
+    await waitFor(() => expect(mutateSpy).toHaveBeenCalled());
+    expect(screen.queryByText("Organization Skill")).not.toBeInTheDocument();
+  });
+});
+
+describe("SkillsList delete", () => {
+  afterEach(() => {
+    skills = [];
+    mutateSpy.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces the backend's reason and leaves the skill in place when delete fails", async () => {
+    skills = [workspaceSkill];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(409, { error: "Skill is referenced" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Skill is referenced")).toBeInTheDocument(),
+    );
+    expect(mutateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/workspaces/ws1/skills/s2",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("deletes from the org-scoped path on the Organization surface (no workspaceId)", async () => {
+    skills = [orgSkill];
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillsList orgId="org1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    // The Organization surface checks the live attachment count (a GET)
+    // before opening the confirm dialog.
+    fireEvent.click(await screen.findByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(mutateSpy).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/skills/s1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});
+
+describe("SkillsList promote", () => {
+  afterEach(() => {
+    skills = [];
+    mutateSpy.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces the backend's reason when promote fails", async () => {
+    skills = [workspaceSkill];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(409, { error: "Name already shared" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Promote to organization"));
+    fireEvent.click(screen.getByRole("button", { name: "Promote" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Name already shared")).toBeInTheDocument(),
+    );
+    expect(mutateSpy).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/workspaces/ws1/skills/s2/promote",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/apps/frontend/components/skills-list.tsx
+++ b/apps/frontend/components/skills-list.tsx
@@ -56,6 +56,7 @@ import {
   ManageAttachmentsDialog,
   SharedWithBadge,
 } from "@/components/manage-sharing";
+import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
 
 // The list serves two surfaces: a Workspace (workspaceId provided) where it
 // shows workspace-scoped Skills plus attached org-scoped Shared Skills as
@@ -130,9 +131,11 @@ export const SkillsList = ({
     count: number;
   } | null>(null);
 
-  const listUrl = workspaceId
-    ? `/organizations/${orgId}/workspaces/${workspaceId}/skills`
-    : `/organizations/${orgId}/skills`;
+  // Resolved once per render and reused for the list's read and every write
+  // below, rather than re-deriving the Organization-vs-Workspace branch at
+  // each call site.
+  const scope: Scope = workspaceId ? { orgId, workspaceId } : { orgId };
+  const listUrl = scopedPath("skills", scope);
   const editBasePath = workspaceId
     ? `/${orgId}/workspace/${workspaceId}/skills`
     : `/${orgId}/settings/skills`;
@@ -150,10 +153,7 @@ export const SkillsList = ({
     results: Agent[];
   }>(
     backendUrl && user && workspaceId
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/agents`,
-        )
+      ? joinUrl(backendUrl, scopedPath("agents", scope))
       : null,
     fetcher,
   );
@@ -186,7 +186,7 @@ export const SkillsList = ({
         const res = await fetch(
           joinUrl(
             backendUrl,
-            `/organizations/${orgId}/attachments?resourceType=skill&resourceId=${skill.id}`,
+            `${scopedPath("attachments", scope)}?resourceType=skill&resourceId=${skill.id}`,
           ),
           { credentials: "include" },
         );
@@ -206,26 +206,18 @@ export const SkillsList = ({
 
   const handleDeleteConfirm = async () => {
     if (!skillToDelete || !backendUrl) return;
-    // Org-scoped Skills are deleted from the Organization surface; workspace
-    // Skills from the workspace route.
-    const deleteUrl =
-      skillToDelete.scope === "organization" && !workspaceId
-        ? `/organizations/${orgId}/skills/${skillToDelete.id}`
-        : `${listUrl}/${skillToDelete.id}`;
     setDeleting(true);
     setDeleteError(null);
     try {
-      const response = await fetch(joinUrl(backendUrl, deleteUrl), {
-        method: "DELETE",
-        credentials: "include",
+      const outcome = await writeEntity(backendUrl, "skills", scope, {
+        id: skillToDelete.id,
       });
-      if (response.ok) {
+      if (outcome.outcome === "success") {
         await mutate();
         setDeleteDialogOpen(false);
         setSkillToDelete(null);
       } else {
-        const info = await response.json().catch(() => ({}));
-        setDeleteError(info.error || "Failed to delete skill.");
+        setDeleteError(outcome.message);
       }
     } finally {
       setDeleting(false);
@@ -237,19 +229,19 @@ export const SkillsList = ({
     setDetaching(true);
     setDetachError(null);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/attachments/skill/${skillId}`,
-        ),
-        { method: "DELETE", credentials: "include" },
+      const outcome = await writeEntity(
+        backendUrl,
+        "attachments/skill",
+        scope,
+        {
+          id: skillId,
+        },
       );
-      if (response.ok) {
+      if (outcome.outcome === "success") {
         setSelectedOrgSkill(null);
         await mutate();
       } else {
-        const info = await response.json().catch(() => ({}));
-        setDetachError(info.error || "Failed to detach skill.");
+        setDetachError(outcome.message);
       }
     } finally {
       setDetaching(false);
@@ -261,19 +253,16 @@ export const SkillsList = ({
     setPromoting(true);
     setPromoteError(null);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/skills/${skillToPromote.id}/promote`,
-        ),
-        { method: "POST", credentials: "include" },
+      const outcome = await writeEntity(
+        backendUrl,
+        `skills/${skillToPromote.id}/promote`,
+        scope,
       );
-      if (response.ok) {
+      if (outcome.outcome === "success") {
         await mutate();
         setSkillToPromote(null);
       } else {
-        const info = await response.json().catch(() => ({}));
-        setPromoteError(info.error || "Failed to promote skill.");
+        setPromoteError(outcome.message);
       }
     } finally {
       setPromoting(false);

--- a/apps/frontend/components/trigger-list.test.tsx
+++ b/apps/frontend/components/trigger-list.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { Trigger } from "@platypus/schemas";
+import {
+  installRadixPointerPolyfills,
+  openDropdownMenu as openMenu,
+} from "@/lib/test-utils";
+
+beforeAll(installRadixPointerPolyfills);
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "u1" } }),
+}));
+
+const { toastErrorSpy } = vi.hoisted(() => ({ toastErrorSpy: vi.fn() }));
+vi.mock("sonner", () => ({
+  toast: { error: toastErrorSpy },
+}));
+
+// The `GET .../triggers` list this component renders. Set per test.
+let triggers: Trigger[] = [];
+const mutateSpy = vi.fn();
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (key?.includes("/triggers")) {
+      return {
+        data: { results: triggers },
+        isLoading: false,
+        mutate: mutateSpy,
+      };
+    }
+    return { data: { results: [] }, isLoading: false };
+  },
+}));
+
+import { TriggerList } from "./trigger-list";
+
+// --- Helpers -----------------------------------------------------------------
+
+const cronTrigger: Trigger = {
+  id: "t1",
+  name: "Nightly job",
+  type: "cron",
+  enabled: true,
+  agentId: "agent1",
+  config: { cronExpression: "0 0 * * *", timezone: "UTC" },
+} as unknown as Trigger;
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  triggers = [];
+  mutateSpy.mockClear();
+  toastErrorSpy.mockClear();
+  vi.restoreAllMocks();
+});
+
+// --- Tests -------------------------------------------------------------------
+
+describe("TriggerList delete", () => {
+  it("deletes through the request module and revalidates on success", async () => {
+    triggers = [cronTrigger];
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TriggerList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(mutateSpy).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/workspaces/ws1/triggers/t1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("does not revalidate when delete is refused", async () => {
+    triggers = [cronTrigger];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(409, { error: "In use" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TriggerList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(mutateSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("TriggerList toggle enabled", () => {
+  it("PUTs the flipped enabled flag and revalidates on success", async () => {
+    triggers = [cronTrigger];
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TriggerList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Disable"));
+
+    await waitFor(() => expect(mutateSpy).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/workspaces/ws1/triggers/t1",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ enabled: false }),
+      }),
+    );
+  });
+});

--- a/apps/frontend/components/trigger-list.tsx
+++ b/apps/frontend/components/trigger-list.tsx
@@ -42,6 +42,7 @@ import { useAuth } from "@/components/auth-provider";
 import { describeSchedule } from "@/lib/cron-utils";
 import { toast } from "sonner";
 import { AgentAvatar } from "@/components/agent-avatar";
+import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
 
 export const TriggerList = ({
   orgId,
@@ -58,6 +59,11 @@ export const TriggerList = ({
   const [isToggling, setIsToggling] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
+  // Resolved once per render and reused for the list's reads and every write
+  // below, rather than re-deriving the Organization-vs-Workspace branch at
+  // each call site.
+  const scope: Scope = { orgId, workspaceId };
+
   const {
     data: triggersData,
     isLoading,
@@ -66,20 +72,14 @@ export const TriggerList = ({
     results: Trigger[];
   }>(
     backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/triggers`,
-        )
+      ? joinUrl(backendUrl, scopedPath("triggers", scope))
       : null,
     fetcher,
   );
 
   const { data: agentsData } = useSWR<{ results: Agent[] }>(
     backendUrl && user
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/agents`,
-        )
+      ? joinUrl(backendUrl, scopedPath("agents", scope))
       : null,
     fetcher,
   );
@@ -102,18 +102,10 @@ export const TriggerList = ({
 
     setIsDeleting(true);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/triggers/${triggerToDelete.id}`,
-        ),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
-      );
-
-      if (response.ok) {
+      const outcome = await writeEntity(backendUrl, "triggers", scope, {
+        id: triggerToDelete.id,
+      });
+      if (outcome.outcome === "success") {
         mutate();
         setDeleteDialogOpen(false);
         setTriggerToDelete(null);
@@ -131,24 +123,11 @@ export const TriggerList = ({
     setTriggerToToggle(trigger);
     setIsToggling(true);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/triggers/${trigger.id}`,
-        ),
-        {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          credentials: "include",
-          body: JSON.stringify({
-            enabled: !trigger.enabled,
-          }),
-        },
-      );
-
-      if (response.ok) {
+      const outcome = await writeEntity(backendUrl, "triggers", scope, {
+        id: trigger.id,
+        data: { enabled: !trigger.enabled },
+      });
+      if (outcome.outcome === "success") {
         mutate();
       }
     } catch {

--- a/apps/frontend/lib/api-write.ts
+++ b/apps/frontend/lib/api-write.ts
@@ -56,7 +56,12 @@ const DEFAULT_MESSAGES = {
   error: "Request failed",
 } as const;
 
-function scopedPath(entity: string, scope: Scope): string {
+/**
+ * The Organization-vs-Workspace path shape (ADR-0007), exported so a caller
+ * resolves it once per component and reuses it for both the list's read and
+ * every write, instead of re-deriving the branch at each call site.
+ */
+export function scopedPath(entity: string, scope: Scope): string {
   return scope.workspaceId
     ? `/organizations/${scope.orgId}/workspaces/${scope.workspaceId}/${entity}`
     : `/organizations/${scope.orgId}/${entity}`;

--- a/apps/frontend/lib/test-utils.ts
+++ b/apps/frontend/lib/test-utils.ts
@@ -1,0 +1,22 @@
+import { fireEvent } from "@testing-library/react";
+
+/**
+ * Radix's DropdownMenu opens on pointerdown and grabs pointer capture,
+ * neither of which jsdom implements. Call once (e.g. in `beforeAll`) before
+ * rendering anything that uses a Radix DropdownMenu/Select/etc.
+ */
+export function installRadixPointerPolyfills() {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+}
+
+/** Opens the first closed Radix DropdownMenu trigger found in the document. */
+export function openDropdownMenu() {
+  const trigger = document.querySelector('[aria-haspopup="menu"]');
+  if (!trigger) {
+    throw new Error("No dropdown menu trigger found in the document");
+  }
+  fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 });
+  fireEvent.pointerUp(trigger, { button: 0, pointerId: 1 });
+}


### PR DESCRIPTION
## Summary
- Agents, Skills, MCP, Providers, Triggers, and the Organization-surface Agents list now read and write through `lib/api-write.ts` instead of restating the Organization-vs-Workspace path branch at each call site.
- Each component resolves its scope once per render via a new `scopedPath()` export from the request module, reused for every read and write (including the secondary attachment-count checks).
- The four detach paths added in #560 keep their response checking — refusals surface the backend's reason and don't revalidate the list.
- The Agent promote-to-organization write is a deliberate exception, kept as a raw `fetch()`: the backend's 422 "blockers" checklist doesn't map onto any `WriteOutcome` variant, and routing it through the module would silently drop that checklist from the UI. It still resolves its URL through the shared `scopedPath()` helper.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (pre-existing unrelated warnings only)
- [x] `pnpm test` — 1901 backend + 330 frontend tests pass
- [x] New characterization tests added for `agents-list`, `org-agents-list`, `skills-list`, `mcp-list`, `trigger-list` covering delete/clone/promote/detach/toggle success and failure paths
- [x] Ran a Standards-axis and Spec-axis code review; addressed the one actionable finding (deduplicated a Radix-dropdown test polyfill into `lib/test-utils.ts`)

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)