### PR TITLE
chore(frontend): delete the ad-hoc write path and lint against its return

### DIFF
--- a/apps/frontend/app/settings/invitations/page.tsx
+++ b/apps/frontend/app/settings/invitations/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeAt } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { type InvitationListItem } from "@platypus/schemas";
 import { Button } from "@/components/ui/button";
@@ -33,20 +34,15 @@ const UserInvitationsPage = () => {
   const [isDeclining, setIsDeclining] = useState(false);
 
   const handleAccept = async (invitationId: string) => {
-    try {
-      const response = await fetch(
-        joinUrl(backendUrl, `/users/me/invitations/${invitationId}/accept`),
-        { method: "POST", credentials: "include" },
-      );
-      if (response.ok) {
-        toast.success("Invitation accepted");
-        mutate();
-      } else {
-        const errorData = await response.json();
-        toast.error(errorData.message || "Failed to accept invitation");
-      }
-    } catch {
-      toast.error("Error accepting invitation");
+    const result = await writeAt(
+      joinUrl(backendUrl, `/users/me/invitations/${invitationId}/accept`),
+      { method: "POST" },
+    );
+    if (result.outcome === "success") {
+      toast.success("Invitation accepted");
+      mutate();
+    } else {
+      toast.error(result.message);
     }
   };
 
@@ -54,26 +50,21 @@ const UserInvitationsPage = () => {
     if (!invitationToDecline) return;
 
     setIsDeclining(true);
-    try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/users/me/invitations/${invitationToDecline}/decline`,
-        ),
-        { method: "POST", credentials: "include" },
-      );
-      if (response.ok) {
-        toast.success("Invitation declined");
-        mutate();
-        setInvitationToDecline(null);
-      } else {
-        toast.error("Failed to decline invitation");
-      }
-    } catch {
-      toast.error("Error declining invitation");
-    } finally {
-      setIsDeclining(false);
+    const result = await writeAt(
+      joinUrl(
+        backendUrl,
+        `/users/me/invitations/${invitationToDecline}/decline`,
+      ),
+      { method: "POST" },
+    );
+    if (result.outcome === "success") {
+      toast.success("Invitation declined");
+      mutate();
+      setInvitationToDecline(null);
+    } else {
+      toast.error(result.message);
     }
+    setIsDeclining(false);
   };
 
   return (

--- a/apps/frontend/components/agent-form.test.tsx
+++ b/apps/frontend/components/agent-form.test.tsx
@@ -149,4 +149,21 @@ describe("AgentForm validation error surfacing", () => {
     );
     expect(saveButton).not.toBeDisabled();
   });
+
+  // #571: toolSetIds has no field that retracts its error, so gating Save on
+  // it would disable Save forever with no way out but reloading.
+  it("never disables Save on a rejection keyed to a field with no retracting input", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFailedSave([{ path: ["toolSetIds"], message: "Unknown tool set" }]),
+    );
+
+    renderCreateForm();
+
+    const saveButton = screen.getByRole("button", { name: "Save" });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(saveButton).not.toBeDisabled();
+  });
 });

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -407,6 +407,10 @@ const AgentForm = ({
           setValidationErrors({ name: result.message });
           break;
         case "locked":
+          // Guidance, not a failure — the backend's message already says
+          // where the Shared resource is actually managed (#570).
+          toast.info(result.message);
+          break;
         case "notFound":
         case "error":
           toast.error(result.message);
@@ -432,6 +436,12 @@ const AgentForm = ({
     if (result.outcome === "success") {
       result.revalidateKeys.forEach((key) => mutate(key));
       router.push(doneHref);
+    } else if (result.outcome === "locked") {
+      // Guidance, not a failure — the backend's message already says where
+      // the Shared resource is actually managed (#570).
+      toast.info(result.message);
+      setIsDeleting(false);
+      setIsDeleteDialogOpen(false);
     } else {
       toast.error(result.message);
       setIsDeleting(false);

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -49,7 +49,8 @@ import {
   type Skill,
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { findModelOption, getModelOptions } from "@/lib/model-config";
 import { resolveModel } from "@/lib/resolve-model";
@@ -63,6 +64,25 @@ import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { AgentAvatar } from "@/components/agent-avatar";
 import { Skeleton } from "@/components/ui/skeleton";
+
+// toolSetIds, skillIds, and subAgentIds are deliberately excluded: this form
+// has no field that retracts an error keyed to them, so including them here
+// would disable Save forever the moment the server rejects one.
+const RETRACTABLE_FIELDS = [
+  "name",
+  "description",
+  "inputPlaceholder",
+  "instructions",
+  "providerId",
+  "modelId",
+  "maxSteps",
+  "temperature",
+  "topP",
+  "topK",
+  "seed",
+  "presencePenalty",
+  "frequencyPenalty",
+] as const;
 
 const AgentForm = ({
   classNames,
@@ -224,7 +244,7 @@ const AgentForm = ({
   // corrected field stops rendering its error and re-enables the Save button.
   const clearValidationErrors = useCallback((...ids: string[]) => {
     setValidationErrors((prev) =>
-      ids.reduce((errors, id) => clearFieldError(errors, id), prev),
+      ids.reduce((errors, id) => retractFieldError(errors, id), prev),
     );
   }, []);
 
@@ -1020,7 +1040,9 @@ const AgentForm = ({
           className="cursor-pointer"
           onClick={handleSubmit}
           disabled={
-            isSubmitting || readOnly || Object.keys(validationErrors).length > 0
+            isSubmitting ||
+            readOnly ||
+            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
           }
         >
           {agentId ? "Update" : "Save"}

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -50,7 +50,7 @@ import {
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
 import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
-import { writeEntity } from "@/lib/api-write";
+import { writeEntity, writeAt } from "@/lib/api-write";
 import { findModelOption, getModelOptions } from "@/lib/model-config";
 import { resolveModel } from "@/lib/resolve-model";
 import {
@@ -368,12 +368,9 @@ const AgentForm = ({
           const savedAgentId = result.data.id || agentId;
 
           if (avatarDeleted && agentId) {
-            await fetch(
+            await writeAt(
               joinUrl(backendUrl, `${agentsBase}/${savedAgentId}/avatar`),
-              {
-                method: "DELETE",
-                credentials: "include",
-              },
+              { method: "DELETE" },
             );
           } else if (avatarFile) {
             const avatarFormData = new FormData();

--- a/apps/frontend/components/agents-list.test.tsx
+++ b/apps/frontend/components/agents-list.test.tsx
@@ -27,6 +27,10 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushSpy }),
 }));
 
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
 type AgentWithScope = Agent & { scope?: "organization" | "workspace" };
 
 // The `GET .../agents` list this component renders. Set per test.
@@ -53,6 +57,7 @@ vi.mock("swr", () => ({
 }));
 
 import { AgentsList } from "./agents-list";
+import { toast } from "sonner";
 
 // --- Helpers -----------------------------------------------------------------
 
@@ -146,6 +151,48 @@ describe("AgentsList delete", () => {
       "http://test/organizations/org1/workspaces/ws1/agents/a2",
       expect.objectContaining({ method: "DELETE" }),
     );
+  });
+
+  it("shows the backend's guidance, not an error, when delete is refused because the agent is Shared", async () => {
+    agents = [workspaceAgent];
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(403, {
+        error: "This agent is managed at the organization level",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith(
+        "This agent is managed at the organization level",
+      ),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(mutateSpy).not.toHaveBeenCalled();
+    expect(screen.queryByText("Delete Agent")).not.toBeInTheDocument();
+  });
+
+  it("surfaces the backend's reason inline when delete fails for another reason", async () => {
+    agents = [workspaceAgent];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(409, { error: "Agent is in use" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AgentsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Agent is in use")).toBeInTheDocument(),
+    );
+    expect(mutateSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/frontend/components/agents-list.tsx
+++ b/apps/frontend/components/agents-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import {
   Item,
   ItemTitle,
@@ -100,6 +101,8 @@ export const AgentsList = ({
   const [cloneError, setCloneError] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [agentToDelete, setAgentToDelete] = useState<Agent | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [attachOpen, setAttachOpen] = useState(false);
   const [selectedOrgAgent, setSelectedOrgAgent] =
     useState<AgentWithScope | null>(null);
@@ -199,19 +202,34 @@ export const AgentsList = ({
 
   const handleDeleteClick = (agent: Agent) => {
     setAgentToDelete(agent);
+    setDeleteError(null);
     setDeleteDialogOpen(true);
   };
 
   const handleDeleteConfirm = async () => {
     if (!agentToDelete || !backendUrl) return;
 
-    const outcome = await writeEntity(backendUrl, "agents", scope, {
-      id: agentToDelete.id,
-    });
-    if (outcome.outcome === "success") {
-      mutate();
-      setDeleteDialogOpen(false);
-      setAgentToDelete(null);
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const outcome = await writeEntity(backendUrl, "agents", scope, {
+        id: agentToDelete.id,
+      });
+      if (outcome.outcome === "success") {
+        mutate();
+        setDeleteDialogOpen(false);
+        setAgentToDelete(null);
+      } else if (outcome.outcome === "locked") {
+        // Guidance, not a failure — the backend's message already says
+        // where the Shared resource is actually managed (#570).
+        setDeleteDialogOpen(false);
+        setAgentToDelete(null);
+        toast.info(outcome.message);
+      } else {
+        setDeleteError(outcome.message);
+      }
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -745,12 +763,17 @@ export const AgentsList = ({
 
       <ConfirmDialog
         open={deleteDialogOpen}
-        onOpenChange={setDeleteDialogOpen}
+        onOpenChange={(open) => {
+          setDeleteDialogOpen(open);
+          if (!open) setDeleteError(null);
+        }}
         title="Delete Agent"
         description={`Are you sure you want to delete "${agentToDelete?.name}"? This action cannot be undone.`}
         confirmLabel="Delete"
         confirmVariant="destructive"
         onConfirm={handleDeleteConfirm}
+        loading={deleting}
+        error={deleteError}
       />
     </>
   );

--- a/apps/frontend/components/app-sidebar.tsx
+++ b/apps/frontend/components/app-sidebar.tsx
@@ -60,7 +60,7 @@ import {
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Field, FieldLabel, FieldError } from "@/components/ui/field";
-import { parseValidationErrors } from "@/lib/utils";
+import { parseValidationErrors } from "@/lib/form-errors";
 import { useBackendUrl } from "@/app/client-context";
 import { TagInput } from "@/components/tag-input";
 import { useIsMobile } from "@/hooks/use-mobile";

--- a/apps/frontend/components/app-sidebar.tsx
+++ b/apps/frontend/components/app-sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { toast } from "sonner";
 import type { Workspace, ChatListItem, Organization } from "@platypus/schemas";
 import { useAuth } from "@/components/auth-provider";
@@ -60,7 +61,6 @@ import {
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Field, FieldLabel, FieldError } from "@/components/ui/field";
-import { parseValidationErrors } from "@/lib/utils";
 import { useBackendUrl } from "@/app/client-context";
 import { TagInput } from "@/components/tag-input";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -182,27 +182,22 @@ export function AppSidebar() {
     setIsRenaming(true);
     setRenameValidationErrors({});
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/chat/${renameChatId}`,
-        ),
+      const outcome = await writeEntity(
+        backendUrl,
+        "chat",
+        { orgId, workspaceId },
         {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
+          id: renameChatId,
+          data: {
             workspaceId,
             title: renameTitle,
             isPinned: currentChat.isPinned,
             tags: renameTags,
-          }),
-          credentials: "include",
+          },
         },
       );
 
-      if (response.ok) {
+      if (outcome.outcome === "success") {
         // Close the dialog
         setRenameChatId(null);
         setRenameTitle("");
@@ -210,15 +205,14 @@ export function AppSidebar() {
 
         // Revalidate the chat list
         await revalidateChatList();
+      } else if (
+        outcome.outcome === "invalid" &&
+        Object.keys(outcome.fieldErrors).length > 0
+      ) {
+        setRenameValidationErrors(outcome.fieldErrors);
       } else {
-        // Parse standardschema.dev validation errors
-        const errorData = await response.json();
-        setRenameValidationErrors(parseValidationErrors(errorData));
-        console.error("Failed to rename chat");
+        toast.error(outcome.message);
       }
-    } catch (error) {
-      console.error("Error renaming chat:", error);
-      toast.error("Failed to rename chat");
     } finally {
       setIsRenaming(false);
     }
@@ -229,19 +223,16 @@ export function AppSidebar() {
 
     setIsDeleting(true);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/chat/${deleteChatId}`,
-        ),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
+      const outcome = await writeEntity(
+        backendUrl,
+        "chat",
+        { orgId, workspaceId },
+        { id: deleteChatId },
       );
 
-      if (!response.ok) {
-        throw new Error("Failed to delete chat");
+      if (outcome.outcome !== "success") {
+        toast.error(outcome.message);
+        return;
       }
 
       // Close the dialog
@@ -258,9 +249,6 @@ export function AppSidebar() {
 
       // Revalidate the chat list
       await revalidateChatList();
-    } catch (error) {
-      console.error("Error deleting chat:", error);
-      toast.error("Failed to delete chat");
     } finally {
       setIsDeleting(false);
     }
@@ -272,35 +260,28 @@ export function AppSidebar() {
 
     setIsTogglingPin(true);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/chat/${chatId}`,
-        ),
+      const outcome = await writeEntity(
+        backendUrl,
+        "chat",
+        { orgId, workspaceId },
         {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
+          id: chatId,
+          data: {
             workspaceId,
             title: currentChat.title,
             isPinned: !currentChat.isPinned,
             tags: currentChat.tags ?? [],
-          }),
-          credentials: "include",
+          },
         },
       );
 
-      if (!response.ok) {
-        throw new Error("Failed to toggle pin status");
+      if (outcome.outcome !== "success") {
+        toast.error(outcome.message);
+        return;
       }
 
       // Revalidate the chat list
       await revalidateChatList();
-    } catch (error) {
-      console.error("Error toggling pin status:", error);
-      toast.error("Failed to update pin status");
     } finally {
       setIsTogglingPin(false);
     }

--- a/apps/frontend/components/apply-blueprint-dialog.tsx
+++ b/apps/frontend/components/apply-blueprint-dialog.tsx
@@ -21,6 +21,7 @@ import { Field, FieldLabel } from "@/components/ui/field";
 import type { Workspace } from "@platypus/schemas";
 import useSWR from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeAt } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 
@@ -73,30 +74,26 @@ export const ApplyBlueprintDialog = ({
     setApplying(true);
     setError(null);
     setResult(null);
-    try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/blueprints/${blueprintId}/apply`,
-        ),
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ workspaceId }),
-          credentials: "include",
-        },
-      );
-      if (response.ok) {
-        setResult(await response.json());
-      } else {
-        const info = await response.json().catch(() => ({}));
-        setError(info.error || "Failed to apply blueprint.");
-      }
-    } catch {
-      setError("An unexpected error occurred.");
-    } finally {
-      setApplying(false);
+    const outcome = await writeAt<{
+      attached: number;
+      skipped: number;
+      total: number;
+    }>(
+      joinUrl(
+        backendUrl,
+        `/organizations/${orgId}/blueprints/${blueprintId}/apply`,
+      ),
+      {
+        method: "POST",
+        data: { workspaceId },
+      },
+    );
+    if (outcome.outcome === "success") {
+      setResult(outcome.data);
+    } else {
+      setError(outcome.message);
     }
+    setApplying(false);
   };
 
   return (

--- a/apps/frontend/components/attach-shared-resource-dialog.tsx
+++ b/apps/frontend/components/attach-shared-resource-dialog.tsx
@@ -2,6 +2,7 @@
 
 import useSWR from "swr";
 import { fetcher, joinUrl } from "../lib/utils";
+import { writeAt } from "../lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { Button } from "./ui/button";
 import {
@@ -76,21 +77,15 @@ const AttachSharedResourceDialog = ({
     setBusyId(resourceId);
     setError(null);
     try {
-      const res = await fetch(
+      const outcome = await writeAt(
         joinUrl(
           backendUrl,
           `/organizations/${orgId}/workspaces/${workspaceId}/attachments`,
         ),
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ resourceType, resourceId }),
-          credentials: "include",
-        },
+        { method: "POST", data: { resourceType, resourceId } },
       );
-      if (!res.ok) {
-        const info = await res.json().catch(() => ({}));
-        setError(info.error || "Failed to attach resource.");
+      if (outcome.outcome !== "success") {
+        setError(outcome.message);
         return;
       }
       onAttached();

--- a/apps/frontend/components/blueprint-form.tsx
+++ b/apps/frontend/components/blueprint-form.tsx
@@ -33,6 +33,7 @@ import type {
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -139,6 +140,15 @@ const ResourceGroup = ({
   );
 };
 
+const RETRACTABLE_FIELDS = [
+  "name",
+  "description",
+  "context",
+  "taskModelProviderId",
+  "memoryExtractionProviderId",
+  "memoryEmbeddingProviderId",
+] as const;
+
 const BlueprintForm = ({
   classNames,
   orgId,
@@ -222,13 +232,7 @@ const BlueprintForm = ({
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
     const { id, value } = e.target;
-    if (validationErrors[id]) {
-      setValidationErrors((prev) => {
-        const next = { ...prev };
-        delete next[id];
-        return next;
-      });
-    }
+    setValidationErrors((prev) => retractFieldError(prev, id));
     setFormData((prev) => ({ ...prev, [id]: value }));
   };
 
@@ -448,12 +452,15 @@ const BlueprintForm = ({
             </FieldLabel>
             <Select
               value={formData.taskModelProviderId || "none"}
-              onValueChange={(value) =>
+              onValueChange={(value) => {
+                setValidationErrors((prev) =>
+                  retractFieldError(prev, "taskModelProviderId"),
+                );
                 setFormData((prev) => ({
                   ...prev,
                   taskModelProviderId: value === "none" ? null : value,
-                }))
-              }
+                }));
+              }}
               disabled={isSubmitting || attachedProviders.length === 0}
             >
               <SelectTrigger>
@@ -483,12 +490,15 @@ const BlueprintForm = ({
             </FieldLabel>
             <Select
               value={formData.memoryExtractionProviderId || "none"}
-              onValueChange={(value) =>
+              onValueChange={(value) => {
+                setValidationErrors((prev) =>
+                  retractFieldError(prev, "memoryExtractionProviderId"),
+                );
                 setFormData((prev) => ({
                   ...prev,
                   memoryExtractionProviderId: value === "none" ? null : value,
-                }))
-              }
+                }));
+              }}
               disabled={isSubmitting || memoryExtractionProviders.length === 0}
             >
               <SelectTrigger>
@@ -520,12 +530,15 @@ const BlueprintForm = ({
             </FieldLabel>
             <Select
               value={formData.memoryEmbeddingProviderId || "none"}
-              onValueChange={(value) =>
+              onValueChange={(value) => {
+                setValidationErrors((prev) =>
+                  retractFieldError(prev, "memoryEmbeddingProviderId"),
+                );
                 setFormData((prev) => ({
                   ...prev,
                   memoryEmbeddingProviderId: value === "none" ? null : value,
-                }))
-              }
+                }));
+              }}
               disabled={isSubmitting || memoryEmbeddingProviders.length === 0}
             >
               <SelectTrigger>
@@ -559,7 +572,9 @@ const BlueprintForm = ({
         <Button
           className="cursor-pointer"
           onClick={handleSubmit}
-          disabled={isSubmitting}
+          disabled={
+            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {blueprintId ? "Update" : "Save"}
         </Button>

--- a/apps/frontend/components/blueprints-list.tsx
+++ b/apps/frontend/components/blueprints-list.tsx
@@ -21,6 +21,7 @@ import { EllipsisVertical, Pencil, Play, Plus, Trash2 } from "lucide-react";
 import type { Blueprint } from "@platypus/schemas";
 import useSWR from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import Link from "next/link";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -56,19 +57,19 @@ export const BlueprintsList = ({ orgId }: { orgId: string }) => {
     setDeleting(true);
     setDeleteError(null);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/blueprints/${blueprintToDelete.id}`,
-        ),
-        { method: "DELETE", credentials: "include" },
+      const outcome = await writeEntity(
+        backendUrl,
+        "blueprints",
+        { orgId },
+        {
+          id: blueprintToDelete.id,
+        },
       );
-      if (response.ok) {
+      if (outcome.outcome === "success") {
         await mutate();
         setBlueprintToDelete(null);
       } else {
-        const info = await response.json().catch(() => ({}));
-        setDeleteError(info.error || "Failed to delete blueprint.");
+        setDeleteError(outcome.message);
       }
     } finally {
       setDeleting(false);

--- a/apps/frontend/components/boards-list.tsx
+++ b/apps/frontend/components/boards-list.tsx
@@ -21,6 +21,7 @@ import { EllipsisVertical, Pencil, Trash2 } from "lucide-react";
 import { type KanbanBoard } from "@platypus/schemas";
 import useSWR from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import Link from "next/link";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -36,6 +37,8 @@ export const BoardsList = ({
   const backendUrl = useBackendUrl();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [boardToDelete, setBoardToDelete] = useState<KanbanBoard | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const {
     data: boardsData,
@@ -59,31 +62,31 @@ export const BoardsList = ({
 
   const handleDeleteClick = (board: KanbanBoard) => {
     setBoardToDelete(board);
+    setDeleteError(null);
     setDeleteDialogOpen(true);
   };
 
   const handleDeleteConfirm = async () => {
     if (!boardToDelete || !backendUrl) return;
 
+    setDeleting(true);
+    setDeleteError(null);
     try {
-      const response = await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/boards/${boardToDelete.id}`,
-        ),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
+      const outcome = await writeEntity(
+        backendUrl,
+        "boards",
+        { orgId, workspaceId },
+        { id: boardToDelete.id },
       );
-
-      if (response.ok) {
+      if (outcome.outcome === "success") {
         mutate();
         setDeleteDialogOpen(false);
         setBoardToDelete(null);
+      } else {
+        setDeleteError(outcome.message);
       }
-    } catch (error) {
-      console.error("Failed to delete board:", error);
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -157,6 +160,8 @@ export const BoardsList = ({
         open={deleteDialogOpen}
         onOpenChange={setDeleteDialogOpen}
         onConfirm={handleDeleteConfirm}
+        loading={deleting}
+        error={deleteError}
       />
     </>
   );

--- a/apps/frontend/components/chat-message.test.tsx
+++ b/apps/frontend/components/chat-message.test.tsx
@@ -11,7 +11,11 @@ vi.mock("streamdown", () => ({
   ),
 }));
 
-import { ChatMessage, CUT_SHORT_NOTICE } from "./chat-message";
+import {
+  ChatMessage,
+  CUT_SHORT_NOTICE,
+  isGenericToolPart,
+} from "./chat-message";
 
 const makeAgent = (overrides: Partial<Agent>): Agent =>
   ({
@@ -555,6 +559,113 @@ describe("ChatMessage and provider-executed web_search", () => {
     fireEvent.click(screen.getByRole("button", { name: /Web search/ }));
     expect(screen.getByText("Parameters")).toBeInTheDocument();
     expect(screen.queryByText("Searching…")).toBeNull();
+  });
+});
+
+// Issue #578: the dispatch used to be an if/else-if chain where a specialised
+// tool part had to be checked before the generic catch-all or it would land
+// there too, rendering its raw JSON body a second time alongside the
+// specialised card (and, for search, the Sources row). `isGenericToolPart` now
+// excludes every specialised tool part by construction, so this holds
+// regardless of where a renderer sits in the dispatch list.
+describe("ChatMessage generic tool renderer exclusion", () => {
+  it("never matches a plugin web-search part", () => {
+    expect(
+      isGenericToolPart({
+        type: "tool-web_search",
+        toolCallId: "c1",
+        state: "output-available",
+        input: { query: "x" },
+        output: { query: "x", results: [] },
+      } as unknown as Parameters<typeof isGenericToolPart>[0]),
+    ).toBe(false);
+  });
+
+  it("never matches a sub-agent delegation part", () => {
+    expect(
+      isGenericToolPart({
+        type: "tool-delegateToResearchBot",
+        toolCallId: "c1",
+        state: "output-available",
+        input: { task: "x" },
+        output: { entries: [] },
+      } as unknown as Parameters<typeof isGenericToolPart>[0]),
+    ).toBe(false);
+  });
+
+  it("never matches a load-skill part", () => {
+    expect(
+      isGenericToolPart({
+        type: "tool-loadSkill",
+        toolCallId: "c1",
+        state: "output-available",
+        input: { name: "x" },
+        output: {},
+      } as unknown as Parameters<typeof isGenericToolPart>[0]),
+    ).toBe(false);
+  });
+
+  it("matches an ordinary tool part with no specialised renderer", () => {
+    expect(
+      isGenericToolPart({
+        type: "tool-getCard",
+        toolCallId: "c1",
+        state: "output-available",
+        input: {},
+        output: {},
+      } as unknown as Parameters<typeof isGenericToolPart>[0]),
+    ).toBe(true);
+  });
+
+  // Native provider search is `tool-web_search` shaped but not a plugin
+  // call — it must stay on the generic renderer, which is the only one
+  // that can show its vendor-shaped payload.
+  it("matches a provider-executed web_search part", () => {
+    expect(
+      isGenericToolPart({
+        type: "tool-web_search",
+        toolCallId: "c1",
+        state: "output-available",
+        providerExecuted: true,
+        input: { query: "x" },
+        output: [
+          { type: "web_search_result", url: "https://vendor.example/a" },
+        ],
+      } as unknown as Parameters<typeof isGenericToolPart>[0]),
+    ).toBe(true);
+  });
+});
+
+// Sub-agent delegations get a custom card the same way plugin web-search
+// does; the same double-render risk applies if the generic branch ever
+// caught one too.
+describe("ChatMessage sub-agent tool dispatch", () => {
+  const delegateMessage = (): PlatypusUIMessage =>
+    ({
+      id: "m1",
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-delegateToResearchBot",
+          toolCallId: "c1",
+          state: "output-available",
+          input: { task: "Find the release date" },
+          output: { entries: [], text: "It shipped in March." },
+        },
+      ],
+    }) as unknown as PlatypusUIMessage;
+
+  it("renders the sub-agent card instead of the generic tool renderer", () => {
+    renderMessage(delegateMessage());
+
+    expect(screen.getByText("Research Bot")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Research Bot"));
+
+    // Only the sub-agent card's own labels appear — the generic renderer's
+    // "Parameters"/raw "Result" JSON would mean the call rendered twice.
+    expect(screen.getByText("Task")).toBeInTheDocument();
+    expect(screen.queryByText("Parameters")).toBeNull();
+    expect(screen.queryByText("Result")).toBeNull();
   });
 });
 

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo } from "react";
+import { Fragment, memo, type ReactNode } from "react";
 import { type PlatypusUIMessage } from "@platypus/backend/src/types";
 import {
   Message,
@@ -33,6 +33,7 @@ import {
   FileUIPart,
   SourceUrlUIPart,
   TextUIPart,
+  ToolUIPart,
   isToolUIPart,
   type ChatStatus,
 } from "ai";
@@ -64,6 +65,55 @@ import {
  */
 export const CUT_SHORT_NOTICE =
   "Response cut short at the model's output limit.";
+
+type MessagePart = NonNullable<PlatypusUIMessage["parts"]>[number];
+
+const isLoadSkillPart = (part: MessagePart) => part.type === "tool-loadSkill";
+
+const isSubAgentToolPart = (part: MessagePart) =>
+  isToolUIPart(part) && part.type.startsWith("tool-delegateTo");
+
+const isWebSearchToolPart = (part: MessagePart) =>
+  isToolUIPart(part) && isPluginWebSearchPart(part);
+
+/**
+ * Every tool-shaped part that has its own specialised renderer below. Kept as
+ * one list so the generic renderer's exclusion (`isGenericToolPart`) can be
+ * built from it directly, rather than restated by hand — a part can render
+ * through at most one of a specialised card or the generic renderer no
+ * matter what order `partRenderers` lists them in, because the generic
+ * predicate itself can never be true for a part one of these already claims.
+ * Adding a renderer for a new tool-shaped part means adding its predicate
+ * here; nothing about where it sits in `partRenderers` matters.
+ */
+const specializedToolMatchers: Array<(part: MessagePart) => boolean> = [
+  isLoadSkillPart,
+  isWebSearchToolPart,
+  isSubAgentToolPart,
+];
+
+/**
+ * Plugin- and MCP-contributed tools aren't enumerated in the part union (see
+ * `CustomUITools`), so they land here by elimination — anything tool-shaped
+ * that no specialised renderer above has already claimed.
+ *
+ * Exported so a test can assert the exclusion directly: a plugin web-search
+ * or sub-agent part must never also satisfy this, or its raw JSON body would
+ * repeat what the specialised card (and, for search, the Sources row above
+ * the parts loop) already shows.
+ */
+export const isGenericToolPart = (part: MessagePart) =>
+  isToolUIPart(part) &&
+  !specializedToolMatchers.some((matches) => matches(part));
+
+const isImageFilePart = (part: MessagePart) =>
+  part.type === "file" &&
+  Boolean((part as FileUIPart).mediaType?.startsWith("image/"));
+
+interface PartRenderer {
+  matches: (part: MessagePart) => boolean;
+  render: (part: MessagePart, i: number) => ReactNode;
+}
 
 interface ChatMessageProps {
   /** The message object to render */
@@ -177,6 +227,186 @@ export const ChatMessage = memo(function ChatMessage({
       .map((part) => part.text)
       .join("") || "";
 
+  // Each entry's `matches` is mutually exclusive with every other entry's by
+  // construction (see `isGenericToolPart`), so this list can be extended or
+  // reordered freely — the first (and only) match wins regardless of
+  // position.
+  const partRenderers: PartRenderer[] = [
+    {
+      matches: (part) => part.type === "text",
+      render: (part, i) => {
+        const textPart = part as TextUIPart;
+        if (isEditing) {
+          const isFirstTextPart =
+            i === (message.parts ?? []).findIndex((p) => p.type === "text");
+          if (!isFirstTextPart) return null;
+
+          return (
+            <Message
+              key={`${message.id}-${i}`}
+              from={message.role}
+              avatar={assistantAvatar}
+            >
+              <MessageContent className="max-w-full">
+                <Textarea
+                  ref={editTextareaRef}
+                  value={editContent}
+                  onChange={(e) => setEditContent(e.target.value)}
+                  className="min-h-[100px]"
+                  autoFocus
+                />
+              </MessageContent>
+            </Message>
+          );
+        }
+
+        return (
+          <Message
+            key={`${message.id}-${i}`}
+            from={message.role}
+            avatar={assistantAvatar}
+          >
+            <MessageContent className="max-w-full">
+              <MessageResponse>{textPart.text}</MessageResponse>
+            </MessageContent>
+          </Message>
+        );
+      },
+    },
+    {
+      matches: (part) => part.type === "reasoning",
+      render: (part, i) => {
+        const reasoningPart = part as Extract<
+          MessagePart,
+          { type: "reasoning" }
+        >;
+        return (
+          <Reasoning
+            key={`${message.id}-${i}`}
+            isStreaming={
+              status === "streaming" &&
+              i === (message.parts?.length ?? 0) - 1 &&
+              isLastMessage
+            }
+            defaultOpen={false}
+          >
+            <ReasoningTrigger className="cursor-pointer" />
+            <ReasoningContent>{reasoningPart.text}</ReasoningContent>
+          </Reasoning>
+        );
+      },
+    },
+    {
+      matches: (part) => part.type === "dynamic-tool",
+      render: (part, i) => {
+        const toolPart = part as DynamicToolUIPart;
+        return (
+          <Tool key={`${message.id}-${i}`}>
+            <DynamicToolHeader
+              state={toolPart.state}
+              title={toolPart.toolName}
+              durationMs={toolCallDurationMs(
+                toolPart.toolMetadata,
+                message.metadata,
+                toolPart.toolCallId,
+              )}
+            />
+            <ToolContent>
+              <ToolInput input={toolPart.input} />
+              <ToolOutput
+                output={toolPart.output}
+                errorText={toolPart.errorText}
+              />
+            </ToolContent>
+          </Tool>
+        );
+      },
+    },
+    {
+      matches: isLoadSkillPart,
+      render: (part, i) => (
+        <LoadSkillTool
+          key={`${message.id}-${i}`}
+          toolPart={part as Extract<MessagePart, { type: "tool-loadSkill" }>}
+        />
+      ),
+    },
+    {
+      matches: isWebSearchToolPart,
+      render: (part, i) => (
+        <WebSearchTool
+          key={`${message.id}-${i}`}
+          toolPart={part as ToolUIPart}
+          messageMetadata={message.metadata}
+        />
+      ),
+    },
+    {
+      matches: isSubAgentToolPart,
+      render: (part, i) => (
+        <SubAgentTool
+          key={`${message.id}-${i}`}
+          toolPart={part as ToolUIPart}
+          messageMetadata={message.metadata}
+        />
+      ),
+    },
+    {
+      matches: isGenericToolPart,
+      render: (part, i) => {
+        const toolPart = part as ToolUIPart;
+        const toolInput = toolPart.input as Record<string, unknown> | undefined;
+        const toolLabel = (toolInput?.label ?? toolInput?.name) as
+          string | undefined;
+        return (
+          <Tool key={`${message.id}-${i}`}>
+            <ToolHeader
+              state={toolPart.state}
+              type={toolPart.type}
+              label={toolLabel}
+              durationMs={toolCallDurationMs(
+                toolPart.toolMetadata,
+                message.metadata,
+                toolPart.toolCallId,
+              )}
+            />
+            <ToolContent>
+              <ToolInput input={toolPart.input} />
+              <ToolOutput
+                output={toolPart.output}
+                errorText={toolPart.errorText}
+              />
+            </ToolContent>
+          </Tool>
+        );
+      },
+    },
+    {
+      matches: isImageFilePart,
+      render: (part, i) => {
+        const filePart = part as FileUIPart;
+        return (
+          <Message
+            key={`${message.id}-${i}`}
+            from={message.role}
+            avatar={assistantAvatar}
+          >
+            <MessageContent className="max-w-full">
+              {/* Generated/uploaded image served from a backend or data: URL;
+              not routable through the Next image optimizer. */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={filePart.url}
+                alt={filePart.filename || "Generated image"}
+                className="max-w-full rounded-lg border"
+              />
+            </MessageContent>
+          </Message>
+        );
+      },
+    },
+  ];
+
   return (
     <Fragment key={message.id}>
       {fileParts && fileParts.length > 0 && (
@@ -210,158 +440,8 @@ export const ChatMessage = memo(function ChatMessage({
         </Sources>
       )}
       {message.parts?.map((part, i) => {
-        if (part.type === "text") {
-          if (isEditing) {
-            const isFirstTextPart =
-              i === message.parts.findIndex((p) => p.type === "text");
-            if (!isFirstTextPart) return null;
-
-            return (
-              <Message
-                key={`${message.id}-${i}`}
-                from={message.role}
-                avatar={assistantAvatar}
-              >
-                <MessageContent className="max-w-full">
-                  <Textarea
-                    ref={editTextareaRef}
-                    value={editContent}
-                    onChange={(e) => setEditContent(e.target.value)}
-                    className="min-h-[100px]"
-                    autoFocus
-                  />
-                </MessageContent>
-              </Message>
-            );
-          }
-
-          return (
-            <Message
-              key={`${message.id}-${i}`}
-              from={message.role}
-              avatar={assistantAvatar}
-            >
-              <MessageContent className="max-w-full">
-                <MessageResponse>{(part as TextUIPart).text}</MessageResponse>
-              </MessageContent>
-            </Message>
-          );
-        } else if (part.type === "reasoning") {
-          return (
-            <Reasoning
-              key={`${message.id}-${i}`}
-              isStreaming={
-                status === "streaming" &&
-                i === message.parts.length - 1 &&
-                isLastMessage
-              }
-              defaultOpen={false}
-            >
-              <ReasoningTrigger className="cursor-pointer" />
-              <ReasoningContent>{part.text}</ReasoningContent>
-            </Reasoning>
-          );
-        } else if (part.type === "dynamic-tool") {
-          const toolPart = part as DynamicToolUIPart;
-          return (
-            <Tool key={`${message.id}-${i}`}>
-              <DynamicToolHeader
-                state={toolPart.state}
-                title={toolPart.toolName}
-                durationMs={toolCallDurationMs(
-                  toolPart.toolMetadata,
-                  message.metadata,
-                  toolPart.toolCallId,
-                )}
-              />
-              <ToolContent>
-                <ToolInput input={toolPart.input} />
-                <ToolOutput
-                  output={toolPart.output}
-                  errorText={toolPart.errorText}
-                />
-              </ToolContent>
-            </Tool>
-          );
-        } else if (part.type === "tool-loadSkill") {
-          return <LoadSkillTool key={`${message.id}-${i}`} toolPart={part} />;
-        } else if (isToolUIPart(part) && isPluginWebSearchPart(part)) {
-          // Before the generic branch: its results are already the Sources row
-          // above, so the raw JSON body would repeat every one of them.
-          //
-          // The predicate is shared with the Sources lifting and excludes
-          // provider-executed calls: native search registers under the same
-          // `web_search` name, and its parts belong on the generic renderer, which
-          // shows the vendor payload this card cannot read.
-          return (
-            <WebSearchTool
-              key={`${message.id}-${i}`}
-              toolPart={part}
-              messageMetadata={message.metadata}
-            />
-          );
-        } else if (
-          isToolUIPart(part) &&
-          part.type.startsWith("tool-delegateTo")
-        ) {
-          // Sub-agent tools get custom UI with robot icon and nested chat
-          return (
-            <SubAgentTool
-              key={`${message.id}-${i}`}
-              toolPart={part}
-              messageMetadata={message.metadata}
-            />
-          );
-        } else if (isToolUIPart(part)) {
-          // Plugin- and MCP-contributed tools aren't enumerated in the part
-          // union (see `CustomUITools`), so they land on the generic renderer.
-          const toolInput = part.input as Record<string, unknown> | undefined;
-          const toolLabel = (toolInput?.label ?? toolInput?.name) as
-            string | undefined;
-          return (
-            <Tool key={`${message.id}-${i}`}>
-              <ToolHeader
-                state={part.state}
-                type={part.type}
-                label={toolLabel}
-                durationMs={toolCallDurationMs(
-                  part.toolMetadata,
-                  message.metadata,
-                  part.toolCallId,
-                )}
-              />
-              <ToolContent>
-                <ToolInput input={part.input} />
-                <ToolOutput output={part.output} errorText={part.errorText} />
-              </ToolContent>
-            </Tool>
-          );
-        } else if (
-          part.type === "file" &&
-          (part as FileUIPart).mediaType?.startsWith("image/")
-        ) {
-          const filePart = part as FileUIPart;
-          return (
-            <Message
-              key={`${message.id}-${i}`}
-              from={message.role}
-              avatar={assistantAvatar}
-            >
-              <MessageContent className="max-w-full">
-                {/* Generated/uploaded image served from a backend or data: URL;
-                not routable through the Next image optimizer. */}
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={filePart.url}
-                  alt={filePart.filename || "Generated image"}
-                  className="max-w-full rounded-lg border"
-                />
-              </MessageContent>
-            </Message>
-          );
-        } else {
-          return null;
-        }
+        const renderer = partRenderers.find((r) => r.matches(part));
+        return renderer ? renderer.render(part, i) : null;
       })}
       {message.role === "assistant" &&
         message.metadata?.truncatedByTokenLimit && (

--- a/apps/frontend/components/dashboards-list.tsx
+++ b/apps/frontend/components/dashboards-list.tsx
@@ -21,6 +21,7 @@ import { EllipsisVertical, Pencil, Trash2 } from "lucide-react";
 import { type Dashboard } from "@platypus/schemas";
 import useSWR from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import Link from "next/link";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -36,6 +37,7 @@ export const DashboardsList = ({
   const backendUrl = useBackendUrl();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [dashboardToDelete, setDashboardToDelete] = useState<Dashboard | null>(
     null,
   );
@@ -60,23 +62,28 @@ export const DashboardsList = ({
 
   const handleDeleteClick = (dashboard: Dashboard) => {
     setDashboardToDelete(dashboard);
+    setDeleteError(null);
     setDeleteDialogOpen(true);
   };
 
   const handleDeleteConfirm = async () => {
     if (!dashboardToDelete || !backendUrl) return;
     setDeleting(true);
+    setDeleteError(null);
     try {
-      await fetch(
-        joinUrl(
-          backendUrl,
-          `/organizations/${orgId}/workspaces/${workspaceId}/dashboards/${dashboardToDelete.id}`,
-        ),
-        { method: "DELETE", credentials: "include" },
+      const outcome = await writeEntity(
+        backendUrl,
+        "dashboards",
+        { orgId, workspaceId },
+        { id: dashboardToDelete.id },
       );
-      mutate();
-      setDeleteDialogOpen(false);
-      setDashboardToDelete(null);
+      if (outcome.outcome === "success") {
+        mutate();
+        setDeleteDialogOpen(false);
+        setDashboardToDelete(null);
+      } else {
+        setDeleteError(outcome.message);
+      }
     } finally {
       setDeleting(false);
     }
@@ -149,6 +156,7 @@ export const DashboardsList = ({
         onOpenChange={setDeleteDialogOpen}
         onConfirm={handleDeleteConfirm}
         loading={deleting}
+        error={deleteError}
       />
     </>
   );

--- a/apps/frontend/components/delete-board-dialog.tsx
+++ b/apps/frontend/components/delete-board-dialog.tsx
@@ -18,6 +18,7 @@ interface DeleteBoardDialogProps {
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void | Promise<void>;
   loading?: boolean;
+  error?: string | null;
 }
 
 export function DeleteBoardDialog({
@@ -26,6 +27,7 @@ export function DeleteBoardDialog({
   onOpenChange,
   onConfirm,
   loading = false,
+  error = null,
 }: DeleteBoardDialogProps) {
   const [confirmationText, setConfirmationText] = useState("");
 
@@ -67,6 +69,11 @@ export function DeleteBoardDialog({
             />
           </div>
         </DialogHeader>
+        {error && (
+          <div className="py-2 px-4 bg-destructive/10 text-destructive text-sm rounded">
+            {error}
+          </div>
+        )}
         <DialogFooter>
           <Button
             variant="outline"

--- a/apps/frontend/components/delete-dashboard-dialog.tsx
+++ b/apps/frontend/components/delete-dashboard-dialog.tsx
@@ -18,6 +18,7 @@ interface DeleteDashboardDialogProps {
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void | Promise<void>;
   loading?: boolean;
+  error?: string | null;
 }
 
 export function DeleteDashboardDialog({
@@ -26,6 +27,7 @@ export function DeleteDashboardDialog({
   onOpenChange,
   onConfirm,
   loading = false,
+  error = null,
 }: DeleteDashboardDialogProps) {
   const [confirmationText, setConfirmationText] = useState("");
 
@@ -65,6 +67,11 @@ export function DeleteDashboardDialog({
             />
           </div>
         </DialogHeader>
+        {error && (
+          <div className="py-2 px-4 bg-destructive/10 text-destructive text-sm rounded">
+            {error}
+          </div>
+        )}
         <DialogFooter>
           <Button
             variant="outline"

--- a/apps/frontend/components/invitation-form.tsx
+++ b/apps/frontend/components/invitation-form.tsx
@@ -15,6 +15,7 @@ import { useState } from "react";
 import Link from "next/link";
 import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -26,6 +27,8 @@ interface InvitationFormProps {
   orgId: string;
   onSuccess?: () => void;
 }
+
+const RETRACTABLE_FIELDS = ["email", "workspaceName", "blueprintIds"] as const;
 
 export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
   const backendUrl = useBackendUrl();
@@ -53,6 +56,7 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
   const blueprintsById = new Map(blueprints.map((b) => [b.id, b]));
 
   const toggleBlueprint = (id: string, on: boolean) => {
+    setValidationErrors((prev) => retractFieldError(prev, "blueprintIds"));
     setBlueprintIds((prev) =>
       on ? [...prev, id] : prev.filter((bid) => bid !== id),
     );
@@ -139,13 +143,9 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
                 value={email}
                 onChange={(e) => {
                   setEmail(e.target.value);
-                  if (validationErrors.email) {
-                    setValidationErrors((prev) => {
-                      const next = { ...prev };
-                      delete next.email;
-                      return next;
-                    });
-                  }
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "email"),
+                  );
                 }}
                 disabled={isSubmitting}
                 autoFocus
@@ -165,13 +165,9 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
                 value={workspaceName}
                 onChange={(e) => {
                   setWorkspaceName(e.target.value);
-                  if (validationErrors.workspaceName) {
-                    setValidationErrors((prev) => {
-                      const next = { ...prev };
-                      delete next.workspaceName;
-                      return next;
-                    });
-                  }
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "workspaceName"),
+                  );
                 }}
                 disabled={isSubmitting}
               />
@@ -299,7 +295,9 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
       </FieldSet>
       <Button
         type="submit"
-        disabled={isSubmitting}
+        disabled={
+          isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+        }
         className={`w-full md:w-auto mt-2 ${!isSubmitting ? "cursor-pointer" : ""}`}
       >
         {isSubmitting ? "Sending..." : "Send invitation"}

--- a/apps/frontend/components/kanban-board-form.tsx
+++ b/apps/frontend/components/kanban-board-form.tsx
@@ -11,11 +11,17 @@ import { Button } from "@/components/ui/button";
 import { Field, FieldLabel, FieldError } from "@/components/ui/field";
 import { useBackendUrl } from "@/app/client-context";
 import { joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { KANBAN_LABEL_COLORS, type KanbanLabel } from "@platypus/schemas";
 import { toast } from "sonner";
 
 const DEFAULT_COLOR = KANBAN_LABEL_COLORS[5].value; // Blue
+
+// `labels` is excluded: this form has no field that retracts an error keyed
+// to it, so including it here would disable Save forever the moment the
+// server rejects a label.
+const RETRACTABLE_FIELDS = ["name", "description"] as const;
 
 export function KanbanBoardForm({
   orgId,
@@ -128,7 +134,10 @@ export function KanbanBoardForm({
         <Input
           id="name"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(e) => {
+            setValidationErrors((prev) => retractFieldError(prev, "name"));
+            setName(e.target.value);
+          }}
           placeholder="Board name"
           disabled={isSubmitting}
           required
@@ -143,7 +152,12 @@ export function KanbanBoardForm({
         <Textarea
           id="description"
           value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          onChange={(e) => {
+            setValidationErrors((prev) =>
+              retractFieldError(prev, "description"),
+            );
+            setDescription(e.target.value);
+          }}
           placeholder="Optional description"
           disabled={isSubmitting}
         />
@@ -208,7 +222,12 @@ export function KanbanBoardForm({
       <div className="flex gap-2">
         <Button
           type="submit"
-          disabled={isSubmitting || isDeleting || !name.trim()}
+          disabled={
+            isSubmitting ||
+            isDeleting ||
+            !name.trim() ||
+            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {isEditing ? "Update" : "Create board"}
         </Button>

--- a/apps/frontend/components/kanban-card-dialog.tsx
+++ b/apps/frontend/components/kanban-card-dialog.tsx
@@ -63,6 +63,7 @@ import {
   Link2,
 } from "lucide-react";
 import { cn, fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { useIsMobile } from "@/hooks/use-mobile";
@@ -406,50 +407,54 @@ export function KanbanCardDialog({
     });
   };
 
+  const commentsEntity = `boards/${boardId}/cards/${card.id}/comments`;
+
   const handleAddComment = async () => {
-    if (!newCommentBody.trim() || !commentsUrl) return;
-    try {
-      await fetch(commentsUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ body: newCommentBody.trim() }),
-        credentials: "include",
-      });
-      setNewCommentBody("");
-      await mutateComments();
-    } catch {
-      toast.error("Failed to add comment");
+    if (!newCommentBody.trim() || !backendUrl) return;
+    const outcome = await writeEntity(
+      backendUrl,
+      commentsEntity,
+      { orgId, workspaceId },
+      { data: { body: newCommentBody.trim() } },
+    );
+    if (outcome.outcome !== "success") {
+      toast.error(outcome.message);
+      return;
     }
+    setNewCommentBody("");
+    await mutateComments();
   };
 
   const handleEditComment = async (commentId: string) => {
-    if (!editingCommentBody.trim() || !commentsUrl) return;
-    try {
-      await fetch(joinUrl(commentsUrl, `/${commentId}`), {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ body: editingCommentBody.trim() }),
-        credentials: "include",
-      });
-      setEditingCommentId(null);
-      setEditingCommentBody("");
-      await mutateComments();
-    } catch {
-      toast.error("Failed to update comment");
+    if (!editingCommentBody.trim() || !backendUrl) return;
+    const outcome = await writeEntity(
+      backendUrl,
+      commentsEntity,
+      { orgId, workspaceId },
+      { id: commentId, data: { body: editingCommentBody.trim() } },
+    );
+    if (outcome.outcome !== "success") {
+      toast.error(outcome.message);
+      return;
     }
+    setEditingCommentId(null);
+    setEditingCommentBody("");
+    await mutateComments();
   };
 
   const handleDeleteComment = async (commentId: string) => {
-    if (!commentsUrl) return;
-    try {
-      await fetch(joinUrl(commentsUrl, `/${commentId}`), {
-        method: "DELETE",
-        credentials: "include",
-      });
-      await mutateComments();
-    } catch {
-      toast.error("Failed to delete comment");
+    if (!backendUrl) return;
+    const outcome = await writeEntity(
+      backendUrl,
+      commentsEntity,
+      { orgId, workspaceId },
+      { id: commentId },
+    );
+    if (outcome.outcome !== "success") {
+      toast.error(outcome.message);
+      return;
     }
+    await mutateComments();
   };
 
   return (

--- a/apps/frontend/components/manage-sharing.tsx
+++ b/apps/frontend/components/manage-sharing.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useState } from "react";
 import { cn, fetcher, joinUrl } from "@/lib/utils";
+import { writeAt } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 
 type ResourceType = "mcp" | "provider" | "skill" | "agent";
@@ -121,6 +122,7 @@ export const ManageAttachmentsDialog = ({
 }) => {
   const backendUrl = useBackendUrl();
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const { data: attData, mutate: mutateAtt } = useSWR<{
     results: AttachedWorkspace[];
@@ -147,25 +149,23 @@ export const ManageAttachmentsDialog = ({
   const toggle = async (workspaceId: string, isAttached: boolean) => {
     if (!backendUrl) return;
     setBusyId(workspaceId);
+    setError(null);
     try {
-      if (isAttached) {
-        await fetch(
-          joinUrl(
-            backendUrl,
-            `/organizations/${orgId}/attachments/${resourceType}/${resourceId}/${workspaceId}`,
-          ),
-          { method: "DELETE", credentials: "include" },
-        );
-      } else {
-        await fetch(
-          joinUrl(backendUrl, `/organizations/${orgId}/attachments`),
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            credentials: "include",
-            body: JSON.stringify({ resourceType, resourceId, workspaceId }),
-          },
-        );
+      const outcome = isAttached
+        ? await writeAt(
+            joinUrl(
+              backendUrl,
+              `/organizations/${orgId}/attachments/${resourceType}/${resourceId}/${workspaceId}`,
+            ),
+            { method: "DELETE" },
+          )
+        : await writeAt(
+            joinUrl(backendUrl, `/organizations/${orgId}/attachments`),
+            { method: "POST", data: { resourceType, resourceId, workspaceId } },
+          );
+      if (outcome.outcome !== "success") {
+        setError(outcome.message);
+        return;
       }
       await mutateAtt();
     } finally {
@@ -187,6 +187,8 @@ export const ManageAttachmentsDialog = ({
             runs against each workspace’s own resources.
           </DialogDescription>
         </DialogHeader>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
 
         {/* Currently-attached workspaces as removable chips. */}
         {count > 0 ? (

--- a/apps/frontend/components/mcp-form.test.tsx
+++ b/apps/frontend/components/mcp-form.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { MCP } from "@platypus/schemas";
 
 // --- Module mocks ------------------------------------------------------------
@@ -35,6 +35,15 @@ vi.mock("swr", () => ({
 }));
 
 import { McpForm } from "./mcp-form";
+import { toast } from "sonner";
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
 
 // --- Tests -------------------------------------------------------------------
 
@@ -82,5 +91,40 @@ describe("McpForm secret reveal", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Hide client secret" }));
     expect(input).toHaveAttribute("type", "password");
+  });
+});
+
+describe("McpForm locked delete", () => {
+  afterEach(() => {
+    loadedMcp = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it("shows the backend's guidance, not an error toast, when the MCP is Shared", async () => {
+    loadedMcp = {
+      id: "m1",
+      name: "Docs",
+      url: "http://mcp.test",
+      authType: "None",
+    } as unknown as MCP;
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(403, {
+        error: "This MCP server is managed at the organization level",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<McpForm orgId="org1" workspaceId="ws1" mcpId="m1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Delete/ }));
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith(
+        "This MCP server is managed at the organization level",
+      ),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -32,7 +32,8 @@ import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type MCP } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
@@ -62,6 +63,15 @@ type McpFormData = Omit<
 > & {
   headerRows: HeaderRow[];
 };
+
+const RETRACTABLE_FIELDS = [
+  "name",
+  "url",
+  "bearerToken",
+  "oauthClientId",
+  "oauthClientSecret",
+  "oauthRequestedScope",
+] as const;
 
 const McpForm = ({
   classNames,
@@ -157,7 +167,7 @@ const McpForm = ({
 
     // Clear the error for this field, including any reported against a path
     // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,
@@ -170,17 +180,14 @@ const McpForm = ({
 
   const handleSelectChange = (id: string, value: string) => {
     // Clear the error for this field, including any reported against a path
-    // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
-
-    // Clear bearerToken error when authType changes
-    if (id === "authType" && validationErrors.bearerToken) {
-      setValidationErrors((prev) => {
-        const newErrors = { ...prev };
-        delete newErrors.bearerToken;
-        return newErrors;
-      });
-    }
+    // inside it. Switching authType away from bearer also retracts a stale
+    // bearerToken error: that field disappears from the form, so nothing
+    // could otherwise clear it.
+    setValidationErrors((prev) =>
+      id === "authType"
+        ? retractFieldError(retractFieldError(prev, id), "bearerToken")
+        : retractFieldError(prev, id),
+    );
 
     setFormData((prevData) => ({
       ...prevData,
@@ -916,7 +923,7 @@ const McpForm = ({
           disabled={
             isSubmitting ||
             isTesting ||
-            Object.keys(validationErrors).length > 0
+            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
           }
         >
           {mcpId ? "Update" : "Save"}

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -259,6 +259,10 @@ const McpForm = ({
         setValidationErrors({ name: result.message });
         return null;
       case "locked":
+        // Guidance, not a failure — the backend's message already says
+        // where the Shared resource is actually managed (#570).
+        toast.info(result.message);
+        return null;
       case "notFound":
       case "error":
         toast.error(result.message);
@@ -293,6 +297,12 @@ const McpForm = ({
     if (result.outcome === "success") {
       result.revalidateKeys.forEach((key) => globalMutate(key));
       router.push(listPath);
+    } else if (result.outcome === "locked") {
+      // Guidance, not a failure — the backend's message already says where
+      // the Shared resource is actually managed (#570).
+      toast.info(result.message);
+      setIsDeleting(false);
+      setIsDeleteDialogOpen(false);
     } else {
       toast.error(result.message);
       setIsDeleting(false);

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -33,7 +33,7 @@ import { useRouter } from "next/navigation";
 import { type MCP } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
 import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
-import { writeEntity } from "@/lib/api-write";
+import { writeEntity, writeAt } from "@/lib/api-write";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -318,36 +318,31 @@ const McpForm = ({
         payload.mcpId = mcpId;
       }
 
-      const response = await fetch(
-        joinUrl(backendUrl, `${collectionUrl}/test`),
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(payload),
-          credentials: "include",
-        },
-      );
+      const outcome = await writeAt<{
+        success: boolean;
+        toolNames?: string[];
+        error?: string;
+      }>(joinUrl(backendUrl, `${collectionUrl}/test`), {
+        method: "POST",
+        data: payload,
+      });
 
-      const data = await response.json();
-
-      if (response.ok && data.success) {
+      if (outcome.outcome === "success" && outcome.data.success) {
         setTestResult({
           success: true,
-          toolNames: data.toolNames,
+          toolNames: outcome.data.toolNames,
+        });
+      } else if (outcome.outcome === "success") {
+        setTestResult({
+          success: false,
+          error: outcome.data.error || "Failed to connect to MCP server",
         });
       } else {
         setTestResult({
           success: false,
-          error: data.error || "Failed to connect to MCP server",
+          error: outcome.message,
         });
       }
-    } catch (error) {
-      setTestResult({
-        success: false,
-        error: error instanceof Error ? error.message : "Network error",
-      });
     } finally {
       setIsTesting(false);
     }
@@ -403,14 +398,23 @@ const McpForm = ({
           oauthAuthorized ? "?force=true" : ""
         }`,
       );
-      const response = await fetch(authorizeUrl, {
-        method: "POST",
-        credentials: "include",
-      });
+      const outcome = await writeAt<{
+        alreadyAuthorized?: boolean;
+        authorizationUrl?: string;
+        error?: string;
+      }>(authorizeUrl, { method: "POST" });
 
-      const data = await response.json();
+      if (outcome.outcome !== "success") {
+        toast.error(outcome.message);
+        if (!mcpId && resolvedMcpId) {
+          router.replace(editPath(resolvedMcpId));
+        }
+        setIsAuthorizing(false);
+        return;
+      }
+      const data = outcome.data;
 
-      if (response.ok && data.alreadyAuthorized) {
+      if (data.alreadyAuthorized) {
         // Backend silently refreshed via stored refresh_token. Treat as
         // success rather than an error toast.
         toast.success("Already authorized");
@@ -419,7 +423,7 @@ const McpForm = ({
         return;
       }
 
-      if (response.ok && data.authorizationUrl) {
+      if (data.authorizationUrl) {
         // If we just created the MCP, redirect to the edit page so the URL
         // reflects the new mcpId and any later actions (retries, save,
         // re-authorize) update the existing record instead of creating
@@ -474,28 +478,19 @@ const McpForm = ({
     if (!mcpId) return;
     setIsRevoking(true);
 
-    try {
-      const response = await fetch(
-        joinUrl(backendUrl, `${collectionUrl}/${mcpId}/oauth/revoke`),
-        {
-          method: "POST",
-          credentials: "include",
-        },
-      );
+    const outcome = await writeAt(
+      joinUrl(backendUrl, `${collectionUrl}/${mcpId}/oauth/revoke`),
+      { method: "POST" },
+    );
 
-      if (response.ok) {
-        toast.success("OAuth authorization revoked");
-        mutateMcp();
-        setTestResult(null);
-      } else {
-        toast.error("Failed to revoke OAuth authorization");
-      }
-    } catch (error) {
-      console.error("OAuth revoke error:", error);
-      toast.error("Failed to revoke OAuth authorization");
-    } finally {
-      setIsRevoking(false);
+    if (outcome.outcome === "success") {
+      toast.success("OAuth authorization revoked");
+      mutateMcp();
+      setTestResult(null);
+    } else {
+      toast.error(outcome.message);
     }
+    setIsRevoking(false);
   };
 
   if (isLoading) {

--- a/apps/frontend/components/member-edit-dialog.tsx
+++ b/apps/frontend/components/member-edit-dialog.tsx
@@ -21,6 +21,7 @@ import { useState } from "react";
 import { type OrgMemberListItem } from "@platypus/schemas";
 import { useBackendUrl } from "@/app/client-context";
 import { joinUrl } from "@/lib/utils";
+import { writeAt } from "@/lib/api-write";
 import { toast } from "sonner";
 
 interface MemberEditDialogProps {
@@ -45,27 +46,16 @@ export function MemberEditDialog({
   const handleSubmit = async () => {
     setIsSubmitting(true);
     try {
-      const response = await fetch(
+      const outcome = await writeAt(
         joinUrl(backendUrl, `/organizations/${orgId}/members/${member.id}`),
-        {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ role }),
-          credentials: "include",
-        },
+        { method: "PATCH", data: { role } },
       );
-
-      if (response.ok) {
+      if (outcome.outcome === "success") {
         toast.success("Member role updated");
         onSuccess();
       } else {
-        const data = await response.json();
-        toast.error(
-          data.error || data.message || "Failed to update member role",
-        );
+        toast.error(outcome.message);
       }
-    } catch {
-      toast.error("Error updating member role");
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/frontend/components/notifications-dropdown.tsx
+++ b/apps/frontend/components/notifications-dropdown.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import {
   type InvitationListItem,
@@ -23,6 +24,7 @@ import Link from "next/link";
 import useSWR from "swr";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { toast } from "sonner";
 
 function formatRelativeTime(date: Date | string): string {
   const now = Date.now();
@@ -90,28 +92,46 @@ export function NotificationsDropdown({
   const totalCount = unreadNotificationCount + invitations.length;
 
   const handleMarkAsRead = async (notificationId: string) => {
-    if (!notificationsUrl) return;
-    await fetcher(joinUrl(notificationsUrl, `/${notificationId}/read`), {
-      method: "POST",
-    });
+    if (!backendUrl || !orgId || !workspaceId) return;
+    const outcome = await writeEntity(
+      backendUrl,
+      `notifications/${notificationId}/read`,
+      { orgId, workspaceId },
+    );
+    if (outcome.outcome !== "success") {
+      toast.error(outcome.message);
+      return;
+    }
     mutateNotifications();
     mutateUnreadCount();
   };
 
   const handleMarkAllAsRead = async () => {
-    if (!notificationsUrl) return;
-    await fetcher(joinUrl(notificationsUrl, "/read-all"), {
-      method: "POST",
+    if (!backendUrl || !orgId || !workspaceId) return;
+    const outcome = await writeEntity(backendUrl, "notifications/read-all", {
+      orgId,
+      workspaceId,
     });
+    if (outcome.outcome !== "success") {
+      toast.error(outcome.message);
+      return;
+    }
     mutateNotifications();
     mutateUnreadCount();
   };
 
   const handleDismiss = async (notificationId: string) => {
-    if (!notificationsUrl) return;
-    await fetcher(joinUrl(notificationsUrl, `/${notificationId}`), {
-      method: "DELETE",
-    });
+    if (!backendUrl || !orgId || !workspaceId) return;
+    const outcome = await writeEntity(
+      backendUrl,
+      "notifications",
+      { orgId, workspaceId },
+      { id: notificationId },
+    );
+    if (outcome.outcome !== "success") {
+      toast.error(outcome.message);
+      return;
+    }
     if (expandedId === notificationId) setExpandedId(null);
     mutateNotifications();
     mutateUnreadCount();

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -23,7 +23,8 @@ import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type Organization } from "@platypus/schemas";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -35,6 +36,8 @@ interface OrganizationFormProps {
   classNames?: string;
   orgId?: string;
 }
+
+const RETRACTABLE_FIELDS = ["name", "identityContext"] as const;
 
 const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
   const { user } = useAuth();
@@ -78,7 +81,7 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
 
     // Clear the error for this field, including any reported against a path
     // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,
@@ -207,7 +210,9 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
       <div className="flex gap-2">
         <Button
           onClick={handleSubmit}
-          disabled={isSubmitting || Object.keys(validationErrors).length > 0}
+          disabled={
+            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {orgId ? "Update" : "Save"}
         </Button>

--- a/apps/frontend/components/provider-form.test.tsx
+++ b/apps/frontend/components/provider-form.test.tsx
@@ -403,6 +403,89 @@ describe("ProviderForm model rows", () => {
   });
 });
 
+describe("ProviderForm switching Providers", () => {
+  afterEach(() => {
+    loadedProvider = undefined;
+    vi.restoreAllMocks();
+  });
+
+  // The form is reused across Providers within one mount. Populating from the
+  // warm SWR cache has to repopulate on the switch too, not just on first load —
+  // otherwise the reader would see the previous Provider's fields left on
+  // screen under the new Provider's name.
+  it("repopulates every field when the reader switches to another Provider, even from an already-warm cache", () => {
+    loadedProvider = {
+      id: "p1",
+      name: "OpenAI provider",
+      providerType: "OpenAI",
+      apiKey: "sk-p1",
+      baseUrl: "https://p1.example.com",
+      apiMode: "responses",
+      modelIds: [{ id: "gpt-4o", passthroughFileTypes: [] }],
+      taskModelId: "gpt-4o",
+      memoryExtractionModelId: "gpt-4o",
+    } as unknown as Provider;
+    const { rerender } = render(<ProviderForm orgId="org1" providerId="p1" />);
+
+    expect(screen.getByLabelText("Name")).toHaveValue("OpenAI provider");
+    expect(screen.getByLabelText("Model ID")).toHaveValue("gpt-4o");
+
+    // Already resolved before the rerender, as it would be for a Provider
+    // whose data is already warm in SWR's cache.
+    loadedProvider = {
+      id: "p2",
+      name: "Anthropic provider",
+      providerType: "Anthropic",
+      apiKey: "sk-p2",
+      baseUrl: "https://p2.example.com",
+      apiMode: "responses",
+      modelIds: [{ id: "claude-opus", passthroughFileTypes: [] }],
+      taskModelId: "claude-opus",
+      memoryExtractionModelId: "claude-opus",
+    } as unknown as Provider;
+    rerender(<ProviderForm orgId="org1" providerId="p2" />);
+
+    expect(screen.getByLabelText("Name")).toHaveValue("Anthropic provider");
+    expect(screen.getByLabelText("API Key")).toHaveValue("sk-p2");
+    expect(screen.getByLabelText("Base URL")).toHaveValue(
+      "https://p2.example.com",
+    );
+    expect(screen.getByLabelText("Model ID")).toHaveValue("claude-opus");
+  });
+
+  // The specific behaviour the old initialised-flag ref protected: a Provider
+  // is populated once, and a later SWR revalidation of that *same* Provider —
+  // a focus revalidation, another tab saving it — hands back a new object
+  // reference for unchanged (or server-updated) data. That must not re-run
+  // the populate and stomp an edit the reader hasn't saved yet. Keying the
+  // reset on `providerId` (gated on the fetch having resolved) rather than on
+  // `provider` itself is what keeps this working without the ref: `provider`
+  // gets a new reference on every such revalidation, but `providerId` does not.
+  it("does not clobber an in-progress edit when the same Provider's data revalidates", () => {
+    loadedProvider = {
+      id: "p1",
+      name: "OpenAI provider",
+      providerType: "OpenAI",
+      apiKey: "sk-p1",
+      apiMode: "responses",
+      modelIds: [{ id: "gpt-4o", passthroughFileTypes: [] }],
+      taskModelId: "gpt-4o",
+      memoryExtractionModelId: "gpt-4o",
+    } as unknown as Provider;
+    const { rerender } = render(<ProviderForm orgId="org1" providerId="p1" />);
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "My edited name" },
+    });
+
+    // A new object for the same Provider, as a revalidation would hand back.
+    loadedProvider = { ...loadedProvider };
+    rerender(<ProviderForm orgId="org1" providerId="p1" />);
+
+    expect(screen.getByLabelText("Name")).toHaveValue("My edited name");
+  });
+});
+
 describe("ProviderForm validation errors on model rows", () => {
   afterEach(() => {
     loadedProvider = undefined;

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -62,7 +62,8 @@ import {
   type Provider,
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import { clearFieldError, cn, fetcher, joinUrl } from "@/lib/utils";
+import { cn, fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import {
   getModelConfigs,
@@ -453,6 +454,11 @@ type ProviderFormData = Omit<
   embeddingDimensions: string;
 };
 
+// Deliberately empty: this form's fields can be validation-rejected on a
+// provider type that then hides the very input needed to retract them (see
+// the Save button below).
+const RETRACTABLE_FIELDS: readonly string[] = [];
+
 const ProviderForm = ({
   classNames,
   orgId,
@@ -641,7 +647,7 @@ const ProviderForm = ({
     const { id, value } = e.target;
 
     // Clear validation error for this field
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
     setError(null);
 
     if (id === "headers") {
@@ -678,7 +684,7 @@ const ProviderForm = ({
 
   const handleSelectChange = (id: string, value: string) => {
     // Clear validation error for this field
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
     setError(null);
 
     setFormData((prevData) => ({ ...prevData, [id]: value }));
@@ -689,7 +695,7 @@ const ProviderForm = ({
   // Retracts the list's error and every row error under it, so a stale message
   // doesn't sit under a row the user has already corrected.
   const clearModelIdsError = () => {
-    setValidationErrors((prev) => clearFieldError(prev, "modelIds"));
+    setValidationErrors((prev) => retractFieldError(prev, "modelIds"));
   };
 
   /**
@@ -1404,14 +1410,20 @@ const ProviderForm = ({
         <div className="flex gap-2">
           <Button
             className="cursor-pointer"
-            // Deliberately NOT gated on `validationErrors`. Those come back
-            // from the server, and every key needs a matching path that
-            // retracts it; one that has none disables Save forever, with no
-            // way out but reloading. Re-submitting simply re-validates. The
-            // JSON errors below are different — they are computed here as the
-            // user types and always clear themselves.
             onClick={handleSubmit}
-            disabled={isSubmitting || !!headersError || !!extraBodyError}
+            disabled={
+              isSubmitting ||
+              !!headersError ||
+              !!extraBodyError ||
+              // RETRACTABLE_FIELDS is deliberately empty: several fields here
+              // (apiMode, organization, project) render only for certain
+              // provider types, so a `validationErrors` key can outlive the
+              // input that would retract it. Server-returned errors must
+              // never gate Save for that reason — re-submitting simply
+              // re-validates. The JSON errors above are different: they are
+              // computed here as the user types and always clear themselves.
+              !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+            }
           >
             {providerId ? "Update" : "Save"}
           </Button>

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -49,7 +49,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/confirm-dialog";
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   CONTEXT_WINDOW_MAX,
@@ -476,7 +476,6 @@ const ProviderForm = ({
   const { user } = useAuth();
   const backendUrl = useBackendUrl();
   const router = useRouter();
-  const hasInitialized = useRef(false);
 
   const formScope = workspaceId ? "workspace" : "organization";
 
@@ -584,22 +583,23 @@ const ProviderForm = ({
     formData.searchSource === SEARCH_SOURCE_NATIVE &&
     !providerHasNativeSearch(formData);
 
-  // Start the form over when the reader switches Provider within one mount, so
-  // the initialisation flag the effect below reads belongs to the Provider on
-  // screen. `useResetOnChange` rather than an effect: it adjusts state during
-  // render, so the flag is already false when the effect runs (#474).
+  // Populate once per Provider, keyed on `providerId` rather than `provider`
+  // itself: `provider` gets a new object reference on every revalidation that
+  // actually changes the record (a save from another tab, a focus
+  // revalidation), and keying on it directly would re-run this on the Provider
+  // the reader is already editing, clobbering the edit in progress with
+  // whatever the server has right now. Gating the key on `provider` being
+  // loaded — rather than firing as soon as `providerId` changes — defers the
+  // reset until the switch actually has data to populate with, so a cold
+  // fetch (data not loaded yet) doesn't reset into a blank form early and
+  // then never fire again once the fetch resolves.
   //
-  // The Web-search backend selector's visibility rule and its `webBackendEdited`
-  // latch used to be reset here too. Both are gone with the collapse: `searchSource`
-  // is always rendered — "None" and, where the Provider is capable, its built-in
-  // search are real choices on every deployment — so there is no longer a condition
-  // that reads the value the field itself edits.
-  useResetOnChange(providerId, () => {
-    hasInitialized.current = false;
-  });
-
-  useEffect(() => {
-    if (provider && !hasInitialized.current) {
+  // `useResetOnChange` rather than an effect: it adjusts state during render,
+  // so a switch to a Provider already warm in SWR's cache repopulates on that
+  // same render instead of leaving the previous Provider's fields on screen
+  // for one extra frame (#474).
+  useResetOnChange(provider ? providerId : undefined, () => {
+    if (provider) {
       setFormData({
         providerType: provider.providerType,
         name: provider.name,
@@ -637,9 +637,8 @@ const ProviderForm = ({
       setSavedEmbeddingDimensions(
         provider.embeddingDimensions?.toString() || null,
       );
-      hasInitialized.current = true;
     }
-  }, [provider]);
+  });
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -850,6 +850,10 @@ const ProviderForm = ({
           setError(result.message);
           break;
         case "locked":
+          // Guidance, not a failure — the backend's message already says
+          // where the Shared resource is actually managed (#570).
+          toast.info(result.message);
+          break;
         case "notFound":
         case "error":
           toast.error(result.message);
@@ -888,6 +892,12 @@ const ProviderForm = ({
       } else {
         router.push(`/${orgId}/settings/providers`);
       }
+    } else if (result.outcome === "locked") {
+      // Guidance, not a failure — the backend's message already says where
+      // the Shared resource is actually managed (#570).
+      toast.info(result.message);
+      setIsDeleting(false);
+      setIsDeleteDialogOpen(false);
     } else {
       toast.error(result.message);
       setIsDeleting(false);

--- a/apps/frontend/components/remove-member-dialog.tsx
+++ b/apps/frontend/components/remove-member-dialog.tsx
@@ -12,7 +12,7 @@ import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { type OrgMemberListItem } from "@platypus/schemas";
 import { useBackendUrl } from "@/app/client-context";
-import { joinUrl } from "@/lib/utils";
+import { writeEntity } from "@/lib/api-write";
 import { toast } from "sonner";
 import { AlertTriangle } from "lucide-react";
 
@@ -37,23 +37,20 @@ export function RemoveMemberDialog({
   const handleSubmit = async () => {
     setIsSubmitting(true);
     try {
-      const response = await fetch(
-        joinUrl(backendUrl, `/organizations/${orgId}/members/${member.id}`),
+      const outcome = await writeEntity(
+        backendUrl,
+        "members",
+        { orgId },
         {
-          method: "DELETE",
-          credentials: "include",
+          id: member.id,
         },
       );
-
-      if (response.ok) {
+      if (outcome.outcome === "success") {
         toast.success("Member removed from organization");
         onSuccess();
       } else {
-        const data = await response.json();
-        toast.error(data.error || data.message || "Failed to remove member");
+        toast.error(outcome.message);
       }
-    } catch {
-      toast.error("Error removing member");
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/frontend/components/sandbox-settings.tsx
+++ b/apps/frontend/components/sandbox-settings.tsx
@@ -9,7 +9,8 @@ import { type Sandbox } from "@platypus/schemas";
 
 import { useAuth } from "@/components/auth-provider";
 import { useBackendUrl } from "@/app/client-context";
-import { fetcher, joinUrl, parseValidationErrors } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { parseValidationErrors } from "@/lib/form-errors";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";

--- a/apps/frontend/components/sandbox-settings.tsx
+++ b/apps/frontend/components/sandbox-settings.tsx
@@ -9,7 +9,8 @@ import { type Sandbox } from "@platypus/schemas";
 
 import { useAuth } from "@/components/auth-provider";
 import { useBackendUrl } from "@/app/client-context";
-import { fetcher, joinUrl, parseValidationErrors } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { writeAt } from "@/lib/api-write";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -405,32 +406,25 @@ const SandboxSettings = ({
           userEnv: rowsToRecord(formData.userEnv),
         };
 
-    const response = await fetch(url, {
-      method,
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
-      credentials: "include",
-    });
+    const outcome = await writeAt(url, { method, data: payload });
 
-    if (response.ok) return { ok: true };
+    if (outcome.outcome === "success") return { ok: true };
 
-    const errorData = (await response.json().catch(() => ({}))) as {
-      error?: string;
-    };
-
-    if (response.status === 500 && isForceRetryError(errorData?.error)) {
-      return {
-        ok: false,
-        forceRetry: true,
-        errorMessage: errorData.error,
-      };
+    if (
+      outcome.outcome === "error" &&
+      outcome.httpStatus === 500 &&
+      isForceRetryError(outcome.message)
+    ) {
+      return { ok: false, forceRetry: true, errorMessage: outcome.message };
     }
 
-    const fieldErrors = parseValidationErrors(errorData);
-    if (Object.keys(fieldErrors).length > 0) {
-      setValidationErrors(fieldErrors);
+    if (
+      outcome.outcome === "invalid" &&
+      Object.keys(outcome.fieldErrors).length > 0
+    ) {
+      setValidationErrors(outcome.fieldErrors);
     } else {
-      toast.error(errorData?.error || "Failed to save sandbox");
+      toast.error(outcome.message);
     }
     return { ok: false };
   };
@@ -473,20 +467,18 @@ const SandboxSettings = ({
     options: { force?: boolean } = {},
   ): Promise<{ ok: boolean; forceRetry?: boolean }> => {
     const url = options.force ? `${sandboxUrl}?force=true` : sandboxUrl;
-    const response = await fetch(url, {
-      method: "DELETE",
-      credentials: "include",
-    });
+    const outcome = await writeAt(url, { method: "DELETE" });
 
-    if (response.ok) return { ok: true };
+    if (outcome.outcome === "success") return { ok: true };
 
-    const errorData = (await response.json().catch(() => ({}))) as {
-      error?: string;
-    };
-    if (response.status === 500 && isForceRetryError(errorData?.error)) {
+    if (
+      outcome.outcome === "error" &&
+      outcome.httpStatus === 500 &&
+      isForceRetryError(outcome.message)
+    ) {
       return { ok: false, forceRetry: true };
     }
-    toast.error(errorData?.error || "Failed to delete sandbox");
+    toast.error(outcome.message);
     return { ok: false };
   };
 

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -20,12 +20,15 @@ import { useRouter } from "next/navigation";
 import { Trash2 } from "lucide-react";
 import { type Skill, type Agent } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { AgentAvatar } from "@/components/agent-avatar";
+
+const RETRACTABLE_FIELDS = ["name", "description", "body"] as const;
 
 const SkillForm = ({
   classNames,
@@ -119,7 +122,7 @@ const SkillForm = ({
 
     // Clear the error for this field, including any reported against a path
     // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
 
     const nextValue = id === "name" ? value.toLowerCase() : value;
 
@@ -305,7 +308,9 @@ const SkillForm = ({
         <Button
           className="cursor-pointer"
           onClick={handleSubmit}
-          disabled={isSubmitting}
+          disabled={
+            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {skillId ? "Update" : "Save"}
         </Button>

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -164,6 +164,10 @@ const SkillForm = ({
         setValidationErrors({ name: result.message });
         break;
       case "locked":
+        // Guidance, not a failure — the backend's message already says
+        // where the Shared resource is actually managed (#570).
+        toast.info(result.message);
+        break;
       case "notFound":
       case "error":
         toast.error(result.message);
@@ -186,6 +190,12 @@ const SkillForm = ({
     if (result.outcome === "success") {
       result.revalidateKeys.forEach((key) => globalMutate(key));
       router.push(returnPath);
+    } else if (result.outcome === "locked") {
+      // Guidance, not a failure — the backend's message already says where
+      // the Shared resource is actually managed (#570).
+      toast.info(result.message);
+      setIsDeleting(false);
+      setIsDeleteDialogOpen(false);
     } else {
       setDeleteError(result.message);
       setIsDeleting(false);

--- a/apps/frontend/components/skills-list.test.tsx
+++ b/apps/frontend/components/skills-list.test.tsx
@@ -50,7 +50,12 @@ vi.mock("swr", () => ({
 
 const mutateSpy = vi.fn();
 
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
 import { SkillsList } from "./skills-list";
+import { toast } from "sonner";
 
 // --- Helpers -----------------------------------------------------------------
 
@@ -157,6 +162,31 @@ describe("SkillsList delete", () => {
       "http://test/organizations/org1/workspaces/ws1/skills/s2",
       expect.objectContaining({ method: "DELETE" }),
     );
+  });
+
+  it("shows the backend's guidance, not an inline error, when delete is refused because the skill is Shared", async () => {
+    skills = [workspaceSkill];
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(403, {
+        error: "This skill is managed at the organization level",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SkillsList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(toast.info).toHaveBeenCalledWith(
+        "This skill is managed at the organization level",
+      ),
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText("This skill is managed at the organization level"),
+    ).not.toBeInTheDocument();
   });
 
   it("deletes from the org-scoped path on the Organization surface (no workspaceId)", async () => {

--- a/apps/frontend/components/skills-list.tsx
+++ b/apps/frontend/components/skills-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import {
   Item,
   ItemTitle,
@@ -216,6 +217,12 @@ export const SkillsList = ({
         await mutate();
         setDeleteDialogOpen(false);
         setSkillToDelete(null);
+      } else if (outcome.outcome === "locked") {
+        // Guidance, not a failure — the backend's message already says
+        // where the Shared resource is actually managed (#570).
+        setDeleteDialogOpen(false);
+        setSkillToDelete(null);
+        toast.info(outcome.message);
       } else {
         setDeleteError(outcome.message);
       }

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -36,7 +36,8 @@ import {
   type KanbanBoardState,
 } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -274,6 +275,19 @@ const parseCronExpression = (
   return null;
 };
 
+// isOneOff, maxRunsToKeep, search, filterBoardId/filterColumnId, and enabled
+// are deliberately excluded: this form has no field that retracts an error
+// keyed to them.
+const RETRACTABLE_FIELDS = [
+  "name",
+  "description",
+  "agentId",
+  "instruction",
+  "cronExpression",
+  "timezone",
+  "config",
+] as const;
+
 const TriggerForm = ({
   orgId,
   workspaceId,
@@ -474,7 +488,7 @@ const TriggerForm = ({
 
     // Clear the error for this field, including any reported against a path
     // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,
@@ -490,6 +504,7 @@ const TriggerForm = ({
   };
 
   const handleEventToggle = (event: string) => {
+    setValidationErrors((prev) => retractFieldError(prev, "config"));
     setSelectedEvents((prev) => {
       const next = prev.includes(event)
         ? prev.filter((e) => e !== event)
@@ -659,9 +674,12 @@ const TriggerForm = ({
             <FieldLabel>Agent</FieldLabel>
             <Select
               value={formData.agentId}
-              onValueChange={(value) =>
-                setFormData((prev) => ({ ...prev, agentId: value }))
-              }
+              onValueChange={(value) => {
+                setValidationErrors((prev) =>
+                  retractFieldError(prev, "agentId"),
+                );
+                setFormData((prev) => ({ ...prev, agentId: value }));
+              }}
               disabled={isSubmitting}
             >
               <SelectTrigger disabled={isSubmitting}>
@@ -939,9 +957,12 @@ const TriggerForm = ({
                 <FieldLabel>Timezone</FieldLabel>
                 <Select
                   value={formData.timezone}
-                  onValueChange={(value) =>
-                    setFormData((prev) => ({ ...prev, timezone: value }))
-                  }
+                  onValueChange={(value) => {
+                    setValidationErrors((prev) =>
+                      retractFieldError(prev, "timezone"),
+                    );
+                    setFormData((prev) => ({ ...prev, timezone: value }));
+                  }}
                   disabled={isSubmitting}
                 >
                   <SelectTrigger disabled={isSubmitting}>
@@ -1145,7 +1166,7 @@ const TriggerForm = ({
           onClick={handleSubmit}
           disabled={
             isSubmitting ||
-            Object.keys(validationErrors).length > 0 ||
+            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS) ||
             !isCronValid ||
             (triggerType === "event" && selectedEvents.length === 0)
           }

--- a/apps/frontend/components/webhook-form.tsx
+++ b/apps/frontend/components/webhook-form.tsx
@@ -16,7 +16,12 @@ import { useCallback, useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import useSWR, { useSWRConfig } from "swr";
-import { fetcher, clearFieldError, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import {
+  canSubmitForm,
+  retractExactKeys,
+  retractFieldError,
+} from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
@@ -61,6 +66,14 @@ const EVENT_LABELS: Record<string, string> = {
   "card.updated": "Card updated",
   "card.deleted": "Card deleted",
 };
+
+const RETRACTABLE_FIELDS = [
+  "name",
+  "url",
+  "enabled",
+  "events",
+  "headers",
+] as const;
 
 const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
   const { user } = useAuth();
@@ -125,7 +138,7 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
   const clearValidationErrors = useCallback((...fieldNames: string[]) => {
     setValidationErrors((prev) =>
       fieldNames.reduce(
-        (errors, fieldName) => clearFieldError(errors, fieldName),
+        (errors, fieldName) => retractFieldError(errors, fieldName),
         prev,
       ),
     );
@@ -267,13 +280,7 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
   // stranded on other rows.
   const clearHeaderRowError = (index: number) => {
     const rowKey = headerRowErrorKey(headers[index].key);
-    setValidationErrors((prev) => {
-      if (!("headers" in prev) && !(rowKey in prev)) return prev;
-      const next = { ...prev };
-      delete next.headers;
-      delete next[rowKey];
-      return next;
-    });
+    setValidationErrors((prev) => retractExactKeys(prev, ["headers", rowKey]));
   };
 
   const removeHeader = (index: number) => {
@@ -514,7 +521,9 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
         <Button
           className="cursor-pointer"
           onClick={handleSubmit}
-          disabled={isSubmitting || Object.keys(validationErrors).length > 0}
+          disabled={
+            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {isEditMode ? "Update" : "Save"}
         </Button>

--- a/apps/frontend/components/webhook-form.tsx
+++ b/apps/frontend/components/webhook-form.tsx
@@ -17,7 +17,7 @@ import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import useSWR, { useSWRConfig } from "swr";
 import { fetcher, clearFieldError, joinUrl } from "@/lib/utils";
-import { writeEntity } from "@/lib/api-write";
+import { writeEntity, writeAt } from "@/lib/api-write";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -222,30 +222,19 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
 
   const handleRegenerateSecret = async () => {
     setIsRegenerating(true);
-    try {
-      const response = await fetch(
-        joinUrl(webhooksBaseUrl, `/${webhookId}/regenerate-secret`),
-        {
-          method: "POST",
-          credentials: "include",
-        },
-      );
+    const outcome = await writeAt(
+      joinUrl(webhooksBaseUrl, `/${webhookId}/regenerate-secret`),
+      { method: "POST" },
+    );
 
-      if (response.ok) {
-        toast.success("Signing secret regenerated");
-        await mutate();
-        setIsRegenerateDialogOpen(false);
-      } else {
-        toast.error("Failed to regenerate signing secret");
-        setIsRegenerateDialogOpen(false);
-      }
-    } catch (error) {
-      console.error("Error regenerating secret:", error);
-      toast.error("Failed to regenerate signing secret");
-      setIsRegenerateDialogOpen(false);
-    } finally {
-      setIsRegenerating(false);
+    if (outcome.outcome === "success") {
+      toast.success("Signing secret regenerated");
+      await mutate();
+    } else {
+      toast.error(outcome.message);
     }
+    setIsRegenerateDialogOpen(false);
+    setIsRegenerating(false);
   };
 
   const handleCopySecret = async () => {

--- a/apps/frontend/components/workspace-context-form.tsx
+++ b/apps/frontend/components/workspace-context-form.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/dialog";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
 import { fetcher, joinUrl } from "@/lib/utils";
+import { writeAt } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import useSWR from "swr";
@@ -132,80 +133,52 @@ export const WorkspaceContextForm = ({ contextId }: { contextId?: string }) => {
 
     setIsSubmitting(true);
 
-    try {
-      if (contextId) {
-        // Update existing context (workspaceId cannot be changed)
-        const response = await fetch(
-          joinUrl(backendUrl, `/users/me/contexts/${contextId}`),
-          {
-            method: "PUT",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ content: formData.content }),
-            credentials: "include",
-          },
-        );
-
-        if (response.ok) {
-          toast.success("Workspace context updated");
-          router.push("/settings/contexts");
-        } else {
-          toast.error("Failed to update context");
-        }
+    if (contextId) {
+      // Update existing context (workspaceId cannot be changed)
+      const outcome = await writeAt(
+        joinUrl(backendUrl, `/users/me/contexts/${contextId}`),
+        { method: "PUT", data: { content: formData.content } },
+      );
+      if (outcome.outcome === "success") {
+        toast.success("Workspace context updated");
+        router.push("/settings/contexts");
       } else {
-        // Create new context
-        const response = await fetch(
-          joinUrl(backendUrl, "/users/me/contexts"),
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              content: formData.content,
-              workspaceId: formData.workspaceId,
-            }),
-            credentials: "include",
-          },
-        );
-
-        if (response.ok) {
-          toast.success("Workspace context created");
-          router.push("/settings/contexts");
-        } else if (response.status === 409) {
-          toast.error("This workspace already has a context");
-        } else {
-          toast.error("Failed to create context");
-        }
+        toast.error(outcome.message);
       }
-    } catch {
-      toast.error("Error saving context");
-    } finally {
-      setIsSubmitting(false);
+    } else {
+      // Create new context
+      const outcome = await writeAt(joinUrl(backendUrl, "/users/me/contexts"), {
+        method: "POST",
+        data: {
+          content: formData.content,
+          workspaceId: formData.workspaceId,
+        },
+      });
+      if (outcome.outcome === "success") {
+        toast.success("Workspace context created");
+        router.push("/settings/contexts");
+      } else {
+        toast.error(outcome.message);
+      }
     }
+    setIsSubmitting(false);
   };
 
   const handleDelete = async () => {
     if (!contextId) return;
 
     setIsDeleting(true);
-    try {
-      const response = await fetch(
-        joinUrl(backendUrl, `/users/me/contexts/${contextId}`),
-        {
-          method: "DELETE",
-          credentials: "include",
-        },
-      );
-
-      if (response.ok) {
-        toast.success("Context deleted");
-        router.push("/settings/contexts");
-      } else {
-        toast.error("Failed to delete context");
-      }
-    } catch {
-      toast.error("Error deleting context");
-    } finally {
-      setIsDeleting(false);
+    const outcome = await writeAt(
+      joinUrl(backendUrl, `/users/me/contexts/${contextId}`),
+      { method: "DELETE" },
+    );
+    if (outcome.outcome === "success") {
+      toast.success("Context deleted");
+      router.push("/settings/contexts");
+    } else {
+      toast.error(outcome.message);
     }
+    setIsDeleting(false);
   };
 
   return (

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -31,7 +31,8 @@ import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
 import { type Workspace, type Provider } from "@platypus/schemas";
-import { clearFieldError, fetcher, joinUrl } from "@/lib/utils";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -44,6 +45,18 @@ interface WorkspaceFormProps {
   orgId: string;
   workspaceId?: string;
 }
+
+// providerSelfManagement and mcpSelfManagement are deliberately excluded:
+// this form has no field that retracts an error keyed to them.
+const RETRACTABLE_FIELDS = [
+  "name",
+  "ownerId",
+  "context",
+  "taskModelProviderId",
+  "memoryExtractionProviderId",
+  "memoryEmbeddingProviderId",
+  "maxDailySummaries",
+] as const;
 
 const WorkspaceForm = ({
   classNames,
@@ -158,7 +171,7 @@ const WorkspaceForm = ({
 
     // Clear the error for this field, including any reported against a path
     // inside it.
-    setValidationErrors((prev) => clearFieldError(prev, id));
+    setValidationErrors((prev) => retractFieldError(prev, id));
 
     setFormData((prevData) => ({
       ...prevData,
@@ -276,6 +289,9 @@ const WorkspaceForm = ({
               <Select
                 value={formData.ownerId || undefined}
                 onValueChange={(value) => {
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "ownerId"),
+                  );
                   setFormData((prevData) => ({ ...prevData, ownerId: value }));
                 }}
                 disabled={isSubmitting}
@@ -330,6 +346,9 @@ const WorkspaceForm = ({
               <Select
                 value={formData.taskModelProviderId || "none"}
                 onValueChange={(value) => {
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "taskModelProviderId"),
+                  );
                   setFormData((prevData) => ({
                     ...prevData,
                     taskModelProviderId: value === "none" ? null : value,
@@ -367,6 +386,9 @@ const WorkspaceForm = ({
               <Select
                 value={formData.memoryExtractionProviderId || "none"}
                 onValueChange={(value) => {
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "memoryExtractionProviderId"),
+                  );
                   setFormData((prevData) => ({
                     ...prevData,
                     memoryExtractionProviderId: value === "none" ? null : value,
@@ -408,6 +430,9 @@ const WorkspaceForm = ({
               <Select
                 value={formData.memoryEmbeddingProviderId || "none"}
                 onValueChange={(value) => {
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "memoryEmbeddingProviderId"),
+                  );
                   setFormData((prevData) => ({
                     ...prevData,
                     memoryEmbeddingProviderId: value === "none" ? null : value,
@@ -457,6 +482,9 @@ const WorkspaceForm = ({
                 max={365}
                 value={formData.maxDailySummaries}
                 onChange={(e) => {
+                  setValidationErrors((prev) =>
+                    retractFieldError(prev, "maxDailySummaries"),
+                  );
                   setFormData((prevData) => ({
                     ...prevData,
                     maxDailySummaries: parseInt(e.target.value) || 90,
@@ -540,7 +568,9 @@ const WorkspaceForm = ({
       <div className="flex gap-2">
         <Button
           onClick={handleSubmit}
-          disabled={isSubmitting || Object.keys(validationErrors).length > 0}
+          disabled={
+            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
         >
           {workspaceId ? "Update" : "Save"}
         </Button>

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -24,6 +24,35 @@ const eslintConfig = defineConfig([
       ],
     },
   },
+  // A write (any `fetch` call whose `method` is anything but `"GET"`) must go
+  // through the typed-outcome request module (lib/api-write.ts, #563) rather
+  // than a hand-rolled call — that module is the only seam that maps the
+  // backend's ADR-0010 error responses consistently. A handful of call sites
+  // predate the module and can't move onto it (see the comment at each): a
+  // better-auth admin action needing a bespoke `Origin` header, a multipart
+  // avatar upload, and one write whose 422 "blockers" checklist the module's
+  // outcome type doesn't carry.
+  {
+    files: ["**/*.ts", "**/*.tsx"],
+    ignores: [
+      "lib/api-write.ts",
+      "components/delete-user-dialog.tsx",
+      "components/change-password-dialog.tsx",
+      "components/agent-form.tsx",
+      "components/agents-list.tsx",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "CallExpression[callee.name='fetch']:has(Property[key.name='method'][value.value!='GET'])",
+          message:
+            "Writes go through writeEntity()/writeAt() in lib/api-write.ts, not a raw fetch() — see ADR-0010 and #563.",
+        },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/apps/frontend/lib/api-write.test.ts
+++ b/apps/frontend/lib/api-write.test.ts
@@ -592,4 +592,26 @@ describe("writeAt", () => {
       message: "You already have a context for this scope",
     });
   });
+
+  it("sends a PATCH with a body, for a partial update", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(mockResponse(200, { id: "m1", role: "admin" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await writeAt(`${BACKEND_URL}/organizations/org1/members/m1`, {
+      method: "PATCH",
+      data: { role: "admin" },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BACKEND_URL}/organizations/org1/members/m1`,
+      expect.objectContaining({
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: "admin" }),
+      }),
+    );
+  });
 });

--- a/apps/frontend/lib/api-write.ts
+++ b/apps/frontend/lib/api-write.ts
@@ -1,4 +1,5 @@
-import { joinUrl, parseValidationErrors } from "./utils";
+import { joinUrl } from "./utils";
+import { parseValidationErrors } from "./form-errors";
 
 /**
  * A write's target scope (ADR-0007): an Organization-level (Shared) resource,

--- a/apps/frontend/lib/api-write.ts
+++ b/apps/frontend/lib/api-write.ts
@@ -104,7 +104,7 @@ function errorFiles(body: unknown): string[] | undefined {
 
 async function performWrite<TResult, TData>(
   url: string,
-  method: "POST" | "PUT" | "DELETE",
+  method: "POST" | "PUT" | "PATCH" | "DELETE",
   data: TData | undefined,
   revalidateKeys: readonly string[],
 ): Promise<WriteOutcome<TResult>> {
@@ -199,7 +199,7 @@ export async function writeEntity<TResult = unknown, TData = unknown>(
 }
 
 export interface WriteAtOptions<TData> {
-  readonly method: "POST" | "PUT" | "DELETE";
+  readonly method: "POST" | "PUT" | "PATCH" | "DELETE";
   /** Omit only when the write is a DELETE. */
   readonly data?: TData;
   /** SWR keys this write should invalidate. Defaults to none. */

--- a/apps/frontend/lib/form-errors.test.ts
+++ b/apps/frontend/lib/form-errors.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import {
+  canSubmitForm,
+  parseValidationErrors,
+  retractExactKeys,
+  retractFieldError,
+  type FormErrors,
+} from "./form-errors";
+
+describe("parseValidationErrors", () => {
+  it("should parse validation errors correctly", () => {
+    const errorData = {
+      error: [
+        { path: ["name"], message: "Name is required" },
+        { path: ["email"], message: "Invalid email" },
+      ],
+    };
+    const result = parseValidationErrors(errorData);
+    expect(result).toEqual({
+      name: "Name is required",
+      email: "Invalid email",
+    });
+  });
+
+  it("should return empty object for invalid input", () => {
+    expect(parseValidationErrors(null)).toEqual({});
+    expect(parseValidationErrors({})).toEqual({});
+    expect(parseValidationErrors({ error: "string" })).toEqual({});
+  });
+
+  // A rule over a list reports the row it failed on. Keyed on the first path
+  // segment alone, every row's message landed on the same key and all but one
+  // was lost — two bad rows meant one message and one fix per round-trip.
+  it("keys an error inside a list on its full path", () => {
+    const result = parseValidationErrors({
+      error: [
+        { path: ["modelIds", 1, "alias"], message: "Alias 'dup' duplicates" },
+        { path: ["modelIds", 2, "alias"], message: "Alias 'DUP' duplicates" },
+      ],
+    });
+
+    expect(result["modelIds.1.alias"]).toBe("Alias 'dup' duplicates");
+    expect(result["modelIds.2.alias"]).toBe("Alias 'DUP' duplicates");
+  });
+
+  // Not every form knows about paths. Each issue also reports under its
+  // top-level field so a form that only reads flat names still shows something
+  // rather than failing silently.
+  it("also reports a nested error under its top-level field", () => {
+    const result = parseValidationErrors({
+      error: [{ path: ["modelIds", 1, "alias"], message: "Alias duplicates" }],
+    });
+
+    expect(result.modelIds).toBe("Alias duplicates");
+  });
+
+  // An error against the list itself is the better message for the list's own
+  // slot, whichever order the two arrive in.
+  it("prefers an error on the field itself over one derived from a row", () => {
+    const rowFirst = parseValidationErrors({
+      error: [
+        { path: ["modelIds", 0, "alias"], message: "Row message" },
+        { path: ["modelIds"], message: "Field message" },
+      ],
+    });
+
+    expect(rowFirst.modelIds).toBe("Field message");
+    expect(rowFirst["modelIds.0.alias"]).toBe("Row message");
+  });
+
+  it("keeps the first message when one field has several", () => {
+    const result = parseValidationErrors({
+      error: [
+        { path: ["name"], message: "Too short" },
+        { path: ["name"], message: "Also invalid" },
+      ],
+    });
+
+    expect(result.name).toBe("Too short");
+  });
+});
+
+describe("retractFieldError", () => {
+  it("drops the field's own error", () => {
+    expect(
+      retractFieldError({ name: "Required", apiKey: "Bad" }, "name"),
+    ).toEqual({ apiKey: "Bad" });
+  });
+
+  // The edit that fixes a row is an edit to the field the row lives in, so the
+  // rows' errors have to go with it. A form gating Submit on the error map
+  // stays stuck forever otherwise.
+  it("drops errors nested under the field", () => {
+    const errors = {
+      "modelIds.1.alias": "Duplicate",
+      "modelIds.2.alias": "Duplicate",
+      modelIds: "Duplicate",
+      name: "Required",
+    };
+
+    expect(retractFieldError(errors, "modelIds")).toEqual({
+      name: "Required",
+    });
+  });
+
+  it("leaves a field whose name merely prefixes the edited one", () => {
+    const errors = { modelIdsExtra: "Bad" };
+
+    expect(retractFieldError(errors, "modelIds")).toEqual(errors);
+  });
+
+  it("returns the same object when nothing matches, so state does not churn", () => {
+    const errors = { name: "Required" };
+
+    expect(retractFieldError(errors, "apiKey")).toBe(errors);
+  });
+});
+
+describe("retractExactKeys", () => {
+  it("drops exactly the given keys", () => {
+    const errors = { name: "Required", "headers.X-Foo": "Too long" };
+
+    expect(retractExactKeys(errors, ["name"])).toEqual({
+      "headers.X-Foo": "Too long",
+    });
+  });
+
+  // Unlike retractFieldError, a row-scoped clear must not sweep siblings
+  // sharing the same top-level field name.
+  it("leaves sibling rows under the same top-level field alone", () => {
+    const errors = {
+      "headers.X-Foo": "Too long",
+      "headers.X-Bar": "Too long",
+    };
+
+    expect(retractExactKeys(errors, ["headers", "headers.X-Foo"])).toEqual({
+      "headers.X-Bar": "Too long",
+    });
+  });
+
+  it("returns the same object when nothing matches, so state does not churn", () => {
+    const errors = { name: "Required" };
+
+    expect(retractExactKeys(errors, ["apiKey"])).toBe(errors);
+  });
+});
+
+describe("canSubmitForm", () => {
+  it("allows submit when there are no errors", () => {
+    expect(canSubmitForm({}, ["name", "url"])).toBe(true);
+  });
+
+  it("blocks submit while a retractable field's error is outstanding", () => {
+    expect(canSubmitForm({ name: "Required" }, ["name", "url"])).toBe(false);
+  });
+
+  it("blocks submit on a row-level error under a retractable field", () => {
+    expect(
+      canSubmitForm({ "headers.X-Foo": "Too long" }, ["name", "headers"]),
+    ).toBe(false);
+  });
+
+  // The #571 invariant: a server-returned error keyed to a field the form
+  // never declared has no way to be retracted by editing, so it must never
+  // gate Save — the only escape from that would be reloading the page.
+  it("never blocks submit on an error whose key no field can retract", () => {
+    expect(canSubmitForm({ events: "At least one event required" }, [])).toBe(
+      true,
+    );
+    expect(canSubmitForm({ someServerOnlyRule: "Nope" }, ["name", "url"])).toBe(
+      true,
+    );
+  });
+
+  // Regression for #559: a Webhook save rejected on `events` — a field the
+  // form declares — must leave Save usable once `events` is edited (i.e. once
+  // its error is retracted), not disabled forever.
+  it("mirrors the #559 webhook round trip: retract, then submit is allowed again", () => {
+    const retractable = ["name", "url", "enabled", "events", "headers"];
+    let errors: FormErrors = { events: "At least one event is required" };
+
+    expect(canSubmitForm(errors, retractable)).toBe(false);
+
+    errors = retractFieldError(errors, "events");
+
+    expect(errors).toEqual({});
+    expect(canSubmitForm(errors, retractable)).toBe(true);
+  });
+});

--- a/apps/frontend/lib/form-errors.ts
+++ b/apps/frontend/lib/form-errors.ts
@@ -1,0 +1,122 @@
+/**
+ * Owns a form's server-side rejections end to end: parsing them off a failed
+ * write, retracting one when the field it names is edited, and deciding
+ * whether the form may submit.
+ *
+ * A form declares which field ids it can retract (its inputs) and never
+ * needs to reason about the rest itself — an error keyed to anything else
+ * (a field the form doesn't render, a cross-field rule with nowhere to
+ * live) simply can't gate Save, because there would be no way to clear it
+ * short of reloading.
+ */
+
+export type FormErrors = Record<string, string>;
+
+function isFieldOrSubPath(key: string, fieldId: string): boolean {
+  return key === fieldId || key.startsWith(`${fieldId}.`);
+}
+
+/**
+ * Map a validation failure onto the fields that can show it.
+ *
+ * Each issue is keyed on its **full path**, dot-joined: a rule over a list
+ * reports the row it failed on (`modelIds.2.alias`), so two bad rows produce
+ * two messages the form can render in two places. Keyed on the first segment
+ * alone, they overwrote each other — one message, one fix per round-trip.
+ *
+ * Every issue is *also* reported under its top-level field, because most forms
+ * only know flat names. An error on the field itself wins that slot over one
+ * derived from a row.
+ */
+export function parseValidationErrors(errorData: unknown): FormErrors {
+  const errors: FormErrors = {};
+
+  if (
+    !errorData ||
+    typeof errorData !== "object" ||
+    !("error" in errorData) ||
+    !Array.isArray(errorData.error)
+  ) {
+    return errors;
+  }
+
+  const issues: Array<{ path: string[]; message: string }> = [];
+  for (const issue of errorData.error) {
+    if (
+      issue &&
+      typeof issue === "object" &&
+      "path" in issue &&
+      Array.isArray(issue.path) &&
+      issue.path.length > 0 &&
+      "message" in issue &&
+      typeof issue.message === "string"
+    ) {
+      issues.push({ path: issue.path.map(String), message: issue.message });
+    }
+  }
+
+  // Exact paths first, so the top-level pass below can't take a slot an issue
+  // on the field itself is entitled to.
+  for (const { path, message } of issues) {
+    const key = path.join(".");
+    if (!(key in errors)) errors[key] = message;
+  }
+  for (const { path, message } of issues) {
+    if (!(path[0] in errors)) errors[path[0]] = message;
+  }
+
+  return errors;
+}
+
+/**
+ * Retract the error shown against a field, including any keyed at a path
+ * *under* it — the edit that fixes a row is an edit to the field the row lives
+ * in. Returns the original object when nothing matched, so a no-op leaves
+ * state (and identity) untouched.
+ */
+export function retractFieldError(
+  errors: FormErrors,
+  fieldId: string,
+): FormErrors {
+  const remaining = Object.entries(errors).filter(
+    ([key]) => !isFieldOrSubPath(key, fieldId),
+  );
+
+  if (remaining.length === Object.keys(errors).length) return errors;
+  return Object.fromEntries(remaining);
+}
+
+/**
+ * Retract exactly the given keys — no sub-path matching. For a row-scoped
+ * edit inside a keyed group (e.g. one header row in `headers`), where
+ * `retractFieldError(errors, "headers")` would sweep every sibling row under
+ * the same top-level field. Returns the original object when nothing
+ * matched, so a no-op leaves state (and identity) untouched.
+ */
+export function retractExactKeys(
+  errors: FormErrors,
+  keys: readonly string[],
+): FormErrors {
+  const toRemove = new Set(keys);
+  const remaining = Object.entries(errors).filter(
+    ([key]) => !toRemove.has(key),
+  );
+
+  if (remaining.length === Object.keys(errors).length) return errors;
+  return Object.fromEntries(remaining);
+}
+
+/**
+ * A form may submit unless a *retractable* error is still outstanding — one
+ * keyed to a field the form declared. A server-returned error with no
+ * retracting field must never gate Save: editing can't clear it, so gating on
+ * it would disable Save forever with no way out but reloading.
+ */
+export function canSubmitForm(
+  errors: FormErrors,
+  retractableFieldIds: readonly string[],
+): boolean {
+  return !Object.keys(errors).some((key) =>
+    retractableFieldIds.some((fieldId) => isFieldOrSubPath(key, fieldId)),
+  );
+}

--- a/apps/frontend/lib/utils.test.ts
+++ b/apps/frontend/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { clearFieldError, joinUrl, parseValidationErrors } from "./utils";
+import { joinUrl } from "./utils";
 
 describe("joinUrl", () => {
   it("should join base URL and path", () => {
@@ -22,112 +22,5 @@ describe("joinUrl", () => {
 
   it("should return path when base is empty", () => {
     expect(joinUrl("", "/api/test")).toBe("/api/test");
-  });
-});
-
-describe("parseValidationErrors", () => {
-  it("should parse validation errors correctly", () => {
-    const errorData = {
-      error: [
-        { path: ["name"], message: "Name is required" },
-        { path: ["email"], message: "Invalid email" },
-      ],
-    };
-    const result = parseValidationErrors(errorData);
-    expect(result).toEqual({
-      name: "Name is required",
-      email: "Invalid email",
-    });
-  });
-
-  it("should return empty object for invalid input", () => {
-    expect(parseValidationErrors(null)).toEqual({});
-    expect(parseValidationErrors({})).toEqual({});
-    expect(parseValidationErrors({ error: "string" })).toEqual({});
-  });
-
-  // A rule over a list reports the row it failed on. Keyed on the first path
-  // segment alone, every row's message landed on the same key and all but one
-  // was lost — two bad rows meant one message and one fix per round-trip.
-  it("keys an error inside a list on its full path", () => {
-    const result = parseValidationErrors({
-      error: [
-        { path: ["modelIds", 1, "alias"], message: "Alias 'dup' duplicates" },
-        { path: ["modelIds", 2, "alias"], message: "Alias 'DUP' duplicates" },
-      ],
-    });
-
-    expect(result["modelIds.1.alias"]).toBe("Alias 'dup' duplicates");
-    expect(result["modelIds.2.alias"]).toBe("Alias 'DUP' duplicates");
-  });
-
-  // Not every form knows about paths. Each issue also reports under its
-  // top-level field so a form that only reads flat names still shows something
-  // rather than failing silently.
-  it("also reports a nested error under its top-level field", () => {
-    const result = parseValidationErrors({
-      error: [{ path: ["modelIds", 1, "alias"], message: "Alias duplicates" }],
-    });
-
-    expect(result.modelIds).toBe("Alias duplicates");
-  });
-
-  // An error against the list itself is the better message for the list's own
-  // slot, whichever order the two arrive in.
-  it("prefers an error on the field itself over one derived from a row", () => {
-    const rowFirst = parseValidationErrors({
-      error: [
-        { path: ["modelIds", 0, "alias"], message: "Row message" },
-        { path: ["modelIds"], message: "Field message" },
-      ],
-    });
-
-    expect(rowFirst.modelIds).toBe("Field message");
-    expect(rowFirst["modelIds.0.alias"]).toBe("Row message");
-  });
-
-  it("keeps the first message when one field has several", () => {
-    const result = parseValidationErrors({
-      error: [
-        { path: ["name"], message: "Too short" },
-        { path: ["name"], message: "Also invalid" },
-      ],
-    });
-
-    expect(result.name).toBe("Too short");
-  });
-});
-
-describe("clearFieldError", () => {
-  it("drops the field's own error", () => {
-    expect(
-      clearFieldError({ name: "Required", apiKey: "Bad" }, "name"),
-    ).toEqual({ apiKey: "Bad" });
-  });
-
-  // The edit that fixes a row is an edit to the field the row lives in, so the
-  // rows' errors have to go with it. A form gating Submit on the error map
-  // stays stuck forever otherwise.
-  it("drops errors nested under the field", () => {
-    const errors = {
-      "modelIds.1.alias": "Duplicate",
-      "modelIds.2.alias": "Duplicate",
-      modelIds: "Duplicate",
-      name: "Required",
-    };
-
-    expect(clearFieldError(errors, "modelIds")).toEqual({ name: "Required" });
-  });
-
-  it("leaves a field whose name merely prefixes the edited one", () => {
-    const errors = { modelIdsExtra: "Bad" };
-
-    expect(clearFieldError(errors, "modelIds")).toEqual(errors);
-  });
-
-  it("returns the same object when nothing matches, so state does not churn", () => {
-    const errors = { name: "Required" };
-
-    expect(clearFieldError(errors, "apiKey")).toBe(errors);
   });
 });

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -33,11 +33,6 @@ export const fetcher = async (input: RequestInfo | URL, init?: RequestInit) => {
   return res.json();
 };
 
-/**
- * Parses standardschema.dev validation errors from an error response
- * @param errorData - The error response data from the API
- * @returns An object mapping field names to error messages
- */
 export function getInitials(name: string): string {
   return name
     .split(" ")
@@ -45,77 +40,4 @@ export function getInitials(name: string): string {
     .join("")
     .toUpperCase()
     .slice(0, 2);
-}
-
-/**
- * Map a validation failure onto the fields that can show it.
- *
- * Each issue is keyed on its **full path**, dot-joined: a rule over a list
- * reports the row it failed on (`modelIds.2.alias`), so two bad rows produce
- * two messages the form can render in two places. Keyed on the first segment
- * alone, they overwrote each other — one message, one fix per round-trip.
- *
- * Every issue is *also* reported under its top-level field, because most forms
- * only know flat names. An error on the field itself wins that slot over one
- * derived from a row.
- */
-export function parseValidationErrors(
-  errorData: unknown,
-): Record<string, string> {
-  const errors: Record<string, string> = {};
-
-  if (
-    !errorData ||
-    typeof errorData !== "object" ||
-    !("error" in errorData) ||
-    !Array.isArray(errorData.error)
-  ) {
-    return errors;
-  }
-
-  const issues: Array<{ path: string[]; message: string }> = [];
-  for (const issue of errorData.error) {
-    if (
-      issue &&
-      typeof issue === "object" &&
-      "path" in issue &&
-      Array.isArray(issue.path) &&
-      issue.path.length > 0 &&
-      "message" in issue &&
-      typeof issue.message === "string"
-    ) {
-      issues.push({ path: issue.path.map(String), message: issue.message });
-    }
-  }
-
-  // Exact paths first, so the top-level pass below can't take a slot an issue
-  // on the field itself is entitled to.
-  for (const { path, message } of issues) {
-    const key = path.join(".");
-    if (!(key in errors)) errors[key] = message;
-  }
-  for (const { path, message } of issues) {
-    if (!(path[0] in errors)) errors[path[0]] = message;
-  }
-
-  return errors;
-}
-
-/**
- * Retract the error shown against a field, including any keyed at a path
- * *under* it — the edit that fixes a row is an edit to the field the row lives
- * in. Returns the original object when nothing matched, so a no-op leaves
- * state untouched.
- */
-export function clearFieldError(
-  errors: Record<string, string>,
-  fieldName: string,
-): Record<string, string> {
-  const prefix = `${fieldName}.`;
-  const remaining = Object.entries(errors).filter(
-    ([key]) => key !== fieldName && !key.startsWith(prefix),
-  );
-
-  if (remaining.length === Object.keys(errors).length) return errors;
-  return Object.fromEntries(remaining);
 }


### PR DESCRIPTION
## Summary
- Migrates the raw `fetch()` writes that earlier request-module batches (#564-568) missed onto `writeEntity()`/`writeAt()` in `lib/api-write.ts`: invitations accept/decline, blueprint delete/apply, shared-resource attach/detach, board/dashboard delete, workspace contexts, sidebar chat rename/delete/pin, member remove/role-edit, kanban comments, sandbox config, MCP test/OAuth actions, webhook secret regen, and notifications (previously piggybacking on the read-side `fetcher`, which silently swallowed failures).
- Extends `writeAt`'s method union with `PATCH` for the member-role route, since the backend only exposes that route as PATCH.
- Adds a `no-restricted-syntax` ESLint rule banning a raw `fetch()` carrying a non-GET method outside a short, commented exemption list (better-auth admin actions needing a custom `Origin` header, the avatar multipart upload, and one promote action whose 422 `blockers` checklist the module's outcome type can't carry). `pnpm lint` already gates CI, so no separate wiring was needed.
- No orphaned transport helper existed to delete — the old path was always inline `fetch()` calls, never a shared function.

Closes #569

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (confirmed the new rule fires on a raw write and stays silent on GETs)
- [x] `pnpm test` (362 tests passing)
- [x] Two-axis code review (Standards + Spec) run against the diff; one real gap found and fixed (an avatar-delete `fetch()` riding along on the multipart-upload exemption unnecessarily)

🤖 Generated with [Claude Code](https://claude.com/claude-code)