### PR TITLE
fix(frontend): surface refused writes on the agent avatar and trigger toggle

### DIFF
--- a/apps/frontend/components/agent-form.test.tsx
+++ b/apps/frontend/components/agent-form.test.tsx
@@ -38,6 +38,9 @@ const providersResponse = { data: { results: [provider] }, isLoading: false };
 const emptyListResponse = { data: { results: [] }, isLoading: false };
 const nullResponse = { data: undefined, isLoading: false };
 
+// Set by a test that renders in edit mode (agentId="a1") before rendering.
+let agentResponse: { data: unknown; isLoading: boolean } = nullResponse;
+
 // useSWR is called for providers, skills, agents, and (when editing) the agent.
 // Key off the request URL so each call gets the right payload. A null key means
 // SWR would not fetch — mirror that by returning no data.
@@ -47,6 +50,9 @@ vi.mock("swr", () => ({
     if (!key) return nullResponse;
     if (typeof key === "string" && key.endsWith("/providers")) {
       return providersResponse;
+    }
+    if (typeof key === "string" && key.endsWith("/agents/a1")) {
+      return agentResponse;
     }
     return emptyListResponse;
   },
@@ -69,6 +75,14 @@ function renderCreateForm() {
   return render(
     <AgentForm orgId="org1" workspaceId="ws1" toolSets={[]} agents={[]} />,
   );
+}
+
+function mockSequence(...responses: Array<Partial<Response>>) {
+  const fn = vi.fn();
+  for (const response of responses) {
+    fn.mockResolvedValueOnce(response as Response);
+  }
+  return fn;
 }
 
 // --- Tests -------------------------------------------------------------------
@@ -165,5 +179,98 @@ describe("AgentForm validation error surfacing", () => {
 
     await waitFor(() => expect(toastError).toHaveBeenCalled());
     expect(saveButton).not.toBeDisabled();
+  });
+});
+
+// #595: the Agent itself already saved by the time either avatar write runs,
+// so a refused avatar write is a partial success — it must toast, not block
+// navigation or silently look like it worked.
+describe("AgentForm avatar write partial-success handling", () => {
+  beforeEach(() => {
+    push.mockReset();
+    toastError.mockReset();
+    mutate.mockReset();
+    agentResponse = nullResponse;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    agentResponse = nullResponse;
+  });
+
+  it("surfaces a toast but still navigates when the avatar upload fails after a successful agent save", async () => {
+    const file = new File(["avatar-bytes"], "avatar.png", {
+      type: "image/png",
+    });
+    const fetchMock = mockSequence(
+      { ok: true, status: 200, json: async () => ({ id: "a1" }) },
+      {
+        ok: false,
+        status: 500,
+        json: async () => ({ error: "Storage unavailable" }),
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderCreateForm();
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith("/org1/workspace/ws1"),
+    );
+    expect(toastError).toHaveBeenCalledWith("Storage unavailable");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces a toast but still navigates when the avatar delete fails after a successful agent save", async () => {
+    agentResponse = {
+      data: {
+        id: "a1",
+        name: "Bot",
+        description: "A helpful bot",
+        instructions: "Be helpful",
+        providerId: "p1",
+        modelId: "gpt-4o",
+        maxSteps: 5,
+        avatarUrl: "http://cdn.test/avatar.png",
+      },
+      isLoading: false,
+    };
+    const fetchMock = mockSequence(
+      { ok: true, status: 200, json: async () => ({ id: "a1" }) },
+      {
+        ok: false,
+        status: 403,
+        json: async () => ({ error: "Avatar storage locked" }),
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <AgentForm
+        orgId="org1"
+        workspaceId="ws1"
+        toolSets={[]}
+        agents={[]}
+        agentId="a1"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("Bot")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Remove/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith("/org1/workspace/ws1"),
+    );
+    expect(toastError).toHaveBeenCalledWith("Avatar storage locked");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -51,7 +51,7 @@ import {
 import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
-import { writeEntity, writeAt } from "@/lib/api-write";
+import { writeEntity, writeAt, errorMessage } from "@/lib/api-write";
 import { findModelOption, getModelOptions } from "@/lib/model-config";
 import { resolveModel } from "@/lib/resolve-model";
 import {
@@ -387,15 +387,23 @@ const AgentForm = ({
         case "success": {
           const savedAgentId = result.data.id || agentId;
 
+          // The Agent itself already saved, so a failed avatar write is a
+          // partial success, not a reason to block navigation — surface a
+          // toast and continue on (#595).
           if (avatarDeleted && agentId) {
-            await writeAt(
+            const avatarOutcome = await writeAt(
               joinUrl(backendUrl, `${agentsBase}/${savedAgentId}/avatar`),
               { method: "DELETE" },
             );
+            if (avatarOutcome.outcome !== "success") {
+              toast.error(avatarOutcome.message);
+            }
           } else if (avatarFile) {
+            // Multipart upload can't go through writeAt (JSON-only body), so
+            // this call stays raw fetch — see the eslint.config.mjs exception.
             const avatarFormData = new FormData();
             avatarFormData.append("file", avatarFile);
-            await fetch(
+            const avatarResponse = await fetch(
               joinUrl(backendUrl, `${agentsBase}/${savedAgentId}/avatar`),
               {
                 method: "POST",
@@ -403,6 +411,12 @@ const AgentForm = ({
                 credentials: "include",
               },
             );
+            if (!avatarResponse.ok) {
+              const body: unknown = await avatarResponse
+                .json()
+                .catch(() => null);
+              toast.error(errorMessage(body) ?? "Failed to upload the avatar");
+            }
           }
 
           result.revalidateKeys.forEach((key) => mutate(key));

--- a/apps/frontend/components/dashboards-list.test.tsx
+++ b/apps/frontend/components/dashboards-list.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { Dashboard } from "@platypus/schemas";
+import {
+  installRadixPointerPolyfills,
+  openDropdownMenu as openMenu,
+} from "@/lib/test-utils";
+
+beforeAll(installRadixPointerPolyfills);
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "u1" } }),
+}));
+
+// The `GET .../dashboards` list this component renders. Set per test.
+let dashboards: Dashboard[] = [];
+const mutateSpy = vi.fn();
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: () => ({
+    data: { results: dashboards },
+    isLoading: false,
+    mutate: mutateSpy,
+  }),
+}));
+
+import { DashboardsList } from "./dashboards-list";
+
+// --- Helpers -----------------------------------------------------------------
+
+const dashboard: Dashboard = {
+  id: "d1",
+  name: "Revenue",
+  description: "Revenue overview",
+} as unknown as Dashboard;
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+async function openDeleteDialog() {
+  openMenu();
+  fireEvent.click(screen.getByText("Delete"));
+  // The confirmation input must be typed before the destructive button enables.
+  fireEvent.change(
+    screen.getByPlaceholderText("Type 'Delete dashboard' to confirm"),
+    { target: { value: "Delete dashboard" } },
+  );
+}
+
+afterEach(() => {
+  dashboards = [];
+  mutateSpy.mockClear();
+  vi.restoreAllMocks();
+});
+
+// --- Tests -------------------------------------------------------------------
+
+describe("DashboardsList delete", () => {
+  it("deletes through the request module and revalidates on success", async () => {
+    dashboards = [dashboard];
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<DashboardsList orgId="org1" workspaceId="ws1" />);
+    await openDeleteDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(mutateSpy).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/workspaces/ws1/dashboards/d1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("surfaces the backend's reason inline and does not revalidate when delete is refused", async () => {
+    dashboards = [dashboard];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(409, { error: "Dashboard is in use" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<DashboardsList orgId="org1" workspaceId="ws1" />);
+    await openDeleteDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Dashboard is in use")).toBeInTheDocument(),
+    );
+    expect(mutateSpy).not.toHaveBeenCalled();
+    // The dialog stays open on a refused delete, letting the user retry.
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/kanban-card-dialog.test.tsx
+++ b/apps/frontend/components/kanban-card-dialog.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { KanbanCard, KanbanCardComment } from "@platypus/schemas";
+import { installRadixPointerPolyfills } from "@/lib/test-utils";
+
+beforeAll(() => {
+  installRadixPointerPolyfills();
+  // The dialog picks a mobile/desktop layout off this; force desktop so only
+  // one copy of the comments section renders.
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }) as unknown as typeof window.matchMedia;
+});
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "u1", name: "Alice", image: null } }),
+}));
+
+const { toastErrorSpy } = vi.hoisted(() => ({ toastErrorSpy: vi.fn() }));
+vi.mock("sonner", () => ({
+  toast: { error: toastErrorSpy, success: vi.fn() },
+}));
+
+// The `GET .../comments` and `.../agents` lists this dialog renders. Set per
+// test.
+let comments: KanbanCardComment[] = [];
+const mutateCommentsSpy = vi.fn();
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (typeof key === "string" && key.includes("/comments")) {
+      return { data: { results: comments }, mutate: mutateCommentsSpy };
+    }
+    return { data: { results: [] }, mutate: vi.fn() };
+  },
+}));
+
+import { KanbanCardDialog } from "./kanban-card-dialog";
+
+// --- Helpers -----------------------------------------------------------------
+
+const card: KanbanCard = {
+  id: "c1",
+  title: "Ship the release",
+  body: "Details",
+  labelIds: [],
+  assignees: [],
+  dueDate: null,
+  priority: "none",
+  createdAt: new Date("2026-01-01").toISOString(),
+  updatedAt: new Date("2026-01-01").toISOString(),
+} as unknown as KanbanCard;
+
+const existingComment: KanbanCardComment = {
+  id: "cm1",
+  body: "First comment",
+  createdByName: "Bob",
+  createdAt: new Date("2026-01-01").toISOString(),
+} as unknown as KanbanCardComment;
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+function renderDialog() {
+  return render(
+    <KanbanCardDialog
+      card={card}
+      labels={[]}
+      columns={[]}
+      columnId={null}
+      open={true}
+      onOpenChange={() => {}}
+      onSave={() => {}}
+      onDelete={() => {}}
+      orgId="org1"
+      workspaceId="ws1"
+      boardId="b1"
+    />,
+  );
+}
+
+afterEach(() => {
+  comments = [];
+  mutateCommentsSpy.mockClear();
+  toastErrorSpy.mockClear();
+  vi.restoreAllMocks();
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }) as unknown as typeof window.matchMedia;
+});
+
+// --- Tests -------------------------------------------------------------------
+
+describe("KanbanCardDialog add comment", () => {
+  it("surfaces the backend's reason and does not revalidate when the comment is refused", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(400, { error: "Comment too long" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderDialog();
+
+    fireEvent.change(screen.getByPlaceholderText("Add a comment..."), {
+      target: { value: "A new comment" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Comment" }));
+
+    await waitFor(() =>
+      expect(toastErrorSpy).toHaveBeenCalledWith("Comment too long"),
+    );
+    expect(mutateCommentsSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("KanbanCardDialog edit comment", () => {
+  it("surfaces the backend's reason and does not revalidate when the edit is refused", async () => {
+    comments = [existingComment];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(404, { error: "Comment not found" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderDialog();
+
+    fireEvent.click(screen.getByText("Edit"));
+    fireEvent.change(screen.getByDisplayValue("First comment"), {
+      target: { value: "Edited comment" },
+    });
+    // The comment's own Save button renders before the card-level Save
+    // button in document order.
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" })[0]);
+
+    await waitFor(() =>
+      expect(toastErrorSpy).toHaveBeenCalledWith("Comment not found"),
+    );
+    expect(mutateCommentsSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("KanbanCardDialog delete comment", () => {
+  it("surfaces the backend's reason and does not revalidate when the delete is refused", async () => {
+    comments = [existingComment];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(409, { error: "Comment already deleted" }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderDialog();
+
+    // The comment's own "Delete" link renders before the card-level Delete
+    // button in document order.
+    fireEvent.click(screen.getAllByText("Delete")[0]);
+    // The confirm button inside the just-opened popover is the last "Delete"
+    // in the document — the card-level Delete popover trigger is also named
+    // "Delete" but stays closed.
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+
+    await waitFor(() =>
+      expect(toastErrorSpy).toHaveBeenCalledWith("Comment already deleted"),
+    );
+    expect(mutateCommentsSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/components/manage-sharing.test.tsx
+++ b/apps/frontend/components/manage-sharing.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { installRadixPointerPolyfills } from "@/lib/test-utils";
+
+// The Command palette (cmdk) needs a ResizeObserver and scrollIntoView, which
+// jsdom lacks.
+beforeAll(() => {
+  installRadixPointerPolyfills();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+// The attachments and workspaces lists this component renders. Set per test.
+let attached: { workspaceId: string; workspaceName: string }[] = [];
+let workspaces: { id: string; name: string }[] = [];
+const mutateAttSpy = vi.fn();
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (typeof key === "string" && key.includes("/attachments?")) {
+      return { data: { results: attached }, mutate: mutateAttSpy };
+    }
+    if (typeof key === "string" && key.endsWith("/workspaces")) {
+      return { data: { results: workspaces } };
+    }
+    return { data: undefined };
+  },
+}));
+
+import { ManageAttachmentsDialog } from "./manage-sharing";
+
+// --- Helpers -----------------------------------------------------------------
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  attached = [];
+  workspaces = [];
+  mutateAttSpy.mockClear();
+  vi.restoreAllMocks();
+});
+
+// --- Tests -------------------------------------------------------------------
+
+describe("ManageAttachmentsDialog attach", () => {
+  it("POSTs the attachment and revalidates on success", async () => {
+    workspaces = [{ id: "ws1", name: "Engineering" }];
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <ManageAttachmentsDialog
+        orgId="org1"
+        resourceType="agent"
+        resourceId="a1"
+        resourceName="Support Bot"
+        open={true}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Engineering"));
+
+    await waitFor(() => expect(mutateAttSpy).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/organizations/org1/attachments",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          resourceType: "agent",
+          resourceId: "a1",
+          workspaceId: "ws1",
+        }),
+      }),
+    );
+  });
+
+  it("surfaces the backend's reason inline and does not revalidate when attach is refused", async () => {
+    workspaces = [{ id: "ws1", name: "Engineering" }];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(409, { error: "Already attached" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <ManageAttachmentsDialog
+        orgId="org1"
+        resourceType="agent"
+        resourceId="a1"
+        resourceName="Support Bot"
+        open={true}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Engineering"));
+
+    await waitFor(() =>
+      expect(screen.getByText("Already attached")).toBeInTheDocument(),
+    );
+    expect(mutateAttSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("ManageAttachmentsDialog detach", () => {
+  it("surfaces the backend's reason inline and does not revalidate when detach is refused", async () => {
+    attached = [{ workspaceId: "ws1", workspaceName: "Engineering" }];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(403, { error: "Locked elsewhere" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <ManageAttachmentsDialog
+        orgId="org1"
+        resourceType="agent"
+        resourceId="a1"
+        resourceName="Support Bot"
+        open={true}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Detach Engineering"));
+
+    await waitFor(() =>
+      expect(screen.getByText("Locked elsewhere")).toBeInTheDocument(),
+    );
+    expect(mutateAttSpy).not.toHaveBeenCalled();
+    // The chip stays — no optimistic removal on a refused detach.
+    expect(screen.getByText("Engineering")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/trigger-list.test.tsx
+++ b/apps/frontend/components/trigger-list.test.tsx
@@ -125,4 +125,21 @@ describe("TriggerList toggle enabled", () => {
       }),
     );
   });
+
+  it("surfaces the backend's reason and does not flip when the toggle is refused", async () => {
+    triggers = [cronTrigger];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(409, { error: "Trigger is running" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TriggerList orgId="org1" workspaceId="ws1" />);
+    openMenu();
+    fireEvent.click(screen.getByText("Disable"));
+
+    await waitFor(() =>
+      expect(toastErrorSpy).toHaveBeenCalledWith("Trigger is running"),
+    );
+    expect(mutateSpy).not.toHaveBeenCalled();
+  });
 });

--- a/apps/frontend/components/trigger-list.tsx
+++ b/apps/frontend/components/trigger-list.tsx
@@ -129,6 +129,8 @@ export const TriggerList = ({
       });
       if (outcome.outcome === "success") {
         mutate();
+      } else {
+        toast.error(outcome.message);
       }
     } catch {
       toast.error("Failed to toggle trigger");

--- a/apps/frontend/lib/api-write.ts
+++ b/apps/frontend/lib/api-write.ts
@@ -85,7 +85,7 @@ export function scopedUrl(
   return joinUrl(backendUrl, scopedPath(entity, scope));
 }
 
-function errorMessage(body: unknown): string | undefined {
+export function errorMessage(body: unknown): string | undefined {
   if (body && typeof body === "object" && "error" in body) {
     const { error } = body as { error: unknown };
     if (typeof error === "string") return error;


### PR DESCRIPTION
## Summary
- Closes #595. Sites 1, 2, 4, and 5 (Kanban comments, dashboard delete, org sharing toggle, agent delete) were already fixed by prior merged PRs (#599, #600, #603); this fixes the two remaining sites.
- **Agent avatar write** (`agent-form.tsx`): a refused avatar delete or upload after a successful Agent save now toasts the backend's error message while still navigating — the Agent itself saved, so it's a partial success, not a blocker.
- **Trigger enable toggle** (`trigger-list.tsx`): a refused toggle now toasts the backend's message instead of silently leaving the switch looking like it worked.
- Backfills missing test coverage for the four already-fixed surfaces (`kanban-card-dialog.tsx`, `dashboards-list.tsx`, `manage-sharing.tsx`) so all six sites named in #595 have tests per its acceptance criteria.
- Exports `errorMessage` from `lib/api-write.ts` so the (deliberately raw, multipart) avatar-upload fetch can parse its error body the same way `performWrite` does.

## Test plan
- [x] `pnpm --filter frontend typecheck`
- [x] `pnpm test` (394 frontend tests, 1902 backend tests, all passing)
- [x] `pnpm lint` (clean — only pre-existing unrelated warnings)
- [x] Two-axis code review (Standards + Spec sub-agents) — no hard violations, full spec compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)