### PR TITLE
chore(frontend): move the 11 form modules onto the request module

### DIFF
--- a/apps/backend/src/routes/invitation.test.ts
+++ b/apps/backend/src/routes/invitation.test.ts
@@ -133,6 +133,28 @@ describe("Invitation Routes", () => {
       });
     });
 
+    it("409s with the central error envelope on a duplicate org+email invitation", async () => {
+      mockSession({ id: "admin-1", email: "admin@example.com", role: "user" });
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.returning.mockRejectedValueOnce({
+        code: "23505",
+        constraint: "unique_invitation_org_email",
+      });
+
+      const res = await app.request(baseUrl, {
+        method: "POST",
+        body: JSON.stringify({ email: "user@example.com" }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(409);
+      expect(await res.json()).toEqual({
+        error:
+          "A pending invitation already exists for this user and organization",
+        files: undefined,
+      });
+    });
+
     it("should return 400 if inviting self", async () => {
       mockSession({ id: "admin-1", email: "admin@example.com", role: "user" });
       // requireOrgAccess

--- a/apps/backend/src/routes/invitation.ts
+++ b/apps/backend/src/routes/invitation.ts
@@ -13,6 +13,7 @@ import { requireAuth } from "../middleware/authentication.ts";
 import { orgScopeOf, requireOrgAccess } from "../middleware/authorization.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
+import { ConflictError } from "../errors.ts";
 
 const invitation = new Hono<{ Variables: Variables }>();
 
@@ -111,12 +112,8 @@ invitation.post(
         !!e.detail?.includes("already exists");
 
       if (isDuplicate) {
-        return c.json(
-          {
-            message:
-              "A pending invitation already exists for this user and organization",
-          },
-          409,
+        throw new ConflictError(
+          "A pending invitation already exists for this user and organization",
         );
       }
       logger.error({ error }, "Error creating invitation");

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/boards/[boardId]/settings/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/boards/[boardId]/settings/page.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { use, useState } from "react";
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
 import { useRouter } from "next/navigation";
 import type { KanbanBoardState } from "@platypus/schemas";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { BackButton } from "@/components/back-button";
 import { KanbanBoardForm } from "@/components/kanban-board-form";
 import { DeleteBoardDialog } from "@/components/delete-board-dialog";
+import { toast } from "sonner";
 
 const BoardSettingsPage = ({
   params,
@@ -20,6 +22,7 @@ const BoardSettingsPage = ({
   const { user } = useAuth();
   const backendUrl = useBackendUrl();
   const router = useRouter();
+  const { mutate: globalMutate } = useSWRConfig();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
 
@@ -35,11 +38,18 @@ const BoardSettingsPage = ({
 
   const handleDeleteConfirm = async () => {
     setIsDeleting(true);
-    try {
-      await fetch(baseUrl, { method: "DELETE", credentials: "include" });
+    const result = await writeEntity(
+      backendUrl,
+      "boards",
+      { orgId, workspaceId },
+      { id: boardId },
+    );
+
+    if (result.outcome === "success") {
+      result.revalidateKeys.forEach((key) => globalMutate(key));
       router.push(`/${orgId}/workspace/${workspaceId}`);
-    } catch (err) {
-      console.error("Failed to delete board:", err);
+    } else {
+      toast.error(result.message);
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);
     }

--- a/apps/frontend/components/agent-form.test.tsx
+++ b/apps/frontend/components/agent-form.test.tsx
@@ -57,9 +57,10 @@ import { AgentForm } from "./agent-form";
 
 // --- Helpers -----------------------------------------------------------------
 
-function mockFailedSave(error: unknown) {
+function mockFailedSave(error: unknown, status = 400) {
   return vi.fn().mockResolvedValue({
     ok: false,
+    status,
     json: async () => ({ error }),
   } as unknown as Response);
 }

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -49,12 +49,8 @@ import {
   type Skill,
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import {
-  clearFieldError,
-  fetcher,
-  parseValidationErrors,
-  joinUrl,
-} from "@/lib/utils";
+import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { findModelOption, getModelOptions } from "@/lib/model-config";
 import { resolveModel } from "@/lib/resolve-model";
 import {
@@ -361,61 +357,60 @@ const AgentForm = ({
         subAgentIds: formData.subAgentIds,
       };
 
-      const url = agentId
-        ? joinUrl(backendUrl, `${agentsBase}/${agentId}`)
-        : joinUrl(backendUrl, agentsBase);
-
-      const method = agentId ? "PUT" : "POST";
-
-      const response = await fetch(url, {
-        method,
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-        credentials: "include",
+      const scope = orgScoped ? { orgId } : { orgId, workspaceId };
+      const result = await writeEntity<Agent>(backendUrl, "agents", scope, {
+        id: agentId,
+        data: payload,
       });
 
-      if (response.ok) {
-        const savedAgent = await response.json();
-        const savedAgentId = savedAgent.id || agentId;
+      switch (result.outcome) {
+        case "success": {
+          const savedAgentId = result.data.id || agentId;
 
-        if (avatarDeleted && agentId) {
-          await fetch(
-            joinUrl(backendUrl, `${agentsBase}/${savedAgentId}/avatar`),
-            {
-              method: "DELETE",
-              credentials: "include",
-            },
-          );
-        } else if (avatarFile) {
-          const avatarFormData = new FormData();
-          avatarFormData.append("file", avatarFile);
-          await fetch(
-            joinUrl(backendUrl, `${agentsBase}/${savedAgentId}/avatar`),
-            {
-              method: "POST",
-              body: avatarFormData,
-              credentials: "include",
-            },
-          );
+          if (avatarDeleted && agentId) {
+            await fetch(
+              joinUrl(backendUrl, `${agentsBase}/${savedAgentId}/avatar`),
+              {
+                method: "DELETE",
+                credentials: "include",
+              },
+            );
+          } else if (avatarFile) {
+            const avatarFormData = new FormData();
+            avatarFormData.append("file", avatarFile);
+            await fetch(
+              joinUrl(backendUrl, `${agentsBase}/${savedAgentId}/avatar`),
+              {
+                method: "POST",
+                body: avatarFormData,
+                credentials: "include",
+              },
+            );
+          }
+
+          result.revalidateKeys.forEach((key) => mutate(key));
+          router.push(doneHref);
+          break;
         }
-
-        await mutate(joinUrl(backendUrl, agentsBase));
-        router.push(doneHref);
-      } else {
-        // Parse standardschema.dev validation errors
-        const errorData = await response.json();
-        const errors = parseValidationErrors(errorData);
-        setValidationErrors(errors);
-        // Surface a user-visible signal even when the failure maps to a field
-        // without an inline error, so a rejected save is never silent (#331).
-        toast.error(
-          Object.keys(errors).length > 0
-            ? "Please fix the highlighted fields and try again"
-            : "Failed to save agent",
-        );
-        console.error("Failed to save agent");
+        case "invalid":
+          setValidationErrors(result.fieldErrors);
+          // Surface a user-visible signal even when the failure maps to a
+          // field without an inline error, so a rejected save is never
+          // silent (#331).
+          toast.error(
+            Object.keys(result.fieldErrors).length > 0
+              ? "Please fix the highlighted fields and try again"
+              : "Failed to save agent",
+          );
+          break;
+        case "conflict":
+          setValidationErrors({ name: result.message });
+          break;
+        case "locked":
+        case "notFound":
+        case "error":
+          toast.error(result.message);
+          break;
       }
     } catch (error) {
       console.error("Error saving agent:", error);
@@ -429,26 +424,16 @@ const AgentForm = ({
     if (!agentId) return;
 
     setIsDeleting(true);
-    try {
-      const response = await fetch(
-        joinUrl(backendUrl, `${agentsBase}/${agentId}`),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
-      );
+    const scope = orgScoped ? { orgId } : { orgId, workspaceId };
+    const result = await writeEntity(backendUrl, "agents", scope, {
+      id: agentId,
+    });
 
-      if (response.ok) {
-        router.push(doneHref);
-      } else {
-        console.error("Failed to delete agent");
-        toast.error("Failed to delete agent");
-        setIsDeleting(false);
-        setIsDeleteDialogOpen(false);
-      }
-    } catch (error) {
-      console.error("Error deleting agent:", error);
-      toast.error("Failed to delete agent");
+    if (result.outcome === "success") {
+      result.revalidateKeys.forEach((key) => mutate(key));
+      router.push(doneHref);
+    } else {
+      toast.error(result.message);
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);
     }

--- a/apps/frontend/components/blueprint-form.tsx
+++ b/apps/frontend/components/blueprint-form.tsx
@@ -31,8 +31,9 @@ import type {
   AttachmentResourceType,
   Provider,
 } from "@platypus/schemas";
-import useSWR from "swr";
-import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import useSWR, { useSWRConfig } from "swr";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 
@@ -153,6 +154,7 @@ const BlueprintForm = ({
 
   const { user } = useAuth();
   const backendUrl = useBackendUrl();
+  const { mutate: globalMutate } = useSWRConfig();
 
   const collectionUrl = `/organizations/${orgId}/blueprints`;
   const returnPath = `/${orgId}/settings/blueprints`;
@@ -280,82 +282,73 @@ const BlueprintForm = ({
     setIsSubmitting(true);
     setValidationErrors({});
     setFormError(null);
-    try {
-      const items: BlueprintItem[] = [...selected].map((key) => {
-        const [resourceType, resourceId] = key.split(":");
-        return {
-          resourceType: resourceType as AttachmentResourceType,
-          resourceId,
-        };
-      });
-      const payload = {
-        name: formData.name,
-        description: formData.description || undefined,
-        items,
-        // Tier 2 pointer-settings (ADR-0008). Null clears the slot; on apply a
-        // null slot leaves the workspace's existing value untouched.
-        context: formData.context || null,
-        taskModelProviderId: formData.taskModelProviderId,
-        memoryExtractionProviderId: formData.memoryExtractionProviderId,
-        memoryEmbeddingProviderId: formData.memoryEmbeddingProviderId,
+
+    const items: BlueprintItem[] = [...selected].map((key) => {
+      const [resourceType, resourceId] = key.split(":");
+      return {
+        resourceType: resourceType as AttachmentResourceType,
+        resourceId,
       };
+    });
+    const payload = {
+      name: formData.name,
+      description: formData.description || undefined,
+      items,
+      // Tier 2 pointer-settings (ADR-0008). Null clears the slot; on apply a
+      // null slot leaves the workspace's existing value untouched.
+      context: formData.context || null,
+      taskModelProviderId: formData.taskModelProviderId,
+      memoryExtractionProviderId: formData.memoryExtractionProviderId,
+      memoryEmbeddingProviderId: formData.memoryEmbeddingProviderId,
+    };
 
-      const url = blueprintId
-        ? joinUrl(backendUrl, `${collectionUrl}/${blueprintId}`)
-        : joinUrl(backendUrl, collectionUrl);
-      const method = blueprintId ? "PUT" : "POST";
+    const result = await writeEntity(
+      backendUrl,
+      "blueprints",
+      { orgId },
+      { id: blueprintId, data: payload },
+    );
 
-      const response = await fetch(url, {
-        method,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-        credentials: "include",
-      });
-
-      if (response.ok) {
+    switch (result.outcome) {
+      case "success":
+        result.revalidateKeys.forEach((key) => globalMutate(key));
         router.push(returnPath);
-      } else {
-        const errorData = await response.json();
-        if (response.status === 409) {
-          setValidationErrors({ name: errorData.error || errorData.message });
-        } else if (response.status === 422) {
-          setFormError(
-            errorData.error ||
-              "A blueprint may only list organization-scoped resources.",
-          );
-        } else {
-          setValidationErrors(parseValidationErrors(errorData));
+        break;
+      case "invalid":
+        setValidationErrors(result.fieldErrors);
+        if (Object.keys(result.fieldErrors).length === 0) {
+          setFormError(result.message);
         }
-      }
-    } catch (error) {
-      console.error("Error saving blueprint:", error);
-      setFormError("An unexpected error occurred.");
-    } finally {
-      setIsSubmitting(false);
+        break;
+      case "conflict":
+        setValidationErrors({ name: result.message });
+        break;
+      case "locked":
+      case "notFound":
+      case "error":
+        setFormError(result.message);
+        break;
     }
+
+    setIsSubmitting(false);
   };
 
   const handleDelete = async () => {
     if (!blueprintId) return;
     setIsDeleting(true);
     setDeleteError(null);
-    try {
-      const response = await fetch(
-        joinUrl(backendUrl, `${collectionUrl}/${blueprintId}`),
-        { method: "DELETE", credentials: "include" },
-      );
-      if (response.ok) {
-        router.push(returnPath);
-      } else {
-        const errorData = await response.json();
-        setDeleteError(
-          errorData.error || errorData.message || "Failed to delete blueprint",
-        );
-        setIsDeleting(false);
-      }
-    } catch (error) {
-      console.error("Error deleting blueprint:", error);
-      setDeleteError("An unexpected error occurred");
+    const result = await writeEntity(
+      backendUrl,
+      "blueprints",
+      { orgId },
+      { id: blueprintId },
+    );
+
+    if (result.outcome === "success") {
+      result.revalidateKeys.forEach((key) => globalMutate(key));
+      router.push(returnPath);
+    } else {
+      setDeleteError(result.message);
       setIsDeleting(false);
     }
   };

--- a/apps/frontend/components/invitation-form.test.tsx
+++ b/apps/frontend/components/invitation-form.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "u1" } }),
+}));
+
+const toastError = vi.fn();
+const toastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: (...args: unknown[]) => toastSuccess(...args),
+  },
+}));
+
+// The form never has any Blueprints to offer in these tests.
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: () => ({ data: { results: [] }, isLoading: false }),
+  useSWRConfig: () => ({ mutate: vi.fn() }),
+}));
+
+import { InvitationForm } from "./invitation-form";
+
+// --- Helpers -----------------------------------------------------------------
+
+function mockResponse(status: number, body: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response);
+}
+
+function renderForm() {
+  return render(<InvitationForm orgId="org1" />);
+}
+
+function submit() {
+  fireEvent.change(screen.getByLabelText("Email"), {
+    target: { value: "user@example.com" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Send invitation" }));
+}
+
+// --- Tests -------------------------------------------------------------------
+
+describe("InvitationForm conflict handling", () => {
+  beforeEach(() => {
+    toastError.mockReset();
+    toastSuccess.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // A duplicate invite is a 409 from the central error seam (ADR-0010),
+  // carrying `{ error: "..." }` — the request module surfaces it as a
+  // conflict outcome rather than the generic validation fallback.
+  it("shows the backend's message against the Email field on a duplicate invite", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockResponse(409, {
+        error:
+          "A pending invitation already exists for this user and organization",
+      }),
+    );
+
+    renderForm();
+    submit();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "A pending invitation already exists for this user and organization",
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("never discards a rejection silently — a plain 400 message still surfaces", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockResponse(400, { error: "You cannot invite yourself" }),
+    );
+
+    renderForm();
+    submit();
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith("You cannot invite yourself"),
+    );
+  });
+
+  it("clears the form and reports success once the invite is accepted", async () => {
+    vi.stubGlobal("fetch", mockResponse(201, { id: "inv-1" }));
+
+    renderForm();
+    submit();
+
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith("Invitation created"),
+    );
+    expect(screen.getByLabelText("Email")).toHaveValue("");
+  });
+});

--- a/apps/frontend/components/invitation-form.tsx
+++ b/apps/frontend/components/invitation-form.tsx
@@ -13,8 +13,9 @@ import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { useState } from "react";
 import Link from "next/link";
-import useSWR from "swr";
-import { fetcher, parseValidationErrors, joinUrl } from "@/lib/utils";
+import useSWR, { useSWRConfig } from "swr";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import type { Blueprint } from "@platypus/schemas";
@@ -29,6 +30,7 @@ interface InvitationFormProps {
 export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
   const backendUrl = useBackendUrl();
   const { user } = useAuth();
+  const { mutate: globalMutate } = useSWRConfig();
 
   const [email, setEmail] = useState("");
   const [workspaceName, setWorkspaceName] = useState("");
@@ -71,52 +73,52 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
     setIsSubmitting(true);
     setValidationErrors({});
 
-    try {
-      const response = await fetch(
-        joinUrl(backendUrl, `/organizations/${orgId}/invitations`),
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            email,
-            // Optional; the workspace provisioned on accept defaults to
-            // "<member name>'s Workspace" when blank (ADR-0008).
-            ...(workspaceName.trim()
-              ? { workspaceName: workspaceName.trim() }
-              : {}),
-            // The ordered set of blueprints applied on accept (ADR-0009).
-            ...(blueprintIds.length ? { blueprintIds } : {}),
-          }),
-          credentials: "include",
+    const result = await writeEntity(
+      backendUrl,
+      "invitations",
+      { orgId },
+      {
+        data: {
+          email,
+          // Optional; the workspace provisioned on accept defaults to
+          // "<member name>'s Workspace" when blank (ADR-0008).
+          ...(workspaceName.trim()
+            ? { workspaceName: workspaceName.trim() }
+            : {}),
+          // The ordered set of blueprints applied on accept (ADR-0009).
+          ...(blueprintIds.length ? { blueprintIds } : {}),
         },
-      );
+      },
+    );
 
-      if (response.ok) {
+    switch (result.outcome) {
+      case "success":
+        result.revalidateKeys.forEach((key) => globalMutate(key));
         toast.success("Invitation created");
         setEmail("");
         setWorkspaceName("");
         setBlueprintIds([]);
         onSuccess?.();
-      } else {
-        const errorData = await response.json();
-        const errors = parseValidationErrors(errorData);
-        setValidationErrors(errors);
-
-        if (errorData.message) {
-          toast.error(errorData.message);
-        } else if (errorData.error) {
-          toast.error(errorData.error);
-        } else if (Object.keys(errors).length > 0) {
-          toast.error("Please fix the errors in the form");
-        } else {
-          toast.error("Failed to send invitation");
-        }
-      }
-    } catch {
-      toast.error("Error sending invitation");
-    } finally {
-      setIsSubmitting(false);
+        break;
+      case "invalid":
+        setValidationErrors(result.fieldErrors);
+        toast.error(
+          Object.keys(result.fieldErrors).length > 0
+            ? "Please fix the errors in the form"
+            : result.message,
+        );
+        break;
+      case "conflict":
+        setValidationErrors({ email: result.message });
+        break;
+      case "locked":
+      case "notFound":
+      case "error":
+        toast.error(result.message);
+        break;
     }
+
+    setIsSubmitting(false);
   };
 
   return (

--- a/apps/frontend/components/kanban-board-form.tsx
+++ b/apps/frontend/components/kanban-board-form.tsx
@@ -10,7 +10,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel, FieldError } from "@/components/ui/field";
 import { useBackendUrl } from "@/app/client-context";
-import { joinUrl, parseValidationErrors } from "@/lib/utils";
+import { joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { KANBAN_LABEL_COLORS, type KanbanLabel } from "@platypus/schemas";
 import { toast } from "sonner";
 
@@ -74,50 +75,50 @@ export function KanbanBoardForm({
     setIsSubmitting(true);
     setValidationErrors({});
 
-    const url = isEditing
-      ? joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/boards/${board.id}`,
-        )
-      : joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/boards`,
-        );
+    const result = await writeEntity<{ id: string }>(
+      backendUrl,
+      "boards",
+      { orgId, workspaceId },
+      {
+        id: board?.id,
+        data: { name, description: description || null, labels },
+      },
+    );
 
-    try {
-      const response = await fetch(url, {
-        method: isEditing ? "PUT" : "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name,
-          description: description || null,
-          labels,
-        }),
-        credentials: "include",
-      });
-
-      if (response.ok) {
+    switch (result.outcome) {
+      case "success":
+        result.revalidateKeys.forEach((key) => mutate(key));
         if (isEditing) {
           toast.success("Board updated");
           onSuccess?.();
         } else {
-          const data = await response.json();
           const stateUrl = joinUrl(
             backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}/boards/${data.id}/state`,
+            `/organizations/${orgId}/workspaces/${workspaceId}/boards/${result.data.id}/state`,
           );
-          await mutate(stateUrl, { board: data, columns: [] }, false);
-          router.push(`/${orgId}/workspace/${workspaceId}/boards/${data.id}`);
+          await mutate(stateUrl, { board: result.data, columns: [] }, false);
+          router.push(
+            `/${orgId}/workspace/${workspaceId}/boards/${result.data.id}`,
+          );
         }
-      } else {
-        const errorData = await response.json();
-        setValidationErrors(parseValidationErrors(errorData));
-      }
-    } catch (err) {
-      console.error("Failed to save board:", err);
-    } finally {
-      setIsSubmitting(false);
+        break;
+      case "invalid":
+        setValidationErrors(result.fieldErrors);
+        if (Object.keys(result.fieldErrors).length === 0) {
+          toast.error(result.message);
+        }
+        break;
+      case "conflict":
+        setValidationErrors({ name: result.message });
+        break;
+      case "locked":
+      case "notFound":
+      case "error":
+        toast.error(result.message);
+        break;
     }
+
+    setIsSubmitting(false);
   };
 
   return (

--- a/apps/frontend/components/mcp-form.test.tsx
+++ b/apps/frontend/components/mcp-form.test.tsx
@@ -31,6 +31,7 @@ vi.mock("swr", () => ({
     isLoading: false,
     mutate: vi.fn(),
   }),
+  useSWRConfig: () => ({ mutate: vi.fn() }),
 }));
 
 import { McpForm } from "./mcp-form";

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -31,13 +31,9 @@ import { useState, useEffect } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type MCP } from "@platypus/schemas";
-import useSWR from "swr";
-import {
-  clearFieldError,
-  fetcher,
-  parseValidationErrors,
-  joinUrl,
-} from "@/lib/utils";
+import useSWR, { useSWRConfig } from "swr";
+import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -122,6 +118,7 @@ const McpForm = ({
   const [isRevoking, setIsRevoking] = useState(false);
 
   const router = useRouter();
+  const { mutate: globalMutate } = useSWRConfig();
 
   const {
     data: mcp,
@@ -239,28 +236,34 @@ const McpForm = ({
   const saveMcp = async (existingId?: string): Promise<string | null> => {
     setValidationErrors({});
     const payload = buildPayload();
+    const scope = workspaceId ? { orgId, workspaceId } : { orgId };
 
-    const url = existingId
-      ? joinUrl(backendUrl, `${collectionUrl}/${existingId}`)
-      : joinUrl(backendUrl, collectionUrl);
+    const result = await writeEntity<{ id: string }>(
+      backendUrl,
+      "mcps",
+      scope,
+      { id: existingId, data: payload },
+    );
 
-    const method = existingId ? "PUT" : "POST";
-
-    const response = await fetch(url, {
-      method,
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-      credentials: "include",
-    });
-
-    if (response.ok) {
-      const record = await response.json();
-      return record.id;
+    switch (result.outcome) {
+      case "success":
+        result.revalidateKeys.forEach((key) => globalMutate(key));
+        return result.data.id;
+      case "invalid":
+        setValidationErrors(result.fieldErrors);
+        if (Object.keys(result.fieldErrors).length === 0) {
+          toast.error(result.message);
+        }
+        return null;
+      case "conflict":
+        setValidationErrors({ name: result.message });
+        return null;
+      case "locked":
+      case "notFound":
+      case "error":
+        toast.error(result.message);
+        return null;
     }
-
-    const errorData = await response.json();
-    setValidationErrors(parseValidationErrors(errorData));
-    return null;
   };
 
   const handleSubmit = async () => {
@@ -282,26 +285,16 @@ const McpForm = ({
     if (!mcpId) return;
 
     setIsDeleting(true);
-    try {
-      const response = await fetch(
-        joinUrl(backendUrl, `${collectionUrl}/${mcpId}`),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
-      );
+    const scope = workspaceId ? { orgId, workspaceId } : { orgId };
+    const result = await writeEntity(backendUrl, "mcps", scope, {
+      id: mcpId,
+    });
 
-      if (response.ok) {
-        router.push(listPath);
-      } else {
-        console.error("Failed to delete MCP");
-        toast.error("Failed to delete MCP server");
-        setIsDeleting(false);
-        setIsDeleteDialogOpen(false);
-      }
-    } catch (error) {
-      console.error("Error deleting MCP:", error);
-      toast.error("Failed to delete MCP server");
+    if (result.outcome === "success") {
+      result.revalidateKeys.forEach((key) => globalMutate(key));
+      router.push(listPath);
+    } else {
+      toast.error(result.message);
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);
     }

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -23,17 +23,13 @@ import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type Organization } from "@platypus/schemas";
-import {
-  clearFieldError,
-  fetcher,
-  parseValidationErrors,
-  joinUrl,
-} from "@/lib/utils";
+import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { Trash2 } from "lucide-react";
 import { toast } from "sonner";
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
 
 interface OrganizationFormProps {
   classNames?: string;
@@ -44,8 +40,9 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
   const { user } = useAuth();
   const backendUrl = useBackendUrl();
   const router = useRouter();
+  const { mutate: globalMutate } = useSWRConfig();
 
-  const { data: organization, mutate } = useSWR<Organization>(
+  const { data: organization } = useSWR<Organization>(
     orgId && user ? joinUrl(backendUrl, `/organizations/${orgId}`) : null,
     fetcher,
   );
@@ -92,76 +89,69 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
   const handleSubmit = async () => {
     setIsSubmitting(true);
     setValidationErrors({});
-    try {
-      const url = orgId
-        ? joinUrl(backendUrl, `/organizations/${orgId}`)
-        : joinUrl(backendUrl, "/organizations");
 
-      const method = orgId ? "PUT" : "POST";
+    // identityContext is update-only (the create schema accepts name only).
+    const payload = orgId
+      ? {
+          name: formData.name,
+          identityContext: formData.identityContext || null,
+        }
+      : { name: formData.name };
 
-      // identityContext is update-only (the create schema accepts name only).
-      const payload = orgId
-        ? {
-            name: formData.name,
-            identityContext: formData.identityContext || null,
-          }
-        : { name: formData.name };
+    const result = await writeEntity<Organization>(
+      backendUrl,
+      "organizations",
+      {},
+      { id: orgId, data: payload },
+    );
 
-      const response = await fetch(url, {
-        method,
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-        credentials: "include",
-      });
-
-      if (response.ok) {
+    switch (result.outcome) {
+      case "success":
+        result.revalidateKeys.forEach((key) => globalMutate(key));
         if (orgId) {
           toast.success("Organization updated");
-          mutate(); // Refresh the local cache
           router.refresh();
         } else {
-          const organization = await response.json();
           toast.success("Organization created");
-          router.push(`/${organization.id}`);
+          router.push(`/${result.data.id}`);
         }
-      } else {
-        // Parse standardschema.dev validation errors
-        const errorData = await response.json();
-        setValidationErrors(parseValidationErrors(errorData));
-        toast.error("Failed to save organization");
-      }
-    } catch (error) {
-      console.error("Error saving organization:", error);
-      toast.error("Error saving organization");
-    } finally {
-      setIsSubmitting(false);
+        break;
+      case "invalid":
+        setValidationErrors(result.fieldErrors);
+        if (Object.keys(result.fieldErrors).length === 0) {
+          toast.error(result.message);
+        }
+        break;
+      case "conflict":
+        setValidationErrors({ name: result.message });
+        break;
+      case "locked":
+      case "notFound":
+      case "error":
+        toast.error(result.message);
+        break;
     }
+
+    setIsSubmitting(false);
   };
 
   const handleDelete = async () => {
     if (!orgId) return;
 
     setIsDeleting(true);
-    try {
-      const response = await fetch(
-        joinUrl(backendUrl, `/organizations/${orgId}`),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
-      );
-      if (response.ok) {
-        toast.success("Organization deleted");
-        window.location.href = `/`;
-      } else {
-        toast.error("Failed to delete organization");
-        setIsDeleting(false);
-        setIsDeleteDialogOpen(false);
-      }
-    } catch {
-      toast.error("Error deleting organization");
+    const result = await writeEntity(
+      backendUrl,
+      "organizations",
+      {},
+      { id: orgId },
+    );
+
+    if (result.outcome === "success") {
+      result.revalidateKeys.forEach((key) => globalMutate(key));
+      toast.success("Organization deleted");
+      window.location.href = `/`;
+    } else {
+      toast.error(result.message);
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);
     }

--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -55,6 +55,7 @@ vi.mock("swr", () => ({
     }
     return { data: loadedProvider, isLoading: false, mutate: vi.fn() };
   },
+  useSWRConfig: () => ({ mutate: vi.fn() }),
 }));
 
 import { ProviderForm } from "./provider-form";

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -61,14 +61,9 @@ import {
   type AliasRepoint,
   type Provider,
 } from "@platypus/schemas";
-import useSWR from "swr";
-import {
-  clearFieldError,
-  cn,
-  fetcher,
-  parseValidationErrors,
-  joinUrl,
-} from "@/lib/utils";
+import useSWR, { useSWRConfig } from "swr";
+import { clearFieldError, cn, fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import {
   getModelConfigs,
   defaultPassthroughFileTypes,
@@ -530,11 +525,12 @@ const ProviderForm = ({
         : joinUrl(backendUrl, `/organizations/${orgId}/providers/${providerId}`)
       : null;
 
-  const {
-    data: provider,
-    isLoading,
-    mutate,
-  } = useSWR<ProviderWithScope>(fetchUrl, fetcher);
+  const { mutate: globalMutate } = useSWRConfig();
+
+  const { data: provider, isLoading } = useSWR<ProviderWithScope>(
+    fetchUrl,
+    fetcher,
+  );
 
   // The Web-search backends this deployment has installed (ADR-0014). Org-scoped
   // rather than workspace-scoped because this form serves both Provider scopes and
@@ -825,53 +821,39 @@ const ProviderForm = ({
           : null,
       };
 
-      const url = providerId
-        ? formScope === "workspace"
-          ? joinUrl(
-              backendUrl,
-              `/organizations/${orgId}/workspaces/${workspaceId}/providers/${providerId}`,
-            )
-          : joinUrl(
-              backendUrl,
-              `/organizations/${orgId}/providers/${providerId}`,
-            )
-        : formScope === "workspace"
-          ? joinUrl(
-              backendUrl,
-              `/organizations/${orgId}/workspaces/${workspaceId}/providers`,
-            )
-          : joinUrl(backendUrl, `/organizations/${orgId}/providers`);
+      const scope =
+        formScope === "workspace" ? { orgId, workspaceId } : { orgId };
+      const result = await writeEntity<{
+        id: string;
+        aliasRepoints?: unknown;
+      }>(backendUrl, "providers", scope, { id: providerId, data: payload });
 
-      const method = providerId ? "PUT" : "POST";
-
-      const response = await fetch(url, {
-        method,
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-        credentials: "include",
-      });
-
-      if (response.ok) {
-        const saved = await response.json().catch(() => null);
-        reportAliasRepoints(saved?.aliasRepoints);
-        if (providerId) {
-          await mutate();
-        }
-        if (formScope === "workspace") {
-          router.push(`/${orgId}/workspace/${workspaceId}/settings/providers`);
-        } else {
-          router.push(`/${orgId}/settings/providers`);
-        }
-      } else {
-        const errorData = await response.json();
-        if (response.status === 409) {
-          setError(errorData.message || "A conflict occurred");
-        } else {
-          // Parse standardschema.dev validation errors
-          setValidationErrors(parseValidationErrors(errorData));
-        }
+      switch (result.outcome) {
+        case "success":
+          reportAliasRepoints(result.data.aliasRepoints);
+          result.revalidateKeys.forEach((key) => globalMutate(key));
+          if (formScope === "workspace") {
+            router.push(
+              `/${orgId}/workspace/${workspaceId}/settings/providers`,
+            );
+          } else {
+            router.push(`/${orgId}/settings/providers`);
+          }
+          break;
+        case "invalid":
+          setValidationErrors(result.fieldErrors);
+          if (Object.keys(result.fieldErrors).length === 0) {
+            toast.error(result.message);
+          }
+          break;
+        case "conflict":
+          setError(result.message);
+          break;
+        case "locked":
+        case "notFound":
+        case "error":
+          toast.error(result.message);
+          break;
       }
     } catch (error) {
       console.error("Error saving provider:", error);
@@ -893,38 +875,21 @@ const ProviderForm = ({
     if (!providerId) return;
 
     setIsDeleting(true);
-    try {
-      const deleteUrl =
-        formScope === "workspace"
-          ? joinUrl(
-              backendUrl,
-              `/organizations/${orgId}/workspaces/${workspaceId}/providers/${providerId}`,
-            )
-          : joinUrl(
-              backendUrl,
-              `/organizations/${orgId}/providers/${providerId}`,
-            );
+    const scope =
+      formScope === "workspace" ? { orgId, workspaceId } : { orgId };
+    const result = await writeEntity(backendUrl, "providers", scope, {
+      id: providerId,
+    });
 
-      const response = await fetch(deleteUrl, {
-        method: "DELETE",
-        credentials: "include",
-      });
-
-      if (response.ok) {
-        if (formScope === "workspace") {
-          router.push(`/${orgId}/workspace/${workspaceId}/settings/providers`);
-        } else {
-          router.push(`/${orgId}/settings/providers`);
-        }
+    if (result.outcome === "success") {
+      result.revalidateKeys.forEach((key) => globalMutate(key));
+      if (formScope === "workspace") {
+        router.push(`/${orgId}/workspace/${workspaceId}/settings/providers`);
       } else {
-        console.error("Failed to delete provider");
-        toast.error("Failed to delete provider");
-        setIsDeleting(false);
-        setIsDeleteDialogOpen(false);
+        router.push(`/${orgId}/settings/providers`);
       }
-    } catch (error) {
-      console.error("Error deleting provider:", error);
-      toast.error("Failed to delete provider");
+    } else {
+      toast.error(result.message);
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);
     }

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -19,13 +19,10 @@ import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 import { type Skill, type Agent } from "@platypus/schemas";
-import useSWR from "swr";
-import {
-  clearFieldError,
-  fetcher,
-  parseValidationErrors,
-  joinUrl,
-} from "@/lib/utils";
+import useSWR, { useSWRConfig } from "swr";
+import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
+import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { AgentAvatar } from "@/components/agent-avatar";
@@ -49,6 +46,7 @@ const SkillForm = ({
 
   const { user } = useAuth();
   const backendUrl = useBackendUrl();
+  const { mutate: globalMutate } = useSWRConfig();
 
   // The scope determines the backend collection and where we return after save.
   const collectionUrl = workspaceId
@@ -134,50 +132,45 @@ const SkillForm = ({
   const handleSubmit = async () => {
     setIsSubmitting(true);
     setValidationErrors({});
-    try {
-      const payload = {
-        name: formData.name,
-        description: formData.description,
-        body: formData.body,
-        // Scope and agent associations only apply to the workspace surface.
-        ...(workspaceId
-          ? { workspaceId, agentIds: selectedAgentIds }
-          : { organizationId: orgId }),
-      };
 
-      const url = skillId
-        ? joinUrl(backendUrl, `${collectionUrl}/${skillId}`)
-        : joinUrl(backendUrl, collectionUrl);
+    const payload = {
+      name: formData.name,
+      description: formData.description,
+      body: formData.body,
+      // Scope and agent associations only apply to the workspace surface.
+      ...(workspaceId
+        ? { workspaceId, agentIds: selectedAgentIds }
+        : { organizationId: orgId }),
+    };
 
-      const method = skillId ? "PUT" : "POST";
+    const scope = workspaceId ? { orgId, workspaceId } : { orgId };
+    const result = await writeEntity(backendUrl, "skills", scope, {
+      id: skillId,
+      data: payload,
+    });
 
-      const response = await fetch(url, {
-        method,
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-        credentials: "include",
-      });
-
-      if (response.ok) {
+    switch (result.outcome) {
+      case "success":
+        result.revalidateKeys.forEach((key) => globalMutate(key));
         router.push(returnPath);
-      } else {
-        const errorData = await response.json();
-        if (response.status === 409) {
-          setValidationErrors({
-            name: errorData.error || errorData.message,
-          });
-        } else {
-          setValidationErrors(parseValidationErrors(errorData));
+        break;
+      case "invalid":
+        setValidationErrors(result.fieldErrors);
+        if (Object.keys(result.fieldErrors).length === 0) {
+          toast.error(result.message);
         }
-        console.error("Failed to save skill");
-      }
-    } catch (error) {
-      console.error("Error saving skill:", error);
-    } finally {
-      setIsSubmitting(false);
+        break;
+      case "conflict":
+        setValidationErrors({ name: result.message });
+        break;
+      case "locked":
+      case "notFound":
+      case "error":
+        toast.error(result.message);
+        break;
     }
+
+    setIsSubmitting(false);
   };
 
   const handleDelete = async () => {
@@ -185,27 +178,16 @@ const SkillForm = ({
 
     setIsDeleting(true);
     setDeleteError(null);
-    try {
-      const response = await fetch(
-        joinUrl(backendUrl, `${collectionUrl}/${skillId}`),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
-      );
+    const scope = workspaceId ? { orgId, workspaceId } : { orgId };
+    const result = await writeEntity(backendUrl, "skills", scope, {
+      id: skillId,
+    });
 
-      if (response.ok) {
-        router.push(returnPath);
-      } else {
-        const errorData = await response.json();
-        setDeleteError(
-          errorData.error || errorData.message || "Failed to delete skill",
-        );
-        setIsDeleting(false);
-      }
-    } catch (error) {
-      console.error("Error deleting skill:", error);
-      setDeleteError("An unexpected error occurred");
+    if (result.outcome === "success") {
+      result.revalidateKeys.forEach((key) => globalMutate(key));
+      router.push(returnPath);
+    } else {
+      setDeleteError(result.message);
       setIsDeleting(false);
     }
   };

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -35,13 +35,9 @@ import {
   type KanbanBoard,
   type KanbanBoardState,
 } from "@platypus/schemas";
-import useSWR from "swr";
-import {
-  clearFieldError,
-  fetcher,
-  parseValidationErrors,
-  joinUrl,
-} from "@/lib/utils";
+import useSWR, { useSWRConfig } from "swr";
+import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { Cron } from "croner";
@@ -292,6 +288,7 @@ const TriggerForm = ({
 
   const { user } = useAuth();
   const backendUrl = useBackendUrl();
+  const { mutate: globalMutate } = useSWRConfig();
 
   const { data: agentsData, isLoading: agentsLoading } = useSWR<{
     results: Agent[];
@@ -548,33 +545,32 @@ const TriggerForm = ({
               },
             };
 
-      const url = triggerId
-        ? joinUrl(
-            backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}/triggers/${triggerId}`,
-          )
-        : joinUrl(
-            backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}/triggers`,
-          );
+      const result = await writeEntity(
+        backendUrl,
+        "triggers",
+        { orgId, workspaceId },
+        { id: triggerId, data: payload },
+      );
 
-      const method = triggerId ? "PUT" : "POST";
-
-      const response = await fetch(url, {
-        method,
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-        credentials: "include",
-      });
-
-      if (response.ok) {
-        router.push(`/${orgId}/workspace/${workspaceId}`);
-      } else {
-        const errorData = await response.json();
-        setValidationErrors(parseValidationErrors(errorData));
-        toast.error("Failed to save trigger");
+      switch (result.outcome) {
+        case "success":
+          result.revalidateKeys.forEach((key) => globalMutate(key));
+          router.push(`/${orgId}/workspace/${workspaceId}`);
+          break;
+        case "invalid":
+          setValidationErrors(result.fieldErrors);
+          if (Object.keys(result.fieldErrors).length === 0) {
+            toast.error(result.message);
+          }
+          break;
+        case "conflict":
+          setValidationErrors({ name: result.message });
+          break;
+        case "locked":
+        case "notFound":
+        case "error":
+          toast.error(result.message);
+          break;
       }
     } catch {
       toast.error("Error saving trigger");
@@ -587,27 +583,18 @@ const TriggerForm = ({
     if (!triggerId) return;
 
     setIsDeleting(true);
-    try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/triggers/${triggerId}`,
-        ),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
-      );
+    const result = await writeEntity(
+      backendUrl,
+      "triggers",
+      { orgId, workspaceId },
+      { id: triggerId },
+    );
 
-      if (response.ok) {
-        router.push(`/${orgId}/workspace/${workspaceId}`);
-      } else {
-        toast.error("Failed to delete trigger");
-        setIsDeleting(false);
-        setIsDeleteDialogOpen(false);
-      }
-    } catch {
-      toast.error("Error deleting trigger");
+    if (result.outcome === "success") {
+      result.revalidateKeys.forEach((key) => globalMutate(key));
+      router.push(`/${orgId}/workspace/${workspaceId}`);
+    } else {
+      toast.error(result.message);
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);
     }

--- a/apps/frontend/components/webhook-form.test.tsx
+++ b/apps/frontend/components/webhook-form.test.tsx
@@ -30,15 +30,17 @@ vi.mock("sonner", () => ({
 vi.mock("swr", () => ({
   __esModule: true,
   default: () => ({ data: undefined, isLoading: false, mutate: vi.fn() }),
+  useSWRConfig: () => ({ mutate: vi.fn() }),
 }));
 
 import { WebhookForm } from "./webhook-form";
 
 // --- Helpers -----------------------------------------------------------------
 
-function mockFailedSave(error: unknown) {
+function mockFailedSave(error: unknown, status = 400) {
   return vi.fn().mockResolvedValue({
     ok: false,
+    status,
     json: async () => ({ error }),
   } as unknown as Response);
 }

--- a/apps/frontend/components/webhook-form.tsx
+++ b/apps/frontend/components/webhook-form.tsx
@@ -15,13 +15,9 @@ import { ConfirmDialog } from "@/components/confirm-dialog";
 import { useCallback, useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
-import useSWR from "swr";
-import {
-  fetcher,
-  parseValidationErrors,
-  clearFieldError,
-  joinUrl,
-} from "@/lib/utils";
+import useSWR, { useSWRConfig } from "swr";
+import { fetcher, clearFieldError, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -70,6 +66,7 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
   const { user } = useAuth();
   const backendUrl = useBackendUrl();
   const router = useRouter();
+  const { mutate: globalMutate } = useSWRConfig();
 
   const [name, setName] = useState("");
   const [url, setUrl] = useState("");
@@ -170,60 +167,54 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
     setIsSubmitting(true);
     setValidationErrors({});
 
-    try {
-      const payload = buildPayload();
-      const requestUrl = isEditMode
-        ? joinUrl(webhooksBaseUrl, `/${webhookId}`)
-        : webhooksBaseUrl;
-      const method = isEditMode ? "PUT" : "POST";
+    const payload = buildPayload();
+    const result = await writeEntity(
+      backendUrl,
+      "webhooks",
+      { orgId, workspaceId },
+      { id: webhookId, data: payload },
+    );
 
-      const response = await fetch(requestUrl, {
-        method,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-        credentials: "include",
-      });
-
-      if (response.ok) {
-        if (isEditMode) {
-          toast.success("Webhook updated");
-          await mutate();
-        } else {
-          toast.success("Webhook created");
-        }
+    switch (result.outcome) {
+      case "success":
+        result.revalidateKeys.forEach((key) => globalMutate(key));
+        toast.success(isEditMode ? "Webhook updated" : "Webhook created");
         router.push(`/${orgId}/workspace/${workspaceId}/settings/webhooks`);
-      } else {
-        const errorData = await response.json();
-        setValidationErrors(parseValidationErrors(errorData));
-      }
-    } catch (error) {
-      console.error("Error saving webhook:", error);
-      toast.error("Failed to save webhook");
-    } finally {
-      setIsSubmitting(false);
+        break;
+      case "invalid":
+        setValidationErrors(result.fieldErrors);
+        if (Object.keys(result.fieldErrors).length === 0) {
+          toast.error(result.message);
+        }
+        break;
+      case "conflict":
+        setValidationErrors({ name: result.message });
+        break;
+      case "locked":
+      case "notFound":
+      case "error":
+        toast.error(result.message);
+        break;
     }
+
+    setIsSubmitting(false);
   };
 
   const handleDelete = async () => {
     setIsDeleting(true);
-    try {
-      const response = await fetch(joinUrl(webhooksBaseUrl, `/${webhookId}`), {
-        method: "DELETE",
-        credentials: "include",
-      });
+    const result = await writeEntity(
+      backendUrl,
+      "webhooks",
+      { orgId, workspaceId },
+      { id: webhookId },
+    );
 
-      if (response.ok) {
-        toast.success("Webhook deleted");
-        router.push(`/${orgId}/workspace/${workspaceId}/settings/webhooks`);
-      } else {
-        console.error("Failed to delete webhook");
-        toast.error("Failed to delete webhook");
-        setIsDeleting(false);
-        setIsDeleteDialogOpen(false);
-      }
-    } catch (error) {
-      console.error("Error deleting webhook:", error);
-      toast.error("Failed to delete webhook");
+    if (result.outcome === "success") {
+      result.revalidateKeys.forEach((key) => globalMutate(key));
+      toast.success("Webhook deleted");
+      router.push(`/${orgId}/workspace/${workspaceId}/settings/webhooks`);
+    } else {
+      toast.error(result.message);
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);
     }

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -31,12 +31,8 @@ import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type Workspace, type Provider } from "@platypus/schemas";
-import {
-  clearFieldError,
-  fetcher,
-  parseValidationErrors,
-  joinUrl,
-} from "@/lib/utils";
+import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { Trash2 } from "lucide-react";
@@ -59,7 +55,7 @@ const WorkspaceForm = ({
   const router = useRouter();
   const { mutate: globalMutate } = useSWRConfig();
 
-  const { data: workspace, mutate } = useSWR<Workspace>(
+  const { data: workspace } = useSWR<Workspace>(
     workspaceId && user
       ? joinUrl(backendUrl, `/organizations/${orgId}/workspaces/${workspaceId}`)
       : null,
@@ -173,100 +169,81 @@ const WorkspaceForm = ({
   const handleSubmit = async () => {
     setIsSubmitting(true);
     setValidationErrors({});
-    try {
-      const url = workspaceId
-        ? joinUrl(
-            backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}`,
-          )
-        : joinUrl(backendUrl, `/organizations/${orgId}/workspaces`);
 
-      const method = workspaceId ? "PUT" : "POST";
+    const payload = workspaceId
+      ? {
+          name: formData.name,
+          context: formData.context || null,
+          taskModelProviderId: formData.taskModelProviderId,
+          memoryExtractionProviderId: formData.memoryExtractionProviderId,
+          memoryEmbeddingProviderId: formData.memoryEmbeddingProviderId,
+          maxDailySummaries: formData.maxDailySummaries,
+          // Admin-only; the backend strips these for non-admins (ADR-0006).
+          providerSelfManagement: formData.providerSelfManagement,
+          mcpSelfManagement: formData.mcpSelfManagement,
+        }
+      : {
+          organizationId: orgId,
+          name: formData.name,
+          context: formData.context || null,
+          // ADR-0008: an admin assigns the owner; defaults to themselves.
+          ownerId: formData.ownerId || user?.id,
+        };
 
-      const payload = workspaceId
-        ? {
-            name: formData.name,
-            context: formData.context || null,
-            taskModelProviderId: formData.taskModelProviderId,
-            memoryExtractionProviderId: formData.memoryExtractionProviderId,
-            memoryEmbeddingProviderId: formData.memoryEmbeddingProviderId,
-            maxDailySummaries: formData.maxDailySummaries,
-            // Admin-only; the backend strips these for non-admins (ADR-0006).
-            providerSelfManagement: formData.providerSelfManagement,
-            mcpSelfManagement: formData.mcpSelfManagement,
-          }
-        : {
-            organizationId: orgId,
-            name: formData.name,
-            context: formData.context || null,
-            // ADR-0008: an admin assigns the owner; defaults to themselves.
-            ownerId: formData.ownerId || user?.id,
-          };
+    const result = await writeEntity<Workspace>(
+      backendUrl,
+      "workspaces",
+      { orgId },
+      { id: workspaceId, data: payload },
+    );
 
-      const response = await fetch(url, {
-        method,
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(payload),
-        credentials: "include",
-      });
-
-      if (response.ok) {
+    switch (result.outcome) {
+      case "success":
+        result.revalidateKeys.forEach((key) => globalMutate(key));
         if (workspaceId) {
           toast.success("Workspace updated");
-          mutate(); // Refresh the local cache
-          globalMutate(
-            joinUrl(backendUrl, `/organizations/${orgId}/workspaces`),
-          );
           router.refresh();
         } else {
-          const workspace = await response.json();
           toast.success("Workspace created");
-          globalMutate(
-            joinUrl(backendUrl, `/organizations/${orgId}/workspaces`),
-          );
-          router.push(`/${orgId}/workspace/${workspace.id}`);
+          router.push(`/${orgId}/workspace/${result.data.id}`);
         }
-      } else {
-        // Parse standardschema.dev validation errors
-        const errorData = await response.json();
-        setValidationErrors(parseValidationErrors(errorData));
-        toast.error("Failed to save workspace");
-      }
-    } catch (error) {
-      console.error("Error saving workspace:", error);
-      toast.error("Error saving workspace");
-    } finally {
-      setIsSubmitting(false);
+        break;
+      case "invalid":
+        setValidationErrors(result.fieldErrors);
+        if (Object.keys(result.fieldErrors).length === 0) {
+          toast.error(result.message);
+        }
+        break;
+      case "conflict":
+        setValidationErrors({ name: result.message });
+        break;
+      case "locked":
+      case "notFound":
+      case "error":
+        toast.error(result.message);
+        break;
     }
+
+    setIsSubmitting(false);
   };
 
   const handleDelete = async () => {
     if (!workspaceId) return;
 
     setIsDeleting(true);
-    try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}`,
-        ),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
-      );
-      if (response.ok) {
-        toast.success("Workspace deleted");
-        window.location.href = `/${orgId}`;
-      } else {
-        toast.error("Failed to delete workspace");
-        setIsDeleting(false);
-        setIsDeleteDialogOpen(false);
-      }
-    } catch {
-      toast.error("Error deleting workspace");
+    const result = await writeEntity(
+      backendUrl,
+      "workspaces",
+      { orgId },
+      { id: workspaceId },
+    );
+
+    if (result.outcome === "success") {
+      result.revalidateKeys.forEach((key) => globalMutate(key));
+      toast.success("Workspace deleted");
+      window.location.href = `/${orgId}`;
+    } else {
+      toast.error(result.message);
       setIsDeleting(false);
       setIsDeleteDialogOpen(false);
     }

--- a/apps/frontend/lib/api-write.test.ts
+++ b/apps/frontend/lib/api-write.test.ts
@@ -98,6 +98,45 @@ describe("writeEntity — transport", () => {
     expect(init.headers).toBeUndefined();
   });
 
+  it("POSTs to the root collection path when the scope carries no orgId", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(mockResponse(201, { id: "org1" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeEntity(
+      BACKEND_URL,
+      "organizations",
+      {},
+      { data: { name: "Acme" } },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4000/organizations",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "Acme" }),
+      }),
+    );
+  });
+
+  it("PUTs to the root item path when the scope carries no orgId but an id is given", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeEntity(
+      BACKEND_URL,
+      "organizations",
+      {},
+      { id: "org1", data: { name: "Renamed" } },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:4000/organizations/org1",
+      expect.objectContaining({ method: "PUT" }),
+    );
+  });
+
   it("always sends credentials: include", async () => {
     const fetchMock = vi.fn().mockResolvedValue(mockResponse(200, {}));
     vi.stubGlobal("fetch", fetchMock);
@@ -112,6 +151,17 @@ describe("writeEntity — transport", () => {
     );
 
     expect(fetchMock.mock.calls[0][1].credentials).toBe("include");
+  });
+
+  it("DELETEs the root item path when the scope carries no orgId", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeEntity(BACKEND_URL, "organizations", {}, { id: "org1" });
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("http://localhost:4000/organizations/org1");
+    expect(init.method).toBe("DELETE");
   });
 });
 

--- a/apps/frontend/lib/api-write.ts
+++ b/apps/frontend/lib/api-write.ts
@@ -2,11 +2,13 @@ import { joinUrl, parseValidationErrors } from "./utils";
 
 /**
  * A write's target scope (ADR-0007): an Organization-level (Shared) resource,
- * or a resource inside one Workspace. Presence of `workspaceId` is what
- * distinguishes the two — there is deliberately no separate discriminant to
- * get out of sync with it.
+ * a resource inside one Workspace, or — when `orgId` itself is omitted — the
+ * root `/organizations` collection, for writes to an Organization itself.
+ * Presence of `workspaceId` is what distinguishes the scoped two — there is
+ * deliberately no separate discriminant to get out of sync with it.
  */
 export type Scope =
+  | { readonly orgId?: undefined; readonly workspaceId?: undefined }
   | { readonly orgId: string; readonly workspaceId?: undefined }
   | { readonly orgId: string; readonly workspaceId: string };
 
@@ -57,6 +59,7 @@ const DEFAULT_MESSAGES = {
 } as const;
 
 function scopedPath(entity: string, scope: Scope): string {
+  if (!scope.orgId) return `/${entity}`;
   return scope.workspaceId
     ? `/organizations/${scope.orgId}/workspaces/${scope.workspaceId}/${entity}`
     : `/organizations/${scope.orgId}/${entity}`;


### PR DESCRIPTION
## Summary

- Migrates all 11 form components (agent, mcp, provider, organization, workspace, skill, blueprint, webhook, trigger, kanban-board, invitation) from hand-rolled `fetch()` onto `writeEntity()` (`apps/frontend/lib/api-write.ts`, added in #563), so a conflict, lock, or validation rejection is handled the same way everywhere and always surfaces the backend's actual message. Every form now revalidates its lists through the module's declared `revalidateKeys` instead of each choosing its own policy (or none).
- Extends `api-write.ts`'s `Scope` type to accept an org-less "root" scope, since Organization's own CRUD hits `/organizations` directly rather than nesting under an org.
- Fixes `apps/backend/src/routes/invitation.ts`, which returned `{message: ...}` on a duplicate-invite 409, bypassing the central `app.onError` envelope (`{error: ...}`, ADR-0010) that `writeEntity` reads — without this, invitation-form's conflict outcome could never surface the real backend message.
- Fixes the kanban board settings page's delete handler, which never checked `response.ok` before navigating away on failure.
- Adds `invitation-form.test.tsx` (previously untested) covering the new conflict path.

Closes #564

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (0 errors, 3 pre-existing warnings unrelated to this change)
- [x] `pnpm test` — 1902 backend + 317 frontend tests pass
- [x] Two-axis code review (Standards + Spec) run against `main`; findings addressed (provider-form and trigger-form silently discarding/mis-reporting a validation rejection with no field mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)