### PR TITLE
fix(frontend): populate Global Context on warm-cache remount

### DIFF
--- a/apps/frontend/app/settings/contexts/page.test.tsx
+++ b/apps/frontend/app/settings/contexts/page.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// --- Module mocks ------------------------------------------------------------
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "u1" } }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/components/contexts-list", () => ({
+  ContextsList: () => null,
+}));
+
+// Simulates a *warm* SWR cache: the fetched global context is already present
+// on the very first render, as happens when navigating back from the Edit
+// Workspace Context screen (which subscribes to the same SWR key).
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: () => ({
+    data: {
+      results: [
+        { id: "ctx1", workspaceId: null, content: "saved global context" },
+      ],
+    },
+    mutate: vi.fn(),
+  }),
+}));
+
+import ContextsPage from "./page";
+
+// --- Tests -------------------------------------------------------------------
+
+describe("ContextsPage global context field", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows the saved global context immediately when SWR data is already warm on mount", () => {
+    render(<ContextsPage />);
+
+    expect(
+      screen.getByDisplayValue("saved global context"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/app/settings/contexts/page.tsx
+++ b/apps/frontend/app/settings/contexts/page.tsx
@@ -17,6 +17,10 @@ interface ContextWithWorkspaceName extends Context {
   workspaceName?: string | null;
 }
 
+const findGlobalContext = (contexts?: {
+  results: ContextWithWorkspaceName[];
+}) => contexts?.results.find((c) => !c.workspaceId);
+
 const ContextsPage = () => {
   const { user } = useAuth();
   const backendUrl = useBackendUrl();
@@ -25,7 +29,9 @@ const ContextsPage = () => {
     results: ContextWithWorkspaceName[];
   }>(user ? joinUrl(backendUrl, "/users/me/contexts") : null, fetcher);
 
-  const [globalContextContent, setGlobalContextContent] = useState("");
+  const [globalContextContent, setGlobalContextContent] = useState(
+    () => findGlobalContext(contexts)?.content || "",
+  );
   const [isSavingGlobal, setIsSavingGlobal] = useState(false);
 
   // Sync server-provided global context into editable local state whenever the
@@ -33,12 +39,11 @@ const ContextsPage = () => {
   const [prevContexts, setPrevContexts] = useState(contexts);
   if (contexts !== prevContexts) {
     setPrevContexts(contexts);
-    const globalCtx = contexts?.results.find((c) => !c.workspaceId);
-    setGlobalContextContent(globalCtx?.content || "");
+    setGlobalContextContent(findGlobalContext(contexts)?.content || "");
   }
 
   const handleSaveGlobal = async () => {
-    const globalCtx = contexts?.results.find((c) => !c.workspaceId);
+    const globalCtx = findGlobalContext(contexts);
     setIsSavingGlobal(true);
 
     const outcome = globalCtx


### PR DESCRIPTION
## Summary
- Fixes #543 — the Global Context textarea in **My Settings → Context** rendered empty after navigating back from the Edit Workspace Context screen, because the local state only synced when the SWR `contexts` reference changed after mount — which never happens on a warm-cache remount.
- Seeds `globalContextContent` from `contexts` via a lazy `useState` initializer so a warm cache populates the field on the very first render.
- Dedupes the repeated global-context lookup into a shared `findGlobalContext` helper.

## Test plan
- [x] Added `apps/frontend/app/settings/contexts/page.test.tsx`, mocking `swr` to return data synchronously on first render (the warm-cache scenario) and asserting the field shows the saved content immediately — verified it fails against the old code and passes with the fix.
- [x] `pnpm --filter frontend typecheck`
- [x] `pnpm --filter frontend test` (424 tests passing)
- [x] `pnpm --filter frontend lint` (clean, only pre-existing unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)