### PR TITLE
chore(frontend): extract one shared test harness for form tests

### DIFF
--- a/apps/frontend/components/agent-form.test.tsx
+++ b/apps/frontend/components/agent-form.test.tsx
@@ -1,74 +1,48 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { Provider } from "@platypus/schemas";
+import {
+  navigationMock,
+  configMock,
+  authMock,
+  toastMock,
+  swrMock,
+  push,
+  toastError,
+  setData,
+  setDataFor,
+  resetFormHarness,
+  stubRejectedSave,
+  stubSaveSequence,
+} from "@/lib/form-test-harness";
 
 // --- Module mocks ------------------------------------------------------------
 
-const push = vi.fn();
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push }),
-}));
+vi.mock("next/navigation", () => navigationMock);
+vi.mock("@/app/client-context", () => configMock);
+vi.mock("@/components/auth-provider", () => authMock);
+vi.mock("sonner", () => toastMock);
+// useSWR is called for providers, skills, agents, and (when editing) the
+// agent. The harness keys its responses off the request URL suffix, so
+// each call gets the right payload; a key with no matcher (skills, the
+// agents list) falls back to the default set below.
+vi.mock("swr", () => swrMock);
 
-vi.mock("@/app/client-context", () => ({
-  useBackendUrl: () => "http://test",
-}));
+import { AgentForm } from "./agent-form";
 
-vi.mock("@/components/auth-provider", () => ({
-  useAuth: () => ({ user: { id: "u1" } }),
-}));
+// --- Helpers -----------------------------------------------------------------
 
-const toastError = vi.fn();
-vi.mock("sonner", () => ({
-  toast: {
-    error: (...args: unknown[]) => toastError(...args),
-    success: vi.fn(),
-  },
-}));
-
-const mutate = vi.fn();
 const provider: Provider = {
   id: "p1",
   name: "OpenAI",
   modelIds: [{ id: "gpt-4o", passthroughFileTypes: [] }],
 } as unknown as Provider;
 
-// Stable references so re-renders don't churn identity (which would retrigger
-// useResetOnChange and loop).
-const providersResponse = { data: { results: [provider] }, isLoading: false };
-const emptyListResponse = { data: { results: [] }, isLoading: false };
-const nullResponse = { data: undefined, isLoading: false };
-
-// Set by a test that renders in edit mode (agentId="a1") before rendering.
-let agentResponse: { data: unknown; isLoading: boolean } = nullResponse;
-
-// useSWR is called for providers, skills, agents, and (when editing) the agent.
-// Key off the request URL so each call gets the right payload. A null key means
-// SWR would not fetch — mirror that by returning no data.
-vi.mock("swr", () => ({
-  __esModule: true,
-  default: (key: string | null) => {
-    if (!key) return nullResponse;
-    if (typeof key === "string" && key.endsWith("/providers")) {
-      return providersResponse;
-    }
-    if (typeof key === "string" && key.endsWith("/agents/a1")) {
-      return agentResponse;
-    }
-    return emptyListResponse;
-  },
-  useSWRConfig: () => ({ mutate }),
-}));
-
-import { AgentForm } from "./agent-form";
-
-// --- Helpers -----------------------------------------------------------------
-
-function mockFailedSave(error: unknown, status = 400) {
-  return vi.fn().mockResolvedValue({
-    ok: false,
-    status,
-    json: async () => ({ error }),
-  } as unknown as Response);
+// Registered fresh in each test's beforeEach (below) since resetFormHarness
+// clears the harness's data-fetching registrations along with its spies.
+function registerSwrData() {
+  setData({ results: [] });
+  setDataFor("/providers", { results: [provider] });
 }
 
 function renderCreateForm() {
@@ -77,21 +51,12 @@ function renderCreateForm() {
   );
 }
 
-function mockSequence(...responses: Array<Partial<Response>>) {
-  const fn = vi.fn();
-  for (const response of responses) {
-    fn.mockResolvedValueOnce(response as Response);
-  }
-  return fn;
-}
-
 // --- Tests -------------------------------------------------------------------
 
 describe("AgentForm validation error surfacing", () => {
   beforeEach(() => {
-    push.mockReset();
-    toastError.mockReset();
-    mutate.mockReset();
+    resetFormHarness();
+    registerSwrData();
   });
 
   afterEach(() => {
@@ -99,10 +64,7 @@ describe("AgentForm validation error surfacing", () => {
   });
 
   it("renders an inline error and marks the Model control invalid when the server rejects modelId", async () => {
-    vi.stubGlobal(
-      "fetch",
-      mockFailedSave([{ path: ["modelId"], message: "Model is required" }]),
-    );
+    stubRejectedSave([{ path: ["modelId"], message: "Model is required" }]);
 
     renderCreateForm();
 
@@ -121,10 +83,7 @@ describe("AgentForm validation error surfacing", () => {
   });
 
   it("shows a generic error toast when the failure maps to no inline field", async () => {
-    vi.stubGlobal(
-      "fetch",
-      mockFailedSave("something went wrong on the server"),
-    );
+    stubRejectedSave("something went wrong on the server");
 
     renderCreateForm();
 
@@ -136,10 +95,7 @@ describe("AgentForm validation error surfacing", () => {
   });
 
   it("clears a field's error and re-enables Save once the field is edited", async () => {
-    vi.stubGlobal(
-      "fetch",
-      mockFailedSave([{ path: ["maxSteps"], message: "Invalid max steps" }]),
-    );
+    stubRejectedSave([{ path: ["maxSteps"], message: "Invalid max steps" }]);
 
     renderCreateForm();
 
@@ -167,10 +123,7 @@ describe("AgentForm validation error surfacing", () => {
   // #571: toolSetIds has no field that retracts its error, so gating Save on
   // it would disable Save forever with no way out but reloading.
   it("never disables Save on a rejection keyed to a field with no retracting input", async () => {
-    vi.stubGlobal(
-      "fetch",
-      mockFailedSave([{ path: ["toolSetIds"], message: "Unknown tool set" }]),
-    );
+    stubRejectedSave([{ path: ["toolSetIds"], message: "Unknown tool set" }]);
 
     renderCreateForm();
 
@@ -187,30 +140,23 @@ describe("AgentForm validation error surfacing", () => {
 // navigation or silently look like it worked.
 describe("AgentForm avatar write partial-success handling", () => {
   beforeEach(() => {
-    push.mockReset();
-    toastError.mockReset();
-    mutate.mockReset();
-    agentResponse = nullResponse;
+    resetFormHarness();
+    registerSwrData();
+    setDataFor("/agents/a1", undefined);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    agentResponse = nullResponse;
   });
 
   it("surfaces a toast but still navigates when the avatar upload fails after a successful agent save", async () => {
     const file = new File(["avatar-bytes"], "avatar.png", {
       type: "image/png",
     });
-    const fetchMock = mockSequence(
-      { ok: true, status: 200, json: async () => ({ id: "a1" }) },
-      {
-        ok: false,
-        status: 500,
-        json: async () => ({ error: "Storage unavailable" }),
-      },
+    const fetchMock = stubSaveSequence(
+      { status: 200, body: { id: "a1" } },
+      { status: 500, body: { error: "Storage unavailable" } },
     );
-    vi.stubGlobal("fetch", fetchMock);
 
     const { container } = renderCreateForm();
     const fileInput = container.querySelector(
@@ -228,28 +174,20 @@ describe("AgentForm avatar write partial-success handling", () => {
   });
 
   it("surfaces a toast but still navigates when the avatar delete fails after a successful agent save", async () => {
-    agentResponse = {
-      data: {
-        id: "a1",
-        name: "Bot",
-        description: "A helpful bot",
-        instructions: "Be helpful",
-        providerId: "p1",
-        modelId: "gpt-4o",
-        maxSteps: 5,
-        avatarUrl: "http://cdn.test/avatar.png",
-      },
-      isLoading: false,
-    };
-    const fetchMock = mockSequence(
-      { ok: true, status: 200, json: async () => ({ id: "a1" }) },
-      {
-        ok: false,
-        status: 403,
-        json: async () => ({ error: "Avatar storage locked" }),
-      },
+    setDataFor("/agents/a1", {
+      id: "a1",
+      name: "Bot",
+      description: "A helpful bot",
+      instructions: "Be helpful",
+      providerId: "p1",
+      modelId: "gpt-4o",
+      maxSteps: 5,
+      avatarUrl: "http://cdn.test/avatar.png",
+    });
+    const fetchMock = stubSaveSequence(
+      { status: 200, body: { id: "a1" } },
+      { status: 403, body: { error: "Avatar storage locked" } },
     );
-    vi.stubGlobal("fetch", fetchMock);
 
     render(
       <AgentForm

--- a/apps/frontend/components/mcp-form.test.tsx
+++ b/apps/frontend/components/mcp-form.test.tsx
@@ -1,66 +1,44 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { MCP } from "@platypus/schemas";
+import {
+  navigationMock,
+  configMock,
+  authMock,
+  toastMock,
+  swrMock,
+  setData,
+  resetFormHarness,
+  stubRejectedSave,
+} from "@/lib/form-test-harness";
 
 // --- Module mocks ------------------------------------------------------------
 
-const push = vi.fn();
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push }),
-}));
-
-vi.mock("@/app/client-context", () => ({
-  useBackendUrl: () => "http://test",
-}));
-
-vi.mock("@/components/auth-provider", () => ({
-  useAuth: () => ({ user: { id: "u1" } }),
-}));
-
-vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
-}));
-
-// The MCP the edit form loads. Set per test before rendering.
-let loadedMcp: MCP | undefined;
-
-vi.mock("swr", () => ({
-  __esModule: true,
-  default: () => ({
-    data: loadedMcp,
-    isLoading: false,
-    mutate: vi.fn(),
-  }),
-  useSWRConfig: () => ({ mutate: vi.fn() }),
-}));
+vi.mock("next/navigation", () => navigationMock);
+vi.mock("@/app/client-context", () => configMock);
+vi.mock("@/components/auth-provider", () => authMock);
+vi.mock("sonner", () => toastMock);
+vi.mock("swr", () => swrMock);
 
 import { McpForm } from "./mcp-form";
 import { toast } from "sonner";
-
-function jsonResponse(status: number, body: unknown) {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    json: async () => body,
-  } as unknown as Response;
-}
 
 // --- Tests -------------------------------------------------------------------
 
 describe("McpForm secret reveal", () => {
   afterEach(() => {
-    loadedMcp = undefined;
+    resetFormHarness();
     vi.restoreAllMocks();
   });
 
   it("toggles the bearer token between masked and revealed", () => {
-    loadedMcp = {
+    setData({
       id: "m1",
       name: "Docs",
       url: "http://mcp.test",
       authType: "Bearer",
       bearerToken: "secret-token",
-    } as unknown as MCP;
+    } as unknown as MCP);
     render(<McpForm orgId="org1" mcpId="m1" />);
 
     const input = screen.getByLabelText("Bearer Token");
@@ -74,13 +52,13 @@ describe("McpForm secret reveal", () => {
   });
 
   it("toggles the OAuth client secret between masked and revealed", () => {
-    loadedMcp = {
+    setData({
       id: "m1",
       name: "Docs",
       url: "http://mcp.test",
       authType: "OAuth",
       oauthClientId: "client-id",
-    } as unknown as MCP;
+    } as unknown as MCP);
     render(<McpForm orgId="org1" mcpId="m1" />);
 
     const input = screen.getByLabelText("Client Secret");
@@ -96,23 +74,21 @@ describe("McpForm secret reveal", () => {
 
 describe("McpForm locked delete", () => {
   afterEach(() => {
-    loadedMcp = undefined;
+    resetFormHarness();
     vi.restoreAllMocks();
   });
 
   it("shows the backend's guidance, not an error toast, when the MCP is Shared", async () => {
-    loadedMcp = {
+    setData({
       id: "m1",
       name: "Docs",
       url: "http://mcp.test",
       authType: "None",
-    } as unknown as MCP;
-    const fetchMock = vi.fn().mockResolvedValue(
-      jsonResponse(403, {
-        error: "This MCP server is managed at the organization level",
-      }),
+    } as unknown as MCP);
+    stubRejectedSave(
+      "This MCP server is managed at the organization level",
+      403,
     );
-    vi.stubGlobal("fetch", fetchMock);
 
     render(<McpForm orgId="org1" workspaceId="ws1" mcpId="m1" />);
 

--- a/apps/frontend/components/webhook-form.test.tsx
+++ b/apps/frontend/components/webhook-form.test.tsx
@@ -1,49 +1,30 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  navigationMock,
+  configMock,
+  authMock,
+  toastMock,
+  swrMock,
+  push,
+  resetFormHarness,
+  jsonResponse,
+  stubRejectedSave,
+} from "@/lib/form-test-harness";
 
 // --- Module mocks ------------------------------------------------------------
 
-const push = vi.fn();
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push }),
-}));
-
-vi.mock("@/app/client-context", () => ({
-  useBackendUrl: () => "http://test",
-}));
-
-vi.mock("@/components/auth-provider", () => ({
-  useAuth: () => ({ user: { id: "u1" } }),
-}));
-
-const toastSuccess = vi.fn();
-const toastError = vi.fn();
-vi.mock("sonner", () => ({
-  toast: {
-    error: (...args: unknown[]) => toastError(...args),
-    success: (...args: unknown[]) => toastSuccess(...args),
-  },
-}));
-
+vi.mock("next/navigation", () => navigationMock);
+vi.mock("@/app/client-context", () => configMock);
+vi.mock("@/components/auth-provider", () => authMock);
+vi.mock("sonner", () => toastMock);
 // The create form never keys a fetch off a webhook id, so SWR never loads
-// real data here.
-vi.mock("swr", () => ({
-  __esModule: true,
-  default: () => ({ data: undefined, isLoading: false, mutate: vi.fn() }),
-  useSWRConfig: () => ({ mutate: vi.fn() }),
-}));
+// real data here — the harness's default (unset) response is `undefined`.
+vi.mock("swr", () => swrMock);
 
 import { WebhookForm } from "./webhook-form";
 
 // --- Helpers -----------------------------------------------------------------
-
-function mockFailedSave(error: unknown, status = 400) {
-  return vi.fn().mockResolvedValue({
-    ok: false,
-    status,
-    json: async () => ({ error }),
-  } as unknown as Response);
-}
 
 function renderForm() {
   return render(<WebhookForm orgId="org1" workspaceId="ws1" />);
@@ -53,9 +34,7 @@ function renderForm() {
 
 describe("WebhookForm validation error surfacing", () => {
   beforeEach(() => {
-    push.mockReset();
-    toastSuccess.mockReset();
-    toastError.mockReset();
+    resetFormHarness();
   });
 
   afterEach(() => {
@@ -63,10 +42,9 @@ describe("WebhookForm validation error surfacing", () => {
   });
 
   it("saves, shows the rejected events error, then saves again once corrected", async () => {
-    const fetchMock = mockFailedSave([
+    const fetchMock = stubRejectedSave([
       { path: ["events"], message: "At least one event is required" },
     ]);
-    vi.stubGlobal("fetch", fetchMock);
 
     renderForm();
 
@@ -95,20 +73,14 @@ describe("WebhookForm validation error surfacing", () => {
     expect(saveButton).not.toBeDisabled();
 
     // The round trip completes: re-submitting now succeeds.
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({}),
-    } as unknown as Response);
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, {}));
     fireEvent.click(saveButton);
 
     await waitFor(() => expect(push).toHaveBeenCalled());
   });
 
   it("clears the enabled field's error when the switch is toggled", async () => {
-    vi.stubGlobal(
-      "fetch",
-      mockFailedSave([{ path: ["enabled"], message: "Invalid enabled" }]),
-    );
+    stubRejectedSave([{ path: ["enabled"], message: "Invalid enabled" }]);
 
     renderForm();
 
@@ -126,12 +98,9 @@ describe("WebhookForm validation error surfacing", () => {
   });
 
   it("retracts a row-level headers error only when that row is edited", async () => {
-    vi.stubGlobal(
-      "fetch",
-      mockFailedSave([
-        { path: ["headers", "X-Foo"], message: "Header value is too long" },
-      ]),
-    );
+    stubRejectedSave([
+      { path: ["headers", "X-Foo"], message: "Header value is too long" },
+    ]);
 
     renderForm();
 

--- a/apps/frontend/lib/form-test-harness.ts
+++ b/apps/frontend/lib/form-test-harness.ts
@@ -1,0 +1,143 @@
+import { vi, type Mock } from "vitest";
+
+/**
+ * Shared setup for the form test files (agent-form, mcp-form, webhook-form):
+ * one navigation, config, auth, toast and data-fetching mock, plus helpers
+ * for stubbing an accepted or rejected save, in place of three hand-rolled
+ * copies of the same ~35 lines.
+ *
+ * These are plain module-level exports rather than something built by a
+ * factory function: `vi.mock("swr", () => swrMock)` needs `swrMock` to be a
+ * value Vitest's hoisting transform can see without moving it — hoisting
+ * only special-cases local `vi.fn()` declarations, not arbitrary function
+ * calls, so a `createHarness()` call assigned to a local const breaks (its
+ * `vi.mock` gets hoisted above the assignment, the const doesn't move with
+ * it). Importing a ready-made binding sidesteps that: nothing here needs
+ * hoisting. Each test file gets its own copy of this module (Vitest
+ * isolates modules per test file by default), so these module-level
+ * mutables don't leak state across files — only within one file, which
+ * `resetFormHarness` and `setData`/`setDataFor` are for.
+ *
+ * Usage — the `vi.mock` calls stay in the test file itself, as literal
+ * calls, so Vitest's hoisting can find them:
+ *
+ * ```ts
+ * import {
+ *   navigationMock, configMock, authMock, toastMock, swrMock,
+ * } from "@/lib/form-test-harness";
+ *
+ * vi.mock("next/navigation", () => navigationMock);
+ * vi.mock("@/app/client-context", () => configMock);
+ * vi.mock("@/components/auth-provider", () => authMock);
+ * vi.mock("sonner", () => toastMock);
+ * vi.mock("swr", () => swrMock);
+ * ```
+ */
+
+export interface SwrResponse<T = unknown> {
+  data: T;
+  isLoading: boolean;
+  mutate: Mock;
+}
+
+export const push = vi.fn();
+export const toastError = vi.fn();
+export const toastSuccess = vi.fn();
+export const toastInfo = vi.fn();
+export const configuredMutate = vi.fn();
+
+export const navigationMock = { useRouter: () => ({ push }) };
+export const configMock = { useBackendUrl: () => "http://test" };
+export const authMock = { useAuth: () => ({ user: { id: "u1" } }) };
+export const toastMock = {
+  toast: { error: toastError, success: toastSuccess, info: toastInfo },
+};
+
+function buildResponse(data: unknown): SwrResponse {
+  return { data, isLoading: false, mutate: vi.fn() };
+}
+
+const nullResponse: SwrResponse = buildResponse(undefined);
+
+// Every response handed out is created once, here, and returned by
+// reference on every subsequent call for the same key — never rebuilt per
+// call. Forms key their reset-on-load effect off this `data` reference
+// (`useResetOnChange(entity, ...)`); a mock that rebuilt the object on every
+// render would churn that identity and retrigger the reset on every render,
+// looping.
+let defaultResponse: SwrResponse = nullResponse;
+const responsesByKeySuffix = new Map<string, SwrResponse>();
+
+/** Sets the response returned for any key with no more specific match. */
+export function setData(data: unknown) {
+  defaultResponse = buildResponse(data);
+}
+
+/** Sets the response returned for a key ending in `keySuffix`. */
+export function setDataFor(keySuffix: string, data: unknown) {
+  responsesByKeySuffix.set(keySuffix, buildResponse(data));
+}
+
+function swrFetcher(key: string | null): SwrResponse {
+  if (!key) return nullResponse;
+  for (const [suffix, response] of responsesByKeySuffix) {
+    if (key.endsWith(suffix)) return response;
+  }
+  return defaultResponse;
+}
+
+export const swrMock = {
+  __esModule: true,
+  default: swrFetcher,
+  useSWRConfig: () => ({ mutate: configuredMutate }),
+};
+
+/** Resets spies and data-fetching registrations between tests. */
+export function resetFormHarness() {
+  push.mockReset();
+  toastError.mockReset();
+  toastSuccess.mockReset();
+  toastInfo.mockReset();
+  configuredMutate.mockReset();
+  defaultResponse = nullResponse;
+  responsesByKeySuffix.clear();
+}
+
+/** Builds a fetch-shaped `Response` resolving to `body` with `status`. */
+export function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+/** Stubs global `fetch` to resolve with an accepted (2xx) save. */
+export function stubAcceptedSave(body: unknown = {}, status = 200): Mock {
+  const fetchMock = vi.fn().mockResolvedValue(jsonResponse(status, body));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+/** Stubs global `fetch` to resolve with a rejected save, `{ error }`. */
+export function stubRejectedSave(error: unknown, status = 400): Mock {
+  const fetchMock = vi.fn().mockResolvedValue(jsonResponse(status, { error }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+/**
+ * Stubs global `fetch` to resolve each call in turn with the given
+ * `{ status, body }` responses — for flows that make more than one request
+ * (e.g. a save followed by a dependent, separately-failing write).
+ */
+export function stubSaveSequence(
+  ...responses: Array<{ status: number; body: unknown }>
+): Mock {
+  const fetchMock = vi.fn();
+  for (const { status, body } of responses) {
+    fetchMock.mockResolvedValueOnce(jsonResponse(status, body));
+  }
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}


### PR DESCRIPTION
## Summary
- Extracts navigation, config, auth, toast, and data-fetching mocks (plus save-stubbing helpers) from `agent-form.test.tsx`, `mcp-form.test.tsx`, and `webhook-form.test.tsx` into a new `apps/frontend/lib/form-test-harness.ts`.
- Preserves the stable-object-reference property `agent-form.test.tsx` relied on (churning `data` identity retriggers `useResetOnChange` and loops), now documented once in the harness instead of only in one file.
- No production code changes.

## Test plan
- [x] `pnpm test` — all 423 frontend tests pass, including the three migrated files, with assertions unchanged
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format` (prettier --check)
- [x] Ran `/code-review` (Standards + Spec sub-agents) — no hard violations; addressed the two minor suggestions (deduped a repeated response-shape helper, made `agent-form.test.tsx` use `resetFormHarness()` consistently)

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)