### PR TITLE
chore(frontend): move the remaining pages onto the request module

### DIFF
--- a/apps/frontend/app/[orgId]/settings/invitations/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/invitations/page.tsx
@@ -3,6 +3,7 @@
 import { useParams } from "next/navigation";
 import { InvitationForm } from "@/components/invitation-form";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import {
   type InvitationListItem,
@@ -68,26 +69,20 @@ const OrgInvitationsPage = () => {
     if (!invitationToDelete) return;
 
     setIsDeleting(true);
-    try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/invitations/${invitationToDelete}`,
-        ),
-        { method: "DELETE", credentials: "include" },
-      );
-      if (response.ok) {
-        toast.success("Invitation deleted");
-        mutate();
-        setInvitationToDelete(null);
-      } else {
-        toast.error("Failed to delete invitation");
-      }
-    } catch {
-      toast.error("Error deleting invitation");
-    } finally {
-      setIsDeleting(false);
+    const outcome = await writeEntity(
+      backendUrl,
+      "invitations",
+      { orgId },
+      { id: invitationToDelete },
+    );
+    if (outcome.outcome === "success") {
+      toast.success("Invitation deleted");
+      mutate();
+      setInvitationToDelete(null);
+    } else {
+      toast.error(outcome.message);
     }
+    setIsDeleting(false);
   };
 
   const getStatusBadge = (status: string) => {

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/[dashboardId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/[dashboardId]/page.tsx
@@ -12,6 +12,7 @@ import { ResponsiveGridLayout } from "react-grid-layout";
 import type { LayoutItem } from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
 import { fetcher, joinUrl, cn } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import {
@@ -184,29 +185,26 @@ const DashboardPage = ({
     }
   };
 
+  const widgetsEntity = `dashboards/${dashboardId}/widgets`;
+
   // Cancel: undo pending additions and discard all other staged changes
   const cancelEdit = async () => {
     if (backendUrl && pendingAdditions.size > 0) {
-      try {
-        const results = await Promise.all(
-          [...pendingAdditions].map((widgetId) =>
-            fetch(
-              joinUrl(
-                backendUrl,
-                `/organizations/${orgId}/workspaces/${workspaceId}/dashboards/${dashboardId}/widgets/${widgetId}`,
-              ),
-              { method: "DELETE", credentials: "include" },
-            ),
+      const outcomes = await Promise.all(
+        [...pendingAdditions].map((widgetId) =>
+          writeEntity(
+            backendUrl,
+            widgetsEntity,
+            { orgId, workspaceId },
+            { id: widgetId },
           ),
-        );
-        if (results.some((res) => !res.ok)) {
-          throw new Error("Failed to remove widget");
-        }
-        await mutateWidgets();
-      } catch {
+        ),
+      );
+      if (outcomes.some((outcome) => outcome.outcome !== "success")) {
         toast.error("Failed to cancel dashboard changes");
         return;
       }
+      await mutateWidgets();
     }
     setPendingDeletions(new Set());
     setPendingAdditions(new Set());
@@ -217,47 +215,41 @@ const DashboardPage = ({
   // Done: execute pending deletions then persist layouts
   const saveEdit = async () => {
     if (!backendUrl || !dashboard) return;
-    try {
-      const deleteResults = await Promise.all(
-        [...pendingDeletions].map((widgetId) =>
-          fetch(
-            joinUrl(
-              backendUrl,
-              `/organizations/${orgId}/workspaces/${workspaceId}/dashboards/${dashboardId}/widgets/${widgetId}`,
-            ),
-            { method: "DELETE", credentials: "include" },
-          ),
-        ),
-      );
-      if (deleteResults.some((res) => !res.ok)) {
-        throw new Error("Failed to delete widget");
-      }
-      const layoutRes = await fetch(
-        joinUrl(
+    const deleteOutcomes = await Promise.all(
+      [...pendingDeletions].map((widgetId) =>
+        writeEntity(
           backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/dashboards/${dashboardId}`,
+          widgetsEntity,
+          { orgId, workspaceId },
+          { id: widgetId },
         ),
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: JSON.stringify({
-            desktopLayout: stagedDesktop,
-            mobileLayout: stagedMobile,
-          }),
-        },
-      );
-      if (!layoutRes.ok) {
-        throw new Error("Failed to save layout");
-      }
-      await Promise.all([mutateWidgets(), mutateDashboard()]);
-      setPendingDeletions(new Set());
-      setPendingAdditions(new Set());
-      setEditMode(false);
-      setEditingWidgetId(null);
-    } catch {
+      ),
+    );
+    if (deleteOutcomes.some((outcome) => outcome.outcome !== "success")) {
       toast.error("Failed to save dashboard changes");
+      return;
     }
+    const layoutOutcome = await writeEntity(
+      backendUrl,
+      "dashboards",
+      { orgId, workspaceId },
+      {
+        id: dashboardId,
+        data: {
+          desktopLayout: stagedDesktop,
+          mobileLayout: stagedMobile,
+        },
+      },
+    );
+    if (layoutOutcome.outcome !== "success") {
+      toast.error("Failed to save dashboard changes");
+      return;
+    }
+    await Promise.all([mutateWidgets(), mutateDashboard()]);
+    setPendingDeletions(new Set());
+    setPendingAdditions(new Set());
+    setEditMode(false);
+    setEditingWidgetId(null);
   };
 
   // Sync layout only on user drag/resize stop to avoid the grid overwriting
@@ -279,34 +271,21 @@ const DashboardPage = ({
   const handleAddWidget = async () => {
     if (!backendUrl || !newWidgetTitle.trim()) return;
     setAddWidgetError(null);
-    let res: Response;
-    try {
-      res = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/dashboards/${dashboardId}/widgets`,
-        ),
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: JSON.stringify({ type: newWidgetType, title: newWidgetTitle }),
-        },
-      );
-    } catch {
+    const outcome = await writeEntity<Widget>(
+      backendUrl,
+      widgetsEntity,
+      { orgId, workspaceId },
+      { data: { type: newWidgetType, title: newWidgetTitle } },
+    );
+    if (outcome.outcome === "conflict") {
+      setAddWidgetError(outcome.message);
+      return;
+    }
+    if (outcome.outcome !== "success") {
       toast.error("Failed to add widget");
       return;
     }
-    if (res.status === 409) {
-      const body = await res.json();
-      setAddWidgetError(body.error);
-      return;
-    }
-    if (!res.ok) {
-      toast.error("Failed to add widget");
-      return;
-    }
-    const widget: Widget = await res.json();
+    const widget = outcome.data;
 
     // Track as pending so Cancel can delete it from the API.
     setPendingAdditions((prev) => new Set([...prev, widget.id]));
@@ -378,27 +357,18 @@ const DashboardPage = ({
     title: string,
   ) => {
     if (!backendUrl) return;
-    try {
-      const res = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/dashboards/${dashboardId}/widgets/${widget.id}`,
-        ),
-        {
-          method: "PUT",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: JSON.stringify({ type: widget.type, data, title }),
-        },
-      );
-      if (!res.ok) {
-        throw new Error("Failed to save widget");
-      }
-      await mutateWidgets();
-      setEditingWidgetId(null);
-    } catch {
+    const outcome = await writeEntity(
+      backendUrl,
+      widgetsEntity,
+      { orgId, workspaceId },
+      { id: widget.id, data: { type: widget.type, data, title } },
+    );
+    if (outcome.outcome !== "success") {
       toast.error("Failed to save widget");
+      return;
     }
+    await mutateWidgets();
+    setEditingWidgetId(null);
   };
 
   // Stamp minH onto every layout item at render time. Values are per widget

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/[dashboardId]/settings/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/[dashboardId]/settings/page.tsx
@@ -13,6 +13,7 @@ import { DeleteDashboardDialog } from "@/components/delete-dashboard-dialog";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import type { Dashboard } from "@platypus/schemas";
 import { toast } from "sonner";
 
@@ -57,39 +58,44 @@ const DashboardSettingsPage = ({
     if (!backendUrl || !displayName.trim()) return;
     setSaving(true);
     setSaveError(null);
-    try {
-      const res = await fetch(dashUrl!, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({
+    const outcome = await writeEntity(
+      backendUrl,
+      "dashboards",
+      { orgId, workspaceId },
+      {
+        id: dashboardId,
+        data: {
           name: displayName.trim(),
           description: displayDescription.trim() || null,
-        }),
-      });
-      if (res.status === 409) {
-        const body = await res.json();
-        setSaveError(body.error);
-        return;
-      }
-      if (res.ok) {
-        await mutate();
-        setName("");
-        setDescription(null);
-        toast.success("Dashboard updated");
-      }
-    } finally {
-      setSaving(false);
+        },
+      },
+    );
+    if (outcome.outcome === "conflict") {
+      setSaveError(outcome.message);
+    } else if (outcome.outcome === "success") {
+      await mutate();
+      setName("");
+      setDescription(null);
+      toast.success("Dashboard updated");
+    } else {
+      setSaveError(outcome.message);
     }
+    setSaving(false);
   };
 
   const handleDelete = async () => {
     if (!backendUrl) return;
     setDeleting(true);
-    try {
-      await fetch(dashUrl!, { method: "DELETE", credentials: "include" });
+    const outcome = await writeEntity(
+      backendUrl,
+      "dashboards",
+      { orgId, workspaceId },
+      { id: dashboardId },
+    );
+    if (outcome.outcome === "success") {
       router.push(`/${orgId}/workspace/${workspaceId}`);
-    } finally {
+    } else {
+      toast.error(outcome.message);
       setDeleting(false);
       setDeleteOpen(false);
     }

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/create/page.tsx
@@ -10,6 +10,8 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useBackendUrl } from "@/app/client-context";
 import { joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
+import type { Dashboard } from "@platypus/schemas";
 
 const CreateDashboardPage = ({
   params,
@@ -29,41 +31,33 @@ const CreateDashboardPage = ({
     if (!backendUrl || !name.trim()) return;
     setLoading(true);
     setError(null);
-    try {
-      const res = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/dashboards`,
-        ),
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: JSON.stringify({
-            name: name.trim(),
-            description: description.trim() || null,
-          }),
+    const outcome = await writeEntity<Dashboard>(
+      backendUrl,
+      "dashboards",
+      { orgId, workspaceId },
+      {
+        data: {
+          name: name.trim(),
+          description: description.trim() || null,
         },
+      },
+    );
+    if (outcome.outcome === "conflict") {
+      setError(outcome.message);
+    } else if (outcome.outcome === "success") {
+      const dashboard = outcome.data;
+      const dashUrl = joinUrl(
+        backendUrl,
+        `/organizations/${orgId}/workspaces/${workspaceId}/dashboards/${dashboard.id}`,
       );
-      if (res.status === 409) {
-        const body = await res.json();
-        setError(body.error);
-        return;
-      }
-      if (res.ok) {
-        const dashboard = await res.json();
-        const dashUrl = joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/dashboards/${dashboard.id}`,
-        );
-        await mutate(dashUrl, dashboard, false);
-        router.push(
-          `/${orgId}/workspace/${workspaceId}/dashboards/${dashboard.id}`,
-        );
-      }
-    } finally {
-      setLoading(false);
+      await mutate(dashUrl, dashboard, false);
+      router.push(
+        `/${orgId}/workspace/${workspaceId}/dashboards/${dashboard.id}`,
+      );
+    } else {
+      setError(outcome.message);
     }
+    setLoading(false);
   };
 
   return (

--- a/apps/frontend/app/oauth/mcp/callback/oauth-callback-handler.tsx
+++ b/apps/frontend/app/oauth/mcp/callback/oauth-callback-handler.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useBackendUrl } from "@/app/client-context";
 import { joinUrl } from "@/lib/utils";
+import { writeAt } from "@/lib/api-write";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -44,61 +45,46 @@ export const OAuthCallbackHandler = ({
     }
 
     const exchangeCode = async () => {
-      try {
-        const response = await fetch(
-          joinUrl(backendUrl, "/oauth/mcp/callback"),
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ code, state }),
-            credentials: "include",
-          },
-        );
+      const outcome = await writeAt<{
+        mcpId: string;
+        orgId: string;
+        workspaceId?: string;
+      }>(joinUrl(backendUrl, "/oauth/mcp/callback"), {
+        method: "POST",
+        data: { code, state },
+      });
 
-        if (response.ok) {
-          const data = await response.json();
+      if (outcome.outcome === "success") {
+        const data = outcome.data;
 
-          // If opened as a popup, notify the opener and close
-          if (
-            notifyOpenerAndClose({
-              type: OAUTH_MCP_SUCCESS_EVENT,
-              mcpId: data.mcpId,
-            })
-          )
-            return;
-
-          // Fallback: if not a popup (e.g. popup was blocked and we fell
-          // back to same-window redirect), navigate to the MCP edit page. An
-          // org-scoped (Shared) MCP has no workspaceId, so it edits under the
-          // organization settings surface.
-          const mcpEditPath = data.workspaceId
-            ? `/${data.orgId}/workspace/${data.workspaceId}/settings/mcp/${data.mcpId}`
-            : `/${data.orgId}/settings/mcp/${data.mcpId}`;
-          window.location.replace(mcpEditPath);
-        } else {
-          const data = await response.json().catch(() => ({}));
-          const message =
-            data.error || "Failed to complete OAuth authorization.";
-
-          // Notify opener of failure if in a popup
-          if (notifyOpenerAndClose({ type: OAUTH_MCP_ERROR_EVENT, message }))
-            return;
-
-          setError(message);
-          setIsProcessing(false);
-        }
-      } catch (err) {
-        const message =
-          err instanceof Error
-            ? err.message
-            : "Network error during OAuth exchange.";
-
-        if (notifyOpenerAndClose({ type: OAUTH_MCP_ERROR_EVENT, message }))
+        // If opened as a popup, notify the opener and close
+        if (
+          notifyOpenerAndClose({
+            type: OAUTH_MCP_SUCCESS_EVENT,
+            mcpId: data.mcpId,
+          })
+        )
           return;
 
-        setError(message);
-        setIsProcessing(false);
+        // Fallback: if not a popup (e.g. popup was blocked and we fell
+        // back to same-window redirect), navigate to the MCP edit page. An
+        // org-scoped (Shared) MCP has no workspaceId, so it edits under the
+        // organization settings surface.
+        const mcpEditPath = data.workspaceId
+          ? `/${data.orgId}/workspace/${data.workspaceId}/settings/mcp/${data.mcpId}`
+          : `/${data.orgId}/settings/mcp/${data.mcpId}`;
+        window.location.replace(mcpEditPath);
+        return;
       }
+
+      const message = outcome.message;
+
+      // Notify opener of failure if in a popup
+      if (notifyOpenerAndClose({ type: OAUTH_MCP_ERROR_EVENT, message }))
+        return;
+
+      setError(message);
+      setIsProcessing(false);
     };
 
     exchangeCode();

--- a/apps/frontend/app/settings/contexts/page.tsx
+++ b/apps/frontend/app/settings/contexts/page.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@/components/auth-provider";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeAt } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { type Context } from "@platypus/schemas";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
@@ -40,54 +41,30 @@ const ContextsPage = () => {
     const globalCtx = contexts?.results.find((c) => !c.workspaceId);
     setIsSavingGlobal(true);
 
-    try {
-      if (globalCtx) {
-        // Update existing global context
-        const response = await fetch(
+    const outcome = globalCtx
+      ? await writeAt(
           joinUrl(backendUrl, `/users/me/contexts/${globalCtx.id}`),
           {
             method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ content: globalContextContent }),
-            credentials: "include",
+            data: { content: globalContextContent },
           },
-        );
+        )
+      : await writeAt(joinUrl(backendUrl, "/users/me/contexts"), {
+          method: "POST",
+          data: { content: globalContextContent, workspaceId: undefined },
+        });
 
-        if (response.ok) {
-          toast.success("Global context saved");
-          mutate();
-        } else {
-          toast.error("Failed to update context");
-        }
-      } else {
-        // Create new global context
-        const response = await fetch(
-          joinUrl(backendUrl, "/users/me/contexts"),
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              content: globalContextContent,
-              workspaceId: undefined,
-            }),
-            credentials: "include",
-          },
-        );
-
-        if (response.ok) {
-          toast.success("Global context saved");
-          mutate();
-        } else if (response.status === 409) {
-          toast.error("You already have a global context");
-        } else {
-          toast.error("Failed to create context");
-        }
-      }
-    } catch {
-      toast.error("Error saving context");
-    } finally {
-      setIsSavingGlobal(false);
+    if (outcome.outcome === "success") {
+      toast.success("Global context saved");
+      mutate();
+    } else if (!globalCtx && outcome.outcome === "conflict") {
+      toast.error("You already have a global context");
+    } else {
+      toast.error(
+        globalCtx ? "Failed to update context" : "Failed to create context",
+      );
     }
+    setIsSavingGlobal(false);
   };
 
   return (

--- a/apps/frontend/lib/api-write.test.ts
+++ b/apps/frontend/lib/api-write.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { writeEntity } from "./api-write";
+import { writeEntity, writeAt } from "./api-write";
 
 function mockResponse(status: number, body: unknown) {
   return {
@@ -426,5 +426,103 @@ describe("writeEntity — outcomes", () => {
     if (result.outcome === "success") {
       expect(result.data).toBeNull();
     }
+  });
+});
+
+describe("writeAt", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends the given method and body to the given URL", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(mockResponse(201, { id: "c1" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeAt(`${BACKEND_URL}/users/me/contexts`, {
+      method: "POST",
+      data: { content: "hi" },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BACKEND_URL}/users/me/contexts`,
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "hi" }),
+      }),
+    );
+  });
+
+  it("sends no body for a DELETE", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeAt(`${BACKEND_URL}/users/me/contexts/c1`, {
+      method: "DELETE",
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.method).toBe("DELETE");
+    expect(init.body).toBeUndefined();
+    expect(init.headers).toBeUndefined();
+  });
+
+  it("defaults revalidateKeys to an empty array when omitted", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(mockResponse(200, { ok: true })),
+    );
+
+    const result = await writeAt(`${BACKEND_URL}/oauth/mcp/callback`, {
+      method: "POST",
+      data: { code: "x", state: "y" },
+    });
+
+    expect(result).toEqual({
+      outcome: "success",
+      data: { ok: true },
+      revalidateKeys: [],
+    });
+  });
+
+  it("carries caller-supplied revalidateKeys on success", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(200, {})));
+
+    const result = await writeAt(`${BACKEND_URL}/users/me/contexts/c1`, {
+      method: "PUT",
+      data: { content: "updated" },
+      revalidateKeys: [`${BACKEND_URL}/users/me/contexts`],
+    });
+
+    expect(result.outcome).toBe("success");
+    if (result.outcome === "success") {
+      expect(result.revalidateKeys).toEqual([
+        `${BACKEND_URL}/users/me/contexts`,
+      ]);
+    }
+  });
+
+  it("maps outcomes through the same ADR-0010 mapping as writeEntity", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockResponse(409, {
+          error: "You already have a context for this scope",
+        }),
+      ),
+    );
+
+    const result = await writeAt(`${BACKEND_URL}/users/me/contexts`, {
+      method: "POST",
+      data: { content: "hi" },
+    });
+
+    expect(result).toEqual({
+      outcome: "conflict",
+      message: "You already have a context for this scope",
+    });
   });
 });

--- a/apps/frontend/lib/api-write.ts
+++ b/apps/frontend/lib/api-write.ts
@@ -80,29 +80,12 @@ function errorFiles(body: unknown): string[] | undefined {
   return undefined;
 }
 
-/**
- * Owns a single write (create, update, or delete) to the Platypus API: the
- * base URL, the Organization-vs-Workspace path shape, credentials, the HTTP
- * method, and the outcome mapping that mirrors the backend's ADR-0010 error
- * seam. Callers pass `id`/`data` rather than a method: `id` absent means
- * create (POST), `id` present with `data` means update (PUT), `id` present
- * without `data` means delete (DELETE).
- */
-export async function writeEntity<TResult = unknown, TData = unknown>(
-  backendUrl: string,
-  entity: string,
-  scope: Scope,
-  options: WriteOptions<TData> = {},
+async function performWrite<TResult, TData>(
+  url: string,
+  method: "POST" | "PUT" | "DELETE",
+  data: TData | undefined,
+  revalidateKeys: readonly string[],
 ): Promise<WriteOutcome<TResult>> {
-  const { id, data } = options;
-  const method: "POST" | "PUT" | "DELETE" =
-    id === undefined ? "POST" : data === undefined ? "DELETE" : "PUT";
-
-  const path = scopedPath(entity, scope);
-  const collectionUrl = joinUrl(backendUrl, path);
-  const url =
-    id === undefined ? collectionUrl : joinUrl(backendUrl, `${path}/${id}`);
-
   let response: Response;
   try {
     response = await fetch(url, {
@@ -122,8 +105,6 @@ export async function writeEntity<TResult = unknown, TData = unknown>(
   const body: unknown = await response.json().catch(() => null);
 
   if (response.ok) {
-    const revalidateKeys =
-      method === "PUT" ? [collectionUrl, url] : [collectionUrl];
     return { outcome: "success", data: body as TResult, revalidateKeys };
   }
 
@@ -165,4 +146,54 @@ export async function writeEntity<TResult = unknown, TData = unknown>(
         httpStatus: response.status,
       };
   }
+}
+
+/**
+ * Owns a single write (create, update, or delete) to the Platypus API: the
+ * base URL, the Organization-vs-Workspace path shape, credentials, the HTTP
+ * method, and the outcome mapping that mirrors the backend's ADR-0010 error
+ * seam. Callers pass `id`/`data` rather than a method: `id` absent means
+ * create (POST), `id` present with `data` means update (PUT), `id` present
+ * without `data` means delete (DELETE).
+ */
+export async function writeEntity<TResult = unknown, TData = unknown>(
+  backendUrl: string,
+  entity: string,
+  scope: Scope,
+  options: WriteOptions<TData> = {},
+): Promise<WriteOutcome<TResult>> {
+  const { id, data } = options;
+  const method: "POST" | "PUT" | "DELETE" =
+    id === undefined ? "POST" : data === undefined ? "DELETE" : "PUT";
+
+  const path = scopedPath(entity, scope);
+  const collectionUrl = joinUrl(backendUrl, path);
+  const url =
+    id === undefined ? collectionUrl : joinUrl(backendUrl, `${path}/${id}`);
+  const revalidateKeys =
+    method === "PUT" ? [collectionUrl, url] : [collectionUrl];
+
+  return performWrite<TResult, TData>(url, method, data, revalidateKeys);
+}
+
+export interface WriteAtOptions<TData> {
+  readonly method: "POST" | "PUT" | "DELETE";
+  /** Omit only when the write is a DELETE. */
+  readonly data?: TData;
+  /** SWR keys this write should invalidate. Defaults to none. */
+  readonly revalidateKeys?: readonly string[];
+}
+
+/**
+ * Same transport and ADR-0010 outcome mapping as `writeEntity`, for the
+ * handful of writes that don't fit its Organization/Workspace scope (ADR-0007)
+ * — a user-scoped resource, or a one-off action endpoint. The caller supplies
+ * the full URL, so there's no scope or entity path to get out of sync with it.
+ */
+export async function writeAt<TResult = unknown, TData = unknown>(
+  url: string,
+  options: WriteAtOptions<TData>,
+): Promise<WriteOutcome<TResult>> {
+  const { method, data, revalidateKeys = [] } = options;
+  return performWrite<TResult, TData>(url, method, data, revalidateKeys);
 }


### PR DESCRIPTION
## Summary
- Migrate the remaining page-level raw `fetch()` writes onto `lib/api-write.ts`: the Dashboard pages, the Organization invitations page, the user Contexts page, and the MCP OAuth callback.
- Add `writeAt(url, options)` to `lib/api-write.ts` for writes that don't fit `writeEntity`'s Organization/Workspace scope (ADR-0007) — a user-scoped resource and a one-off OAuth callback endpoint — sharing the same transport/outcome mapping via a new internal `performWrite` helper.
- Replace the dashboard surface's bespoke 409-conflict decoding with the module's typed `conflict` outcome.
- Preserve the #561 response checks throughout (all 5 dashboard mutations still gate on success).

## Test plan
- [x] `pnpm --filter @platypus/frontend test` — 316 tests pass, including new `writeAt` coverage in `api-write.test.ts`
- [x] `pnpm --filter @platypus/frontend typecheck`
- [x] `pnpm --filter @platypus/frontend lint` — clean (pre-existing warnings only, none introduced)
- [x] Two-axis code review (Standards + Spec) — no violations found

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)