### PR TITLE
chore(frontend): move type-to-confirm into the shared confirm dialog

### DIFF
--- a/apps/frontend/components/confirm-dialog.test.tsx
+++ b/apps/frontend/components/confirm-dialog.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfirmDialog } from "./confirm-dialog";
+
+describe("ConfirmDialog", () => {
+  it("enables confirm immediately when no confirmPhrase is set", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete thing"
+        description="Are you sure?"
+        confirmLabel="Delete"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Delete" })).toBeEnabled();
+  });
+
+  it("disables confirm until the typed phrase matches, case-insensitively", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete workspace"
+        description="Are you sure?"
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        confirmPhrase="Delete workspace"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const confirmButton = screen.getByRole("button", { name: "Delete" });
+    const input = screen.getByPlaceholderText(
+      "Type 'Delete workspace' to confirm",
+    );
+
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "wrong phrase" } });
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "delete workspace" } });
+    expect(confirmButton).toBeEnabled();
+
+    fireEvent.click(confirmButton);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the typed phrase when the dialog reopens", () => {
+    const { rerender } = render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete workspace"
+        description="Are you sure?"
+        confirmPhrase="Delete workspace"
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(
+      "Type 'Delete workspace' to confirm",
+    );
+    fireEvent.change(input, { target: { value: "delete workspace" } });
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeEnabled();
+
+    rerender(
+      <ConfirmDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        title="Delete workspace"
+        description="Are you sure?"
+        confirmPhrase="Delete workspace"
+        onConfirm={vi.fn()}
+      />,
+    );
+    rerender(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete workspace"
+        description="Are you sure?"
+        confirmPhrase="Delete workspace"
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    const reopenedInput = screen.getByPlaceholderText(
+      "Type 'Delete workspace' to confirm",
+    );
+    expect(reopenedInput).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeDisabled();
+  });
+
+  it("keeps the dialog non-dismissible while loading, regardless of confirmPhrase", () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        title="Delete workspace"
+        description="Are you sure?"
+        confirmPhrase="Delete workspace"
+        onConfirm={vi.fn()}
+        loading={true}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText(
+      "Type 'Delete workspace' to confirm",
+    );
+    expect(input).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+  });
+});

--- a/apps/frontend/components/confirm-dialog.tsx
+++ b/apps/frontend/components/confirm-dialog.tsx
@@ -9,6 +9,9 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useState } from "react";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -22,6 +25,9 @@ interface ConfirmDialogProps {
   onCancel?: () => void;
   loading?: boolean;
   error?: string | null;
+  // When set, the confirm button stays disabled until the user types this
+  // phrase (case-insensitively) into an input rendered in the dialog.
+  confirmPhrase?: string;
 }
 
 export const ConfirmDialog = ({
@@ -36,7 +42,19 @@ export const ConfirmDialog = ({
   onCancel,
   loading = false,
   error = null,
+  confirmPhrase,
 }: ConfirmDialogProps) => {
+  const [typedPhrase, setTypedPhrase] = useState("");
+
+  useResetOnChange(open, () => {
+    if (open) {
+      setTypedPhrase("");
+    }
+  });
+
+  const phraseMatches =
+    !confirmPhrase || typedPhrase.toLowerCase() === confirmPhrase.toLowerCase();
+
   const handleCancel = () => {
     if (onCancel) {
       onCancel();
@@ -69,6 +87,16 @@ export const ConfirmDialog = ({
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
+          {confirmPhrase && (
+            <div className="mt-4">
+              <Input
+                placeholder={`Type '${confirmPhrase}' to confirm`}
+                value={typedPhrase}
+                onChange={(e) => setTypedPhrase(e.target.value)}
+                disabled={loading}
+              />
+            </div>
+          )}
         </DialogHeader>
         {error && (
           <div className="py-2 px-4 bg-destructive/10 text-destructive text-sm rounded">
@@ -82,7 +110,7 @@ export const ConfirmDialog = ({
           <Button
             variant={confirmVariant}
             onClick={onConfirm}
-            disabled={loading}
+            disabled={loading || !phraseMatches}
           >
             {confirmLabel}
           </Button>

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -11,14 +11,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
@@ -60,7 +53,6 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
   >({});
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const [deleteInput, setDeleteInput] = useState("");
   const [isDeleting, setIsDeleting] = useState(false);
 
   useResetOnChange(organization, () => {
@@ -220,10 +212,7 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
         {orgId && (
           <Button
             variant="outline"
-            onClick={() => {
-              setIsDeleteDialogOpen(true);
-              setDeleteInput("");
-            }}
+            onClick={() => setIsDeleteDialogOpen(true)}
             disabled={isSubmitting}
           >
             <Trash2 /> Delete
@@ -231,63 +220,17 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
         )}
       </div>
 
-      <Dialog
+      <ConfirmDialog
         open={isDeleteDialogOpen}
-        onOpenChange={(open) => {
-          if (!isDeleting) {
-            setIsDeleteDialogOpen(open);
-          }
-        }}
-      >
-        <DialogContent
-          onPointerDownOutside={(e) => {
-            if (isDeleting) {
-              e.preventDefault();
-            }
-          }}
-          onEscapeKeyDown={(e) => {
-            if (isDeleting) {
-              e.preventDefault();
-            }
-          }}
-          showCloseButton={false}
-        >
-          <DialogHeader>
-            <DialogTitle>Delete Organization</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete this organization? This action
-              cannot be undone.
-            </DialogDescription>
-            <div className="mt-4">
-              <Input
-                placeholder="Type 'Delete organization' to confirm"
-                value={deleteInput}
-                onChange={(e) => setDeleteInput(e.target.value)}
-                disabled={isDeleting}
-              />
-            </div>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsDeleteDialogOpen(false)}
-              disabled={isDeleting}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDelete}
-              disabled={
-                isDeleting ||
-                deleteInput.toLowerCase() !== "delete organization"
-              }
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onOpenChange={setIsDeleteDialogOpen}
+        title="Delete Organization"
+        description="Are you sure you want to delete this organization? This action cannot be undone."
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        confirmPhrase="Delete organization"
+        onConfirm={handleDelete}
+        loading={isDeleting}
+      />
     </div>
   );
 };

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -19,14 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
@@ -138,7 +131,6 @@ const WorkspaceForm = ({
   >({});
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const [deleteInput, setDeleteInput] = useState("");
   const [isDeleting, setIsDeleting] = useState(false);
 
   // When creating, default the owner to the current admin until they pick
@@ -584,10 +576,7 @@ const WorkspaceForm = ({
         {workspaceId && (
           <Button
             variant="outline"
-            onClick={() => {
-              setIsDeleteDialogOpen(true);
-              setDeleteInput("");
-            }}
+            onClick={() => setIsDeleteDialogOpen(true)}
             disabled={isSubmitting}
           >
             <Trash2 /> Delete
@@ -595,62 +584,17 @@ const WorkspaceForm = ({
         )}
       </div>
 
-      <Dialog
+      <ConfirmDialog
         open={isDeleteDialogOpen}
-        onOpenChange={(open) => {
-          if (!isDeleting) {
-            setIsDeleteDialogOpen(open);
-          }
-        }}
-      >
-        <DialogContent
-          onPointerDownOutside={(e) => {
-            if (isDeleting) {
-              e.preventDefault();
-            }
-          }}
-          onEscapeKeyDown={(e) => {
-            if (isDeleting) {
-              e.preventDefault();
-            }
-          }}
-          showCloseButton={false}
-        >
-          <DialogHeader>
-            <DialogTitle>Delete Workspace</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete this workspace? This action cannot
-              be undone.
-            </DialogDescription>
-            <div className="mt-4">
-              <Input
-                placeholder="Type 'Delete workspace' to confirm"
-                value={deleteInput}
-                onChange={(e) => setDeleteInput(e.target.value)}
-                disabled={isDeleting}
-              />
-            </div>
-          </DialogHeader>
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setIsDeleteDialogOpen(false)}
-              disabled={isDeleting}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDelete}
-              disabled={
-                isDeleting || deleteInput.toLowerCase() !== "delete workspace"
-              }
-            >
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+        onOpenChange={setIsDeleteDialogOpen}
+        title="Delete Workspace"
+        description="Are you sure you want to delete this workspace? This action cannot be undone."
+        confirmLabel="Delete"
+        confirmVariant="destructive"
+        confirmPhrase="Delete workspace"
+        onConfirm={handleDelete}
+        loading={isDeleting}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Add an optional `confirmPhrase` prop to the shared `ConfirmDialog` — it renders a type-to-confirm input and keeps Confirm disabled until the typed text matches (case-insensitive), resetting via the existing `useResetOnChange` hook whenever the dialog reopens.
- Move Workspace deletion and Organization deletion onto `ConfirmDialog`, deleting their inline duplicate dialogs and preserving the same phrases ("Delete workspace" / "Delete organization").

Closes #575

## Test plan
- [x] `pnpm --filter frontend test` — 427 tests pass, including new `confirm-dialog.test.tsx` coverage (no-phrase default, phrase gating, reset-on-reopen, loading disables everything)
- [x] `pnpm --filter frontend typecheck`
- [x] `pnpm --filter frontend lint` (0 errors; pre-existing unrelated warnings only)
- [x] Manual review via `/code-review` (Standards + Spec sub-agents) — one Standards finding fixed, Spec confirmed all acceptance criteria met

🤖 Generated with [Claude Code](https://claude.com/claude-code)