### PR TITLE
chore(docs): say what Base URL takes for a model server on the host

### DIFF
--- a/apps/docs/content/getting-started/index.mdx
+++ b/apps/docs/content/getting-started/index.mdx
@@ -150,6 +150,10 @@ Fill in the form:
   Anthropic, Google, Bedrock. Running Ollama, vLLM or Azure OpenAI? Pick
   **OpenAI** and set **Base URL** — see
   [Supported vendors](/self-hosting/providers-and-auth#supported-vendors).
+  Running that model server on this machine while Platypus runs in Docker? See
+  [Reaching a model server on the host
+  machine](/self-hosting/providers-and-auth#reaching-a-model-server-on-the-host-machine)
+  for what **Base URL** takes.
 - **Name** — a label for this connection.
 - **API Key** — your credential from that vendor.
 - **Models** — a repeatable list, not a text box. Click **Add model** for each

--- a/apps/docs/content/self-hosting/docker-compose.mdx
+++ b/apps/docs/content/self-hosting/docker-compose.mdx
@@ -87,6 +87,10 @@ while the browser talks to the backend at its public URL. See
 [Configuration & environment](/self-hosting/configuration) for how these URLs fit
 together.
 
+Those ports carry traffic inward. For the other direction — the backend calling
+a model server running on the host machine rather than in the stack — see
+[Reaching a model server on the host machine](/self-hosting/providers-and-auth#reaching-a-model-server-on-the-host-machine).
+
 ### Volumes
 
 - `postgres_data` — a named volume holding the database. Your data lives here;

--- a/apps/docs/content/self-hosting/providers-and-auth.mdx
+++ b/apps/docs/content/self-hosting/providers-and-auth.mdx
@@ -27,16 +27,77 @@ code — there is no "custom vendor" type.
 That is not the same as five supported endpoints. Anything speaking the OpenAI
 API is reached through the **OpenAI** type with `baseUrl` pointed at it:
 
-| You want to run…  | Provider type | What you set                                                                                        |
-| ----------------- | ------------- | --------------------------------------------------------------------------------------------------- |
-| Ollama            | OpenAI        | `baseUrl` → your Ollama host's `/v1`; any non-empty API key                                         |
-| vLLM              | OpenAI        | `baseUrl` → your vLLM server; usually `apiMode: "chat"`                                             |
-| Azure OpenAI      | OpenAI        | `baseUrl` → your Azure deployment endpoint                                                          |
-| LiteLLM / a proxy | OpenAI        | `baseUrl` → the gateway (see [Fronting a Provider with a proxy](#fronting-a-provider-with-a-proxy)) |
+| You want to run…  | Provider type | What you set                                                                                                                                                                                       |
+| ----------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Ollama            | OpenAI        | `baseUrl` → your Ollama host's `/v1` (see [Reaching a model server on the host machine](#reaching-a-model-server-on-the-host-machine)); any non-empty API key; **API Mode** → **Chat Completions** |
+| vLLM              | OpenAI        | `baseUrl` → your vLLM server; usually `apiMode: "chat"`                                                                                                                                            |
+| Azure OpenAI      | OpenAI        | `baseUrl` → your Azure deployment endpoint                                                                                                                                                         |
+| LiteLLM / a proxy | OpenAI        | `baseUrl` → the gateway (see [Fronting a Provider with a proxy](#fronting-a-provider-with-a-proxy))                                                                                                |
 
 So "is my stack supported?" comes down to: does it speak the OpenAI API? If yes,
 it works through the OpenAI type. If it speaks only a bespoke protocol, put a
 translating gateway in front of it.
+
+### Reaching a model server on the host machine
+
+Ollama, LM Studio and llama.cpp normally run on the machine hosting the Docker
+stack, not inside it. Writing `http://localhost:11434/v1` in **Base URL** fails:
+inside the backend container `localhost` is the container, and nothing is
+listening on that port there.
+
+Use the host alias instead — `http://host.docker.internal:11434/v1`. The shipped
+`compose.yaml` already maps that alias to the host gateway on the `backend`
+service, so it resolves on Docker Desktop and on Linux Docker Engine 20.10+ with
+no edit. If you run the backend image outside that Compose file, add the mapping
+yourself:
+
+```yaml
+services:
+  backend:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
+
+<Callout type="warning">
+  Right URL, connection refused. Ollama listens on `127.0.0.1:11434` by
+  default, and traffic arriving through the host gateway reaches the bridge
+  address rather than loopback — so **Base URL** can be exactly right and the
+  Provider still fails to connect. Start Ollama with `OLLAMA_HOST=0.0.0.0` so it
+  accepts those connections. LM Studio and llama.cpp each have a listen-address
+  setting of their own and need the same change. That opens the port to every
+  interface the machine has, so firewall it where the machine isn't yours alone.
+</Callout>
+
+**Or run the model server in the stack.** Where you operate both sides, add the
+model server to `compose.yaml` on the same `platypus-network` and skip the host
+gateway altogether. **Base URL** then names the service and its container port —
+`http://ollama:11434/v1` — with no `ports:` entry needed, since the backend
+reaches it over the private network rather than the host. It is the steadier of
+the two: the same **Base URL** works on every machine that runs the stack.
+
+A working Ollama Provider, field by field:
+
+| Field                                      | What to enter                                                                            |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| **Provider Type**                          | **OpenAI**                                                                               |
+| **Name**                                   | A label for the connection, e.g. `Local Ollama`                                          |
+| **API Key**                                | Any non-empty placeholder — the field is required, and Ollama ignores the value          |
+| **Base URL**                               | `http://host.docker.internal:11434/v1`, or `http://ollama:11434/v1` as a Compose service |
+| **Models**                                 | One entry per model you have pulled, id exactly as `ollama list` reports it              |
+| **API Mode** (under **Advanced settings**) | **Chat Completions**                                                                     |
+
+The **Base URL** ends in `/v1`: that is where Ollama serves its OpenAI-compatible
+API, and Platypus appends the route to what you give it. **API Mode** defaults to
+**Responses**, which Ollama does not implement — leave the default in place and
+every turn fails no matter how correct the URL is.
+
+<Callout type="info">
+  This is the **backend** reaching a Provider, which the per-Sandbox
+  `extraHosts` allowlist has no bearing on. That allowlist governs what an
+  agent's own execution container can reach — see [Sandbox
+  infrastructure](/self-hosting/sandbox). Granting a Sandbox a host alias does
+  not make a Provider reachable, and a Provider that works needs nothing from it.
+</Callout>
 
 ### What a Provider holds
 


### PR DESCRIPTION
Closes #504

A self-hoster running Ollama beside the Docker stack writes `http://localhost:11434/v1` into **Base URL** and gets a connection error — inside the backend container `localhost` is the container. The Supported-vendors table pointed at "your Ollama host's `/v1`", which is exactly the unanswered question.

Adds a section to Self-Hosting → Providers & authentication that goes from "Ollama is running on my laptop" to a working Provider:

- why `localhost` reaches the container, and the `host.docker.internal` alias the shipped `compose.yaml` already maps on the backend service (plus the `extra_hosts` mapping to add when a deployment doesn't use that file)
- the trap where the URL is right and the connection is still refused, with `OLLAMA_HOST=0.0.0.0`
- running the model server as a Compose service on the same network, and the **Base URL** that follows
- the Ollama Provider form field by field, including **API Mode** → **Chat Completions** (the default, **Responses**, is not implemented by Ollama)
- how this differs from the per-Sandbox `extraHosts` allowlist

Supporting edits: the Ollama row in the Supported-vendors table now names the **API Mode** requirement, and the Compose and Getting-started pages point into the new section.

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)