### PR TITLE
chore(frontend): make message-part dispatch enforce its own ordering

### DIFF
--- a/apps/frontend/components/chat-message.test.tsx
+++ b/apps/frontend/components/chat-message.test.tsx
@@ -11,7 +11,11 @@ vi.mock("streamdown", () => ({
   ),
 }));
 
-import { ChatMessage, CUT_SHORT_NOTICE } from "./chat-message";
+import {
+  ChatMessage,
+  CUT_SHORT_NOTICE,
+  isGenericToolPart,
+} from "./chat-message";
 
 const makeAgent = (overrides: Partial<Agent>): Agent =>
   ({
@@ -555,6 +559,113 @@ describe("ChatMessage and provider-executed web_search", () => {
     fireEvent.click(screen.getByRole("button", { name: /Web search/ }));
     expect(screen.getByText("Parameters")).toBeInTheDocument();
     expect(screen.queryByText("Searching…")).toBeNull();
+  });
+});
+
+// Issue #578: the dispatch used to be an if/else-if chain where a specialised
+// tool part had to be checked before the generic catch-all or it would land
+// there too, rendering its raw JSON body a second time alongside the
+// specialised card (and, for search, the Sources row). `isGenericToolPart` now
+// excludes every specialised tool part by construction, so this holds
+// regardless of where a renderer sits in the dispatch list.
+describe("ChatMessage generic tool renderer exclusion", () => {
+  it("never matches a plugin web-search part", () => {
+    expect(
+      isGenericToolPart({
+        type: "tool-web_search",
+        toolCallId: "c1",
+        state: "output-available",
+        input: { query: "x" },
+        output: { query: "x", results: [] },
+      } as unknown as Parameters<typeof isGenericToolPart>[0]),
+    ).toBe(false);
+  });
+
+  it("never matches a sub-agent delegation part", () => {
+    expect(
+      isGenericToolPart({
+        type: "tool-delegateToResearchBot",
+        toolCallId: "c1",
+        state: "output-available",
+        input: { task: "x" },
+        output: { entries: [] },
+      } as unknown as Parameters<typeof isGenericToolPart>[0]),
+    ).toBe(false);
+  });
+
+  it("never matches a load-skill part", () => {
+    expect(
+      isGenericToolPart({
+        type: "tool-loadSkill",
+        toolCallId: "c1",
+        state: "output-available",
+        input: { name: "x" },
+        output: {},
+      } as unknown as Parameters<typeof isGenericToolPart>[0]),
+    ).toBe(false);
+  });
+
+  it("matches an ordinary tool part with no specialised renderer", () => {
+    expect(
+      isGenericToolPart({
+        type: "tool-getCard",
+        toolCallId: "c1",
+        state: "output-available",
+        input: {},
+        output: {},
+      } as unknown as Parameters<typeof isGenericToolPart>[0]),
+    ).toBe(true);
+  });
+
+  // Native provider search is `tool-web_search` shaped but not a plugin
+  // call — it must stay on the generic renderer, which is the only one
+  // that can show its vendor-shaped payload.
+  it("matches a provider-executed web_search part", () => {
+    expect(
+      isGenericToolPart({
+        type: "tool-web_search",
+        toolCallId: "c1",
+        state: "output-available",
+        providerExecuted: true,
+        input: { query: "x" },
+        output: [
+          { type: "web_search_result", url: "https://vendor.example/a" },
+        ],
+      } as unknown as Parameters<typeof isGenericToolPart>[0]),
+    ).toBe(true);
+  });
+});
+
+// Sub-agent delegations get a custom card the same way plugin web-search
+// does; the same double-render risk applies if the generic branch ever
+// caught one too.
+describe("ChatMessage sub-agent tool dispatch", () => {
+  const delegateMessage = (): PlatypusUIMessage =>
+    ({
+      id: "m1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-delegateToResearchBot",
+          toolCallId: "c1",
+          state: "output-available",
+          input: { task: "Find the release date" },
+          output: { entries: [], text: "It shipped in March." },
+        },
+      ],
+    }) as unknown as PlatypusUIMessage;
+
+  it("renders the sub-agent card instead of the generic tool renderer", () => {
+    renderMessage(delegateMessage());
+
+    expect(screen.getByText("Research Bot")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Research Bot"));
+
+    // Only the sub-agent card's own labels appear — the generic renderer's
+    // "Parameters"/raw "Result" JSON would mean the call rendered twice.
+    expect(screen.getByText("Task")).toBeInTheDocument();
+    expect(screen.queryByText("Parameters")).toBeNull();
+    expect(screen.queryByText("Result")).toBeNull();
   });
 });
 

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo } from "react";
+import { Fragment, memo, type ReactNode } from "react";
 import { type PlatypusUIMessage } from "@platypus/backend/src/types";
 import {
   Message,
@@ -33,6 +33,7 @@ import {
   FileUIPart,
   SourceUrlUIPart,
   TextUIPart,
+  ToolUIPart,
   isToolUIPart,
   type ChatStatus,
 } from "ai";
@@ -64,6 +65,55 @@ import {
  */
 export const CUT_SHORT_NOTICE =
   "Response cut short at the model's output limit.";
+
+type MessagePart = NonNullable<PlatypusUIMessage["parts"]>[number];
+
+const isLoadSkillPart = (part: MessagePart) => part.type === "tool-loadSkill";
+
+const isSubAgentToolPart = (part: MessagePart) =>
+  isToolUIPart(part) && part.type.startsWith("tool-delegateTo");
+
+const isWebSearchToolPart = (part: MessagePart) =>
+  isToolUIPart(part) && isPluginWebSearchPart(part);
+
+/**
+ * Every tool-shaped part that has its own specialised renderer below. Kept as
+ * one list so the generic renderer's exclusion (`isGenericToolPart`) can be
+ * built from it directly, rather than restated by hand — a part can render
+ * through at most one of a specialised card or the generic renderer no
+ * matter what order `partRenderers` lists them in, because the generic
+ * predicate itself can never be true for a part one of these already claims.
+ * Adding a renderer for a new tool-shaped part means adding its predicate
+ * here; nothing about where it sits in `partRenderers` matters.
+ */
+const specializedToolMatchers: Array<(part: MessagePart) => boolean> = [
+  isLoadSkillPart,
+  isWebSearchToolPart,
+  isSubAgentToolPart,
+];
+
+/**
+ * Plugin- and MCP-contributed tools aren't enumerated in the part union (see
+ * `CustomUITools`), so they land here by elimination — anything tool-shaped
+ * that no specialised renderer above has already claimed.
+ *
+ * Exported so a test can assert the exclusion directly: a plugin web-search
+ * or sub-agent part must never also satisfy this, or its raw JSON body would
+ * repeat what the specialised card (and, for search, the Sources row above
+ * the parts loop) already shows.
+ */
+export const isGenericToolPart = (part: MessagePart) =>
+  isToolUIPart(part) &&
+  !specializedToolMatchers.some((matches) => matches(part));
+
+const isImageFilePart = (part: MessagePart) =>
+  part.type === "file" &&
+  Boolean((part as FileUIPart).mediaType?.startsWith("image/"));
+
+interface PartRenderer {
+  matches: (part: MessagePart) => boolean;
+  render: (part: MessagePart, i: number) => ReactNode;
+}
 
 interface ChatMessageProps {
   /** The message object to render */
@@ -177,6 +227,186 @@ export const ChatMessage = memo(function ChatMessage({
       .map((part) => part.text)
       .join("") || "";
 
+  // Each entry's `matches` is mutually exclusive with every other entry's by
+  // construction (see `isGenericToolPart`), so this list can be extended or
+  // reordered freely — the first (and only) match wins regardless of
+  // position.
+  const partRenderers: PartRenderer[] = [
+    {
+      matches: (part) => part.type === "text",
+      render: (part, i) => {
+        const textPart = part as TextUIPart;
+        if (isEditing) {
+          const isFirstTextPart =
+            i === (message.parts ?? []).findIndex((p) => p.type === "text");
+          if (!isFirstTextPart) return null;
+
+          return (
+            <Message
+              key={`${message.id}-${i}`}
+              from={message.role}
+              avatar={assistantAvatar}
+            >
+              <MessageContent className="max-w-full">
+                <Textarea
+                  ref={editTextareaRef}
+                  value={editContent}
+                  onChange={(e) => setEditContent(e.target.value)}
+                  className="min-h-[100px]"
+                  autoFocus
+                />
+              </MessageContent>
+            </Message>
+          );
+        }
+
+        return (
+          <Message
+            key={`${message.id}-${i}`}
+            from={message.role}
+            avatar={assistantAvatar}
+          >
+            <MessageContent className="max-w-full">
+              <MessageResponse>{textPart.text}</MessageResponse>
+            </MessageContent>
+          </Message>
+        );
+      },
+    },
+    {
+      matches: (part) => part.type === "reasoning",
+      render: (part, i) => {
+        const reasoningPart = part as Extract<
+          MessagePart,
+          { type: "reasoning" }
+        >;
+        return (
+          <Reasoning
+            key={`${message.id}-${i}`}
+            isStreaming={
+              status === "streaming" &&
+              i === (message.parts?.length ?? 0) - 1 &&
+              isLastMessage
+            }
+            defaultOpen={false}
+          >
+            <ReasoningTrigger className="cursor-pointer" />
+            <ReasoningContent>{reasoningPart.text}</ReasoningContent>
+          </Reasoning>
+        );
+      },
+    },
+    {
+      matches: (part) => part.type === "dynamic-tool",
+      render: (part, i) => {
+        const toolPart = part as DynamicToolUIPart;
+        return (
+          <Tool key={`${message.id}-${i}`}>
+            <DynamicToolHeader
+              state={toolPart.state}
+              title={toolPart.toolName}
+              durationMs={toolCallDurationMs(
+                toolPart.toolMetadata,
+                message.metadata,
+                toolPart.toolCallId,
+              )}
+            />
+            <ToolContent>
+              <ToolInput input={toolPart.input} />
+              <ToolOutput
+                output={toolPart.output}
+                errorText={toolPart.errorText}
+              />
+            </ToolContent>
+          </Tool>
+        );
+      },
+    },
+    {
+      matches: isLoadSkillPart,
+      render: (part, i) => (
+        <LoadSkillTool
+          key={`${message.id}-${i}`}
+          toolPart={part as Extract<MessagePart, { type: "tool-loadSkill" }>}
+        />
+      ),
+    },
+    {
+      matches: isWebSearchToolPart,
+      render: (part, i) => (
+        <WebSearchTool
+          key={`${message.id}-${i}`}
+          toolPart={part as ToolUIPart}
+          messageMetadata={message.metadata}
+        />
+      ),
+    },
+    {
+      matches: isSubAgentToolPart,
+      render: (part, i) => (
+        <SubAgentTool
+          key={`${message.id}-${i}`}
+          toolPart={part as ToolUIPart}
+          messageMetadata={message.metadata}
+        />
+      ),
+    },
+    {
+      matches: isGenericToolPart,
+      render: (part, i) => {
+        const toolPart = part as ToolUIPart;
+        const toolInput = toolPart.input as Record<string, unknown> | undefined;
+        const toolLabel = (toolInput?.label ?? toolInput?.name) as
+          string | undefined;
+        return (
+          <Tool key={`${message.id}-${i}`}>
+            <ToolHeader
+              state={toolPart.state}
+              type={toolPart.type}
+              label={toolLabel}
+              durationMs={toolCallDurationMs(
+                toolPart.toolMetadata,
+                message.metadata,
+                toolPart.toolCallId,
+              )}
+            />
+            <ToolContent>
+              <ToolInput input={toolPart.input} />
+              <ToolOutput
+                output={toolPart.output}
+                errorText={toolPart.errorText}
+              />
+            </ToolContent>
+          </Tool>
+        );
+      },
+    },
+    {
+      matches: isImageFilePart,
+      render: (part, i) => {
+        const filePart = part as FileUIPart;
+        return (
+          <Message
+            key={`${message.id}-${i}`}
+            from={message.role}
+            avatar={assistantAvatar}
+          >
+            <MessageContent className="max-w-full">
+              {/* Generated/uploaded image served from a backend or data: URL;
+              not routable through the Next image optimizer. */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={filePart.url}
+                alt={filePart.filename || "Generated image"}
+                className="max-w-full rounded-lg border"
+              />
+            </MessageContent>
+          </Message>
+        );
+      },
+    },
+  ];
+
   return (
     <Fragment key={message.id}>
       {fileParts && fileParts.length > 0 && (
@@ -210,158 +440,8 @@ export const ChatMessage = memo(function ChatMessage({
         </Sources>
       )}
       {message.parts?.map((part, i) => {
-        if (part.type === "text") {
-          if (isEditing) {
-            const isFirstTextPart =
-              i === message.parts.findIndex((p) => p.type === "text");
-            if (!isFirstTextPart) return null;
-
-            return (
-              <Message
-                key={`${message.id}-${i}`}
-                from={message.role}
-                avatar={assistantAvatar}
-              >
-                <MessageContent className="max-w-full">
-                  <Textarea
-                    ref={editTextareaRef}
-                    value={editContent}
-                    onChange={(e) => setEditContent(e.target.value)}
-                    className="min-h-[100px]"
-                    autoFocus
-                  />
-                </MessageContent>
-              </Message>
-            );
-          }
-
-          return (
-            <Message
-              key={`${message.id}-${i}`}
-              from={message.role}
-              avatar={assistantAvatar}
-            >
-              <MessageContent className="max-w-full">
-                <MessageResponse>{(part as TextUIPart).text}</MessageResponse>
-              </MessageContent>
-            </Message>
-          );
-        } else if (part.type === "reasoning") {
-          return (
-            <Reasoning
-              key={`${message.id}-${i}`}
-              isStreaming={
-                status === "streaming" &&
-                i === message.parts.length - 1 &&
-                isLastMessage
-              }
-              defaultOpen={false}
-            >
-              <ReasoningTrigger className="cursor-pointer" />
-              <ReasoningContent>{part.text}</ReasoningContent>
-            </Reasoning>
-          );
-        } else if (part.type === "dynamic-tool") {
-          const toolPart = part as DynamicToolUIPart;
-          return (
-            <Tool key={`${message.id}-${i}`}>
-              <DynamicToolHeader
-                state={toolPart.state}
-                title={toolPart.toolName}
-                durationMs={toolCallDurationMs(
-                  toolPart.toolMetadata,
-                  message.metadata,
-                  toolPart.toolCallId,
-                )}
-              />
-              <ToolContent>
-                <ToolInput input={toolPart.input} />
-                <ToolOutput
-                  output={toolPart.output}
-                  errorText={toolPart.errorText}
-                />
-              </ToolContent>
-            </Tool>
-          );
-        } else if (part.type === "tool-loadSkill") {
-          return <LoadSkillTool key={`${message.id}-${i}`} toolPart={part} />;
-        } else if (isToolUIPart(part) && isPluginWebSearchPart(part)) {
-          // Before the generic branch: its results are already the Sources row
-          // above, so the raw JSON body would repeat every one of them.
-          //
-          // The predicate is shared with the Sources lifting and excludes
-          // provider-executed calls: native search registers under the same
-          // `web_search` name, and its parts belong on the generic renderer, which
-          // shows the vendor payload this card cannot read.
-          return (
-            <WebSearchTool
-              key={`${message.id}-${i}`}
-              toolPart={part}
-              messageMetadata={message.metadata}
-            />
-          );
-        } else if (
-          isToolUIPart(part) &&
-          part.type.startsWith("tool-delegateTo")
-        ) {
-          // Sub-agent tools get custom UI with robot icon and nested chat
-          return (
-            <SubAgentTool
-              key={`${message.id}-${i}`}
-              toolPart={part}
-              messageMetadata={message.metadata}
-            />
-          );
-        } else if (isToolUIPart(part)) {
-          // Plugin- and MCP-contributed tools aren't enumerated in the part
-          // union (see `CustomUITools`), so they land on the generic renderer.
-          const toolInput = part.input as Record<string, unknown> | undefined;
-          const toolLabel = (toolInput?.label ?? toolInput?.name) as
-            string | undefined;
-          return (
-            <Tool key={`${message.id}-${i}`}>
-              <ToolHeader
-                state={part.state}
-                type={part.type}
-                label={toolLabel}
-                durationMs={toolCallDurationMs(
-                  part.toolMetadata,
-                  message.metadata,
-                  part.toolCallId,
-                )}
-              />
-              <ToolContent>
-                <ToolInput input={part.input} />
-                <ToolOutput output={part.output} errorText={part.errorText} />
-              </ToolContent>
-            </Tool>
-          );
-        } else if (
-          part.type === "file" &&
-          (part as FileUIPart).mediaType?.startsWith("image/")
-        ) {
-          const filePart = part as FileUIPart;
-          return (
-            <Message
-              key={`${message.id}-${i}`}
-              from={message.role}
-              avatar={assistantAvatar}
-            >
-              <MessageContent className="max-w-full">
-                {/* Generated/uploaded image served from a backend or data: URL;
-                not routable through the Next image optimizer. */}
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={filePart.url}
-                  alt={filePart.filename || "Generated image"}
-                  className="max-w-full rounded-lg border"
-                />
-              </MessageContent>
-            </Message>
-          );
-        } else {
-          return null;
-        }
+        const renderer = partRenderers.find((r) => r.matches(part));
+        return renderer ? renderer.render(part, i) : null;
       })}
       {message.role === "assistant" &&
         message.metadata?.truncatedByTokenLimit && (


### PR DESCRIPTION
## Summary

`ChatMessage`'s per-part dispatch was a nine-branch `if`/`else-if` chain where two branches (the plugin web-search card and the sub-agent delegation card) had to be checked *before* the generic tool-renderer catch-all, or a part they claimed would also fall through to the generic branch and render its raw JSON body a second time — once as the specialised card, once as raw tool output (and, for search, a third time as the Sources pills). Both constraints existed only as prose comments above each branch.

## Approach

Of the three options the ticket named (registry keyed by part type, explicit priority, or narrowing the types so the general branch can't match a specialised part), I went with **narrowing the types** — applied to the catch-all rather than to each specialised branch individually:

- The chain is now a flat array of `{matches, render}` entries (`partRenderers`), looked up with `.find()`.
- Every specialised tool-shaped renderer (load-skill, web-search-plugin, sub-agent-delegation) has its predicate collected in one `specializedToolMatchers` list.
- The generic tool renderer's predicate, `isGenericToolPart`, is defined as `isToolUIPart(part) && !specializedToolMatchers.some(matches => matches(part))` — it structurally cannot be true for any part a specialised renderer already claims.

Because the generic predicate's exclusion is built from the same list the specialised renderers use, the matches are mutually exclusive by construction, not by position. `partRenderers` can be reordered or extended freely: adding a renderer for a new tool-shaped part means adding its predicate to `specializedToolMatchers` (so the generic branch excludes it) and adding an entry to `partRenderers` — nothing about *where* that entry sits matters, unlike the previous if/else-if chain where a misplaced branch silently reintroduced the double-render bug.

A pure registry keyed by `part.type` didn't fit as well: the web-search and sub-agent branches aren't distinguished by `part.type` alone (`isPluginWebSearchPart` reads `providerExecuted`/`toolMetadata`/output shape to tell a plugin search from a native provider search under the same `tool-web_search` type), so a type-keyed map would still need a fallback dispatch step for those cases.

## Testing

- Added unit tests asserting `isGenericToolPart` excludes web-search-plugin, sub-agent-delegation, and load-skill parts, while still matching an ordinary tool part and a provider-executed `web_search` (the case that must *stay* on the generic renderer).
- Added a rendering test proving a sub-agent delegation part renders through `SubAgentTool` rather than also hitting the generic renderer's "Parameters"/"Result" JSON blocks — the double-render regression the ordering used to prevent.
- All existing message-rendering tests pass unchanged.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (full monorepo — 1902 backend + 367 frontend tests)
- [x] `prettier --check` on changed files

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)