### PR TITLE
chore(backend): give Provider a write model that takes the scope

### DIFF
--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -7,7 +7,6 @@ import {
   attachment as attachmentTable,
 } from "../db/schema.ts";
 import { agentCreateSchema, agentUpdateSchema } from "@platypus/schemas";
-import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
@@ -25,6 +24,7 @@ import {
   listScoped,
   requireScoped,
   requireWorkspaceMutable,
+  workspaceScopedWhere,
 } from "../services/scoped-resource.ts";
 import { NotFoundError } from "../errors.ts";
 import { storeAvatar, deleteAvatar } from "../services/avatar.ts";
@@ -154,12 +154,7 @@ agent.post(
     const record = await db
       .update(agentTable)
       .set({ avatarKey: result.key, updatedAt: new Date() })
-      .where(
-        and(
-          eq(agentTable.id, agentId),
-          eq(agentTable.workspaceId, scope.workspaceId),
-        ),
-      )
+      .where(workspaceScopedWhere("agent", agentId, scope.workspaceId))
       .returning();
 
     return c.json(agentWithAvatarUrl(record[0], baseUrl));
@@ -185,12 +180,7 @@ agent.delete(
     const record = await db
       .update(agentTable)
       .set({ avatarKey: null, updatedAt: new Date() })
-      .where(
-        and(
-          eq(agentTable.id, agentId),
-          eq(agentTable.workspaceId, scope.workspaceId),
-        ),
-      )
+      .where(workspaceScopedWhere("agent", agentId, scope.workspaceId))
       .returning();
 
     return c.json(agentWithAvatarUrl(record[0], baseUrl));
@@ -241,12 +231,7 @@ agent.post(
     const [existing] = await db
       .select()
       .from(agentTable)
-      .where(
-        and(
-          eq(agentTable.id, agentId),
-          eq(agentTable.workspaceId, workspaceId),
-        ),
-      )
+      .where(workspaceScopedWhere("agent", agentId, workspaceId))
       .limit(1);
     if (!existing) {
       throw new NotFoundError("Agent not found");
@@ -285,12 +270,7 @@ agent.post(
             workspaceId: null,
             updatedAt: new Date(),
           })
-          .where(
-            and(
-              eq(agentTable.id, agentId),
-              eq(agentTable.workspaceId, workspaceId),
-            ),
-          )
+          .where(workspaceScopedWhere("agent", agentId, workspaceId))
           .returning();
 
         if (!record) {

--- a/apps/backend/src/routes/mcp.ts
+++ b/apps/backend/src/routes/mcp.ts
@@ -12,7 +12,7 @@ import {
   mcpUpdateSchema,
   mcpTestSchema,
 } from "@platypus/schemas";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
@@ -29,6 +29,7 @@ import {
   listScoped,
   requireScoped,
   requireWorkspaceMutable,
+  workspaceScopedWhere,
 } from "../services/scoped-resource.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
@@ -153,12 +154,7 @@ mcp.put(
         }),
         updatedAt: new Date(),
       })
-      .where(
-        and(
-          eq(mcpTable.id, mcpId),
-          eq(mcpTable.workspaceId, scope.workspaceId),
-        ),
-      )
+      .where(workspaceScopedWhere("mcp", mcpId, scope.workspaceId))
       .returning();
     return c.json(sanitizeMcpResponse(record[0]), 200);
   },
@@ -182,12 +178,7 @@ mcp.delete(
 
     await db
       .delete(mcpTable)
-      .where(
-        and(
-          eq(mcpTable.id, mcpId),
-          eq(mcpTable.workspaceId, scope.workspaceId),
-        ),
-      )
+      .where(workspaceScopedWhere("mcp", mcpId, scope.workspaceId))
       .returning();
     return c.json({ message: "MCP deleted" });
   },
@@ -215,12 +206,7 @@ mcp.post(
         const mcpRecord = await db
           .select()
           .from(mcpTable)
-          .where(
-            and(
-              eq(mcpTable.id, data.mcpId),
-              eq(mcpTable.workspaceId, workspaceId),
-            ),
-          )
+          .where(workspaceScopedWhere("mcp", data.mcpId, workspaceId))
           .limit(1);
 
         if (mcpRecord.length === 0) {
@@ -319,7 +305,7 @@ mcp.post(
     const mcpRecord = await db
       .select()
       .from(mcpTable)
-      .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.workspaceId, workspaceId)))
+      .where(workspaceScopedWhere("mcp", mcpId, workspaceId))
       .limit(1);
 
     if (mcpRecord.length === 0) {
@@ -415,7 +401,7 @@ mcp.post(
         ...OAUTH_TOKEN_CLEAR_FIELDS,
         updatedAt: new Date(),
       })
-      .where(and(eq(mcpTable.id, mcpId), eq(mcpTable.workspaceId, workspaceId)))
+      .where(workspaceScopedWhere("mcp", mcpId, workspaceId))
       .returning();
 
     if (record.length === 0) {

--- a/apps/backend/src/routes/org-provider.test.ts
+++ b/apps/backend/src/routes/org-provider.test.ts
@@ -185,6 +185,69 @@ describe("Organization Provider Routes", () => {
     });
   });
 
+  describe("PUT /:providerId", () => {
+    const updateBody = {
+      name: "Renamed",
+      providerType: "OpenAI",
+      apiKey: "sk-123",
+      modelIds: ["gpt-4"],
+      taskModelId: "gpt-4",
+      memoryExtractionModelId: "gpt-4",
+    };
+
+    it("updates an org provider and returns the row", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      // requireOrgScoped: the Provider is a Shared resource of this org
+      mockDb.limit.mockResolvedValueOnce([{ id: "p1", organizationId: orgId }]);
+      // currentProviderModels → the pre-save models, for the alias diff
+      mockDb.limit.mockResolvedValueOnce([{ modelIds: [{ id: "gpt-4" }] }]);
+
+      const updated = { id: "p1", name: "Renamed", organizationId: orgId };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const res = await app.request(`${baseUrl}/p1`, {
+        method: "PUT",
+        body: JSON.stringify(updateBody),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ...updated, aliasRepoints: [] });
+    });
+
+    // #605: the org surface used to skip this check entirely, discovering a
+    // missing Provider only when the UPDATE matched no row.
+    it("returns 404 for a provider that is not a Shared resource of this org, without touching the write", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([]); // requireOrgScoped: not found
+
+      const res = await app.request(`${baseUrl}/missing`, {
+        method: "PUT",
+        body: JSON.stringify(updateBody),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(404);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 for a non-admin", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+
+      const res = await app.request(`${baseUrl}/p1`, {
+        method: "PUT",
+        body: JSON.stringify(updateBody),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(403);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+  });
+
   describe("DELETE /:providerId", () => {
     it("deletes an org provider if admin and not attached", async () => {
       mockSession();
@@ -197,6 +260,26 @@ describe("Organization Provider Routes", () => {
       const res = await app.request(`${baseUrl}/p1`, { method: "DELETE" });
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ message: "Provider deleted" });
+    });
+
+    it("invalidates memory embeddings before deleting, without de-migrating aliases", async () => {
+      // The delete path used to run neither helper (#605): a Provider's
+      // models — and any alias among them — vanish along with the row, so
+      // there is no surviving concrete id for de-migration to rewrite to, but
+      // stale embedding vectors computed against it must still be cleared.
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]) // attachment guard: none
+        .mockResolvedValueOnce([]); // blueprint guard: none
+      mockDb.execute.mockResolvedValueOnce({ rowCount: 0 }); // nullifyEmbeddingsForProvider
+      mockDb.returning.mockResolvedValueOnce([{ id: "p1" }]);
+
+      const res = await app.request(`${baseUrl}/p1`, { method: "DELETE" });
+
+      expect(res.status).toBe(200);
+      expect(mockDb.execute).toHaveBeenCalledTimes(1);
+      expect(mockDb.delete).toHaveBeenCalled();
     });
 
     it("returns 409 when the provider is attached to a workspace", async () => {

--- a/apps/backend/src/routes/org-provider.ts
+++ b/apps/backend/src/routes/org-provider.ts
@@ -1,15 +1,7 @@
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
-import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import { provider as providerTable } from "../db/schema.ts";
 import { providerCreateSchema, providerUpdateSchema } from "@platypus/schemas";
-import { handleEmbeddingConfigChange } from "../services/embedding-invalidation.ts";
-import { dedupeModelConfigs } from "../services/model-capability.ts";
-import {
-  currentProviderModels,
-  deMigrateOrphanedAliases,
-} from "../services/model-alias-migration.ts";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   orgCredentialsVisible,
@@ -18,12 +10,14 @@ import {
 } from "../middleware/authorization.ts";
 import {
   listOrgScoped,
-  orgScopedWhere,
   requireOrgScoped,
-  requireSharedDeletable,
 } from "../services/scoped-resource.ts";
 import { providerReadModel } from "../services/credential-redaction.ts";
-import { NotFoundError } from "../errors.ts";
+import {
+  createProvider,
+  deleteProvider,
+  updateProvider,
+} from "../services/provider-write.ts";
 import type { Variables } from "../server.ts";
 
 const orgProvider = new Hono<{ Variables: Variables }>();
@@ -38,23 +32,8 @@ orgProvider.post(
     const { orgId } = orgScopeOf(c);
     const data = c.req.valid("json");
 
-    if (data.modelIds) {
-      data.modelIds = dedupeModelConfigs(data.modelIds);
-    }
-
-    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
-    // by the central onError (ADR-0010).
-    const record = await db
-      .insert(providerTable)
-      .values({
-        id: nanoid(),
-        ...data,
-        organizationId: orgId,
-        workspaceId: null,
-      })
-      .returning();
-
-    return c.json(record[0], 201);
+    const row = await createProvider({ kind: "organization", orgId }, data);
+    return c.json(row, 201);
   },
 );
 
@@ -94,46 +73,17 @@ orgProvider.put(
     const providerId = c.req.param("providerId");
     const data = c.req.valid("json");
 
-    if (data.modelIds) {
-      data.modelIds = dedupeModelConfigs(data.modelIds);
-    }
+    // `updateProvider` now checks the Provider is a Shared resource of this
+    // Organization before touching embeddings (#605) — this route used to
+    // skip that check and discover a missing row only when the `UPDATE`
+    // matched nothing.
+    const { row, aliasRepoints } = await updateProvider(
+      { kind: "organization", orgId },
+      providerId,
+      data,
+    );
 
-    // Detect and handle embedding config changes before the update
-    await handleEmbeddingConfigChange(providerId, data);
-
-    // Snapshot the models as stored, so an alias this save removes can
-    // de-migrate its references rather than dangling them (ADR-0017).
-    const previousModels = data.modelIds
-      ? await currentProviderModels(providerId)
-      : null;
-
-    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
-    // by the central onError (ADR-0010).
-    const record = await db
-      .update(providerTable)
-      .set({
-        ...data,
-        updatedAt: new Date(),
-      })
-      .where(orgScopedWhere("provider", providerId, orgId))
-      .returning();
-
-    if (record.length === 0) {
-      throw new NotFoundError("Provider not found");
-    }
-
-    // Runs AFTER the row is written: a failed update must not leave Agents
-    // repointed for an alias that still exists.
-    const aliasRepoints =
-      previousModels && data.modelIds
-        ? await deMigrateOrphanedAliases(
-            providerId,
-            previousModels,
-            data.modelIds,
-          )
-        : [];
-
-    return c.json({ ...record[0], aliasRepoints }, 200);
+    return c.json({ ...row, aliasRepoints }, 200);
   },
 );
 
@@ -146,19 +96,10 @@ orgProvider.delete(
     const { orgId } = orgScopeOf(c);
     const providerId = c.req.param("providerId");
 
-    // A Shared resource cannot be deleted while anything still points at it —
-    // an Attachment (ADR-0007) or a Blueprint (ADR-0008). Throws ConflictError
-    // → 409 via the central onError (ADR-0010).
-    await requireSharedDeletable(db, "provider", providerId);
-
-    const result = await db
-      .delete(providerTable)
-      .where(orgScopedWhere("provider", providerId, orgId))
-      .returning();
-
-    if (result.length === 0) {
-      throw new NotFoundError("Provider not found");
-    }
+    // `deleteProvider` throws ConflictError (→409) while an Attachment
+    // (ADR-0007) or Blueprint (ADR-0008) still references the Provider, then
+    // NotFoundError (→404) when the delete matches no row.
+    await deleteProvider({ kind: "organization", orgId }, providerId);
 
     return c.json({ message: "Provider deleted" });
   },

--- a/apps/backend/src/routes/provider.test.ts
+++ b/apps/backend/src/routes/provider.test.ts
@@ -448,10 +448,16 @@ describe("Provider Routes", () => {
       // requireWorkspaceMutable → resolveScoped → workspace-scoped row (no
       // attachment check needed)
       mockDb.limit.mockResolvedValueOnce([{ id: "p1", workspaceId }]);
+      mockDb.execute.mockResolvedValueOnce({ rowCount: 0 }); // nullifyEmbeddingsForProvider
 
       const res = await app.request(`${baseUrl}/p1`, { method: "DELETE" });
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ message: "Provider deleted" });
+      // #605: the delete path used to run neither helper. A Provider's models
+      // — and any alias among them — vanish along with the row, so there is
+      // no surviving concrete id for de-migration to rewrite to, but stale
+      // embedding vectors computed against it must still be cleared.
+      expect(mockDb.execute).toHaveBeenCalledTimes(1);
     });
 
     it("should 404 when deleting an org-scoped provider not attached here", async () => {
@@ -470,6 +476,7 @@ describe("Provider Routes", () => {
       const res = await app.request(`${baseUrl}/p2`, { method: "DELETE" });
       expect(res.status).toBe(404);
       expect(mockDb.delete).not.toHaveBeenCalled();
+      expect(mockDb.execute).not.toHaveBeenCalled();
     });
 
     it("should 403 when deleting an attached org-scoped provider", async () => {
@@ -488,6 +495,7 @@ describe("Provider Routes", () => {
       const res = await app.request(`${baseUrl}/p2`, { method: "DELETE" });
       expect(res.status).toBe(403);
       expect(mockDb.delete).not.toHaveBeenCalled();
+      expect(mockDb.execute).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/routes/provider.ts
+++ b/apps/backend/src/routes/provider.ts
@@ -1,16 +1,7 @@
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
-import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import { provider as providerTable } from "../db/schema.ts";
 import { providerCreateSchema, providerUpdateSchema } from "@platypus/schemas";
-import { eq, and } from "drizzle-orm";
-import { handleEmbeddingConfigChange } from "../services/embedding-invalidation.ts";
-import { dedupeModelConfigs } from "../services/model-capability.ts";
-import {
-  currentProviderModels,
-  deMigrateOrphanedAliases,
-} from "../services/model-alias-migration.ts";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
@@ -20,11 +11,12 @@ import {
   workspaceScopeOf,
 } from "../middleware/authorization.ts";
 import { providerReadModel } from "../services/credential-redaction.ts";
+import { listScoped, requireScoped } from "../services/scoped-resource.ts";
 import {
-  listScoped,
-  requireScoped,
-  requireWorkspaceMutable,
-} from "../services/scoped-resource.ts";
+  createProvider,
+  deleteProvider,
+  updateProvider,
+} from "../services/provider-write.ts";
 import type { Variables } from "../server.ts";
 
 const provider = new Hono<{ Variables: Variables }>();
@@ -43,26 +35,13 @@ provider.post(
   sValidator("json", providerCreateSchema),
   async (c) => {
     const data = c.req.valid("json");
-    const { workspaceId } = workspaceScopeOf(c);
-    if (data.modelIds) {
-      data.modelIds = dedupeModelConfigs(data.modelIds);
-    }
-    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
-    // by the central onError (ADR-0010).
-    const record = await db
-      .insert(providerTable)
-      .values({
-        id: nanoid(),
-        ...data,
-        // The scope comes from the route, never the body — as it does for Agents
-        // and Skills. Spreading the body let a caller name another Workspace, or
-        // set `organizationId` and mint a Shared Provider from the Workspace
-        // surface, which only an Org Admin may do (ADR-0006, ADR-0007).
-        workspaceId,
-        organizationId: null,
-      })
-      .returning();
-    return c.json(record[0], 201);
+    const ctx = workspaceScopeOf(c);
+    // The scope comes from the route, never the body — as it does for Agents
+    // and Skills. Spreading the body let a caller name another Workspace, or
+    // set `organizationId` and mint a Shared Provider from the Workspace
+    // surface, which only an Org Admin may do (ADR-0006, ADR-0007).
+    const row = await createProvider({ kind: "workspace", ctx }, data);
+    return c.json(row, 201);
   },
 );
 
@@ -116,56 +95,21 @@ provider.put(
   requireWorkspaceConfigAccess("providerSelfManagement"),
   sValidator("json", providerUpdateSchema),
   async (c) => {
-    const scope = workspaceScopeOf(c);
+    const ctx = workspaceScopeOf(c);
     const providerId = c.req.param("providerId");
     const data = c.req.valid("json");
-    if (data.modelIds) {
-      data.modelIds = dedupeModelConfigs(data.modelIds);
-    }
 
-    // A Shared Provider is a single source of truth edited only on the
-    // Organization surface (ADR-0007); requireWorkspaceMutable throws NotFound
-    // (→404) when the Provider is not visible here, then Locked (→403) when it
-    // is org-scoped.
-    await requireWorkspaceMutable(db, "provider", providerId, scope);
+    // The five-step save ordering — dedupe, embedding invalidation, alias
+    // snapshot, write, de-migration — lives in the write model; here it's the
+    // Workspace scope's "not visible → 404, Shared → 403" rule (ADR-0007) that
+    // matters (`updateProvider` enforces it via `requireWorkspaceMutable`).
+    const { row, aliasRepoints } = await updateProvider(
+      { kind: "workspace", ctx },
+      providerId,
+      data,
+    );
 
-    // Detect and handle embedding config changes before the update
-    await handleEmbeddingConfigChange(providerId, data);
-
-    // Snapshot the models as stored, so an alias this save removes can
-    // de-migrate its references rather than dangling them (ADR-0017).
-    const previousModels = data.modelIds
-      ? await currentProviderModels(providerId)
-      : null;
-
-    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
-    // by the central onError (ADR-0010).
-    const record = await db
-      .update(providerTable)
-      .set({
-        ...data,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(providerTable.id, providerId),
-          eq(providerTable.workspaceId, scope.workspaceId),
-        ),
-      )
-      .returning();
-
-    // Runs AFTER the row is written: a failed update must not leave Agents
-    // repointed for an alias that still exists.
-    const aliasRepoints =
-      previousModels && data.modelIds
-        ? await deMigrateOrphanedAliases(
-            providerId,
-            previousModels,
-            data.modelIds,
-          )
-        : [];
-
-    return c.json({ ...record[0], aliasRepoints }, 200);
+    return c.json({ ...row, aliasRepoints }, 200);
   },
 );
 
@@ -177,22 +121,14 @@ provider.delete(
   requireWorkspaceAccess,
   requireWorkspaceConfigAccess("providerSelfManagement"),
   async (c) => {
-    const scope = workspaceScopeOf(c);
+    const ctx = workspaceScopeOf(c);
     const providerId = c.req.param("providerId");
 
     // A Shared Provider is deleted only from the Organization surface
-    // (ADR-0007): requireWorkspaceMutable throws NotFound (→404) when the
-    // Provider is not visible here, then Locked (→403) when it is org-scoped.
-    await requireWorkspaceMutable(db, "provider", providerId, scope);
+    // (ADR-0007): `deleteProvider` throws NotFound (→404) when the Provider is
+    // not visible here, then Locked (→403) when it is org-scoped.
+    await deleteProvider({ kind: "workspace", ctx }, providerId);
 
-    await db
-      .delete(providerTable)
-      .where(
-        and(
-          eq(providerTable.id, providerId),
-          eq(providerTable.workspaceId, scope.workspaceId),
-        ),
-      );
     return c.json({ message: "Provider deleted" });
   },
 );

--- a/apps/backend/src/routes/skill.ts
+++ b/apps/backend/src/routes/skill.ts
@@ -19,6 +19,7 @@ import {
   listScoped,
   requireScoped,
   requireWorkspaceMutable,
+  workspaceScopedWhere,
 } from "../services/scoped-resource.ts";
 import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
@@ -149,12 +150,7 @@ skill.put(
         ...data,
         updatedAt: new Date(),
       })
-      .where(
-        and(
-          eq(skillTable.id, skillId),
-          eq(skillTable.workspaceId, scope.workspaceId),
-        ),
-      )
+      .where(workspaceScopedWhere("skill", skillId, scope.workspaceId))
       .returning();
 
     // Update agent associations if agentIds was provided
@@ -239,12 +235,7 @@ skill.delete(
 
     await db
       .delete(skillTable)
-      .where(
-        and(
-          eq(skillTable.id, skillId),
-          eq(skillTable.workspaceId, scope.workspaceId),
-        ),
-      );
+      .where(workspaceScopedWhere("skill", skillId, scope.workspaceId));
 
     return c.json({ message: "Skill deleted" });
   },
@@ -274,12 +265,7 @@ skill.post(
     const [existing] = await db
       .select()
       .from(skillTable)
-      .where(
-        and(
-          eq(skillTable.id, skillId),
-          eq(skillTable.workspaceId, workspaceId),
-        ),
-      )
+      .where(workspaceScopedWhere("skill", skillId, workspaceId))
       .limit(1);
     if (!existing) {
       throw new NotFoundError("Skill not found");
@@ -299,12 +285,7 @@ skill.post(
             workspaceId: null,
             updatedAt: new Date(),
           })
-          .where(
-            and(
-              eq(skillTable.id, skillId),
-              eq(skillTable.workspaceId, workspaceId),
-            ),
-          )
+          .where(workspaceScopedWhere("skill", skillId, workspaceId))
           .returning();
 
         if (!record) {

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -1,4 +1,3 @@
-import { and, eq } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type { z } from "zod";
 import type { agentBaseSchema } from "@platypus/schemas";
@@ -7,7 +6,10 @@ import { agent as agentTable } from "../db/schema.ts";
 import { dedupeArray } from "../utils.ts";
 import type { ScopeContext } from "../scope.ts";
 import { validateSubAgentAssignment } from "./sub-agent-validation.ts";
-import { requireWorkspaceMutable } from "./scoped-resource.ts";
+import {
+  requireWorkspaceMutable,
+  workspaceScopedWhere,
+} from "./scoped-resource.ts";
 import { deleteAvatar } from "./avatar.ts";
 
 /**
@@ -128,12 +130,7 @@ export async function updateAgent(
   const [row] = await db
     .update(agentTable)
     .set({ ...data, updatedAt: new Date() })
-    .where(
-      and(
-        eq(agentTable.id, agentId),
-        eq(agentTable.workspaceId, ctx.workspaceId),
-      ),
-    )
+    .where(workspaceScopedWhere("agent", agentId, ctx.workspaceId))
     .returning();
   return { row };
 }
@@ -153,10 +150,5 @@ export async function deleteAgent(
 
   await db
     .delete(agentTable)
-    .where(
-      and(
-        eq(agentTable.id, agentId),
-        eq(agentTable.workspaceId, ctx.workspaceId),
-      ),
-    );
+    .where(workspaceScopedWhere("agent", agentId, ctx.workspaceId));
 }

--- a/apps/backend/src/services/provider-write.test.ts
+++ b/apps/backend/src/services/provider-write.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDb, resetMockDb } from "../test-utils.ts";
+
+vi.mock("./embedding-invalidation.ts", () => ({
+  handleEmbeddingConfigChange: vi.fn().mockResolvedValue(undefined),
+  nullifyEmbeddingsForProvider: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./model-alias-migration.ts", () => ({
+  currentProviderModels: vi.fn().mockResolvedValue(null),
+  deMigrateOrphanedAliases: vi.fn().mockResolvedValue([]),
+}));
+
+import {
+  createProvider,
+  updateProvider,
+  deleteProvider,
+} from "./provider-write.ts";
+import type {
+  ProviderCreateFields,
+  ProviderUpdateFields,
+} from "./provider-write.ts";
+import {
+  handleEmbeddingConfigChange,
+  nullifyEmbeddingsForProvider,
+} from "./embedding-invalidation.ts";
+import {
+  currentProviderModels,
+  deMigrateOrphanedAliases,
+} from "./model-alias-migration.ts";
+import { ConflictError, LockedError, NotFoundError } from "../errors.ts";
+
+const workspaceCtx = { orgId: "org-1", workspaceId: "ws-1" };
+
+const baseFields = (): ProviderCreateFields => ({
+  name: "OpenAI",
+  providerType: "OpenAI",
+  apiKey: "sk-123",
+  apiMode: "responses",
+  searchSource: "native",
+  modelIds: [],
+  taskModelId: "gpt-4",
+  memoryExtractionModelId: "gpt-4",
+});
+
+const updateFields = (): ProviderUpdateFields => baseFields();
+
+describe("provider-write module", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockDb();
+    vi.mocked(handleEmbeddingConfigChange).mockResolvedValue(undefined);
+    vi.mocked(nullifyEmbeddingsForProvider).mockResolvedValue(undefined);
+    vi.mocked(currentProviderModels).mockResolvedValue(null);
+    vi.mocked(deMigrateOrphanedAliases).mockResolvedValue([]);
+  });
+
+  describe("createProvider", () => {
+    it("inserts a workspace-scoped provider with a generated id", async () => {
+      const inserted = { id: "p1", workspaceId: "ws-1" };
+      mockDb.returning.mockResolvedValueOnce([inserted]);
+
+      const row = await createProvider(
+        { kind: "workspace", ctx: workspaceCtx },
+        baseFields(),
+      );
+
+      expect(row).toEqual(inserted);
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.workspaceId).toBe("ws-1");
+      expect(values.organizationId).toBeNull();
+      expect(typeof values.id).toBe("string");
+    });
+
+    it("inserts an organization-scoped provider with no workspace", async () => {
+      mockDb.returning.mockResolvedValueOnce([{ id: "p1" }]);
+
+      await createProvider(
+        { kind: "organization", orgId: "org-1" },
+        baseFields(),
+      );
+
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.organizationId).toBe("org-1");
+      expect(values.workspaceId).toBeNull();
+    });
+
+    it("dedupes modelIds before insert", async () => {
+      mockDb.returning.mockResolvedValueOnce([{ id: "p1" }]);
+
+      await createProvider(
+        { kind: "workspace", ctx: workspaceCtx },
+        {
+          ...baseFields(),
+          modelIds: [
+            { id: "gpt-4", passthroughFileTypes: [] },
+            { id: "gpt-4", passthroughFileTypes: [] },
+          ],
+        },
+      );
+
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.modelIds).toEqual([
+        { id: "gpt-4", passthroughFileTypes: [] },
+      ]);
+    });
+  });
+
+  describe("updateProvider", () => {
+    it("updates a workspace-scoped provider, checking it exists before touching embeddings", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "p1", workspaceId: "ws-1" }]); // requireWorkspaceMutable
+      const updated = { id: "p1", workspaceId: "ws-1", name: "Renamed" };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const result = await updateProvider(
+        { kind: "workspace", ctx: workspaceCtx },
+        "p1",
+        { ...updateFields(), name: "Renamed" },
+      );
+
+      expect(result).toEqual({ row: updated, aliasRepoints: [] });
+      expect(handleEmbeddingConfigChange).toHaveBeenCalledWith(
+        "p1",
+        expect.objectContaining({ name: "Renamed" }),
+      );
+    });
+
+    it("throws NotFoundError for a workspace-scoped provider not visible here, before touching embeddings", async () => {
+      mockDb.limit.mockResolvedValueOnce([]); // resolveScoped: no row
+
+      await expect(
+        updateProvider(
+          { kind: "workspace", ctx: workspaceCtx },
+          "missing",
+          updateFields(),
+        ),
+      ).rejects.toThrow(NotFoundError);
+      expect(handleEmbeddingConfigChange).not.toHaveBeenCalled();
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("throws LockedError for an attached Shared provider on the workspace surface", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "p1", organizationId: "org-1", workspaceId: null },
+        ])
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attached
+
+      await expect(
+        updateProvider(
+          { kind: "workspace", ctx: workspaceCtx },
+          "p1",
+          updateFields(),
+        ),
+      ).rejects.toThrow(LockedError);
+      expect(handleEmbeddingConfigChange).not.toHaveBeenCalled();
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("updates an organization-scoped provider after checking it is a Shared resource here (#605)", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "p1", organizationId: "org-1", workspaceId: null },
+      ]); // requireOrgScoped
+      const updated = { id: "p1", organizationId: "org-1" };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const result = await updateProvider(
+        { kind: "organization", orgId: "org-1" },
+        "p1",
+        updateFields(),
+      );
+
+      expect(result).toEqual({ row: updated, aliasRepoints: [] });
+      expect(handleEmbeddingConfigChange).toHaveBeenCalled();
+    });
+
+    it("throws NotFoundError for an organization-scoped provider that is not Shared here, before touching embeddings (#605)", async () => {
+      // The existence check the Organization surface used to skip entirely —
+      // it now runs, and refuses, before the write ever reaches the db.
+      mockDb.limit.mockResolvedValueOnce([]); // requireOrgScoped: not found
+
+      await expect(
+        updateProvider(
+          { kind: "organization", orgId: "org-1" },
+          "missing",
+          updateFields(),
+        ),
+      ).rejects.toThrow(NotFoundError);
+      expect(handleEmbeddingConfigChange).not.toHaveBeenCalled();
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("snapshots models before the write and de-migrates orphaned aliases after", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "p1", workspaceId: "ws-1" }]);
+      const previousModels = [
+        { id: "gpt-4", alias: "flagship", passthroughFileTypes: [] },
+      ];
+      const nextModels = [{ id: "gpt-4", passthroughFileTypes: [] }];
+      vi.mocked(currentProviderModels).mockResolvedValueOnce(previousModels);
+      vi.mocked(deMigrateOrphanedAliases).mockResolvedValueOnce([
+        { alias: "flagship", modelId: "gpt-4", agents: 2, chats: 1 },
+      ]);
+      const updated = { id: "p1" };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const result = await updateProvider(
+        { kind: "workspace", ctx: workspaceCtx },
+        "p1",
+        { ...updateFields(), modelIds: nextModels },
+      );
+
+      expect(currentProviderModels).toHaveBeenCalledWith("p1");
+      expect(deMigrateOrphanedAliases).toHaveBeenCalledWith(
+        "p1",
+        previousModels,
+        nextModels,
+      );
+      expect(result.aliasRepoints).toEqual([
+        { alias: "flagship", modelId: "gpt-4", agents: 2, chats: 1 },
+      ]);
+    });
+  });
+
+  describe("deleteProvider", () => {
+    it("deletes a workspace-scoped provider and invalidates embeddings, without de-migrating aliases", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "p1", workspaceId: "ws-1" }]);
+      mockDb.returning.mockResolvedValueOnce([{ id: "p1" }]);
+
+      await deleteProvider({ kind: "workspace", ctx: workspaceCtx }, "p1");
+
+      expect(nullifyEmbeddingsForProvider).toHaveBeenCalledWith("p1");
+      expect(deMigrateOrphanedAliases).not.toHaveBeenCalled();
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+
+    it("throws LockedError for an attached Shared provider on the workspace surface, before invalidating embeddings", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "p1", organizationId: "org-1", workspaceId: null },
+        ])
+        .mockResolvedValueOnce([{ id: "att-1" }]);
+
+      await expect(
+        deleteProvider({ kind: "workspace", ctx: workspaceCtx }, "p1"),
+      ).rejects.toThrow(LockedError);
+      expect(nullifyEmbeddingsForProvider).not.toHaveBeenCalled();
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("deletes an organization-scoped provider once it is confirmed deletable", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([]) // requireSharedDeletable: no attachment
+        .mockResolvedValueOnce([]); // requireSharedDeletable: no blueprint
+      mockDb.returning.mockResolvedValueOnce([{ id: "p1" }]);
+
+      await deleteProvider({ kind: "organization", orgId: "org-1" }, "p1");
+
+      expect(nullifyEmbeddingsForProvider).toHaveBeenCalledWith("p1");
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+
+    it("throws ConflictError while an Attachment still references the organization-scoped provider", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]); // attached
+
+      await expect(
+        deleteProvider({ kind: "organization", orgId: "org-1" }, "p1"),
+      ).rejects.toThrow(ConflictError);
+      expect(nullifyEmbeddingsForProvider).not.toHaveBeenCalled();
+    });
+
+    it("throws NotFoundError when the organization-scoped delete matches no row", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([]) // requireSharedDeletable: no attachment
+        .mockResolvedValueOnce([]); // requireSharedDeletable: no blueprint
+      mockDb.returning.mockResolvedValueOnce([]); // delete matched nothing
+
+      await expect(
+        deleteProvider({ kind: "organization", orgId: "org-1" }, "missing"),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+});

--- a/apps/backend/src/services/provider-write.ts
+++ b/apps/backend/src/services/provider-write.ts
@@ -1,0 +1,215 @@
+import type { z } from "zod";
+import type { SQL } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { db } from "../index.ts";
+import { provider as providerTable } from "../db/schema.ts";
+import type {
+  providerCreateSchema,
+  ProviderUpdateData,
+  AliasRepoint,
+} from "@platypus/schemas";
+import type { ScopeContext } from "../scope.ts";
+import { NotFoundError } from "../errors.ts";
+import { dedupeModelConfigs } from "./model-capability.ts";
+import {
+  handleEmbeddingConfigChange,
+  nullifyEmbeddingsForProvider,
+} from "./embedding-invalidation.ts";
+import {
+  currentProviderModels,
+  deMigrateOrphanedAliases,
+} from "./model-alias-migration.ts";
+import {
+  orgScopedWhere,
+  requireOrgScoped,
+  requireSharedDeletable,
+  requireWorkspaceMutable,
+  workspaceScopedWhere,
+} from "./scoped-resource.ts";
+
+/**
+ * The Provider write model: the five-step save ordering — dedupe model
+ * configs, invalidate stale embeddings (BEFORE the write), snapshot the
+ * current models (BEFORE the write, for the alias diff), write the row, then
+ * de-migrate any alias the save orphaned (AFTER the write) — plus create and
+ * delete. Both the Workspace route (`routes/provider.ts`) and the Organization
+ * route (`routes/org-provider.ts`) are thin adapters over it; they used to
+ * each carry a verbatim copy of the ordering and had already drifted (#605):
+ * the Workspace copy checked the Provider existed before touching embeddings,
+ * the Organization copy did not, discovering a missing row only when the
+ * `UPDATE` matched nothing.
+ *
+ * Distinct from `services/provider.ts`, which is the vendor-SDK adapter
+ * (`openProvider`) — an unrelated seam that happens to share a resource name.
+ */
+
+export type ProviderRow = typeof providerTable.$inferSelect;
+
+/** The fields a create carries — every field but the id and its scope. */
+export type ProviderCreateFields = Omit<
+  z.infer<typeof providerCreateSchema>,
+  "organizationId" | "workspaceId"
+>;
+
+/** The fields an update carries — providerUpdateSchema replaces the form wholesale. */
+export type ProviderUpdateFields = ProviderUpdateData;
+
+export type ProviderUpdateResult = {
+  row: ProviderRow;
+  aliasRepoints: AliasRepoint[];
+};
+
+/**
+ * Which scope a write targets — the Workspace surface (ADR-0006 delegation
+ * applies, a Shared row is locked) or the Organization surface (admin-only,
+ * writes a Shared row directly). The one write model answers both surfaces by
+ * branching on this rather than existing twice.
+ */
+export type ProviderScope =
+  | { kind: "workspace"; ctx: ScopeContext }
+  | { kind: "organization"; orgId: string };
+
+/** Dedupes `modelIds` when the write carries any; passes through otherwise. */
+const dedupeModels = <T extends { modelIds?: unknown }>(fields: T): T =>
+  fields.modelIds
+    ? {
+        ...fields,
+        modelIds: dedupeModelConfigs(
+          fields.modelIds as Parameters<typeof dedupeModelConfigs>[0],
+        ),
+      }
+    : fields;
+
+/**
+ * Creates a new Provider at the given scope. The scope comes from `scope`,
+ * never the body — a caller cannot name another Workspace, or mint a Shared
+ * Provider from the Workspace surface, by setting `organizationId`/
+ * `workspaceId` in the request (ADR-0006, ADR-0007). A duplicate name
+ * surfaces as a Postgres unique violation, mapped to 409 by the central
+ * `onError` (ADR-0010).
+ */
+export async function createProvider(
+  scope: ProviderScope,
+  fields: ProviderCreateFields,
+): Promise<ProviderRow> {
+  const data = dedupeModels(fields);
+
+  const [row] = await db
+    .insert(providerTable)
+    .values({
+      id: nanoid(),
+      ...data,
+      ...(scope.kind === "workspace"
+        ? { workspaceId: scope.ctx.workspaceId, organizationId: null }
+        : { organizationId: scope.orgId, workspaceId: null }),
+    })
+    .returning();
+  return row;
+}
+
+/**
+ * Updates a Provider at the given scope, running the five-step save ordering.
+ * Throws `NotFoundError` when the Provider is not visible at this scope, and
+ * (Workspace scope only) `LockedError` when it is a Shared Provider edited
+ * only on the Organization surface (ADR-0007).
+ */
+export async function updateProvider(
+  scope: ProviderScope,
+  providerId: string,
+  fields: ProviderUpdateFields,
+): Promise<ProviderUpdateResult> {
+  const data = dedupeModels(fields);
+
+  let where: SQL;
+  if (scope.kind === "workspace") {
+    // A Shared Provider is a single source of truth edited only on the
+    // Organization surface (ADR-0007); requireWorkspaceMutable throws
+    // NotFound (→404) when the Provider is not visible here, then Locked
+    // (→403) when it is org-scoped.
+    await requireWorkspaceMutable(db, "provider", providerId, scope.ctx);
+    where = workspaceScopedWhere("provider", providerId, scope.ctx.workspaceId);
+  } else {
+    // The existence check the Organization surface previously skipped
+    // (#605): requireOrgScoped throws NotFound (→404) before the write ever
+    // touches embeddings.
+    await requireOrgScoped(db, "provider", providerId, scope.orgId);
+    where = orgScopedWhere("provider", providerId, scope.orgId);
+  }
+
+  // Detect and handle embedding config changes before the update.
+  await handleEmbeddingConfigChange(providerId, data);
+
+  // Snapshot the models as stored, so an alias this save removes can
+  // de-migrate its references rather than dangling them (ADR-0017).
+  const previousModels = data.modelIds
+    ? await currentProviderModels(providerId)
+    : null;
+
+  // A duplicate name surfaces as a Postgres unique violation, mapped to 409
+  // by the central onError (ADR-0010).
+  const [row] = await db
+    .update(providerTable)
+    .set({ ...data, updatedAt: new Date() })
+    .where(where)
+    .returning();
+
+  // Runs AFTER the row is written: a failed update must not leave Agents
+  // repointed for an alias that still exists.
+  const aliasRepoints =
+    previousModels && data.modelIds
+      ? await deMigrateOrphanedAliases(
+          providerId,
+          previousModels,
+          data.modelIds,
+        )
+      : [];
+
+  return { row, aliasRepoints };
+}
+
+/**
+ * Deletes a Provider at the given scope. Throws `NotFoundError` (Workspace
+ * scope, via `requireWorkspaceMutable`; Organization scope, when the delete
+ * matches no row) and, Workspace scope only, `LockedError` for a Shared
+ * Provider (ADR-0007). Organization scope also throws `ConflictError` while
+ * an Attachment or Blueprint still references the Provider (ADR-0007/0008).
+ */
+export async function deleteProvider(
+  scope: ProviderScope,
+  providerId: string,
+): Promise<void> {
+  let where: SQL;
+  if (scope.kind === "workspace") {
+    await requireWorkspaceMutable(db, "provider", providerId, scope.ctx);
+    where = workspaceScopedWhere("provider", providerId, scope.ctx.workspaceId);
+  } else {
+    // A Shared resource cannot be deleted while anything still points at it —
+    // an Attachment (ADR-0007) or a Blueprint (ADR-0008). Throws ConflictError
+    // → 409 via the central onError (ADR-0010).
+    await requireSharedDeletable(db, "provider", providerId);
+    where = orgScopedWhere("provider", providerId, scope.orgId);
+  }
+
+  // Deleting removes every model this Provider defined, so any Workspace
+  // whose memory embeddings were computed against it now points at a config
+  // that no longer resolves. Run BEFORE the delete: `nullifyEmbeddingsForProvider`
+  // finds affected Workspaces via `workspace.memoryEmbeddingProviderId`, which
+  // the FK's `ON DELETE SET NULL` would otherwise have already cleared.
+  //
+  // Alias de-migration intentionally does NOT run here. De-migration rewrites
+  // a reference to the concrete model id an alias pointed at (ADR-0017) — but
+  // a delete removes every one of this Provider's models, so there is no
+  // surviving concrete id for an orphaned alias to fall back to. That case is
+  // exactly what an update that merely drops one alias exists to handle.
+  await nullifyEmbeddingsForProvider(providerId);
+
+  const result = await db.delete(providerTable).where(where).returning();
+
+  // Workspace scope: requireWorkspaceMutable already established the row
+  // exists, so the delete always matches. Organization scope: requireSharedDeletable
+  // only checks referencing Attachments/Blueprints, not existence, so the
+  // delete itself is where a missing Provider 404s.
+  if (scope.kind === "organization" && result.length === 0) {
+    throw new NotFoundError("Provider not found");
+  }
+}

--- a/apps/backend/src/services/scoped-resource.test.ts
+++ b/apps/backend/src/services/scoped-resource.test.ts
@@ -19,6 +19,7 @@ import {
   listOrgScopedIds,
   orgScopedWhere,
   orgScopedWhereIn,
+  workspaceScopedWhere,
   isScopedResourceType,
 } from "./scoped-resource.ts";
 import { NotFoundError, LockedError, ConflictError } from "../errors.ts";
@@ -223,6 +224,22 @@ describe("ScopedResource module", () => {
       expect(inArray).toHaveBeenCalledWith(agentTable.id, ids);
       expect(eq).toHaveBeenCalledWith(agentTable.organizationId, "org-1");
       expect(isNull).toHaveBeenCalledWith(agentTable.workspaceId);
+    });
+  });
+
+  describe("workspaceScopedWhere", () => {
+    it("matches on id and workspace — the write-side counterpart to resolveScoped", () => {
+      workspaceScopedWhere("agent", "a1", "ws-1");
+
+      expect(eq).toHaveBeenCalledWith(agentTable.id, "a1");
+      expect(eq).toHaveBeenCalledWith(agentTable.workspaceId, "ws-1");
+    });
+
+    it("resolves the columns of the type it is given", () => {
+      workspaceScopedWhere("mcp", "m1", "ws-1");
+
+      expect(eq).toHaveBeenCalledWith(mcpTable.id, "m1");
+      expect(eq).toHaveBeenCalledWith(mcpTable.workspaceId, "ws-1");
     });
   });
 

--- a/apps/backend/src/services/scoped-resource.ts
+++ b/apps/backend/src/services/scoped-resource.ts
@@ -135,6 +135,27 @@ export const orgScopedWhere = (
 };
 
 /**
+ * The `WHERE` clause matching a single Scoped resource inside a Workspace —
+ * the write-side counterpart to {@link resolveScoped}, mirroring
+ * {@link orgScopedWhere} for the Workspace surface. Deliberately narrower than
+ * `resolveScoped`: it matches only a directly-owned (Workspace-scoped) row, not
+ * an attached Shared one, because every Workspace-surface write already
+ * establishes that distinction itself — `requireWorkspaceMutable` throws
+ * `LockedError` for a Shared row before a caller ever builds this predicate.
+ * An `UPDATE`/`DELETE`/`SELECT` on the Workspace surface passes it straight to
+ * `.where(...)`, replacing the hand-rolled `and(eq(table.id, id),
+ * eq(table.workspaceId, workspaceId))` that 18 call sites each re-wrote.
+ */
+export const workspaceScopedWhere = (
+  type: ScopedResourceType,
+  id: string,
+  workspaceId: string,
+): SQL => {
+  const { table } = REGISTRY[type];
+  return allOf(eq(table.id, id), eq(table.workspaceId, workspaceId));
+};
+
+/**
  * {@link orgScopedWhere} over a set of ids — for the callers that validate a
  * batch of references in one query rather than a row at a time.
  */

--- a/apps/backend/src/tools/skill-management.ts
+++ b/apps/backend/src/tools/skill-management.ts
@@ -9,6 +9,7 @@ import {
   listScoped,
   resolveScopedByName,
   workspaceMutationLockedMessage,
+  workspaceScopedWhere,
 } from "../services/scoped-resource.ts";
 import type { ScopeContext } from "../scope.ts";
 
@@ -165,12 +166,7 @@ export function createSkillManagementTools(
 
       await db
         .delete(skillTable)
-        .where(
-          and(
-            eq(skillTable.id, skillId),
-            eq(skillTable.workspaceId, workspaceId),
-          ),
-        );
+        .where(workspaceScopedWhere("skill", skillId, workspaceId));
 
       return { success: true };
     },


### PR DESCRIPTION
## Summary

- Extracts the Provider save/delete lifecycle into a new `services/provider-write.ts` write model, taking a workspace-or-organization scope, so `routes/provider.ts` and `routes/org-provider.ts` become thin adapters instead of each carrying a verbatim (and already-drifted) copy of the five-step save ordering.
- Fixes the drift: the Organization surface now checks the Provider exists (`requireOrgScoped`) before touching embedding invalidation, instead of only discovering a missing row when the `UPDATE` matched nothing.
- Provider delete now runs `nullifyEmbeddingsForProvider` (previously skipped, leaving stale `memory_daily_summary.embedding` rows). Alias de-migration is intentionally skipped on delete, with a comment explaining why: removing the Provider removes every model, so there's no surviving concrete id for an orphaned alias to fall back to.
- Adds `services/scoped-resource.ts`'s workspace-side write predicate (`workspaceScopedWhere`, mirroring the existing `orgScopedWhere`) and migrates the 18 hand-rolled `eq(id) + eq(workspaceId)` predicates across `routes/agent.ts`, `routes/mcp.ts`, `routes/provider.ts`, `routes/skill.ts`, `services/agent.ts`, and `tools/skill-management.ts` to use it.

This covers stages 1–2 of #605's staged Direction (Provider write model, workspace-side write predicate). Stages 3–4 (folding `org-agent.ts` into the Agent write model; new Skill/Attachment write models) are left for a follow-up, per the issue's own guidance to land 1-2 stages and file a follow-up if the rest doesn't fit in one PR.

Refs #605.