### PR TITLE
feat(frontend): gate Save only on errors the form can retract

### DIFF
--- a/apps/frontend/components/agent-form.test.tsx
+++ b/apps/frontend/components/agent-form.test.tsx
@@ -149,4 +149,21 @@ describe("AgentForm validation error surfacing", () => {
     );
     expect(saveButton).not.toBeDisabled();
   });
+
+  // #571: toolSetIds has no field that retracts its error, so gating Save on
+  // it would disable Save forever with no way out but reloading.
+  it("never disables Save on a rejection keyed to a field with no retracting input", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFailedSave([{ path: ["toolSetIds"], message: "Unknown tool set" }]),
+    );
+
+    renderCreateForm();
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(saveButton).not.toBeDisabled();
+  });
 });

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -49,7 +49,8 @@ import {
   type Skill,
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { findModelOption, getModelOptions } from "@/lib/model-config";
 import { resolveModel } from "@/lib/resolve-model";
@@ -63,6 +64,25 @@ import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { AgentAvatar } from "@/components/agent-avatar";
 import { Skeleton } from "@/components/ui/skeleton";
+
+// toolSetIds, skillIds, and subAgentIds are deliberately excluded: this form
+// has no field that retracts an error keyed to them, so including them here
+// would disable Save forever the moment the server rejects one.
+const RETRACTABLE_FIELDS = [
+  "name",
+  "description",
+  "inputPlaceholder",
+  "instructions",
+  "providerId",
+  "modelId",
+  "maxSteps",
+  "temperature",
+  "topP",
+  "topK",
+  "seed",
+  "presencePenalty",
+  "frequencyPenalty",
+] as const;
 
 const AgentForm = ({
   classNames,
@@ -224,7 +244,7 @@ const AgentForm = ({
   // corrected field stops rendering its error and re-enables the Save button.
   const clearValidationErrors = useCallback((...ids: string[]) => {
     setValidationErrors((prev) =>
-      ids.reduce((errors, id) => clearFieldError(errors, id), prev),
+      ids.reduce((errors, id) => retractFieldError(errors, id), prev),
     );
   }, []);
 
@@ -1010,7 +1030,9 @@ const AgentForm = ({
           className="cursor-pointer"
           onClick={handleSubmit}
           disabled={
-            isSubmitting || readOnly || Object.keys(validationErrors).length > 0
+            isSubmitting ||
+            readOnly ||
+            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
           }
         >
           {agentId ? "Update" : "Save"}

--- a/apps/frontend/components/app-sidebar.tsx
+++ b/apps/frontend/components/app-sidebar.tsx
@@ -60,7 +60,7 @@ import {
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Field, FieldLabel, FieldError } from "@/components/ui/field";
-import { parseValidationErrors } from "@/lib/utils";
+import { parseValidationErrors } from "@/lib/form-errors";
 import { useBackendUrl } from "@/app/client-context";
 import { TagInput } from "@/components/tag-input";
 import { useIsMobile } from "@/hooks/use-mobile";

--- a/apps/frontend/components/blueprint-form.tsx
+++ b/apps/frontend/components/blueprint-form.tsx
@@ -33,6 +33,7 @@ import type {
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -139,6 +140,15 @@ const ResourceGroup = ({
   );
 };
 
+const RETRACTABLE_FIELDS = [
+  "name",
+  "description",
+  "context",
+  "taskModelProviderId",
+  "memoryExtractionProviderId",
+  "memoryEmbeddingProviderId",
+] as const;
+
 const BlueprintForm = ({
   classNames,
   orgId,
@@ -222,13 +232,7 @@ const BlueprintForm = ({
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     const { id, value } = e.target;
-    if (validationErrors[id]) {
-      setValidationErrors((prev) => {
-        const next = { ...prev };
-        delete next[id];
-        return next;
-      });
-    }
+    setValidationErrors((prev) => retractFieldError(prev, id));
     setFormData((prev) => ({ ...prev, [id]: value }));
   };
 
@@ -448,12 +452,15 @@ const BlueprintForm = ({
             </FieldLabel>
             <Select
               value={formData.taskModelProviderId || "none"}
-              onValueChange={(value) =>
+              onValueChange={(value) => {
+                setValidationErrors((prev) =>
+                  retractFieldError(prev, "taskModelProviderId"),
+                );
                 setFormData((prev) => ({
                   ...prev,
                   taskModelProviderId: value === "none" ? null : value,
-                }))
-              }
+                }));
+              }}
               disabled={isSubmitting || attachedProviders.length === 0}
             >
               <SelectTrigger>
@@ -483,12 +490,15 @@ const BlueprintForm = ({
             </FieldLabel>
             <Select
               value={formData.memoryExtractionProviderId || "none"}
-              onValueChange={(value) =>
+              onValueChange={(value) => {
+                setValidationErrors((prev) =>
+                  retractFieldError(prev, "memoryExtractionProviderId"),
+                );
                 setFormData((prev) => ({
                   ...prev,
                   memoryExtractionProviderId: value === "none" ? null : value,
-                }))
-              }
+                }));
+              }}
               disabled={isSubmitting || memoryExtractionProviders.length === 0}
             >
               <SelectTrigger>
@@ -520,12 +530,15 @@ const BlueprintForm = ({
             </FieldLabel>
             <Select
               value={formData.memoryEmbeddingProviderId || "none"}
-              onValueChange={(value) =>
+              onValueChange={(value) => {
+                setValidationErrors((prev) =>
+                  retractFieldError(prev, "memoryEmbeddingProviderId"),
+                );
                 setFormData((prev) => ({
                   ...prev,
                   memoryEmbeddingProviderId: value === "none" ? null : value,
-                }))
-              }
+                }));
+              }}
               disabled={isSubmitting || memoryEmbeddingProviders.length === 0}
             >
               <SelectTrigger>
@@ -559,7 +572,9 @@ const BlueprintForm = ({
         <Button
           className="cursor-pointer"
           onClick={handleSubmit}
-          disabled={isSubmitting}
+          disabled={
+            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {blueprintId ? "Update" : "Save"}
         </Button>

--- a/apps/frontend/components/invitation-form.tsx
+++ b/apps/frontend/components/invitation-form.tsx
@@ -15,6 +15,7 @@ import { useState } from "react";
 import Link from "next/link";
 import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -26,6 +27,8 @@ interface InvitationFormProps {
   orgId: string;
   onSuccess?: () => void;
 }
+
+const RETRACTABLE_FIELDS = ["email", "workspaceName", "blueprintIds"] as const;
 
 export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
   const backendUrl = useBackendUrl();
@@ -53,6 +56,7 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
   const blueprintsById = new Map(blueprints.map((b) => [b.id, b]));
 
   const toggleBlueprint = (id: string, on: boolean) => {
+    setValidationErrors((prev) => retractFieldError(prev, "blueprintIds"));
     setBlueprintIds((prev) =>
       on ? [...prev, id] : prev.filter((bid) => bid !== id),
     );
@@ -139,13 +143,9 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
                 value={email}
                 onChange={(e) => {
                   setEmail(e.target.value);
-                  if (validationErrors.email) {
-                    setValidationErrors((prev) => {
-                      const next = { ...prev };
-                      delete next.email;
-                      return next;
-                    });
-                  }
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "email"),
+                  );
                 }}
                 disabled={isSubmitting}
                 autoFocus
@@ -165,13 +165,9 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
                 value={workspaceName}
                 onChange={(e) => {
                   setWorkspaceName(e.target.value);
-                  if (validationErrors.workspaceName) {
-                    setValidationErrors((prev) => {
-                      const next = { ...prev };
-                      delete next.workspaceName;
-                      return next;
-                    });
-                  }
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "workspaceName"),
+                  );
                 }}
                 disabled={isSubmitting}
               />
@@ -299,7 +295,9 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
       </FieldSet>
       <Button
         type="submit"
-        disabled={isSubmitting}
+        disabled={
+          isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+        }
         className={`w-full md:w-auto mt-2 ${!isSubmitting ? "cursor-pointer" : ""}`}
       >
         {isSubmitting ? "Sending..." : "Send invitation"}

--- a/apps/frontend/components/kanban-board-form.tsx
+++ b/apps/frontend/components/kanban-board-form.tsx
@@ -11,11 +11,17 @@ import { Button } from "@/components/ui/button";
 import { Field, FieldLabel, FieldError } from "@/components/ui/field";
 import { useBackendUrl } from "@/app/client-context";
 import { joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { KANBAN_LABEL_COLORS, type KanbanLabel } from "@platypus/schemas";
 import { toast } from "sonner";
 
 const DEFAULT_COLOR = KANBAN_LABEL_COLORS[5].value; // Blue
+
+// `labels` is excluded: this form has no field that retracts an error keyed
+// to it, so including it here would disable Save forever the moment the
+// server rejects a label.
+const RETRACTABLE_FIELDS = ["name", "description"] as const;
 
 export function KanbanBoardForm({
   orgId,
@@ -128,7 +134,10 @@ export function KanbanBoardForm({
         <Input
           id="name"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(e) => {
+            setValidationErrors((prev) => retractFieldError(prev, "name"));
+            setName(e.target.value);
+          }}
           placeholder="Board name"
           disabled={isSubmitting}
           required
@@ -143,7 +152,12 @@ export function KanbanBoardForm({
         <Textarea
           id="description"
           value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          onChange={(e) => {
+            setValidationErrors((prev) =>
+              retractFieldError(prev, "description"),
+            );
+            setDescription(e.target.value);
+          }}
           placeholder="Optional description"
           disabled={isSubmitting}
         />
@@ -208,7 +222,12 @@ export function KanbanBoardForm({
       <div className="flex gap-2">
         <Button
           type="submit"
-          disabled={isSubmitting || isDeleting || !name.trim()}
+          disabled={
+            isSubmitting ||
+            isDeleting ||
+            !name.trim() ||
+            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {isEditing ? "Update" : "Create board"}
         </Button>

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -32,7 +32,8 @@ import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type MCP } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
@@ -62,6 +63,15 @@ type McpFormData = Omit<
 > & {
   headerRows: HeaderRow[];
 };
+
+const RETRACTABLE_FIELDS = [
+  "name",
+  "url",
+  "bearerToken",
+  "oauthClientId",
+  "oauthClientSecret",
+  "oauthRequestedScope",
+] as const;
 
 const McpForm = ({
   classNames,
@@ -157,7 +167,7 @@ const McpForm = ({
 
     // Clear the error for this field, including any reported against a path
     // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,
@@ -170,17 +180,14 @@ const McpForm = ({
 
   const handleSelectChange = (id: string, value: string) => {
     // Clear the error for this field, including any reported against a path
-    // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
-
-    // Clear bearerToken error when authType changes
-    if (id === "authType" && validationErrors.bearerToken) {
-      setValidationErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.bearerToken;
-        return newErrors;
-      });
-    }
+    // inside it. Switching authType away from bearer also retracts a stale
+    // bearerToken error: that field disappears from the form, so nothing
+    // could otherwise clear it.
+    setValidationErrors((prev) =>
+      id === "authType"
+        ? retractFieldError(retractFieldError(prev, id), "bearerToken")
+        : retractFieldError(prev, id),
+    );
 
     setFormData((prevData) => ({
       ...prevData,
@@ -906,7 +913,7 @@ const McpForm = ({
           disabled={
             isSubmitting ||
             isTesting ||
-            Object.keys(validationErrors).length > 0
+            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
           }
         >
           {mcpId ? "Update" : "Save"}

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -23,7 +23,8 @@ import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type Organization } from "@platypus/schemas";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -35,6 +36,8 @@ interface OrganizationFormProps {
   classNames?: string;
   orgId?: string;
 }
+
+const RETRACTABLE_FIELDS = ["name", "identityContext"] as const;
 
 const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
   const { user } = useAuth();
@@ -78,7 +81,7 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
 
     // Clear the error for this field, including any reported against a path
     // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,
@@ -207,7 +210,9 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
       <div className="flex gap-2">
         <Button
           onClick={handleSubmit}
-          disabled={isSubmitting || Object.keys(validationErrors).length > 0}
+          disabled={
+            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {orgId ? "Update" : "Save"}
         </Button>

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -62,7 +62,8 @@ import {
   type Provider,
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import { clearFieldError, cn, fetcher, joinUrl } from "@/lib/utils";
+import { cn, fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import {
   getModelConfigs,
@@ -453,6 +454,11 @@ type ProviderFormData = Omit<
   embeddingDimensions: string;
 };
 
+// Deliberately empty: this form's fields can be validation-rejected on a
+// provider type that then hides the very input needed to retract them (see
+// the Save button below).
+const RETRACTABLE_FIELDS: readonly string[] = [];
+
 const ProviderForm = ({
   classNames,
   orgId,
@@ -641,7 +647,7 @@ const ProviderForm = ({
     const { id, value } = e.target;
 
     // Clear validation error for this field
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
     setError(null);
 
     if (id === "headers") {
@@ -678,7 +684,7 @@ const ProviderForm = ({
 
   const handleSelectChange = (id: string, value: string) => {
     // Clear validation error for this field
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
     setError(null);
 
     setFormData((prevData) => ({ ...prevData, [id]: value }));
@@ -689,7 +695,7 @@ const ProviderForm = ({
   // Retracts the list's error and every row error under it, so a stale message
   // doesn't sit under a row the user has already corrected.
   const clearModelIdsError = () => {
-    setValidationErrors((prev) => clearFieldError(prev, "modelIds"));
+    setValidationErrors((prev) => retractFieldError(prev, "modelIds"));
   };
 
   /**
@@ -1394,14 +1400,20 @@ const ProviderForm = ({
         <div className="flex gap-2">
           <Button
             className="cursor-pointer"
-            // Deliberately NOT gated on `validationErrors`. Those come back
-            // from the server, and every key needs a matching path that
-            // retracts it; one that has none disables Save forever, with no
-            // way out but reloading. Re-submitting simply re-validates. The
-            // JSON errors below are different — they are computed here as the
-            // user types and always clear themselves.
             onClick={handleSubmit}
-            disabled={isSubmitting || !!headersError || !!extraBodyError}
+            disabled={
+              isSubmitting ||
+              !!headersError ||
+              !!extraBodyError ||
+              // RETRACTABLE_FIELDS is deliberately empty: several fields here
+              // (apiMode, organization, project) render only for certain
+              // provider types, so a `validationErrors` key can outlive the
+              // input that would retract it. Server-returned errors must
+              // never gate Save for that reason — re-submitting simply
+              // re-validates. The JSON errors above are different: they are
+              // computed here as the user types and always clear themselves.
+              !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+            }
           >
             {providerId ? "Update" : "Save"}
           </Button>

--- a/apps/frontend/components/sandbox-settings.tsx
+++ b/apps/frontend/components/sandbox-settings.tsx
@@ -9,7 +9,8 @@ import { type Sandbox } from "@platypus/schemas";
 
 import { useAuth } from "@/components/auth-provider";
 import { useBackendUrl } from "@/app/client-context";
-import { fetcher, joinUrl, parseValidationErrors } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { parseValidationErrors } from "@/lib/form-errors";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -20,12 +20,15 @@ import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 import { type Skill, type Agent } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { AgentAvatar } from "@/components/agent-avatar";
+
+const RETRACTABLE_FIELDS = ["name", "description", "body"] as const;
 
 const SkillForm = ({
   classNames,
@@ -119,7 +122,7 @@ const SkillForm = ({
 
     // Clear the error for this field, including any reported against a path
     // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
 
     const nextValue = id === "name" ? value.toLowerCase() : value;
 
@@ -295,7 +298,9 @@ const SkillForm = ({
         <Button
           className="cursor-pointer"
           onClick={handleSubmit}
-          disabled={isSubmitting}
+          disabled={
+            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {skillId ? "Update" : "Save"}
         </Button>

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -36,7 +36,8 @@ import {
   type KanbanBoardState,
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -274,6 +275,19 @@ const parseCronExpression = (
   return null;
 };
 
+// isOneOff, maxRunsToKeep, search, filterBoardId/filterColumnId, and enabled
+// are deliberately excluded: this form has no field that retracts an error
+// keyed to them.
+const RETRACTABLE_FIELDS = [
+  "name",
+  "description",
+  "agentId",
+  "instruction",
+  "cronExpression",
+  "timezone",
+  "config",
+] as const;
+
 const TriggerForm = ({
   orgId,
   workspaceId,
@@ -474,7 +488,7 @@ const TriggerForm = ({
 
     // Clear the error for this field, including any reported against a path
     // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,
@@ -490,6 +504,7 @@ const TriggerForm = ({
   };
 
   const handleEventToggle = (event: string) => {
+    setValidationErrors((prev) => retractFieldError(prev, "config"));
     setSelectedEvents((prev) => {
       const next = prev.includes(event)
         ? prev.filter((e) => e !== event)
@@ -659,9 +674,12 @@ const TriggerForm = ({
             <FieldLabel>Agent</FieldLabel>
             <Select
               value={formData.agentId}
-              onValueChange={(value) =>
-                setFormData((prev) => ({ ...prev, agentId: value }))
-              }
+              onValueChange={(value) => {
+                setValidationErrors((prev) =>
+                  retractFieldError(prev, "agentId"),
+                );
+                setFormData((prev) => ({ ...prev, agentId: value }));
+              }}
               disabled={isSubmitting}
             >
               <SelectTrigger disabled={isSubmitting}>
@@ -939,9 +957,12 @@ const TriggerForm = ({
                 <FieldLabel>Timezone</FieldLabel>
                 <Select
                   value={formData.timezone}
-                  onValueChange={(value) =>
-                    setFormData((prev) => ({ ...prev, timezone: value }))
-                  }
+                  onValueChange={(value) => {
+                    setValidationErrors((prev) =>
+                      retractFieldError(prev, "timezone"),
+                    );
+                    setFormData((prev) => ({ ...prev, timezone: value }));
+                  }}
                   disabled={isSubmitting}
                 >
                   <SelectTrigger disabled={isSubmitting}>
@@ -1145,7 +1166,7 @@ const TriggerForm = ({
           onClick={handleSubmit}
           disabled={
             isSubmitting ||
-            Object.keys(validationErrors).length > 0 ||
+            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS) ||
             !isCronValid ||
             (triggerType === "event" && selectedEvents.length === 0)
           }

--- a/apps/frontend/components/webhook-form.tsx
+++ b/apps/frontend/components/webhook-form.tsx
@@ -16,7 +16,12 @@ import { useCallback, useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import useSWR, { useSWRConfig } from "swr";
-import { fetcher, clearFieldError, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import {
+  canSubmitForm,
+  retractExactKeys,
+  retractFieldError,
+} from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
@@ -61,6 +66,14 @@ const EVENT_LABELS: Record<string, string> = {
   "card.updated": "Card updated",
   "card.deleted": "Card deleted",
 };
+
+const RETRACTABLE_FIELDS = [
+  "name",
+  "url",
+  "enabled",
+  "events",
+  "headers",
+] as const;
 
 const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
   const { user } = useAuth();
@@ -125,7 +138,7 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
   const clearValidationErrors = useCallback((...fieldNames: string[]) => {
     setValidationErrors((prev) =>
       fieldNames.reduce(
-        (errors, fieldName) => clearFieldError(errors, fieldName),
+        (errors, fieldName) => retractFieldError(errors, fieldName),
         prev,
       ),
     );
@@ -267,13 +280,7 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
   // stranded on other rows.
   const clearHeaderRowError = (index: number) => {
     const rowKey = headerRowErrorKey(headers[index].key);
-    setValidationErrors((prev) => {
-      if (!("headers" in prev) && !(rowKey in prev)) return prev;
-      const next = { ...prev };
-      delete next.headers;
-      delete next[rowKey];
-      return next;
-    });
+    setValidationErrors((prev) => retractExactKeys(prev, ["headers", rowKey]));
   };
 
   const removeHeader = (index: number) => {
@@ -514,7 +521,9 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
         <Button
           className="cursor-pointer"
           onClick={handleSubmit}
-          disabled={isSubmitting || Object.keys(validationErrors).length > 0}
+          disabled={
+            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {isEditMode ? "Update" : "Save"}
         </Button>

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -31,7 +31,8 @@ import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type Workspace, type Provider } from "@platypus/schemas";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -44,6 +45,18 @@ interface WorkspaceFormProps {
   orgId: string;
   workspaceId?: string;
 }
+
+// providerSelfManagement and mcpSelfManagement are deliberately excluded:
+// this form has no field that retracts an error keyed to them.
+const RETRACTABLE_FIELDS = [
+  "name",
+  "ownerId",
+  "context",
+  "taskModelProviderId",
+  "memoryExtractionProviderId",
+  "memoryEmbeddingProviderId",
+  "maxDailySummaries",
+] as const;
 
 const WorkspaceForm = ({
   classNames,
@@ -158,7 +171,7 @@ const WorkspaceForm = ({
 
     // Clear the error for this field, including any reported against a path
     // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,
@@ -276,6 +289,9 @@ const WorkspaceForm = ({
               <Select
                 value={formData.ownerId || undefined}
                 onValueChange={(value) => {
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "ownerId"),
+                  );
                   setFormData((prevData) => ({ ...prevData, ownerId: value }));
                 }}
                 disabled={isSubmitting}
@@ -330,6 +346,9 @@ const WorkspaceForm = ({
               <Select
                 value={formData.taskModelProviderId || "none"}
                 onValueChange={(value) => {
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "taskModelProviderId"),
+                  );
                   setFormData((prevData) => ({
                     ...prevData,
                     taskModelProviderId: value === "none" ? null : value,
@@ -367,6 +386,9 @@ const WorkspaceForm = ({
               <Select
                 value={formData.memoryExtractionProviderId || "none"}
                 onValueChange={(value) => {
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "memoryExtractionProviderId"),
+                  );
                   setFormData((prevData) => ({
                     ...prevData,
                     memoryExtractionProviderId: value === "none" ? null : value,
@@ -408,6 +430,9 @@ const WorkspaceForm = ({
               <Select
                 value={formData.memoryEmbeddingProviderId || "none"}
                 onValueChange={(value) => {
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "memoryEmbeddingProviderId"),
+                  );
                   setFormData((prevData) => ({
                     ...prevData,
                     memoryEmbeddingProviderId: value === "none" ? null : value,
@@ -457,6 +482,9 @@ const WorkspaceForm = ({
                 max={365}
                 value={formData.maxDailySummaries}
                 onChange={(e) => {
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "maxDailySummaries"),
+                  );
                   setFormData((prevData) => ({
                     ...prevData,
                     maxDailySummaries: parseInt(e.target.value) || 90,
@@ -540,7 +568,9 @@ const WorkspaceForm = ({
       <div className="flex gap-2">
         <Button
           onClick={handleSubmit}
-          disabled={isSubmitting || Object.keys(validationErrors).length > 0}
+          disabled={
+            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {workspaceId ? "Update" : "Save"}
         </Button>

--- a/apps/frontend/lib/api-write.ts
+++ b/apps/frontend/lib/api-write.ts
@@ -1,4 +1,5 @@
-import { joinUrl, parseValidationErrors } from "./utils";
+import { joinUrl } from "./utils";
+import { parseValidationErrors } from "./form-errors";
 
 /**
  * A write's target scope (ADR-0007): an Organization-level (Shared) resource,

--- a/apps/frontend/lib/form-errors.test.ts
+++ b/apps/frontend/lib/form-errors.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import {
+  canSubmitForm,
+  parseValidationErrors,
+  retractExactKeys,
+  retractFieldError,
+  type FormErrors,
+} from "./form-errors";
+
+describe("parseValidationErrors", () => {
+  it("should parse validation errors correctly", () => {
+    const errorData = {
+      error: [
+        { path: ["name"], message: "Name is required" },
+        { path: ["email"], message: "Invalid email" },
+      ],
+    };
+    const result = parseValidationErrors(errorData);
+    expect(result).toEqual({
+      name: "Name is required",
+      email: "Invalid email",
+    });
+  });
+
+  it("should return empty object for invalid input", () => {
+    expect(parseValidationErrors(null)).toEqual({});
+    expect(parseValidationErrors({})).toEqual({});
+    expect(parseValidationErrors({ error: "string" })).toEqual({});
+  });
+
+  // A rule over a list reports the row it failed on. Keyed on the first path
+  // segment alone, every row's message landed on the same key and all but one
+  // was lost — two bad rows meant one message and one fix per round-trip.
+  it("keys an error inside a list on its full path", () => {
+    const result = parseValidationErrors({
+      error: [
+        { path: ["modelIds", 1, "alias"], message: "Alias 'dup' duplicates" },
+        { path: ["modelIds", 2, "alias"], message: "Alias 'DUP' duplicates" },
+      ],
+    });
+
+    expect(result["modelIds.1.alias"]).toBe("Alias 'dup' duplicates");
+    expect(result["modelIds.2.alias"]).toBe("Alias 'DUP' duplicates");
+  });
+
+  // Not every form knows about paths. Each issue also reports under its
+  // top-level field so a form that only reads flat names still shows something
+  // rather than failing silently.
+  it("also reports a nested error under its top-level field", () => {
+    const result = parseValidationErrors({
+      error: [{ path: ["modelIds", 1, "alias"], message: "Alias duplicates" }],
+    });
+
+    expect(result.modelIds).toBe("Alias duplicates");
+  });
+
+  // An error against the list itself is the better message for the list's own
+  // slot, whichever order the two arrive in.
+  it("prefers an error on the field itself over one derived from a row", () => {
+    const rowFirst = parseValidationErrors({
+      error: [
+        { path: ["modelIds", 0, "alias"], message: "Row message" },
+        { path: ["modelIds"], message: "Field message" },
+      ],
+    });
+
+    expect(rowFirst.modelIds).toBe("Field message");
+    expect(rowFirst["modelIds.0.alias"]).toBe("Row message");
+  });
+
+  it("keeps the first message when one field has several", () => {
+    const result = parseValidationErrors({
+      error: [
+        { path: ["name"], message: "Too short" },
+        { path: ["name"], message: "Also invalid" },
+      ],
+    });
+
+    expect(result.name).toBe("Too short");
+  });
+});
+
+describe("retractFieldError", () => {
+  it("drops the field's own error", () => {
+    expect(
+      retractFieldError({ name: "Required", apiKey: "Bad" }, "name"),
+    ).toEqual({ apiKey: "Bad" });
+  });
+
+  // The edit that fixes a row is an edit to the field the row lives in, so the
+  // rows' errors have to go with it. A form gating Submit on the error map
+  // stays stuck forever otherwise.
+  it("drops errors nested under the field", () => {
+    const errors = {
+      "modelIds.1.alias": "Duplicate",
+      "modelIds.2.alias": "Duplicate",
+      modelIds: "Duplicate",
+      name: "Required",
+    };
+
+    expect(retractFieldError(errors, "modelIds")).toEqual({
+      name: "Required",
+    });
+  });
+
+  it("leaves a field whose name merely prefixes the edited one", () => {
+    const errors = { modelIdsExtra: "Bad" };
+
+    expect(retractFieldError(errors, "modelIds")).toEqual(errors);
+  });
+
+  it("returns the same object when nothing matches, so state does not churn", () => {
+    const errors = { name: "Required" };
+
+    expect(retractFieldError(errors, "apiKey")).toBe(errors);
+  });
+});
+
+describe("retractExactKeys", () => {
+  it("drops exactly the given keys", () => {
+    const errors = { name: "Required", "headers.X-Foo": "Too long" };
+
+    expect(retractExactKeys(errors, ["name"])).toEqual({
+      "headers.X-Foo": "Too long",
+    });
+  });
+
+  // Unlike retractFieldError, a row-scoped clear must not sweep siblings
+  // sharing the same top-level field name.
+  it("leaves sibling rows under the same top-level field alone", () => {
+    const errors = {
+      "headers.X-Foo": "Too long",
+      "headers.X-Bar": "Too long",
+    };
+
+    expect(retractExactKeys(errors, ["headers", "headers.X-Foo"])).toEqual({
+      "headers.X-Bar": "Too long",
+    });
+  });
+
+  it("returns the same object when nothing matches, so state does not churn", () => {
+    const errors = { name: "Required" };
+
+    expect(retractExactKeys(errors, ["apiKey"])).toBe(errors);
+  });
+});
+
+describe("canSubmitForm", () => {
+  it("allows submit when there are no errors", () => {
+    expect(canSubmitForm({}, ["name", "url"])).toBe(true);
+  });
+
+  it("blocks submit while a retractable field's error is outstanding", () => {
+    expect(canSubmitForm({ name: "Required" }, ["name", "url"])).toBe(false);
+  });
+
+  it("blocks submit on a row-level error under a retractable field", () => {
+    expect(
+      canSubmitForm({ "headers.X-Foo": "Too long" }, ["name", "headers"]),
+    ).toBe(false);
+  });
+
+  // The #571 invariant: a server-returned error keyed to a field the form
+  // never declared has no way to be retracted by editing, so it must never
+  // gate Save — the only escape from that would be reloading the page.
+  it("never blocks submit on an error whose key no field can retract", () => {
+    expect(canSubmitForm({ events: "At least one event required" }, [])).toBe(
+      true,
+    );
+    expect(canSubmitForm({ someServerOnlyRule: "Nope" }, ["name", "url"])).toBe(
+      true,
+    );
+  });
+
+  // Regression for #559: a Webhook save rejected on `events` — a field the
+  // form declares — must leave Save usable once `events` is edited (i.e. once
+  // its error is retracted), not disabled forever.
+  it("mirrors the #559 webhook round trip: retract, then submit is allowed again", () => {
+    const retractable = ["name", "url", "enabled", "events", "headers"];
+    let errors: FormErrors = { events: "At least one event is required" };
+
+    expect(canSubmitForm(errors, retractable)).toBe(false);
+
+    errors = retractFieldError(errors, "events");
+
+    expect(errors).toEqual({});
+    expect(canSubmitForm(errors, retractable)).toBe(true);
+  });
+});

--- a/apps/frontend/lib/form-errors.ts
+++ b/apps/frontend/lib/form-errors.ts
@@ -1,0 +1,122 @@
+/**
+ * Owns a form's server-side rejections end to end: parsing them off a failed
+ * write, retracting one when the field it names is edited, and deciding
+ * whether the form may submit.
+ *
+ * A form declares which field ids it can retract (its inputs) and never
+ * needs to reason about the rest itself — an error keyed to anything else
+ * (a field the form doesn't render, a cross-field rule with nowhere to
+ * live) simply can't gate Save, because there would be no way to clear it
+ * short of reloading.
+ */
+
+export type FormErrors = Record<string, string>;
+
+function isFieldOrSubPath(key: string, fieldId: string): boolean {
+  return key === fieldId || key.startsWith(`${fieldId}.`);
+}
+
+/**
+ * Map a validation failure onto the fields that can show it.
+ *
+ * Each issue is keyed on its **full path**, dot-joined: a rule over a list
+ * reports the row it failed on (`modelIds.2.alias`), so two bad rows produce
+ * two messages the form can render in two places. Keyed on the first segment
+ * alone, they overwrote each other — one message, one fix per round-trip.
+ *
+ * Every issue is *also* reported under its top-level field, because most forms
+ * only know flat names. An error on the field itself wins that slot over one
+ * derived from a row.
+ */
+export function parseValidationErrors(errorData: unknown): FormErrors {
+  const errors: FormErrors = {};
+
+  if (
+    !errorData ||
+    typeof errorData !== "object" ||
+    !("error" in errorData) ||
+    !Array.isArray(errorData.error)
+  ) {
+    return errors;
+  }
+
+  const issues: Array<{ path: string[]; message: string }> = [];
+  for (const issue of errorData.error) {
+    if (
+      issue &&
+      typeof issue === "object" &&
+      "path" in issue &&
+      Array.isArray(issue.path) &&
+      issue.path.length > 0 &&
+      "message" in issue &&
+      typeof issue.message === "string"
+    ) {
+      issues.push({ path: issue.path.map(String), message: issue.message });
+    }
+  }
+
+  // Exact paths first, so the top-level pass below can't take a slot an issue
+  // on the field itself is entitled to.
+  for (const { path, message } of issues) {
+    const key = path.join(".");
+    if (!(key in errors)) errors[key] = message;
+  }
+  for (const { path, message } of issues) {
+    if (!(path[0] in errors)) errors[path[0]] = message;
+  }
+
+  return errors;
+}
+
+/**
+ * Retract the error shown against a field, including any keyed at a path
+ * *under* it — the edit that fixes a row is an edit to the field the row lives
+ * in. Returns the original object when nothing matched, so a no-op leaves
+ * state (and identity) untouched.
+ */
+export function retractFieldError(
+  errors: FormErrors,
+  fieldId: string,
+): FormErrors {
+  const remaining = Object.entries(errors).filter(
+    ([key]) => !isFieldOrSubPath(key, fieldId),
+  );
+
+  if (remaining.length === Object.keys(errors).length) return errors;
+  return Object.fromEntries(remaining);
+}
+
+/**
+ * Retract exactly the given keys — no sub-path matching. For a row-scoped
+ * edit inside a keyed group (e.g. one header row in `headers`), where
+ * `retractFieldError(errors, "headers")` would sweep every sibling row under
+ * the same top-level field. Returns the original object when nothing
+ * matched, so a no-op leaves state (and identity) untouched.
+ */
+export function retractExactKeys(
+  errors: FormErrors,
+  keys: readonly string[],
+): FormErrors {
+  const toRemove = new Set(keys);
+  const remaining = Object.entries(errors).filter(
+    ([key]) => !toRemove.has(key),
+  );
+
+  if (remaining.length === Object.keys(errors).length) return errors;
+  return Object.fromEntries(remaining);
+}
+
+/**
+ * A form may submit unless a *retractable* error is still outstanding — one
+ * keyed to a field the form declared. A server-returned error with no
+ * retracting field must never gate Save: editing can't clear it, so gating on
+ * it would disable Save forever with no way out but reloading.
+ */
+export function canSubmitForm(
+  errors: FormErrors,
+  retractableFieldIds: readonly string[],
+): boolean {
+  return !Object.keys(errors).some((key) =>
+    retractableFieldIds.some((fieldId) => isFieldOrSubPath(key, fieldId)),
+  );
+}

--- a/apps/frontend/lib/utils.test.ts
+++ b/apps/frontend/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { clearFieldError, joinUrl, parseValidationErrors } from "./utils";
+import { joinUrl } from "./utils";
 
 describe("joinUrl", () => {
   it("should join base URL and path", () => {
@@ -22,112 +22,5 @@ describe("joinUrl", () => {
 
   it("should return path when base is empty", () => {
     expect(joinUrl("", "/api/test")).toBe("/api/test");
-  });
-});
-
-describe("parseValidationErrors", () => {
-  it("should parse validation errors correctly", () => {
-    const errorData = {
-      error: [
-        { path: ["name"], message: "Name is required" },
-        { path: ["email"], message: "Invalid email" },
-      ],
-    };
-    const result = parseValidationErrors(errorData);
-    expect(result).toEqual({
-      name: "Name is required",
-      email: "Invalid email",
-    });
-  });
-
-  it("should return empty object for invalid input", () => {
-    expect(parseValidationErrors(null)).toEqual({});
-    expect(parseValidationErrors({})).toEqual({});
-    expect(parseValidationErrors({ error: "string" })).toEqual({});
-  });
-
-  // A rule over a list reports the row it failed on. Keyed on the first path
-  // segment alone, every row's message landed on the same key and all but one
-  // was lost — two bad rows meant one message and one fix per round-trip.
-  it("keys an error inside a list on its full path", () => {
-    const result = parseValidationErrors({
-      error: [
-        { path: ["modelIds", 1, "alias"], message: "Alias 'dup' duplicates" },
-        { path: ["modelIds", 2, "alias"], message: "Alias 'DUP' duplicates" },
-      ],
-    });
-
-    expect(result["modelIds.1.alias"]).toBe("Alias 'dup' duplicates");
-    expect(result["modelIds.2.alias"]).toBe("Alias 'DUP' duplicates");
-  });
-
-  // Not every form knows about paths. Each issue also reports under its
-  // top-level field so a form that only reads flat names still shows something
-  // rather than failing silently.
-  it("also reports a nested error under its top-level field", () => {
-    const result = parseValidationErrors({
-      error: [{ path: ["modelIds", 1, "alias"], message: "Alias duplicates" }],
-    });
-
-    expect(result.modelIds).toBe("Alias duplicates");
-  });
-
-  // An error against the list itself is the better message for the list's own
-  // slot, whichever order the two arrive in.
-  it("prefers an error on the field itself over one derived from a row", () => {
-    const rowFirst = parseValidationErrors({
-      error: [
-        { path: ["modelIds", 0, "alias"], message: "Row message" },
-        { path: ["modelIds"], message: "Field message" },
-      ],
-    });
-
-    expect(rowFirst.modelIds).toBe("Field message");
-    expect(rowFirst["modelIds.0.alias"]).toBe("Row message");
-  });
-
-  it("keeps the first message when one field has several", () => {
-    const result = parseValidationErrors({
-      error: [
-        { path: ["name"], message: "Too short" },
-        { path: ["name"], message: "Also invalid" },
-      ],
-    });
-
-    expect(result.name).toBe("Too short");
-  });
-});
-
-describe("clearFieldError", () => {
-  it("drops the field's own error", () => {
-    expect(
-      clearFieldError({ name: "Required", apiKey: "Bad" }, "name"),
-    ).toEqual({ apiKey: "Bad" });
-  });
-
-  // The edit that fixes a row is an edit to the field the row lives in, so the
-  // rows' errors have to go with it. A form gating Submit on the error map
-  // stays stuck forever otherwise.
-  it("drops errors nested under the field", () => {
-    const errors = {
-      "modelIds.1.alias": "Duplicate",
-      "modelIds.2.alias": "Duplicate",
-      modelIds: "Duplicate",
-      name: "Required",
-    };
-
-    expect(clearFieldError(errors, "modelIds")).toEqual({ name: "Required" });
-  });
-
-  it("leaves a field whose name merely prefixes the edited one", () => {
-    const errors = { modelIdsExtra: "Bad" };
-
-    expect(clearFieldError(errors, "modelIds")).toEqual(errors);
-  });
-
-  it("returns the same object when nothing matches, so state does not churn", () => {
-    const errors = { name: "Required" };
-
-    expect(clearFieldError(errors, "apiKey")).toBe(errors);
   });
 });

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -33,11 +33,6 @@ export const fetcher = async (input: RequestInfo | URL, init?: RequestInit) => {
   return res.json();
 };
 
-/**
- * Parses standardschema.dev validation errors from an error response
- * @param errorData - The error response data from the API
- * @returns An object mapping field names to error messages
- */
 export function getInitials(name: string): string {
   return name
     .split(" ")
@@ -45,77 +40,4 @@ export function getInitials(name: string): string {
     .join("")
     .toUpperCase()
     .slice(0, 2);
-}
-
-/**
- * Map a validation failure onto the fields that can show it.
- *
- * Each issue is keyed on its **full path**, dot-joined: a rule over a list
- * reports the row it failed on (`modelIds.2.alias`), so two bad rows produce
- * two messages the form can render in two places. Keyed on the first segment
- * alone, they overwrote each other — one message, one fix per round-trip.
- *
- * Every issue is *also* reported under its top-level field, because most forms
- * only know flat names. An error on the field itself wins that slot over one
- * derived from a row.
- */
-export function parseValidationErrors(
-  errorData: unknown,
-): Record<string, string> {
-  const errors: Record<string, string> = {};
-
-  if (
-    !errorData ||
-    typeof errorData !== "object" ||
-    !("error" in errorData) ||
-    !Array.isArray(errorData.error)
-  ) {
-    return errors;
-  }
-
-  const issues: Array<{ path: string[]; message: string }> = [];
-  for (const issue of errorData.error) {
-    if (
-      issue &&
-      typeof issue === "object" &&
-      "path" in issue &&
-      Array.isArray(issue.path) &&
-      issue.path.length > 0 &&
-      "message" in issue &&
-      typeof issue.message === "string"
-    ) {
-      issues.push({ path: issue.path.map(String), message: issue.message });
-    }
-  }
-
-  // Exact paths first, so the top-level pass below can't take a slot an issue
-  // on the field itself is entitled to.
-  for (const { path, message } of issues) {
-    const key = path.join(".");
-    if (!(key in errors)) errors[key] = message;
-  }
-  for (const { path, message } of issues) {
-    if (!(path[0] in errors)) errors[path[0]] = message;
-  }
-
-  return errors;
-}
-
-/**
- * Retract the error shown against a field, including any keyed at a path
- * *under* it — the edit that fixes a row is an edit to the field the row lives
- * in. Returns the original object when nothing matched, so a no-op leaves
- * state untouched.
- */
-export function clearFieldError(
-  errors: Record<string, string>,
-  fieldName: string,
-): Record<string, string> {
-  const prefix = `${fieldName}.`;
-  const remaining = Object.entries(errors).filter(
-    ([key]) => key !== fieldName && !key.startsWith(prefix),
-  );
-
-  if (remaining.length === Object.keys(errors).length) return errors;
-  return Object.fromEntries(remaining);
 }


### PR DESCRIPTION
## Summary

- Adds `apps/frontend/lib/form-errors.ts` as the single module owning a form's rejections, retractions, and submit-gating: `parseValidationErrors`, `retractFieldError` (sub-path aware, identity-preserving), `retractExactKeys` (row-scoped clears that must not sweep sibling rows), and `canSubmitForm` — which gates Save only on errors keyed to a field the form actually declares as retractable.
- A server-returned error with no retracting field could previously disable Save forever, with no way out but reloading — the narrow version of this was fixed for the Webhook form in #559; this closes the whole class.
- All eleven forms (agent, mcp, provider, organization, workspace, skill, blueprint, webhook, trigger, kanban-board, invitation) now retract and gate through this module, each declaring only the field ids it has a live input for. Hand-rolled exact-key retractions are deleted.

Closes #571.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @platypus/frontend test` — 370 tests passing, including a module-level regression test mirroring the #559 round trip and a form-level test confirming a rejection on a field with no retracting input (e.g. Agent's `toolSetIds`) never disables Save
- [x] `pnpm lint` — no new warnings/errors
- [x] `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)