### PR TITLE
chore(frontend): populate the Provider form from the warm cache like every other form

### DIFF
--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -403,6 +403,89 @@ describe("ProviderForm model rows", () => {
   });
 });
 
+describe("ProviderForm switching Providers", () => {
+  afterEach(() => {
+    loadedProvider = undefined;
+    vi.restoreAllMocks();
+  });
+
+  // The form is reused across Providers within one mount. Populating from the
+  // warm SWR cache has to repopulate on the switch too, not just on first load —
+  // otherwise the reader would see the previous Provider's fields left on
+  // screen under the new Provider's name.
+  it("repopulates every field when the reader switches to another Provider, even from an already-warm cache", () => {
+    loadedProvider = {
+      id: "p1",
+      name: "OpenAI provider",
+      providerType: "OpenAI",
+      apiKey: "sk-p1",
+      baseUrl: "https://p1.example.com",
+      apiMode: "responses",
+      modelIds: [{ id: "gpt-4o", passthroughFileTypes: [] }],
+      taskModelId: "gpt-4o",
+      memoryExtractionModelId: "gpt-4o",
+    } as unknown as Provider;
+    const { rerender } = render(<ProviderForm orgId="org1" providerId="p1" />);
+
+    expect(screen.getByLabelText("Name")).toHaveValue("OpenAI provider");
+    expect(screen.getByLabelText("Model ID")).toHaveValue("gpt-4o");
+
+    // Already resolved before the rerender, as it would be for a Provider
+    // whose data is already warm in SWR's cache.
+    loadedProvider = {
+      id: "p2",
+      name: "Anthropic provider",
+      providerType: "Anthropic",
+      apiKey: "sk-p2",
+      baseUrl: "https://p2.example.com",
+      apiMode: "responses",
+      modelIds: [{ id: "claude-opus", passthroughFileTypes: [] }],
+      taskModelId: "claude-opus",
+      memoryExtractionModelId: "claude-opus",
+    } as unknown as Provider;
+    rerender(<ProviderForm orgId="org1" providerId="p2" />);
+
+    expect(screen.getByLabelText("Name")).toHaveValue("Anthropic provider");
+    expect(screen.getByLabelText("API Key")).toHaveValue("sk-p2");
+    expect(screen.getByLabelText("Base URL")).toHaveValue(
+      "https://p2.example.com",
+    );
+    expect(screen.getByLabelText("Model ID")).toHaveValue("claude-opus");
+  });
+
+  // The specific behaviour the old initialised-flag ref protected: a Provider
+  // is populated once, and a later SWR revalidation of that *same* Provider —
+  // a focus revalidation, another tab saving it — hands back a new object
+  // reference for unchanged (or server-updated) data. That must not re-run
+  // the populate and stomp an edit the reader hasn't saved yet. Keying the
+  // reset on `providerId` (gated on the fetch having resolved) rather than on
+  // `provider` itself is what keeps this working without the ref: `provider`
+  // gets a new reference on every such revalidation, but `providerId` does not.
+  it("does not clobber an in-progress edit when the same Provider's data revalidates", () => {
+    loadedProvider = {
+      id: "p1",
+      name: "OpenAI provider",
+      providerType: "OpenAI",
+      apiKey: "sk-p1",
+      apiMode: "responses",
+      modelIds: [{ id: "gpt-4o", passthroughFileTypes: [] }],
+      taskModelId: "gpt-4o",
+      memoryExtractionModelId: "gpt-4o",
+    } as unknown as Provider;
+    const { rerender } = render(<ProviderForm orgId="org1" providerId="p1" />);
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "My edited name" },
+    });
+
+    // A new object for the same Provider, as a revalidation would hand back.
+    loadedProvider = { ...loadedProvider };
+    rerender(<ProviderForm orgId="org1" providerId="p1" />);
+
+    expect(screen.getByLabelText("Name")).toHaveValue("My edited name");
+  });
+});
+
 describe("ProviderForm validation errors on model rows", () => {
   afterEach(() => {
     loadedProvider = undefined;

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -49,7 +49,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   CONTEXT_WINDOW_MAX,
@@ -470,7 +470,6 @@ const ProviderForm = ({
   const { user } = useAuth();
   const backendUrl = useBackendUrl();
   const router = useRouter();
-  const hasInitialized = useRef(false);
 
   const formScope = workspaceId ? "workspace" : "organization";
 
@@ -578,22 +577,23 @@ const ProviderForm = ({
     formData.searchSource === SEARCH_SOURCE_NATIVE &&
     !providerHasNativeSearch(formData);
 
-  // Start the form over when the reader switches Provider within one mount, so
-  // the initialisation flag the effect below reads belongs to the Provider on
-  // screen. `useResetOnChange` rather than an effect: it adjusts state during
-  // render, so the flag is already false when the effect runs (#474).
+  // Populate once per Provider, keyed on `providerId` rather than `provider`
+  // itself: `provider` gets a new object reference on every revalidation that
+  // actually changes the record (a save from another tab, a focus
+  // revalidation), and keying on it directly would re-run this on the Provider
+  // the reader is already editing, clobbering the edit in progress with
+  // whatever the server has right now. Gating the key on `provider` being
+  // loaded — rather than firing as soon as `providerId` changes — defers the
+  // reset until the switch actually has data to populate with, so a cold
+  // fetch (data not loaded yet) doesn't reset into a blank form early and
+  // then never fire again once the fetch resolves.
   //
-  // The Web-search backend selector's visibility rule and its `webBackendEdited`
-  // latch used to be reset here too. Both are gone with the collapse: `searchSource`
-  // is always rendered — "None" and, where the Provider is capable, its built-in
-  // search are real choices on every deployment — so there is no longer a condition
-  // that reads the value the field itself edits.
-  useResetOnChange(providerId, () => {
-    hasInitialized.current = false;
-  });
-
-  useEffect(() => {
-    if (provider && !hasInitialized.current) {
+  // `useResetOnChange` rather than an effect: it adjusts state during render,
+  // so a switch to a Provider already warm in SWR's cache repopulates on that
+  // same render instead of leaving the previous Provider's fields on screen
+  // for one extra frame (#474).
+  useResetOnChange(provider ? providerId : undefined, () => {
+    if (provider) {
       setFormData({
         providerType: provider.providerType,
         name: provider.name,
@@ -631,9 +631,8 @@ const ProviderForm = ({
       setSavedEmbeddingDimensions(
         provider.embeddingDimensions?.toString() || null,
       );
-      hasInitialized.current = true;
     }
-  }, [provider]);
+  });
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,


### PR DESCRIPTION
## Summary

- Replaces the Provider form's `hasInitialized` ref + paired ~40-line `useEffect` with the shared `useResetOnChange` hook, matching the other nine forms already converted to this pattern.
- Keyed on `providerId` (gated on the fetch having actually resolved) rather than the fetched `provider` object itself — SWR hands back a new object reference on every revalidation of the same Provider (e.g. a focus revalidation), and keying on it directly would re-populate the form and clobber an edit in progress. That's exactly the behaviour the old ref was protecting against, so this diff preserves it rather than just copying the sibling-forms' pattern verbatim.
- Adds two tests: repopulating correctly on a Provider switch (including from an already-warm cache), and *not* clobbering an in-progress edit on a same-Provider revalidation. Both were verified to actually discriminate — the latter fails against a naive `useResetOnChange(provider, ...)` port.

Closes #577

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm --filter @platypus/frontend lint` passes (only pre-existing unrelated warnings)
- [x] `pnpm --filter @platypus/frontend test` — 363/363 pass
- [x] Manually verified the new revalidation test fails against a draft keyed on `provider` directly, confirming it's a real regression test and not a tautology

🤖 Generated with [Claude Code](https://claude.com/claude-code)