### PR TITLE
fix(frontend): surface the locked-Shared-resource message instead of a generic failure

### DIFF
--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -407,6 +407,10 @@ const AgentForm = ({
           setValidationErrors({ name: result.message });
           break;
         case "locked":
+          // Guidance, not a failure — the backend's message already says
+          // where the Shared resource is actually managed (#570).
+          toast.info(result.message);
+          break;
         case "notFound":
         case "error":
           toast.error(result.message);
@@ -432,6 +436,12 @@ const AgentForm = ({
     if (result.outcome === "success") {
       result.revalidateKeys.forEach((key) => mutate(key));
       router.push(doneHref);
+    } else if (result.outcome === "locked") {
+      // Guidance, not a failure — the backend's message already says where
+      // the Shared resource is actually managed (#570).
+      toast.info(result.message);
+      setIsDeleting(false);
+      setIsDeleteDialogOpen(false);
     } else {
       toast.error(result.message);
       setIsDeleting(false);

--- a/apps/frontend/components/agents-list.test.tsx
+++ b/apps/frontend/components/agents-list.test.tsx
@@ -27,6 +27,10 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushSpy }),
 }));
 
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
 type AgentWithScope = Agent & { scope?: "organization" | "workspace" };
 
 // The `GET .../agents` list this component renders. Set per test.
@@ -53,6 +57,7 @@ vi.mock("swr", () => ({
 }));
 
 import { AgentsList } from "./agents-list";
+import { toast } from "sonner";
 
 // --- Helpers -----------------------------------------------------------------
 
@@ -146,6 +151,48 @@ describe("AgentsList delete", () => {
       "http://test/organizations/org1/workspaces/ws1/agents/a2",
       expect.objectContaining({ method: "DELETE" }),
     );
+  });
+
+  it("shows the backend's guidance, not an error, when delete is refused because the agent is Shared", async () => {
+    agents = [workspaceAgent];
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(403, {
+        error: "This agent is managed at the organization level",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith(
+        "This agent is managed at the organization level",
+      ),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(mutateSpy).not.toHaveBeenCalled();
+    expect(screen.queryByText("Delete Agent")).not.toBeInTheDocument();
+  });
+
+  it("surfaces the backend's reason inline when delete fails for another reason", async () => {
+    agents = [workspaceAgent];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(409, { error: "Agent is in use" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Agent is in use")).toBeInTheDocument(),
+    );
+    expect(mutateSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/frontend/components/agents-list.tsx
+++ b/apps/frontend/components/agents-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import {
   Item,
   ItemTitle,
@@ -100,6 +101,8 @@ export const AgentsList = ({
   const [cloneError, setCloneError] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [agentToDelete, setAgentToDelete] = useState<Agent | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [attachOpen, setAttachOpen] = useState(false);
   const [selectedOrgAgent, setSelectedOrgAgent] =
     useState<AgentWithScope | null>(null);
@@ -199,19 +202,34 @@ export const AgentsList = ({
 
   const handleDeleteClick = (agent: Agent) => {
     setAgentToDelete(agent);
+    setDeleteError(null);
     setDeleteDialogOpen(true);
   };
 
   const handleDeleteConfirm = async () => {
     if (!agentToDelete || !backendUrl) return;
 
-    const outcome = await writeEntity(backendUrl, "agents", scope, {
-      id: agentToDelete.id,
-    });
-    if (outcome.outcome === "success") {
-      mutate();
-      setDeleteDialogOpen(false);
-      setAgentToDelete(null);
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const outcome = await writeEntity(backendUrl, "agents", scope, {
+        id: agentToDelete.id,
+      });
+      if (outcome.outcome === "success") {
+        mutate();
+        setDeleteDialogOpen(false);
+        setAgentToDelete(null);
+      } else if (outcome.outcome === "locked") {
+        // Guidance, not a failure — the backend's message already says
+        // where the Shared resource is actually managed (#570).
+        setDeleteDialogOpen(false);
+        setAgentToDelete(null);
+        toast.info(outcome.message);
+      } else {
+        setDeleteError(outcome.message);
+      }
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -745,12 +763,17 @@ export const AgentsList = ({
 
       <ConfirmDialog
         open={deleteDialogOpen}
-        onOpenChange={setDeleteDialogOpen}
+        onOpenChange={(open) => {
+          setDeleteDialogOpen(open);
+          if (!open) setDeleteError(null);
+        }}
         title="Delete Agent"
         description={`Are you sure you want to delete "${agentToDelete?.name}"? This action cannot be undone.`}
         confirmLabel="Delete"
         confirmVariant="destructive"
         onConfirm={handleDeleteConfirm}
+        loading={deleting}
+        error={deleteError}
       />
     </>
   );

--- a/apps/frontend/components/mcp-form.test.tsx
+++ b/apps/frontend/components/mcp-form.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { MCP } from "@platypus/schemas";
 
 // --- Module mocks ------------------------------------------------------------
@@ -35,6 +35,15 @@ vi.mock("swr", () => ({
 }));
 
 import { McpForm } from "./mcp-form";
+import { toast } from "sonner";
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
 
 // --- Tests -------------------------------------------------------------------
 
@@ -82,5 +91,40 @@ describe("McpForm secret reveal", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Hide client secret" }));
     expect(input).toHaveAttribute("type", "password");
+  });
+});
+
+describe("McpForm locked delete", () => {
+  afterEach(() => {
+    loadedMcp = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it("shows the backend's guidance, not an error toast, when the MCP is Shared", async () => {
+    loadedMcp = {
+      id: "m1",
+      name: "Docs",
+      url: "http://mcp.test",
+      authType: "None",
+    } as unknown as MCP;
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(403, {
+        error: "This MCP server is managed at the organization level",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<McpForm orgId="org1" workspaceId="ws1" mcpId="m1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Delete/ }));
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith(
+        "This MCP server is managed at the organization level",
+      ),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -259,6 +259,10 @@ const McpForm = ({
         setValidationErrors({ name: result.message });
         return null;
       case "locked":
+        // Guidance, not a failure — the backend's message already says
+        // where the Shared resource is actually managed (#570).
+        toast.info(result.message);
+        return null;
       case "notFound":
       case "error":
         toast.error(result.message);
@@ -293,6 +297,12 @@ const McpForm = ({
     if (result.outcome === "success") {
       result.revalidateKeys.forEach((key) => globalMutate(key));
       router.push(listPath);
+    } else if (result.outcome === "locked") {
+      // Guidance, not a failure — the backend's message already says where
+      // the Shared resource is actually managed (#570).
+      toast.info(result.message);
+      setIsDeleting(false);
+      setIsDeleteDialogOpen(false);
     } else {
       toast.error(result.message);
       setIsDeleting(false);

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -850,6 +850,10 @@ const ProviderForm = ({
           setError(result.message);
           break;
         case "locked":
+          // Guidance, not a failure — the backend's message already says
+          // where the Shared resource is actually managed (#570).
+          toast.info(result.message);
+          break;
         case "notFound":
         case "error":
           toast.error(result.message);
@@ -888,6 +892,12 @@ const ProviderForm = ({
       } else {
         router.push(`/${orgId}/settings/providers`);
       }
+    } else if (result.outcome === "locked") {
+      // Guidance, not a failure — the backend's message already says where
+      // the Shared resource is actually managed (#570).
+      toast.info(result.message);
+      setIsDeleting(false);
+      setIsDeleteDialogOpen(false);
     } else {
       toast.error(result.message);
       setIsDeleting(false);

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -164,6 +164,10 @@ const SkillForm = ({
         setValidationErrors({ name: result.message });
         break;
       case "locked":
+        // Guidance, not a failure — the backend's message already says
+        // where the Shared resource is actually managed (#570).
+        toast.info(result.message);
+        break;
       case "notFound":
       case "error":
         toast.error(result.message);
@@ -186,6 +190,12 @@ const SkillForm = ({
     if (result.outcome === "success") {
       result.revalidateKeys.forEach((key) => globalMutate(key));
       router.push(returnPath);
+    } else if (result.outcome === "locked") {
+      // Guidance, not a failure — the backend's message already says where
+      // the Shared resource is actually managed (#570).
+      toast.info(result.message);
+      setIsDeleting(false);
+      setIsDeleteDialogOpen(false);
     } else {
       setDeleteError(result.message);
       setIsDeleting(false);

--- a/apps/frontend/components/skills-list.test.tsx
+++ b/apps/frontend/components/skills-list.test.tsx
@@ -50,7 +50,12 @@ vi.mock("swr", () => ({
 
 const mutateSpy = vi.fn();
 
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
 import { SkillsList } from "./skills-list";
+import { toast } from "sonner";
 
 // --- Helpers -----------------------------------------------------------------
 
@@ -157,6 +162,31 @@ describe("SkillsList delete", () => {
       "http://test/organizations/org1/workspaces/ws1/skills/s2",
       expect.objectContaining({ method: "DELETE" }),
     );
+  });
+
+  it("shows the backend's guidance, not an inline error, when delete is refused because the skill is Shared", async () => {
+    skills = [workspaceSkill];
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(403, {
+        error: "This skill is managed at the organization level",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith(
+        "This skill is managed at the organization level",
+      ),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText("This skill is managed at the organization level"),
+    ).not.toBeInTheDocument();
   });
 
   it("deletes from the org-scoped path on the Organization surface (no workspaceId)", async () => {

--- a/apps/frontend/components/skills-list.tsx
+++ b/apps/frontend/components/skills-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import {
   Item,
   ItemTitle,
@@ -216,6 +217,12 @@ export const SkillsList = ({
         await mutate();
         setDeleteDialogOpen(false);
         setSkillToDelete(null);
+      } else if (outcome.outcome === "locked") {
+        // Guidance, not a failure — the backend's message already says
+        // where the Shared resource is actually managed (#570).
+        setDeleteDialogOpen(false);
+        setSkillToDelete(null);
+        toast.info(outcome.message);
       } else {
         setDeleteError(outcome.message);
       }


### PR DESCRIPTION
## Summary
- A refused mutation on a Shared resource now shows the backend's own explanation as guidance (`toast.info`) instead of a generic error toast, for the four resource types that can actually be locked (Agent, Skill, MCP, Provider).
- Fixes `agents-list.tsx`'s delete handler, which previously dropped every failure silently (no locked message, no error at all).
- Adds the same guidance handling to `skills-list.tsx`'s delete action.

## Why this scope
`#563`-`#565` already wired every form/list to read the backend's message, but it was always shown as a plain error, and `agents-list.tsx` genuinely discarded rejections. Only Agent/Skill/MCP/Provider forms are touched — they're the only `ScopedResourceType`s the backend can lock (`apps/backend/src/services/scoped-resource.ts`); the other 7 form modules can never structurally receive this outcome.

Closes #570

## Test plan
- [x] `pnpm typecheck` (whole monorepo)
- [x] `pnpm --filter frontend lint` (no new warnings)
- [x] `pnpm vitest run` in `apps/frontend` — 365 tests pass
- [x] New tests: `mcp-form.test.tsx` (locked delete → guidance toast), `skills-list.test.tsx` (locked delete → guidance, dialog closes), `agents-list.test.tsx` (locked delete → guidance; non-locked failure → surfaced inline)
- [x] Prettier clean
- [x] Reviewed via `/code-review` (parallel Standards + Spec sub-agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)