### PR TITLE
chore(frontend): finish the request-module migration

### DIFF
--- a/apps/frontend/components/agents-list.tsx
+++ b/apps/frontend/components/agents-list.tsx
@@ -56,8 +56,8 @@ import {
   type ToolSet,
   type Skill,
 } from "@platypus/schemas";
-import useSWR from "swr";
-import { fetcher, joinUrl } from "@/lib/utils";
+import { joinUrl } from "@/lib/utils";
+import { useScopedSWR } from "@/hooks/use-scoped-swr";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useBackendUrl } from "@/app/client-context";
@@ -92,7 +92,7 @@ export const AgentsList = ({
   orgId: string;
   workspaceId: string;
 }) => {
-  const { user, actor } = useAuth();
+  const { actor } = useAuth();
   const backendUrl = useBackendUrl();
   const router = useRouter();
   const [cloneDialogOpen, setCloneDialogOpen] = useState(false);
@@ -124,39 +124,21 @@ export const AgentsList = ({
     data: agentsData,
     isLoading: isLoadingAgents,
     mutate,
-  } = useSWR<{
+  } = useScopedSWR<{
     results: AgentWithScope[];
-  }>(
-    backendUrl && user
-      ? joinUrl(backendUrl, scopedPath("agents", scope))
-      : null,
-    fetcher,
-  );
+  }>("agents", scope);
 
-  const { data: providersData, isLoading: isLoadingProviders } = useSWR<{
+  const { data: providersData, isLoading: isLoadingProviders } = useScopedSWR<{
     results: Provider[];
-  }>(
-    backendUrl && user
-      ? joinUrl(backendUrl, scopedPath("providers", scope))
-      : null,
-    fetcher,
-  );
+  }>("providers", scope);
 
-  const { data: toolSetsData } = useSWR<{
+  const { data: toolSetsData } = useScopedSWR<{
     results: ToolSet[];
-  }>(
-    backendUrl && user ? joinUrl(backendUrl, scopedPath("tools", scope)) : null,
-    fetcher,
-  );
+  }>("tools", scope);
 
-  const { data: skillsData } = useSWR<{
+  const { data: skillsData } = useScopedSWR<{
     results: Skill[];
-  }>(
-    backendUrl && user
-      ? joinUrl(backendUrl, scopedPath("skills", scope))
-      : null,
-    fetcher,
-  );
+  }>("skills", scope);
 
   const agents = [...(agentsData?.results || [])].sort((a, b) =>
     a.name.localeCompare(b.name),

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -35,7 +35,7 @@ import {
 } from "@platypus/schemas";
 import { type PlatypusUIMessage } from "@platypus/backend/src/types";
 import { joinUrl } from "@/lib/utils";
-import { writeEntity } from "@/lib/api-write";
+import { writeAt, scopedPath } from "@/lib/api-write";
 import { useScopedSWR } from "@/hooks/use-scoped-swr";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useChatSettings } from "@/hooks/use-chat-settings";
@@ -430,13 +430,17 @@ export const Chat = ({
       // idempotent no-ops, but silently swallowing a real failure (e.g. a
       // network error) would leave them thinking the run was cancelled
       // when it wasn't.
-      void writeEntity(backendUrl || "", `chat/${chatId}/cancel`, scope).then(
-        (outcome) => {
-          if (outcome.outcome !== "success") {
-            toast.error(outcome.message);
-          }
-        },
-      );
+      void writeAt(
+        joinUrl(
+          backendUrl || "",
+          `${scopedPath("chat", scope)}/${chatId}/cancel`,
+        ),
+        { method: "POST" },
+      ).then((outcome) => {
+        if (outcome.outcome !== "success") {
+          toast.error(outcome.message);
+        }
+      });
       return stop();
     }
 

--- a/apps/frontend/components/kanban-board.tsx
+++ b/apps/frontend/components/kanban-board.tsx
@@ -42,7 +42,7 @@ import type {
   KanbanColumn,
 } from "@platypus/schemas";
 import { cn, fetcher, joinUrl } from "@/lib/utils";
-import { writeEntity, type Scope } from "@/lib/api-write";
+import { writeEntity, writeAt, type Scope } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { KanbanColumnComponent } from "@/components/kanban-column";
@@ -417,12 +417,10 @@ export function KanbanBoard({
         if (oldIndex !== newIndex && newIndex !== -1) {
           const reordered = arrayMove(cols, oldIndex, newIndex);
           setLocalColumns(reordered);
-          const outcome = await writeEntity(
-            backendUrl,
-            `${boardPath}/columns`,
-            scope,
-            { id: "reorder", data: { columnIds: reordered.map((c) => c.id) } },
-          );
+          const outcome = await writeAt(joinUrl(baseUrl, "columns/reorder"), {
+            method: "PUT",
+            data: { columnIds: reordered.map((c) => c.id) },
+          });
           if (outcome.outcome === "success") {
             await mutate();
           } else {
@@ -542,7 +540,7 @@ export function KanbanBoard({
         setLocalColumns(null);
       }
     },
-    [backendUrl, boardPath, scope, mutate, setLocalColumns],
+    [backendUrl, baseUrl, boardPath, scope, mutate, setLocalColumns],
   );
 
   const handleAddColumn = useCallback(() => {
@@ -678,12 +676,10 @@ export function KanbanBoard({
       if (newIndex < 0 || newIndex >= currentColumns.length) return;
       const reordered = arrayMove(currentColumns, index, newIndex);
       setLocalColumns(reordered);
-      const outcome = await writeEntity(
-        backendUrl,
-        `${boardPath}/columns`,
-        scope,
-        { id: "reorder", data: { columnIds: reordered.map((c) => c.id) } },
-      );
+      const outcome = await writeAt(joinUrl(baseUrl, "columns/reorder"), {
+        method: "PUT",
+        data: { columnIds: reordered.map((c) => c.id) },
+      });
       if (outcome.outcome === "success") {
         await mutate();
       } else {
@@ -691,7 +687,7 @@ export function KanbanBoard({
         setLocalColumns(null);
       }
     },
-    [data?.columns, backendUrl, boardPath, scope, mutate, setLocalColumns],
+    [data?.columns, baseUrl, mutate, setLocalColumns],
   );
 
   const handleCardSave = useCallback(

--- a/apps/frontend/components/kanban-board.tsx
+++ b/apps/frontend/components/kanban-board.tsx
@@ -527,11 +527,12 @@ export function KanbanBoard({
         });
       });
 
-      const outcome = await writeEntity(
-        backendUrl,
-        `${boardPath}/cards/${active.id}/move`,
-        scope,
-        { data: { columnId: targetColumn.id, afterCardId } },
+      const outcome = await writeAt(
+        joinUrl(baseUrl, `cards/${active.id}/move`),
+        {
+          method: "POST",
+          data: { columnId: targetColumn.id, afterCardId },
+        },
       );
       if (outcome.outcome === "success") {
         await mutate();
@@ -540,7 +541,7 @@ export function KanbanBoard({
         setLocalColumns(null);
       }
     },
-    [backendUrl, baseUrl, boardPath, scope, mutate, setLocalColumns],
+    [baseUrl, mutate, setLocalColumns],
   );
 
   const handleAddColumn = useCallback(() => {
@@ -719,11 +720,12 @@ export function KanbanBoard({
         return;
       }
       if (targetColumnId && targetColumnId !== column.id) {
-        const moveOutcome = await writeEntity(
-          backendUrl,
-          `${boardPath}/cards/${cardId}/move`,
-          scope,
-          { data: { columnId: targetColumnId, afterCardId: null } },
+        const moveOutcome = await writeAt(
+          joinUrl(baseUrl, `cards/${cardId}/move`),
+          {
+            method: "POST",
+            data: { columnId: targetColumnId, afterCardId: null },
+          },
         );
         if (moveOutcome.outcome !== "success") {
           toast.error(moveOutcome.message);
@@ -735,7 +737,7 @@ export function KanbanBoard({
       updateCardIdParam(null);
       await mutate();
     },
-    [columns, backendUrl, boardPath, scope, mutate, updateCardIdParam],
+    [columns, backendUrl, baseUrl, boardPath, scope, mutate, updateCardIdParam],
   );
 
   const handleCardDelete = useCallback(

--- a/apps/frontend/components/mcp-list.tsx
+++ b/apps/frontend/components/mcp-list.tsx
@@ -2,8 +2,8 @@
 
 import { MCP } from "@platypus/schemas";
 import { Item, ItemActions, ItemContent, ItemTitle } from "./ui/item";
-import useSWR from "swr";
-import { cn, fetcher, joinUrl } from "../lib/utils";
+import { cn } from "../lib/utils";
+import { useScopedSWR } from "@/hooks/use-scoped-swr";
 import { useAuth } from "@/components/auth-provider";
 import {
   canConfigureWorkspaceResource,
@@ -31,7 +31,7 @@ import {
 } from "./ui/dialog";
 import { AttachSharedResourceDialog } from "./attach-shared-resource-dialog";
 import { useState } from "react";
-import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
+import { writeEntity, type Scope } from "@/lib/api-write";
 
 const McpList = ({
   className,
@@ -45,7 +45,7 @@ const McpList = ({
   // Add scope to the MCP type for this component
   type McpWithScope = MCP & { scope?: "organization" | "workspace" };
 
-  const { user, actor, workspaceDelegation } = useAuth();
+  const { actor, workspaceDelegation } = useAuth();
   const backendUrl = useBackendUrl();
   const [selectedOrgMcp, setSelectedOrgMcp] = useState<McpWithScope | null>(
     null,
@@ -59,12 +59,9 @@ const McpList = ({
   // each call site.
   const scope: Scope = workspaceId ? { orgId, workspaceId } : { orgId };
 
-  const fetchUrl =
-    backendUrl && user ? joinUrl(backendUrl, scopedPath("mcps", scope)) : null;
-
-  const { data, error, isLoading, mutate } = useSWR<{
+  const { data, error, isLoading, mutate } = useScopedSWR<{
     results: McpWithScope[];
-  }>(fetchUrl, fetcher);
+  }>("mcps", scope);
 
   // Attach, detach, and Promote a Shared resource are the same rule
   // (ADR-0007 / #154), asked of the auth module instead of re-derived here.

--- a/apps/frontend/components/org-agents-list.tsx
+++ b/apps/frontend/components/org-agents-list.tsx
@@ -19,8 +19,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Bot, EllipsisVertical, Pencil, Share2, Trash2 } from "lucide-react";
 import { type Agent } from "@platypus/schemas";
-import useSWR from "swr";
-import { fetcher, joinUrl } from "@/lib/utils";
+import { joinUrl } from "@/lib/utils";
+import { useScopedSWR } from "@/hooks/use-scoped-swr";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { canManageOrgSharedResource } from "@/lib/authorization";
@@ -36,7 +36,7 @@ import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
 // the way a Shared Agent is created; it is then edited, shared, and deleted
 // here on the Organization surface — in Workspaces it is locked.
 export const OrgAgentsList = ({ orgId }: { orgId: string }) => {
-  const { user, actor } = useAuth();
+  const { actor } = useAuth();
   const canManage = canManageOrgSharedResource(actor).allowed;
   const backendUrl = useBackendUrl();
   const [agentToDelete, setAgentToDelete] = useState<Agent | null>(null);
@@ -53,11 +53,9 @@ export const OrgAgentsList = ({ orgId }: { orgId: string }) => {
   // each call site.
   const scope: Scope = { orgId };
 
-  const { data, isLoading, mutate } = useSWR<{ results: Agent[] }>(
-    backendUrl && user
-      ? joinUrl(backendUrl, scopedPath("agents", scope))
-      : null,
-    fetcher,
+  const { data, isLoading, mutate } = useScopedSWR<{ results: Agent[] }>(
+    "agents",
+    scope,
   );
 
   const agents = [...(data?.results || [])].sort((a, b) =>

--- a/apps/frontend/components/trigger-list.tsx
+++ b/apps/frontend/components/trigger-list.tsx
@@ -34,15 +34,13 @@ import {
   type CronTriggerConfig,
   type EventTriggerConfig,
 } from "@platypus/schemas";
-import useSWR from "swr";
-import { fetcher, joinUrl } from "@/lib/utils";
 import Link from "next/link";
 import { useBackendUrl } from "@/app/client-context";
-import { useAuth } from "@/components/auth-provider";
 import { describeSchedule } from "@/lib/cron-utils";
 import { toast } from "sonner";
 import { AgentAvatar } from "@/components/agent-avatar";
-import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
+import { writeEntity, type Scope } from "@/lib/api-write";
+import { useScopedSWR } from "@/hooks/use-scoped-swr";
 
 export const TriggerList = ({
   orgId,
@@ -51,7 +49,6 @@ export const TriggerList = ({
   orgId: string;
   workspaceId: string;
 }) => {
-  const { user } = useAuth();
   const backendUrl = useBackendUrl();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [triggerToDelete, setTriggerToDelete] = useState<Trigger | null>(null);
@@ -68,20 +65,13 @@ export const TriggerList = ({
     data: triggersData,
     isLoading,
     mutate,
-  } = useSWR<{
+  } = useScopedSWR<{
     results: Trigger[];
-  }>(
-    backendUrl && user
-      ? joinUrl(backendUrl, scopedPath("triggers", scope))
-      : null,
-    fetcher,
-  );
+  }>("triggers", scope);
 
-  const { data: agentsData } = useSWR<{ results: Agent[] }>(
-    backendUrl && user
-      ? joinUrl(backendUrl, scopedPath("agents", scope))
-      : null,
-    fetcher,
+  const { data: agentsData } = useScopedSWR<{ results: Agent[] }>(
+    "agents",
+    scope,
   );
 
   const agentsById = Object.fromEntries(


### PR DESCRIPTION
## Summary
- Migrates the last raw-`useSWR` read gates the earlier request-module batches (#563-568, #603) left behind: `agents-list.tsx`, `trigger-list.tsx`, `mcp-list.tsx`, and `org-agents-list.tsx` now read through `useScopedSWR` instead of hand-rolled `joinUrl(backendUrl, scopedPath(...))` keys.
- Contract cleanup in `kanban-board.tsx`: column-reorder and card-move writes were smuggling an action segment (`reorder`, `cards/{id}/move`) through `writeEntity`'s `entity`/`id` slots — moved onto `writeAt` with an explicit URL and method instead.
- Contract cleanup in `chat.tsx`: run-cancel had the same issue (`chat/{id}/cancel` as the entity) — moved onto `writeAt`, preserving the existing fire-and-forget + toast-on-failure behaviour and its comment.
- Most of #597's other enumerated sites (app-sidebar, boards/blueprints-list, member-edit-dialog's PATCH, invitations, sandbox-settings, webhook-form, mcp-form, apply-blueprint/attach-shared-resource dialogs) were already migrated by #603, which closed the overlapping #569 first — verified against current repo state rather than #597's now-stale line numbers.

Closes #597

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (1902 backend + 423 frontend tests passing)
- [x] Two-axis code review (Standards + Spec) run against the diff; Standards found one real gap (the kanban card-move sites had the same action-in-entity-slot smell as the reorder sites) and it was fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)