### PR TITLE
chore(frontend): one image-part predicate, not four that disagree

### DIFF
--- a/apps/frontend/components/ai-elements/message.tsx
+++ b/apps/frontend/components/ai-elements/message.tsx
@@ -8,6 +8,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { isImageAttachment } from "@/lib/message-parts";
 import { cn } from "@/lib/utils";
 import type { FileUIPart, UIMessage } from "ai";
 import type { LinkSafetyConfig } from "streamdown";
@@ -373,9 +374,7 @@ export function MessageAttachment({
   ...props
 }: MessageAttachmentProps) {
   const filename = data.filename || "";
-  const mediaType =
-    data.mediaType?.startsWith("image/") && data.url ? "image" : "file";
-  const isImage = mediaType === "image";
+  const isImage = isImageAttachment(data);
   const attachmentLabel = filename || (isImage ? "Image" : "Attachment");
 
   return (

--- a/apps/frontend/components/ai-elements/prompt-input.test.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.test.tsx
@@ -177,3 +177,48 @@ describe("PromptInput attachments", () => {
     expect(screen.getByText("dropped.png")).toBeInTheDocument();
   });
 });
+
+describe("PromptInputAttachment image parts", () => {
+  // issue #579: a part can carry an image media type with nothing a client
+  // can fetch (e.g. Provider-reference-only). It should render as the plain
+  // file card every non-image attachment gets, not a broken <img>.
+  it("falls back to a file attachment for an image media type with no URL", () => {
+    render(
+      <PromptInput onSubmit={vi.fn()}>
+        <PromptInputAttachment
+          data={{
+            id: "1",
+            type: "file",
+            mediaType: "image/png",
+            url: "",
+            filename: "photo.png",
+          }}
+        />
+      </PromptInput>,
+    );
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.getByText("photo.png")).toBeInTheDocument();
+  });
+
+  it("renders an image media type with a URL as an image", () => {
+    render(
+      <PromptInput onSubmit={vi.fn()}>
+        <PromptInputAttachment
+          data={{
+            id: "1",
+            type: "file",
+            mediaType: "image/png",
+            url: "https://example.com/photo.png",
+            filename: "photo.png",
+          }}
+        />
+      </PromptInput>,
+    );
+
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "https://example.com/photo.png",
+    );
+  });
+});

--- a/apps/frontend/components/ai-elements/prompt-input.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/input-group";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useSpeechToText } from "@/hooks/use-speech-to-text";
+import { isImageAttachment } from "@/lib/message-parts";
 import { cn } from "@/lib/utils";
 import type { ChatStatus, FileUIPart } from "ai";
 import {
@@ -112,9 +113,7 @@ export function PromptInputAttachment({
 
   const filename = data.filename || "";
 
-  const mediaType =
-    data.mediaType?.startsWith("image/") && data.url ? "image" : "file";
-  const isImage = mediaType === "image";
+  const isImage = isImageAttachment(data);
 
   const attachmentLabel = filename || (isImage ? "Image" : "Attachment");
 

--- a/apps/frontend/components/chat-message.test.tsx
+++ b/apps/frontend/components/chat-message.test.tsx
@@ -81,6 +81,48 @@ describe("ChatMessage agent attribution", () => {
   });
 });
 
+type MessagePart = NonNullable<PlatypusUIMessage["parts"]>[number];
+
+describe("ChatMessage image parts", () => {
+  const userMessageWithFilePart = (part: MessagePart): PlatypusUIMessage => ({
+    id: "m1",
+    role: "user",
+    parts: [part, { type: "text", text: "Check this out" }],
+  });
+
+  it("renders an image media type with a URL inline, not as a file attachment", () => {
+    renderMessage(
+      userMessageWithFilePart({
+        type: "file",
+        mediaType: "image/png",
+        url: "https://example.com/a.png",
+        filename: "a.png",
+      }),
+    );
+
+    expect(screen.getByAltText("a.png")).toHaveAttribute(
+      "src",
+      "https://example.com/a.png",
+    );
+  });
+
+  // issue #579: a part can carry an image media type with nothing a client
+  // can fetch (e.g. Provider-reference-only). Rendering it as a broken <img>
+  // would be worse than the plain file card every non-image attachment gets.
+  it("falls back to a file attachment for an image media type with no URL", () => {
+    const { container } = renderMessage(
+      userMessageWithFilePart({
+        type: "file",
+        mediaType: "image/png",
+        url: "",
+        filename: "a.png",
+      }),
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+  });
+});
+
 // A Web-search backend's `web_search` is client-executed, so its citations arrive
 // as a tool result rather than as `source-url` parts. Without lifting them, the
 // same Chat toggle gives pills on Anthropic and nothing on vLLM (ADR-0014).

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -38,6 +38,7 @@ import {
   type ChatStatus,
 } from "ai";
 import { Agent, isPresentableUrl } from "@platypus/schemas";
+import { isImageAttachment } from "@/lib/message-parts";
 import {
   BotIcon,
   CheckIcon,
@@ -107,8 +108,7 @@ export const isGenericToolPart = (part: MessagePart) =>
   !specializedToolMatchers.some((matches) => matches(part));
 
 const isImageFilePart = (part: MessagePart) =>
-  part.type === "file" &&
-  Boolean((part as FileUIPart).mediaType?.startsWith("image/"));
+  part.type === "file" && isImageAttachment(part as FileUIPart);
 
 interface PartRenderer {
   matches: (part: MessagePart) => boolean;
@@ -187,7 +187,7 @@ export const ChatMessage = memo(function ChatMessage({
     ));
   const fileParts = message.parts?.filter(
     (part): part is FileUIPart =>
-      part.type === "file" && !part.mediaType?.startsWith("image/"),
+      part.type === "file" && !isImageFilePart(part),
   );
   // Scheme-checked with the same predicate a plugin result's URL goes through.
   // A vendor is more trusted than a Web-search backend, but the pill is titled by

--- a/apps/frontend/lib/message-parts.test.ts
+++ b/apps/frontend/lib/message-parts.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { isImageAttachment } from "./message-parts";
+
+describe("isImageAttachment", () => {
+  it("is true for an image media type with a URL", () => {
+    expect(
+      isImageAttachment({ mediaType: "image/png", url: "https://x/a.png" }),
+    ).toBe(true);
+  });
+
+  it("is false for an image media type with no URL", () => {
+    expect(isImageAttachment({ mediaType: "image/png", url: "" })).toBe(false);
+  });
+
+  it("is false for a non-image media type with a URL", () => {
+    expect(
+      isImageAttachment({
+        mediaType: "application/pdf",
+        url: "https://x/a.pdf",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/frontend/lib/message-parts.ts
+++ b/apps/frontend/lib/message-parts.ts
@@ -1,0 +1,12 @@
+import type { FileUIPart } from "ai";
+
+/**
+ * Whether a file part should render as an image rather than a generic file
+ * attachment. An image media type with no URL (a Provider-reference-only
+ * file, or a still-uploading part) has nothing a client can put in an `<img
+ * src>` — falling back to the file card there is strictly better than a
+ * broken image, so the URL is required alongside the media type (issue #579).
+ */
+export const isImageAttachment = (
+  part: Pick<FileUIPart, "mediaType" | "url">,
+): boolean => Boolean(part.mediaType?.startsWith("image/") && part.url);


### PR DESCRIPTION
## Summary

Closes #579.

There were four independent copies of "is this file part an image": two in `chat-message.tsx` (inline-render matcher, attachment-filter) tested media type alone; `ai-elements/message.tsx` and `ai-elements/prompt-input.tsx` also required a URL. They now share one predicate, `isImageAttachment` in `apps/frontend/lib/message-parts.ts`.

## The URL decision

An image-media-type part with no URL renders as a **file attachment**, not an image and not nothing. Reasoning: an `<img>` needs a `src` to show anything — a media-type-only part (e.g. a Provider-reference-only file with no client-fetchable URL) has nothing to put there, so rendering it as "image" would just be a broken image icon. Falling back to the same file card every non-image attachment already gets is strictly better, and keeps the predicate a plain two-condition check rather than needing a third "unknown" rendering state.

This does change one existing site's behavior: `chat-message.tsx`'s old local check ignored the URL, so an image-media-type part with no URL previously tried to render inline as a broken `<img>`. It now falls back to the file-attachment row instead, matching what the composer already did.

## Changes

- Added `isImageAttachment(part)` — image media type **and** a non-empty URL.
- `chat-message.tsx`, `ai-elements/message.tsx`, `ai-elements/prompt-input.tsx` all now call it (chat-message.tsx keeps a thin `isImageFilePart` wrapper that narrows the message-part union to file parts first).
- Common-case rendering (image-with-URL, non-image files) is unchanged in both the chat transcript and the composer.

## Test plan

- [x] `apps/frontend/lib/message-parts.test.ts` — unit tests for the predicate (image+URL, image+no-URL, non-image)
- [x] `apps/frontend/components/chat-message.test.tsx` — image with URL renders inline; image with no URL falls back to a file attachment (no `<img>` rendered)
- [x] `apps/frontend/components/ai-elements/prompt-input.test.tsx` — same two cases in the composer
- [x] `pnpm --filter @platypus/frontend test` (390 tests), `pnpm typecheck`, `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)