### PR TITLE
chore(frontend): api-write — distinct forbidden outcome, one shared outcome-applier

### DIFF
--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/boards/[boardId]/settings/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/boards/[boardId]/settings/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import type { KanbanBoardState } from "@platypus/schemas";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { writeEntity } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import { applyDeleteOutcome } from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { BackButton } from "@/components/back-button";
@@ -46,10 +46,8 @@ const BoardSettingsPage = ({
       { id: boardId },
     );
 
-    await applyWriteOutcome(result, {
+    await applyDeleteOutcome(result, {
       mutate: globalMutate,
-      setValidationErrors: () => {},
-      conflictField: null,
       onSuccess: () => router.push(`/${orgId}/workspace/${workspaceId}`),
       onError: (message) => {
         toast.error(message);

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/boards/[boardId]/settings/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/boards/[boardId]/settings/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import type { KanbanBoardState } from "@platypus/schemas";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { writeEntity } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { BackButton } from "@/components/back-button";
@@ -45,14 +46,17 @@ const BoardSettingsPage = ({
       { id: boardId },
     );
 
-    if (result.outcome === "success") {
-      result.revalidateKeys.forEach((key) => globalMutate(key));
-      router.push(`/${orgId}/workspace/${workspaceId}`);
-    } else {
-      toast.error(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    }
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors: () => {},
+      conflictField: null,
+      onSuccess: () => router.push(`/${orgId}/workspace/${workspaceId}`),
+      onError: (message) => {
+        toast.error(message);
+        setIsDeleting(false);
+        setIsDeleteDialogOpen(false);
+      },
+    });
   };
 
   if (error) {

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -52,7 +52,11 @@ import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity, writeAt, errorMessage } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import {
+  applyWriteOutcome,
+  applyDeleteOutcome,
+  toastGuidanceOrError,
+} from "@/lib/apply-write-outcome";
 import { findModelOption, getModelOptions } from "@/lib/model-config";
 import { resolveModel } from "@/lib/resolve-model";
 import {
@@ -398,15 +402,7 @@ const AgentForm = ({
               : "Failed to save agent",
           );
         },
-        onError: (message, outcome) => {
-          if (outcome.outcome === "forbidden") {
-            // Guidance, not a failure — the backend's message already says
-            // where the Shared resource is actually managed (#570).
-            toast.info(message);
-          } else {
-            toast.error(message);
-          }
-        },
+        onError: toastGuidanceOrError,
         onSuccess: async (data) => {
           const savedAgentId = data.id || agentId;
 
@@ -462,19 +458,11 @@ const AgentForm = ({
       id: agentId,
     });
 
-    await applyWriteOutcome(result, {
+    await applyDeleteOutcome(result, {
       mutate,
-      setValidationErrors: () => {},
-      conflictField: null,
       onSuccess: () => router.push(doneHref),
       onError: (message, outcome) => {
-        if (outcome.outcome === "forbidden") {
-          // Guidance, not a failure — the backend's message already says
-          // where the Shared resource is actually managed (#570).
-          toast.info(message);
-        } else {
-          toast.error(message);
-        }
+        toastGuidanceOrError(message, outcome);
         setIsDeleting(false);
         setIsDeleteDialogOpen(false);
       },

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -52,6 +52,7 @@ import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity, writeAt, errorMessage } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import { findModelOption, getModelOptions } from "@/lib/model-config";
 import { resolveModel } from "@/lib/resolve-model";
 import {
@@ -383,9 +384,31 @@ const AgentForm = ({
         data: payload,
       });
 
-      switch (result.outcome) {
-        case "success": {
-          const savedAgentId = result.data.id || agentId;
+      await applyWriteOutcome(result, {
+        mutate,
+        setValidationErrors,
+        onInvalid: (fieldErrors) => {
+          setValidationErrors(fieldErrors);
+          // Surface a user-visible signal even when the failure maps to a
+          // field without an inline error, so a rejected save is never
+          // silent (#331).
+          toast.error(
+            Object.keys(fieldErrors).length > 0
+              ? "Please fix the highlighted fields and try again"
+              : "Failed to save agent",
+          );
+        },
+        onError: (message, outcome) => {
+          if (outcome.outcome === "forbidden") {
+            // Guidance, not a failure — the backend's message already says
+            // where the Shared resource is actually managed (#570).
+            toast.info(message);
+          } else {
+            toast.error(message);
+          }
+        },
+        onSuccess: async (data) => {
+          const savedAgentId = data.id || agentId;
 
           // The Agent itself already saved, so a failed avatar write is a
           // partial success, not a reason to block navigation — surface a
@@ -419,34 +442,9 @@ const AgentForm = ({
             }
           }
 
-          result.revalidateKeys.forEach((key) => mutate(key));
           router.push(doneHref);
-          break;
-        }
-        case "invalid":
-          setValidationErrors(result.fieldErrors);
-          // Surface a user-visible signal even when the failure maps to a
-          // field without an inline error, so a rejected save is never
-          // silent (#331).
-          toast.error(
-            Object.keys(result.fieldErrors).length > 0
-              ? "Please fix the highlighted fields and try again"
-              : "Failed to save agent",
-          );
-          break;
-        case "conflict":
-          setValidationErrors({ name: result.message });
-          break;
-        case "locked":
-          // Guidance, not a failure — the backend's message already says
-          // where the Shared resource is actually managed (#570).
-          toast.info(result.message);
-          break;
-        case "notFound":
-        case "error":
-          toast.error(result.message);
-          break;
-      }
+        },
+      });
     } catch (error) {
       console.error("Error saving agent:", error);
       toast.error("Failed to save agent");
@@ -464,20 +462,23 @@ const AgentForm = ({
       id: agentId,
     });
 
-    if (result.outcome === "success") {
-      result.revalidateKeys.forEach((key) => mutate(key));
-      router.push(doneHref);
-    } else if (result.outcome === "locked") {
-      // Guidance, not a failure — the backend's message already says where
-      // the Shared resource is actually managed (#570).
-      toast.info(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    } else {
-      toast.error(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    }
+    await applyWriteOutcome(result, {
+      mutate,
+      setValidationErrors: () => {},
+      conflictField: null,
+      onSuccess: () => router.push(doneHref),
+      onError: (message, outcome) => {
+        if (outcome.outcome === "forbidden") {
+          // Guidance, not a failure — the backend's message already says
+          // where the Shared resource is actually managed (#570).
+          toast.info(message);
+        } else {
+          toast.error(message);
+        }
+        setIsDeleting(false);
+        setIsDeleteDialogOpen(false);
+      },
+    });
   };
 
   if (providersLoading || agentLoading) {

--- a/apps/frontend/components/agents-list.tsx
+++ b/apps/frontend/components/agents-list.tsx
@@ -66,7 +66,7 @@ import { canManageSharedResource } from "@/lib/authorization";
 import { NoProvidersEmptyState } from "@/components/no-providers-empty-state";
 import { AttachSharedResourceDialog } from "@/components/attach-shared-resource-dialog";
 import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import { applyDeleteOutcome } from "@/lib/apply-write-outcome";
 import { useDetachDialog } from "@/hooks/use-detach-dialog";
 
 // The Agent is shown either in a Workspace, where it may be a workspace-scoped
@@ -197,10 +197,8 @@ export const AgentsList = ({
       const outcome = await writeEntity(backendUrl, "agents", scope, {
         id: agentToDelete.id,
       });
-      await applyWriteOutcome(outcome, {
+      await applyDeleteOutcome(outcome, {
         mutate: () => mutate(),
-        setValidationErrors: () => {},
-        conflictField: null,
         onSuccess: () => {
           setDeleteDialogOpen(false);
           setAgentToDelete(null);

--- a/apps/frontend/components/agents-list.tsx
+++ b/apps/frontend/components/agents-list.tsx
@@ -66,6 +66,8 @@ import { canManageSharedResource } from "@/lib/authorization";
 import { NoProvidersEmptyState } from "@/components/no-providers-empty-state";
 import { AttachSharedResourceDialog } from "@/components/attach-shared-resource-dialog";
 import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import { useDetachDialog } from "@/hooks/use-detach-dialog";
 
 // The Agent is shown either in a Workspace, where it may be a workspace-scoped
 // Agent or an attached org-scoped (Shared) Agent rendered with an Organization
@@ -104,10 +106,8 @@ export const AgentsList = ({
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [attachOpen, setAttachOpen] = useState(false);
-  const [selectedOrgAgent, setSelectedOrgAgent] =
-    useState<AgentWithScope | null>(null);
+  const orgAgentDetach = useDetachDialog<AgentWithScope>();
   const [detaching, setDetaching] = useState(false);
-  const [detachError, setDetachError] = useState<string | null>(null);
   const [agentToPromote, setAgentToPromote] = useState<AgentWithScope | null>(
     null,
   );
@@ -197,19 +197,26 @@ export const AgentsList = ({
       const outcome = await writeEntity(backendUrl, "agents", scope, {
         id: agentToDelete.id,
       });
-      if (outcome.outcome === "success") {
-        mutate();
-        setDeleteDialogOpen(false);
-        setAgentToDelete(null);
-      } else if (outcome.outcome === "locked") {
-        // Guidance, not a failure — the backend's message already says
-        // where the Shared resource is actually managed (#570).
-        setDeleteDialogOpen(false);
-        setAgentToDelete(null);
-        toast.info(outcome.message);
-      } else {
-        setDeleteError(outcome.message);
-      }
+      await applyWriteOutcome(outcome, {
+        mutate: () => mutate(),
+        setValidationErrors: () => {},
+        conflictField: null,
+        onSuccess: () => {
+          setDeleteDialogOpen(false);
+          setAgentToDelete(null);
+        },
+        onError: (message, result) => {
+          if (result.outcome === "forbidden") {
+            // Guidance, not a failure — the backend's message already says
+            // where the Shared resource is actually managed (#570).
+            setDeleteDialogOpen(false);
+            setAgentToDelete(null);
+            toast.info(message);
+          } else {
+            setDeleteError(message);
+          }
+        },
+      });
     } finally {
       setDeleting(false);
     }
@@ -289,7 +296,7 @@ export const AgentsList = ({
   const detachOrgAgent = async (agentId: string) => {
     if (!backendUrl) return;
     setDetaching(true);
-    setDetachError(null);
+    orgAgentDetach.setError(null);
     try {
       const outcome = await writeEntity(
         backendUrl,
@@ -300,10 +307,10 @@ export const AgentsList = ({
         },
       );
       if (outcome.outcome === "success") {
-        setSelectedOrgAgent(null);
+        orgAgentDetach.close();
         await mutate();
       } else {
-        setDetachError(outcome.message);
+        orgAgentDetach.setError(outcome.message);
       }
     } finally {
       setDetaching(false);
@@ -343,10 +350,7 @@ export const AgentsList = ({
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="cursor-pointer"
-                onSelect={() => {
-                  setDetachError(null);
-                  setSelectedOrgAgent(agent);
-                }}
+                onSelect={() => orgAgentDetach.open(agent)}
               >
                 <Unlink /> Detach
               </DropdownMenuItem>
@@ -597,37 +601,28 @@ export const AgentsList = ({
       )}
 
       <Dialog
-        open={!!selectedOrgAgent}
+        open={!!orgAgentDetach.selected}
         onOpenChange={(open) => {
-          if (!open) {
-            setSelectedOrgAgent(null);
-            setDetachError(null);
-          }
+          if (!open) orgAgentDetach.close();
         }}
       >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Detach shared agent</DialogTitle>
             <DialogDescription>
-              Detach <strong>{selectedOrgAgent?.name}</strong> from this
+              Detach <strong>{orgAgentDetach.selected?.name}</strong> from this
               workspace? The shared agent itself is not deleted; it just stops
               appearing here.
             </DialogDescription>
           </DialogHeader>
-          {detachError && (
-            <p className="text-sm text-destructive">{detachError}</p>
+          {orgAgentDetach.error && (
+            <p className="text-sm text-destructive">{orgAgentDetach.error}</p>
           )}
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setSelectedOrgAgent(null);
-                setDetachError(null);
-              }}
-            >
+            <Button variant="outline" onClick={orgAgentDetach.close}>
               Close
             </Button>
-            {canManageShared && selectedOrgAgent && (
+            {canManageShared && orgAgentDetach.selected && (
               <Button asChild variant="ghost">
                 <Link href={`/${orgId}/settings/agents`}>
                   <ExternalLink className="size-4" />
@@ -635,11 +630,11 @@ export const AgentsList = ({
                 </Link>
               </Button>
             )}
-            {selectedOrgAgent && (
+            {orgAgentDetach.selected && (
               <Button
                 variant="destructive"
                 disabled={detaching}
-                onClick={() => detachOrgAgent(selectedOrgAgent.id)}
+                onClick={() => detachOrgAgent(orgAgentDetach.selected!.id)}
               >
                 <Unlink className="size-4" />
                 Detach

--- a/apps/frontend/components/blueprint-form.tsx
+++ b/apps/frontend/components/blueprint-form.tsx
@@ -35,6 +35,7 @@ import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 
@@ -313,26 +314,12 @@ const BlueprintForm = ({
       { id: blueprintId, data: payload },
     );
 
-    switch (result.outcome) {
-      case "success":
-        result.revalidateKeys.forEach((key) => globalMutate(key));
-        router.push(returnPath);
-        break;
-      case "invalid":
-        setValidationErrors(result.fieldErrors);
-        if (Object.keys(result.fieldErrors).length === 0) {
-          setFormError(result.message);
-        }
-        break;
-      case "conflict":
-        setValidationErrors({ name: result.message });
-        break;
-      case "locked":
-      case "notFound":
-      case "error":
-        setFormError(result.message);
-        break;
-    }
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors,
+      onSuccess: () => router.push(returnPath),
+      onError: (message) => setFormError(message),
+    });
 
     setIsSubmitting(false);
   };
@@ -348,13 +335,16 @@ const BlueprintForm = ({
       { id: blueprintId },
     );
 
-    if (result.outcome === "success") {
-      result.revalidateKeys.forEach((key) => globalMutate(key));
-      router.push(returnPath);
-    } else {
-      setDeleteError(result.message);
-      setIsDeleting(false);
-    }
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors: () => {},
+      conflictField: null,
+      onSuccess: () => router.push(returnPath),
+      onError: (message) => {
+        setDeleteError(message);
+        setIsDeleting(false);
+      },
+    });
   };
 
   return (

--- a/apps/frontend/components/blueprint-form.tsx
+++ b/apps/frontend/components/blueprint-form.tsx
@@ -35,7 +35,10 @@ import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import {
+  applyWriteOutcome,
+  applyDeleteOutcome,
+} from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 
@@ -335,10 +338,8 @@ const BlueprintForm = ({
       { id: blueprintId },
     );
 
-    await applyWriteOutcome(result, {
+    await applyDeleteOutcome(result, {
       mutate: globalMutate,
-      setValidationErrors: () => {},
-      conflictField: null,
       onSuccess: () => router.push(returnPath),
       onError: (message) => {
         setDeleteError(message);

--- a/apps/frontend/components/invitation-form.tsx
+++ b/apps/frontend/components/invitation-form.tsx
@@ -17,6 +17,7 @@ import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import type { Blueprint } from "@platypus/schemas";
@@ -95,32 +96,26 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
       },
     );
 
-    switch (result.outcome) {
-      case "success":
-        result.revalidateKeys.forEach((key) => globalMutate(key));
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors,
+      conflictField: "email",
+      onInvalid: (fieldErrors, message) => {
+        setValidationErrors(fieldErrors);
+        toast.error(
+          Object.keys(fieldErrors).length > 0
+            ? "Please fix the errors in the form"
+            : message,
+        );
+      },
+      onSuccess: () => {
         toast.success("Invitation created");
         setEmail("");
         setWorkspaceName("");
         setBlueprintIds([]);
         onSuccess?.();
-        break;
-      case "invalid":
-        setValidationErrors(result.fieldErrors);
-        toast.error(
-          Object.keys(result.fieldErrors).length > 0
-            ? "Please fix the errors in the form"
-            : result.message,
-        );
-        break;
-      case "conflict":
-        setValidationErrors({ email: result.message });
-        break;
-      case "locked":
-      case "notFound":
-      case "error":
-        toast.error(result.message);
-        break;
-    }
+      },
+    });
 
     setIsSubmitting(false);
   };

--- a/apps/frontend/components/kanban-board-form.tsx
+++ b/apps/frontend/components/kanban-board-form.tsx
@@ -13,6 +13,7 @@ import { useBackendUrl } from "@/app/client-context";
 import { joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import { KANBAN_LABEL_COLORS, type KanbanLabel } from "@platypus/schemas";
 import { toast } from "sonner";
 
@@ -91,38 +92,23 @@ export function KanbanBoardForm({
       },
     );
 
-    switch (result.outcome) {
-      case "success":
-        result.revalidateKeys.forEach((key) => mutate(key));
+    await applyWriteOutcome(result, {
+      mutate,
+      setValidationErrors,
+      onSuccess: async (data) => {
         if (isEditing) {
           toast.success("Board updated");
           onSuccess?.();
         } else {
           const stateUrl = joinUrl(
             backendUrl,
-            `/organizations/${orgId}/workspaces/${workspaceId}/boards/${result.data.id}/state`,
+            `/organizations/${orgId}/workspaces/${workspaceId}/boards/${data.id}/state`,
           );
-          await mutate(stateUrl, { board: result.data, columns: [] }, false);
-          router.push(
-            `/${orgId}/workspace/${workspaceId}/boards/${result.data.id}`,
-          );
+          await mutate(stateUrl, { board: data, columns: [] }, false);
+          router.push(`/${orgId}/workspace/${workspaceId}/boards/${data.id}`);
         }
-        break;
-      case "invalid":
-        setValidationErrors(result.fieldErrors);
-        if (Object.keys(result.fieldErrors).length === 0) {
-          toast.error(result.message);
-        }
-        break;
-      case "conflict":
-        setValidationErrors({ name: result.message });
-        break;
-      case "locked":
-      case "notFound":
-      case "error":
-        toast.error(result.message);
-        break;
-    }
+      },
+    });
 
     setIsSubmitting(false);
   };

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -35,6 +35,7 @@ import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity, writeAt } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -252,29 +253,24 @@ const McpForm = ({
       { id: existingId, data: payload },
     );
 
-    switch (result.outcome) {
-      case "success":
-        result.revalidateKeys.forEach((key) => globalMutate(key));
-        return result.data.id;
-      case "invalid":
-        setValidationErrors(result.fieldErrors);
-        if (Object.keys(result.fieldErrors).length === 0) {
-          toast.error(result.message);
+    let savedId: string | null = null;
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors,
+      onSuccess: (data) => {
+        savedId = data.id;
+      },
+      onError: (message, outcome) => {
+        if (outcome.outcome === "forbidden") {
+          // Guidance, not a failure — the backend's message already says
+          // where the Shared resource is actually managed (#570).
+          toast.info(message);
+        } else {
+          toast.error(message);
         }
-        return null;
-      case "conflict":
-        setValidationErrors({ name: result.message });
-        return null;
-      case "locked":
-        // Guidance, not a failure — the backend's message already says
-        // where the Shared resource is actually managed (#570).
-        toast.info(result.message);
-        return null;
-      case "notFound":
-      case "error":
-        toast.error(result.message);
-        return null;
-    }
+      },
+    });
+    return savedId;
   };
 
   const handleSubmit = async () => {
@@ -301,20 +297,23 @@ const McpForm = ({
       id: mcpId,
     });
 
-    if (result.outcome === "success") {
-      result.revalidateKeys.forEach((key) => globalMutate(key));
-      router.push(listPath);
-    } else if (result.outcome === "locked") {
-      // Guidance, not a failure — the backend's message already says where
-      // the Shared resource is actually managed (#570).
-      toast.info(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    } else {
-      toast.error(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    }
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors: () => {},
+      conflictField: null,
+      onSuccess: () => router.push(listPath),
+      onError: (message, outcome) => {
+        if (outcome.outcome === "forbidden") {
+          // Guidance, not a failure — the backend's message already says
+          // where the Shared resource is actually managed (#570).
+          toast.info(message);
+        } else {
+          toast.error(message);
+        }
+        setIsDeleting(false);
+        setIsDeleteDialogOpen(false);
+      },
+    });
   };
 
   const handleTestConnection = async () => {

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -35,7 +35,11 @@ import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity, writeAt } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import {
+  applyWriteOutcome,
+  applyDeleteOutcome,
+  toastGuidanceOrError,
+} from "@/lib/apply-write-outcome";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -260,15 +264,7 @@ const McpForm = ({
       onSuccess: (data) => {
         savedId = data.id;
       },
-      onError: (message, outcome) => {
-        if (outcome.outcome === "forbidden") {
-          // Guidance, not a failure — the backend's message already says
-          // where the Shared resource is actually managed (#570).
-          toast.info(message);
-        } else {
-          toast.error(message);
-        }
-      },
+      onError: toastGuidanceOrError,
     });
     return savedId;
   };
@@ -297,19 +293,11 @@ const McpForm = ({
       id: mcpId,
     });
 
-    await applyWriteOutcome(result, {
+    await applyDeleteOutcome(result, {
       mutate: globalMutate,
-      setValidationErrors: () => {},
-      conflictField: null,
       onSuccess: () => router.push(listPath),
       onError: (message, outcome) => {
-        if (outcome.outcome === "forbidden") {
-          // Guidance, not a failure — the backend's message already says
-          // where the Shared resource is actually managed (#570).
-          toast.info(message);
-        } else {
-          toast.error(message);
-        }
+        toastGuidanceOrError(message, outcome);
         setIsDeleting(false);
         setIsDeleteDialogOpen(false);
       },

--- a/apps/frontend/components/mcp-list.tsx
+++ b/apps/frontend/components/mcp-list.tsx
@@ -32,6 +32,7 @@ import {
 import { AttachSharedResourceDialog } from "./attach-shared-resource-dialog";
 import { useState } from "react";
 import { writeEntity, type Scope } from "@/lib/api-write";
+import { useDetachDialog } from "@/hooks/use-detach-dialog";
 
 const McpList = ({
   className,
@@ -47,12 +48,9 @@ const McpList = ({
 
   const { actor, workspaceDelegation } = useAuth();
   const backendUrl = useBackendUrl();
-  const [selectedOrgMcp, setSelectedOrgMcp] = useState<McpWithScope | null>(
-    null,
-  );
+  const orgMcpDetach = useDetachDialog<McpWithScope>();
   const [attachOpen, setAttachOpen] = useState(false);
   const [detaching, setDetaching] = useState(false);
-  const [detachError, setDetachError] = useState<string | null>(null);
 
   // Resolved once per render and reused for the list's read and every write
   // below, rather than re-deriving the Organization-vs-Workspace branch at
@@ -70,16 +68,16 @@ const McpList = ({
   const detachOrgMcp = async (mcpId: string) => {
     if (!backendUrl || !workspaceId) return;
     setDetaching(true);
-    setDetachError(null);
+    orgMcpDetach.setError(null);
     try {
       const outcome = await writeEntity(backendUrl, "attachments/mcp", scope, {
         id: mcpId,
       });
       if (outcome.outcome === "success") {
-        setSelectedOrgMcp(null);
+        orgMcpDetach.close();
         await mutate();
       } else {
-        setDetachError(outcome.message);
+        orgMcpDetach.setError(outcome.message);
       }
     } finally {
       setDetaching(false);
@@ -145,10 +143,7 @@ const McpList = ({
                 asChild={!isOrgScopedInWorkspace}
                 onClick={
                   isOrgScopedInWorkspace
-                    ? () => {
-                        setDetachError(null);
-                        setSelectedOrgMcp(mcp);
-                      }
+                    ? () => orgMcpDetach.open(mcp)
                     : undefined
                 }
                 className={cn(isOrgScopedInWorkspace && "cursor-pointer")}
@@ -232,41 +227,32 @@ const McpList = ({
         />
       )}
       <Dialog
-        open={!!selectedOrgMcp}
+        open={!!orgMcpDetach.selected}
         onOpenChange={(open) => {
-          if (!open) {
-            setSelectedOrgMcp(null);
-            setDetachError(null);
-          }
+          if (!open) orgMcpDetach.close();
         }}
       >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Organization MCP</DialogTitle>
             <DialogDescription>
-              The MCP server <strong>{selectedOrgMcp?.name}</strong> is managed
-              at the organization level. It can only be edited from the
+              The MCP server <strong>{orgMcpDetach.selected?.name}</strong> is
+              managed at the organization level. It can only be edited from the
               organization settings.
             </DialogDescription>
           </DialogHeader>
-          {detachError && (
-            <p className="text-sm text-destructive">{detachError}</p>
+          {orgMcpDetach.error && (
+            <p className="text-sm text-destructive">{orgMcpDetach.error}</p>
           )}
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setSelectedOrgMcp(null);
-                setDetachError(null);
-              }}
-            >
+            <Button variant="outline" onClick={orgMcpDetach.close}>
               Close
             </Button>
-            {canAttach && selectedOrgMcp && (
+            {canAttach && orgMcpDetach.selected && (
               <Button
                 variant="destructive"
                 disabled={detaching}
-                onClick={() => detachOrgMcp(selectedOrgMcp.id)}
+                onClick={() => detachOrgMcp(orgMcpDetach.selected!.id)}
               >
                 <Unlink className="size-4" />
                 Detach
@@ -274,7 +260,9 @@ const McpList = ({
             )}
             {canAttach && (
               <Button asChild>
-                <Link href={`/${orgId}/settings/mcp/${selectedOrgMcp?.id}`}>
+                <Link
+                  href={`/${orgId}/settings/mcp/${orgMcpDetach.selected?.id}`}
+                >
                   <ExternalLink className="size-4" />
                   Org settings
                 </Link>

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -19,7 +19,10 @@ import { type Organization } from "@platypus/schemas";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import {
+  applyWriteOutcome,
+  applyDeleteOutcome,
+} from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { Trash2 } from "lucide-react";
@@ -129,10 +132,8 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
       { id: orgId },
     );
 
-    await applyWriteOutcome(result, {
+    await applyDeleteOutcome(result, {
       mutate: globalMutate,
-      setValidationErrors: () => {},
-      conflictField: null,
       onSuccess: () => {
         toast.success("Organization deleted");
         window.location.href = `/`;

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -19,6 +19,7 @@ import { type Organization } from "@platypus/schemas";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { Trash2 } from "lucide-react";
@@ -100,32 +101,19 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
       { id: orgId, data: payload },
     );
 
-    switch (result.outcome) {
-      case "success":
-        result.revalidateKeys.forEach((key) => globalMutate(key));
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors,
+      onSuccess: (data) => {
         if (orgId) {
           toast.success("Organization updated");
           router.refresh();
         } else {
           toast.success("Organization created");
-          router.push(`/${result.data.id}`);
+          router.push(`/${data.id}`);
         }
-        break;
-      case "invalid":
-        setValidationErrors(result.fieldErrors);
-        if (Object.keys(result.fieldErrors).length === 0) {
-          toast.error(result.message);
-        }
-        break;
-      case "conflict":
-        setValidationErrors({ name: result.message });
-        break;
-      case "locked":
-      case "notFound":
-      case "error":
-        toast.error(result.message);
-        break;
-    }
+      },
+    });
 
     setIsSubmitting(false);
   };
@@ -141,15 +129,20 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
       { id: orgId },
     );
 
-    if (result.outcome === "success") {
-      result.revalidateKeys.forEach((key) => globalMutate(key));
-      toast.success("Organization deleted");
-      window.location.href = `/`;
-    } else {
-      toast.error(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    }
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors: () => {},
+      conflictField: null,
+      onSuccess: () => {
+        toast.success("Organization deleted");
+        window.location.href = `/`;
+      },
+      onError: (message) => {
+        toast.error(message);
+        setIsDeleting(false);
+        setIsDeleteDialogOpen(false);
+      },
+    });
   };
 
   return (

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -65,7 +65,11 @@ import useSWR, { useSWRConfig } from "swr";
 import { cn, fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import {
+  applyWriteOutcome,
+  applyDeleteOutcome,
+  toastGuidanceOrError,
+} from "@/lib/apply-write-outcome";
 import {
   getModelConfigs,
   defaultPassthroughFileTypes,
@@ -838,15 +842,7 @@ const ProviderForm = ({
         mutate: globalMutate,
         setValidationErrors,
         onConflict: (message) => setError(message),
-        onError: (message, outcome) => {
-          if (outcome.outcome === "forbidden") {
-            // Guidance, not a failure — the backend's message already says
-            // where the Shared resource is actually managed (#570).
-            toast.info(message);
-          } else {
-            toast.error(message);
-          }
-        },
+        onError: toastGuidanceOrError,
         onSuccess: (data) => {
           reportAliasRepoints(data.aliasRepoints);
           if (formScope === "workspace") {
@@ -884,10 +880,8 @@ const ProviderForm = ({
       id: providerId,
     });
 
-    await applyWriteOutcome(result, {
+    await applyDeleteOutcome(result, {
       mutate: globalMutate,
-      setValidationErrors: () => {},
-      conflictField: null,
       onSuccess: () => {
         if (formScope === "workspace") {
           router.push(`/${orgId}/workspace/${workspaceId}/settings/providers`);
@@ -896,13 +890,7 @@ const ProviderForm = ({
         }
       },
       onError: (message, outcome) => {
-        if (outcome.outcome === "forbidden") {
-          // Guidance, not a failure — the backend's message already says
-          // where the Shared resource is actually managed (#570).
-          toast.info(message);
-        } else {
-          toast.error(message);
-        }
+        toastGuidanceOrError(message, outcome);
         setIsDeleting(false);
         setIsDeleteDialogOpen(false);
       },

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -65,6 +65,7 @@ import useSWR, { useSWRConfig } from "swr";
 import { cn, fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import {
   getModelConfigs,
   defaultPassthroughFileTypes,
@@ -833,10 +834,21 @@ const ProviderForm = ({
         aliasRepoints?: unknown;
       }>(backendUrl, "providers", scope, { id: providerId, data: payload });
 
-      switch (result.outcome) {
-        case "success":
-          reportAliasRepoints(result.data.aliasRepoints);
-          result.revalidateKeys.forEach((key) => globalMutate(key));
+      await applyWriteOutcome(result, {
+        mutate: globalMutate,
+        setValidationErrors,
+        onConflict: (message) => setError(message),
+        onError: (message, outcome) => {
+          if (outcome.outcome === "forbidden") {
+            // Guidance, not a failure — the backend's message already says
+            // where the Shared resource is actually managed (#570).
+            toast.info(message);
+          } else {
+            toast.error(message);
+          }
+        },
+        onSuccess: (data) => {
+          reportAliasRepoints(data.aliasRepoints);
           if (formScope === "workspace") {
             router.push(
               `/${orgId}/workspace/${workspaceId}/settings/providers`,
@@ -844,26 +856,8 @@ const ProviderForm = ({
           } else {
             router.push(`/${orgId}/settings/providers`);
           }
-          break;
-        case "invalid":
-          setValidationErrors(result.fieldErrors);
-          if (Object.keys(result.fieldErrors).length === 0) {
-            toast.error(result.message);
-          }
-          break;
-        case "conflict":
-          setError(result.message);
-          break;
-        case "locked":
-          // Guidance, not a failure — the backend's message already says
-          // where the Shared resource is actually managed (#570).
-          toast.info(result.message);
-          break;
-        case "notFound":
-        case "error":
-          toast.error(result.message);
-          break;
-      }
+        },
+      });
     } catch (error) {
       console.error("Error saving provider:", error);
       toast.error("Failed to save provider");
@@ -890,24 +884,29 @@ const ProviderForm = ({
       id: providerId,
     });
 
-    if (result.outcome === "success") {
-      result.revalidateKeys.forEach((key) => globalMutate(key));
-      if (formScope === "workspace") {
-        router.push(`/${orgId}/workspace/${workspaceId}/settings/providers`);
-      } else {
-        router.push(`/${orgId}/settings/providers`);
-      }
-    } else if (result.outcome === "locked") {
-      // Guidance, not a failure — the backend's message already says where
-      // the Shared resource is actually managed (#570).
-      toast.info(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    } else {
-      toast.error(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    }
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors: () => {},
+      conflictField: null,
+      onSuccess: () => {
+        if (formScope === "workspace") {
+          router.push(`/${orgId}/workspace/${workspaceId}/settings/providers`);
+        } else {
+          router.push(`/${orgId}/settings/providers`);
+        }
+      },
+      onError: (message, outcome) => {
+        if (outcome.outcome === "forbidden") {
+          // Guidance, not a failure — the backend's message already says
+          // where the Shared resource is actually managed (#570).
+          toast.info(message);
+        } else {
+          toast.error(message);
+        }
+        setIsDeleting(false);
+        setIsDeleteDialogOpen(false);
+      },
+    });
   };
 
   if (isLoading) {

--- a/apps/frontend/components/providers-list.tsx
+++ b/apps/frontend/components/providers-list.tsx
@@ -32,6 +32,7 @@ import {
 import { AttachSharedResourceDialog } from "./attach-shared-resource-dialog";
 import { useState } from "react";
 import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
+import { useDetachDialog } from "@/hooks/use-detach-dialog";
 
 const ProvidersList = ({
   className,
@@ -47,11 +48,9 @@ const ProvidersList = ({
 
   const { user, actor, workspaceDelegation } = useAuth();
   const backendUrl = useBackendUrl();
-  const [selectedOrgProvider, setSelectedOrgProvider] =
-    useState<ProviderWithScope | null>(null);
+  const orgProviderDetach = useDetachDialog<ProviderWithScope>();
   const [attachOpen, setAttachOpen] = useState(false);
   const [detaching, setDetaching] = useState(false);
-  const [detachError, setDetachError] = useState<string | null>(null);
 
   // Resolved once per render and reused for the list's read and every write
   // below, rather than re-deriving the Organization-vs-Workspace branch at
@@ -74,7 +73,7 @@ const ProvidersList = ({
   const detachOrgProvider = async (providerId: string) => {
     if (!backendUrl || !workspaceId) return;
     setDetaching(true);
-    setDetachError(null);
+    orgProviderDetach.setError(null);
     try {
       const outcome = await writeEntity(
         backendUrl,
@@ -85,10 +84,10 @@ const ProvidersList = ({
         },
       );
       if (outcome.outcome === "success") {
-        setSelectedOrgProvider(null);
+        orgProviderDetach.close();
         await mutate();
       } else {
-        setDetachError(outcome.message);
+        orgProviderDetach.setError(outcome.message);
       }
     } finally {
       setDetaching(false);
@@ -140,10 +139,7 @@ const ProvidersList = ({
                 asChild={!isOrgScopedInWorkspace}
                 onClick={
                   isOrgScopedInWorkspace
-                    ? () => {
-                        setDetachError(null);
-                        setSelectedOrgProvider(provider);
-                      }
+                    ? () => orgProviderDetach.open(provider)
                     : undefined
                 }
                 className={cn(isOrgScopedInWorkspace && "cursor-pointer")}
@@ -227,41 +223,36 @@ const ProvidersList = ({
         />
       )}
       <Dialog
-        open={!!selectedOrgProvider}
+        open={!!orgProviderDetach.selected}
         onOpenChange={(open) => {
-          if (!open) {
-            setSelectedOrgProvider(null);
-            setDetachError(null);
-          }
+          if (!open) orgProviderDetach.close();
         }}
       >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Organization Provider</DialogTitle>
             <DialogDescription>
-              The provider <strong>{selectedOrgProvider?.name}</strong> is
-              managed at the organization level. It can only be edited from the
-              organization settings.
+              The provider <strong>{orgProviderDetach.selected?.name}</strong>{" "}
+              is managed at the organization level. It can only be edited from
+              the organization settings.
             </DialogDescription>
           </DialogHeader>
-          {detachError && (
-            <p className="text-sm text-destructive">{detachError}</p>
+          {orgProviderDetach.error && (
+            <p className="text-sm text-destructive">
+              {orgProviderDetach.error}
+            </p>
           )}
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setSelectedOrgProvider(null);
-                setDetachError(null);
-              }}
-            >
+            <Button variant="outline" onClick={orgProviderDetach.close}>
               Close
             </Button>
-            {canAttach && selectedOrgProvider && (
+            {canAttach && orgProviderDetach.selected && (
               <Button
                 variant="destructive"
                 disabled={detaching}
-                onClick={() => detachOrgProvider(selectedOrgProvider.id)}
+                onClick={() =>
+                  detachOrgProvider(orgProviderDetach.selected!.id)
+                }
               >
                 <Unlink className="size-4" />
                 Detach
@@ -270,7 +261,7 @@ const ProvidersList = ({
             {canAttach && (
               <Button asChild>
                 <Link
-                  href={`/${orgId}/settings/providers/${selectedOrgProvider?.id}`}
+                  href={`/${orgId}/settings/providers/${orgProviderDetach.selected?.id}`}
                 >
                   <ExternalLink className="size-4" />
                   Org settings

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -23,7 +23,11 @@ import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import {
+  applyWriteOutcome,
+  applyDeleteOutcome,
+  toastGuidanceOrError,
+} from "@/lib/apply-write-outcome";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -157,15 +161,7 @@ const SkillForm = ({
       mutate: globalMutate,
       setValidationErrors,
       onSuccess: () => router.push(returnPath),
-      onError: (message, outcome) => {
-        if (outcome.outcome === "forbidden") {
-          // Guidance, not a failure — the backend's message already says
-          // where the Shared resource is actually managed (#570).
-          toast.info(message);
-        } else {
-          toast.error(message);
-        }
-      },
+      onError: toastGuidanceOrError,
     });
 
     setIsSubmitting(false);
@@ -181,11 +177,8 @@ const SkillForm = ({
       id: skillId,
     });
 
-    await applyWriteOutcome(result, {
+    await applyDeleteOutcome(result, {
       mutate: globalMutate,
-      setValidationErrors: () => {},
-      // No field in a delete dialog to key a conflict to.
-      conflictField: null,
       onSuccess: () => router.push(returnPath),
       onError: (message, outcome) => {
         if (outcome.outcome === "forbidden") {

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -23,6 +23,7 @@ import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -152,30 +153,20 @@ const SkillForm = ({
       data: payload,
     });
 
-    switch (result.outcome) {
-      case "success":
-        result.revalidateKeys.forEach((key) => globalMutate(key));
-        router.push(returnPath);
-        break;
-      case "invalid":
-        setValidationErrors(result.fieldErrors);
-        if (Object.keys(result.fieldErrors).length === 0) {
-          toast.error(result.message);
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors,
+      onSuccess: () => router.push(returnPath),
+      onError: (message, outcome) => {
+        if (outcome.outcome === "forbidden") {
+          // Guidance, not a failure — the backend's message already says
+          // where the Shared resource is actually managed (#570).
+          toast.info(message);
+        } else {
+          toast.error(message);
         }
-        break;
-      case "conflict":
-        setValidationErrors({ name: result.message });
-        break;
-      case "locked":
-        // Guidance, not a failure — the backend's message already says
-        // where the Shared resource is actually managed (#570).
-        toast.info(result.message);
-        break;
-      case "notFound":
-      case "error":
-        toast.error(result.message);
-        break;
-    }
+      },
+    });
 
     setIsSubmitting(false);
   };
@@ -190,19 +181,24 @@ const SkillForm = ({
       id: skillId,
     });
 
-    if (result.outcome === "success") {
-      result.revalidateKeys.forEach((key) => globalMutate(key));
-      router.push(returnPath);
-    } else if (result.outcome === "locked") {
-      // Guidance, not a failure — the backend's message already says where
-      // the Shared resource is actually managed (#570).
-      toast.info(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    } else {
-      setDeleteError(result.message);
-      setIsDeleting(false);
-    }
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors: () => {},
+      // No field in a delete dialog to key a conflict to.
+      conflictField: null,
+      onSuccess: () => router.push(returnPath),
+      onError: (message, outcome) => {
+        if (outcome.outcome === "forbidden") {
+          // Guidance, not a failure — the backend's message already says
+          // where the Shared resource is actually managed (#570).
+          toast.info(message);
+          setIsDeleteDialogOpen(false);
+        } else {
+          setDeleteError(message);
+        }
+        setIsDeleting(false);
+      },
+    });
   };
 
   return (

--- a/apps/frontend/components/skills-list.tsx
+++ b/apps/frontend/components/skills-list.tsx
@@ -61,7 +61,7 @@ import {
   SharedWithBadge,
 } from "@/components/manage-sharing";
 import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import { applyDeleteOutcome } from "@/lib/apply-write-outcome";
 import { useDetachDialog } from "@/hooks/use-detach-dialog";
 
 // The list serves two surfaces: a Workspace (workspaceId provided) where it
@@ -217,10 +217,8 @@ export const SkillsList = ({
       const outcome = await writeEntity(backendUrl, "skills", scope, {
         id: skillToDelete.id,
       });
-      await applyWriteOutcome(outcome, {
+      await applyDeleteOutcome(outcome, {
         mutate: () => mutate(),
-        setValidationErrors: () => {},
-        conflictField: null,
         onSuccess: () => {
           setDeleteDialogOpen(false);
           setSkillToDelete(null);

--- a/apps/frontend/components/skills-list.tsx
+++ b/apps/frontend/components/skills-list.tsx
@@ -61,6 +61,8 @@ import {
   SharedWithBadge,
 } from "@/components/manage-sharing";
 import { scopedPath, writeEntity, type Scope } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import { useDetachDialog } from "@/hooks/use-detach-dialog";
 
 // The list serves two surfaces: a Workspace (workspaceId provided) where it
 // shows workspace-scoped Skills plus attached org-scoped Shared Skills as
@@ -117,10 +119,8 @@ export const SkillsList = ({
   );
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
-  const [selectedOrgSkill, setSelectedOrgSkill] =
-    useState<SkillWithScope | null>(null);
+  const orgSkillDetach = useDetachDialog<SkillWithScope>();
   const [detaching, setDetaching] = useState(false);
-  const [detachError, setDetachError] = useState<string | null>(null);
   const [attachOpen, setAttachOpen] = useState(false);
   const [skillToPromote, setSkillToPromote] = useState<SkillWithScope | null>(
     null,
@@ -217,19 +217,26 @@ export const SkillsList = ({
       const outcome = await writeEntity(backendUrl, "skills", scope, {
         id: skillToDelete.id,
       });
-      if (outcome.outcome === "success") {
-        await mutate();
-        setDeleteDialogOpen(false);
-        setSkillToDelete(null);
-      } else if (outcome.outcome === "locked") {
-        // Guidance, not a failure — the backend's message already says
-        // where the Shared resource is actually managed (#570).
-        setDeleteDialogOpen(false);
-        setSkillToDelete(null);
-        toast.info(outcome.message);
-      } else {
-        setDeleteError(outcome.message);
-      }
+      await applyWriteOutcome(outcome, {
+        mutate: () => mutate(),
+        setValidationErrors: () => {},
+        conflictField: null,
+        onSuccess: () => {
+          setDeleteDialogOpen(false);
+          setSkillToDelete(null);
+        },
+        onError: (message, result) => {
+          if (result.outcome === "forbidden") {
+            // Guidance, not a failure — the backend's message already says
+            // where the Shared resource is actually managed (#570).
+            setDeleteDialogOpen(false);
+            setSkillToDelete(null);
+            toast.info(message);
+          } else {
+            setDeleteError(message);
+          }
+        },
+      });
     } finally {
       setDeleting(false);
     }
@@ -238,7 +245,7 @@ export const SkillsList = ({
   const detachOrgSkill = async (skillId: string) => {
     if (!backendUrl || !workspaceId) return;
     setDetaching(true);
-    setDetachError(null);
+    orgSkillDetach.setError(null);
     try {
       const outcome = await writeEntity(
         backendUrl,
@@ -249,10 +256,10 @@ export const SkillsList = ({
         },
       );
       if (outcome.outcome === "success") {
-        setSelectedOrgSkill(null);
+        orgSkillDetach.close();
         await mutate();
       } else {
-        setDetachError(outcome.message);
+        orgSkillDetach.setError(outcome.message);
       }
     } finally {
       setDetaching(false);
@@ -302,10 +309,7 @@ export const SkillsList = ({
                 <Item
                   variant="outline"
                   className="h-full cursor-pointer"
-                  onClick={() => {
-                    setDetachError(null);
-                    setSelectedOrgSkill(skill);
-                  }}
+                  onClick={() => orgSkillDetach.open(skill)}
                 >
                   <ItemContent>
                     <div className="flex items-center gap-2">
@@ -453,49 +457,42 @@ export const SkillsList = ({
       )}
 
       <Dialog
-        open={!!selectedOrgSkill}
+        open={!!orgSkillDetach.selected}
         onOpenChange={(open) => {
-          if (!open) {
-            setSelectedOrgSkill(null);
-            setDetachError(null);
-          }
+          if (!open) orgSkillDetach.close();
         }}
       >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Organization Skill</DialogTitle>
             <DialogDescription>
-              The skill <strong>{selectedOrgSkill?.name}</strong> is managed at
-              the organization level. It can only be edited from the
+              The skill <strong>{orgSkillDetach.selected?.name}</strong> is
+              managed at the organization level. It can only be edited from the
               organization settings.
             </DialogDescription>
           </DialogHeader>
-          {detachError && (
-            <p className="text-sm text-destructive">{detachError}</p>
+          {orgSkillDetach.error && (
+            <p className="text-sm text-destructive">{orgSkillDetach.error}</p>
           )}
           <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => {
-                setSelectedOrgSkill(null);
-                setDetachError(null);
-              }}
-            >
+            <Button variant="outline" onClick={orgSkillDetach.close}>
               Close
             </Button>
-            {canAttach && selectedOrgSkill && (
+            {canAttach && orgSkillDetach.selected && (
               <Button
                 variant="destructive"
                 disabled={detaching}
-                onClick={() => detachOrgSkill(selectedOrgSkill.id)}
+                onClick={() => detachOrgSkill(orgSkillDetach.selected!.id)}
               >
                 <Unlink className="size-4" />
                 Detach
               </Button>
             )}
-            {canAttach && selectedOrgSkill && (
+            {canAttach && orgSkillDetach.selected && (
               <Button asChild>
-                <Link href={`/${orgId}/settings/skills/${selectedOrgSkill.id}`}>
+                <Link
+                  href={`/${orgId}/settings/skills/${orgSkillDetach.selected.id}`}
+                >
                   <ExternalLink className="size-4" />
                   Org settings
                 </Link>

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -39,7 +39,10 @@ import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import {
+  applyWriteOutcome,
+  applyDeleteOutcome,
+} from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { Cron } from "croner";
@@ -591,10 +594,8 @@ const TriggerForm = ({
       { id: triggerId },
     );
 
-    await applyWriteOutcome(result, {
+    await applyDeleteOutcome(result, {
       mutate: globalMutate,
-      setValidationErrors: () => {},
-      conflictField: null,
       onSuccess: () => router.push(`/${orgId}/workspace/${workspaceId}`),
       onError: (message) => {
         toast.error(message);

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -39,6 +39,7 @@ import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { Cron } from "croner";
@@ -567,26 +568,11 @@ const TriggerForm = ({
         { id: triggerId, data: payload },
       );
 
-      switch (result.outcome) {
-        case "success":
-          result.revalidateKeys.forEach((key) => globalMutate(key));
-          router.push(`/${orgId}/workspace/${workspaceId}`);
-          break;
-        case "invalid":
-          setValidationErrors(result.fieldErrors);
-          if (Object.keys(result.fieldErrors).length === 0) {
-            toast.error(result.message);
-          }
-          break;
-        case "conflict":
-          setValidationErrors({ name: result.message });
-          break;
-        case "locked":
-        case "notFound":
-        case "error":
-          toast.error(result.message);
-          break;
-      }
+      await applyWriteOutcome(result, {
+        mutate: globalMutate,
+        setValidationErrors,
+        onSuccess: () => router.push(`/${orgId}/workspace/${workspaceId}`),
+      });
     } catch {
       toast.error("Error saving trigger");
     } finally {
@@ -605,14 +591,17 @@ const TriggerForm = ({
       { id: triggerId },
     );
 
-    if (result.outcome === "success") {
-      result.revalidateKeys.forEach((key) => globalMutate(key));
-      router.push(`/${orgId}/workspace/${workspaceId}`);
-    } else {
-      toast.error(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    }
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors: () => {},
+      conflictField: null,
+      onSuccess: () => router.push(`/${orgId}/workspace/${workspaceId}`),
+      onError: (message) => {
+        toast.error(message);
+        setIsDeleting(false);
+        setIsDeleteDialogOpen(false);
+      },
+    });
   };
 
   return (

--- a/apps/frontend/components/webhook-form.tsx
+++ b/apps/frontend/components/webhook-form.tsx
@@ -23,6 +23,7 @@ import {
   retractFieldError,
 } from "@/lib/form-errors";
 import { writeEntity, writeAt } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -188,27 +189,14 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
       { id: webhookId, data: payload },
     );
 
-    switch (result.outcome) {
-      case "success":
-        result.revalidateKeys.forEach((key) => globalMutate(key));
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors,
+      onSuccess: () => {
         toast.success(isEditMode ? "Webhook updated" : "Webhook created");
         router.push(`/${orgId}/workspace/${workspaceId}/settings/webhooks`);
-        break;
-      case "invalid":
-        setValidationErrors(result.fieldErrors);
-        if (Object.keys(result.fieldErrors).length === 0) {
-          toast.error(result.message);
-        }
-        break;
-      case "conflict":
-        setValidationErrors({ name: result.message });
-        break;
-      case "locked":
-      case "notFound":
-      case "error":
-        toast.error(result.message);
-        break;
-    }
+      },
+    });
 
     setIsSubmitting(false);
   };
@@ -222,15 +210,20 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
       { id: webhookId },
     );
 
-    if (result.outcome === "success") {
-      result.revalidateKeys.forEach((key) => globalMutate(key));
-      toast.success("Webhook deleted");
-      router.push(`/${orgId}/workspace/${workspaceId}/settings/webhooks`);
-    } else {
-      toast.error(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    }
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors: () => {},
+      conflictField: null,
+      onSuccess: () => {
+        toast.success("Webhook deleted");
+        router.push(`/${orgId}/workspace/${workspaceId}/settings/webhooks`);
+      },
+      onError: (message) => {
+        toast.error(message);
+        setIsDeleting(false);
+        setIsDeleteDialogOpen(false);
+      },
+    });
   };
 
   const handleRegenerateSecret = async () => {

--- a/apps/frontend/components/webhook-form.tsx
+++ b/apps/frontend/components/webhook-form.tsx
@@ -23,7 +23,10 @@ import {
   retractFieldError,
 } from "@/lib/form-errors";
 import { writeEntity, writeAt } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import {
+  applyWriteOutcome,
+  applyDeleteOutcome,
+} from "@/lib/apply-write-outcome";
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
@@ -210,10 +213,8 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
       { id: webhookId },
     );
 
-    await applyWriteOutcome(result, {
+    await applyDeleteOutcome(result, {
       mutate: globalMutate,
-      setValidationErrors: () => {},
-      conflictField: null,
       onSuccess: () => {
         toast.success("Webhook deleted");
         router.push(`/${orgId}/workspace/${workspaceId}/settings/webhooks`);

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -27,6 +27,7 @@ import { type Workspace, type Provider } from "@platypus/schemas";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
+import { applyWriteOutcome } from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import {
@@ -208,32 +209,19 @@ const WorkspaceForm = ({
       { id: workspaceId, data: payload },
     );
 
-    switch (result.outcome) {
-      case "success":
-        result.revalidateKeys.forEach((key) => globalMutate(key));
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors,
+      onSuccess: (data) => {
         if (workspaceId) {
           toast.success("Workspace updated");
           router.refresh();
         } else {
           toast.success("Workspace created");
-          router.push(`/${orgId}/workspace/${result.data.id}`);
+          router.push(`/${orgId}/workspace/${data.id}`);
         }
-        break;
-      case "invalid":
-        setValidationErrors(result.fieldErrors);
-        if (Object.keys(result.fieldErrors).length === 0) {
-          toast.error(result.message);
-        }
-        break;
-      case "conflict":
-        setValidationErrors({ name: result.message });
-        break;
-      case "locked":
-      case "notFound":
-      case "error":
-        toast.error(result.message);
-        break;
-    }
+      },
+    });
 
     setIsSubmitting(false);
   };
@@ -249,15 +237,20 @@ const WorkspaceForm = ({
       { id: workspaceId },
     );
 
-    if (result.outcome === "success") {
-      result.revalidateKeys.forEach((key) => globalMutate(key));
-      toast.success("Workspace deleted");
-      window.location.href = `/${orgId}`;
-    } else {
-      toast.error(result.message);
-      setIsDeleting(false);
-      setIsDeleteDialogOpen(false);
-    }
+    await applyWriteOutcome(result, {
+      mutate: globalMutate,
+      setValidationErrors: () => {},
+      conflictField: null,
+      onSuccess: () => {
+        toast.success("Workspace deleted");
+        window.location.href = `/${orgId}`;
+      },
+      onError: (message) => {
+        toast.error(message);
+        setIsDeleting(false);
+        setIsDeleteDialogOpen(false);
+      },
+    });
   };
 
   return (

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -27,7 +27,10 @@ import { type Workspace, type Provider } from "@platypus/schemas";
 import { fetcher, joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
 import { writeEntity } from "@/lib/api-write";
-import { applyWriteOutcome } from "@/lib/apply-write-outcome";
+import {
+  applyWriteOutcome,
+  applyDeleteOutcome,
+} from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import {
@@ -237,10 +240,8 @@ const WorkspaceForm = ({
       { id: workspaceId },
     );
 
-    await applyWriteOutcome(result, {
+    await applyDeleteOutcome(result, {
       mutate: globalMutate,
-      setValidationErrors: () => {},
-      conflictField: null,
       onSuccess: () => {
         toast.success("Workspace deleted");
         window.location.href = `/${orgId}`;

--- a/apps/frontend/hooks/use-detach-dialog.test.tsx
+++ b/apps/frontend/hooks/use-detach-dialog.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useDetachDialog } from "./use-detach-dialog";
+
+describe("useDetachDialog", () => {
+  it("starts with nothing selected and no error", () => {
+    const { result } = renderHook(() => useDetachDialog<{ id: string }>());
+    expect(result.current.selected).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("selects an item and clears any stale error on open", () => {
+    const { result } = renderHook(() => useDetachDialog<{ id: string }>());
+
+    act(() => result.current.setError("stale error"));
+    act(() => result.current.open({ id: "a1" }));
+
+    expect(result.current.selected).toEqual({ id: "a1" });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears both selection and error on close", () => {
+    const { result } = renderHook(() => useDetachDialog<{ id: string }>());
+
+    act(() => result.current.open({ id: "a1" }));
+    act(() => result.current.setError("detach failed"));
+    act(() => result.current.close());
+
+    expect(result.current.selected).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/apps/frontend/hooks/use-detach-dialog.ts
+++ b/apps/frontend/hooks/use-detach-dialog.ts
@@ -1,0 +1,25 @@
+import { useState } from "react";
+
+/**
+ * The Shared-resource detach dialog's state, duplicated across agents-list,
+ * mcp-list, skills-list, and providers-list (#598): which org-scoped item is
+ * selected, and the error from a failed detach — always opened and cleared
+ * together, so they're one piece of state rather than two kept in sync by
+ * hand at every call site.
+ */
+export function useDetachDialog<T>() {
+  const [selected, setSelected] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const open = (item: T) => {
+    setError(null);
+    setSelected(item);
+  };
+
+  const close = () => {
+    setSelected(null);
+    setError(null);
+  };
+
+  return { selected, error, setError, open, close };
+}

--- a/apps/frontend/lib/api-write.test.ts
+++ b/apps/frontend/lib/api-write.test.ts
@@ -288,7 +288,7 @@ describe("writeEntity — outcomes", () => {
     expect(result).toEqual({ outcome: "notFound", message: "Not found" });
   });
 
-  it("maps 403 (LockedError) to a locked outcome", async () => {
+  it("maps a 403 with a message (LockedError or an authorization refusal) to a forbidden outcome, passing the message through", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
@@ -309,8 +309,27 @@ describe("writeEntity — outcomes", () => {
     );
 
     expect(result).toEqual({
-      outcome: "locked",
+      outcome: "forbidden",
       message: "This resource is managed at the organization level",
+    });
+  });
+
+  it("maps a 403 with an empty body to a forbidden outcome with the neutral default message", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockResponse(403, {})));
+
+    const result = await writeEntity(
+      BACKEND_URL,
+      "agents",
+      { orgId: "org1" },
+      {
+        id: "a1",
+        data: { name: "x" },
+      },
+    );
+
+    expect(result).toEqual({
+      outcome: "forbidden",
+      message: "You do not have permission to do this.",
     });
   });
 

--- a/apps/frontend/lib/api-write.ts
+++ b/apps/frontend/lib/api-write.ts
@@ -24,8 +24,15 @@ export interface WriteOptions<TData> {
  * The outcomes the backend's central `onError` (ADR-0010) can produce for a
  * write, plus the field-level shape `sValidator` returns for a 400 before it
  * ever reaches that seam. A caller destructures `outcome` and TypeScript
- * won't let it skip a case, so the four failure modes this ticket exists to
+ * won't let it skip a case, so the five failure modes this ticket exists to
  * stop callers from re-deriving from a raw status code can't be missed.
+ *
+ * `forbidden` covers every 403, whether it's a `LockedError` (resource-state,
+ * ADR-0010) or a middleware authorization refusal (ADR-0006) — the wire
+ * envelope for both is `{ error: string }` with no field distinguishing them
+ * (see ADR-0010's "Authorization is unchanged" note), so this outcome can't
+ * claim to know which one occurred. Its default message stays neutral; a
+ * backend message (locked or otherwise) always passes through unchanged.
  */
 export type WriteOutcome<TResult> =
   | {
@@ -35,7 +42,7 @@ export type WriteOutcome<TResult> =
       readonly revalidateKeys: readonly string[];
     }
   | { readonly outcome: "notFound"; readonly message: string }
-  | { readonly outcome: "locked"; readonly message: string }
+  | { readonly outcome: "forbidden"; readonly message: string }
   | { readonly outcome: "conflict"; readonly message: string }
   | {
       readonly outcome: "invalid";
@@ -53,7 +60,7 @@ export type WriteOutcome<TResult> =
 
 const DEFAULT_MESSAGES = {
   notFound: "Not found",
-  locked: "This resource is managed at the organization level",
+  forbidden: "You do not have permission to do this.",
   conflict: "This operation conflicts with an existing resource",
   invalid: "Validation failed",
   error: "Request failed",
@@ -139,8 +146,8 @@ async function performWrite<TResult, TData>(
       };
     case 403:
       return {
-        outcome: "locked",
-        message: errorMessage(body) ?? DEFAULT_MESSAGES.locked,
+        outcome: "forbidden",
+        message: errorMessage(body) ?? DEFAULT_MESSAGES.forbidden,
       };
     case 409:
       return {

--- a/apps/frontend/lib/apply-write-outcome.test.ts
+++ b/apps/frontend/lib/apply-write-outcome.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { toast } from "sonner";
-import { applyWriteOutcome } from "./apply-write-outcome";
+import {
+  applyWriteOutcome,
+  applyDeleteOutcome,
+  toastGuidanceOrError,
+} from "./apply-write-outcome";
 import type { WriteOutcome } from "./api-write";
 
 vi.mock("sonner", () => ({
@@ -177,4 +181,82 @@ describe("applyWriteOutcome", () => {
       message: "Locked",
     });
   });
+});
+
+describe("applyDeleteOutcome", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("revalidates and calls onSuccess on success", async () => {
+    const mutate = vi.fn();
+    const onSuccess = vi.fn();
+
+    await applyDeleteOutcome(
+      { outcome: "success", data: null, revalidateKeys: ["/a"] },
+      { mutate, onSuccess },
+    );
+
+    expect(mutate).toHaveBeenCalledWith("/a");
+    expect(onSuccess).toHaveBeenCalledWith(null);
+  });
+
+  it("routes a conflict (e.g. still referenced) through onError, with no field to key it to", async () => {
+    const onError = vi.fn();
+
+    await applyDeleteOutcome(
+      { outcome: "conflict", message: "Agent is in use" },
+      { mutate: vi.fn(), onError },
+    );
+
+    expect(onError).toHaveBeenCalledWith("Agent is in use", {
+      outcome: "conflict",
+      message: "Agent is in use",
+    });
+  });
+
+  it.each(["forbidden", "notFound", "error"] as const)(
+    "routes a %s outcome through onError",
+    async (outcome) => {
+      const onError = vi.fn();
+
+      await applyDeleteOutcome(
+        { outcome, message: "Nope" },
+        { mutate: vi.fn(), onError },
+      );
+
+      expect(onError).toHaveBeenCalledWith("Nope", {
+        outcome,
+        message: "Nope",
+      });
+    },
+  );
+});
+
+describe("toastGuidanceOrError", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows an info toast for a forbidden outcome", () => {
+    toastGuidanceOrError("Managed at the organization level", {
+      outcome: "forbidden",
+      message: "Managed at the organization level",
+    });
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "Managed at the organization level",
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it.each(["notFound", "error"] as const)(
+    "shows an error toast for a %s outcome",
+    (outcome) => {
+      toastGuidanceOrError("Nope", { outcome, message: "Nope" });
+
+      expect(toast.error).toHaveBeenCalledWith("Nope");
+      expect(toast.info).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/apps/frontend/lib/apply-write-outcome.test.ts
+++ b/apps/frontend/lib/apply-write-outcome.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { toast } from "sonner";
+import { applyWriteOutcome } from "./apply-write-outcome";
+import type { WriteOutcome } from "./api-write";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+describe("applyWriteOutcome", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("revalidates every key and calls onSuccess with the data on success", async () => {
+    const mutate = vi.fn();
+    const onSuccess = vi.fn();
+    const result: WriteOutcome<{ id: string }> = {
+      outcome: "success",
+      data: { id: "a1" },
+      revalidateKeys: ["/a", "/b"],
+    };
+
+    await applyWriteOutcome(result, {
+      mutate,
+      setValidationErrors: vi.fn(),
+      onSuccess,
+    });
+
+    expect(mutate).toHaveBeenCalledWith("/a");
+    expect(mutate).toHaveBeenCalledWith("/b");
+    expect(onSuccess).toHaveBeenCalledWith({ id: "a1" });
+  });
+
+  it("awaits an async onSuccess before returning", async () => {
+    const order: string[] = [];
+    const onSuccess = vi.fn(async () => {
+      order.push("start");
+      await Promise.resolve();
+      order.push("end");
+    });
+
+    await applyWriteOutcome(
+      { outcome: "success", data: null, revalidateKeys: [] },
+      { mutate: vi.fn(), setValidationErrors: vi.fn(), onSuccess },
+    );
+    order.push("after");
+
+    expect(order).toEqual(["start", "end", "after"]);
+  });
+
+  it("sets field errors on invalid and does not toast when field errors exist", async () => {
+    const setValidationErrors = vi.fn();
+
+    await applyWriteOutcome(
+      {
+        outcome: "invalid",
+        message: "Validation failed",
+        fieldErrors: { name: "Required" },
+      },
+      { mutate: vi.fn(), setValidationErrors },
+    );
+
+    expect(setValidationErrors).toHaveBeenCalledWith({ name: "Required" });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("falls back to onError when invalid carries no field errors", async () => {
+    const setValidationErrors = vi.fn();
+
+    await applyWriteOutcome(
+      { outcome: "invalid", message: "Bad request", fieldErrors: {} },
+      { mutate: vi.fn(), setValidationErrors },
+    );
+
+    expect(setValidationErrors).toHaveBeenCalledWith({});
+    expect(toast.error).toHaveBeenCalledWith("Bad request");
+  });
+
+  it("lets onInvalid fully override the default invalid handling", async () => {
+    const onInvalid = vi.fn();
+    const setValidationErrors = vi.fn();
+
+    await applyWriteOutcome(
+      {
+        outcome: "invalid",
+        message: "Bad request",
+        fieldErrors: { name: "Required" },
+      },
+      { mutate: vi.fn(), setValidationErrors, onInvalid },
+    );
+
+    expect(onInvalid).toHaveBeenCalledWith({ name: "Required" }, "Bad request");
+    expect(setValidationErrors).not.toHaveBeenCalled();
+  });
+
+  it("keys a conflict's message to the default 'name' field", async () => {
+    const setValidationErrors = vi.fn();
+
+    await applyWriteOutcome(
+      { outcome: "conflict", message: "Already exists" },
+      { mutate: vi.fn(), setValidationErrors },
+    );
+
+    expect(setValidationErrors).toHaveBeenCalledWith({
+      name: "Already exists",
+    });
+  });
+
+  it("keys a conflict's message to a custom field", async () => {
+    const setValidationErrors = vi.fn();
+
+    await applyWriteOutcome(
+      { outcome: "conflict", message: "Already exists" },
+      { mutate: vi.fn(), setValidationErrors, conflictField: "email" },
+    );
+
+    expect(setValidationErrors).toHaveBeenCalledWith({
+      email: "Already exists",
+    });
+  });
+
+  it("routes a conflict through onError when there's no field to key it to", async () => {
+    const onError = vi.fn();
+
+    await applyWriteOutcome(
+      { outcome: "conflict", message: "Agent is in use" },
+      {
+        mutate: vi.fn(),
+        setValidationErrors: vi.fn(),
+        conflictField: null,
+        onError,
+      },
+    );
+
+    expect(onError).toHaveBeenCalledWith("Agent is in use", {
+      outcome: "conflict",
+      message: "Agent is in use",
+    });
+  });
+
+  it("lets onConflict fully override the default conflict handling", async () => {
+    const onConflict = vi.fn();
+    const setValidationErrors = vi.fn();
+
+    await applyWriteOutcome(
+      { outcome: "conflict", message: "Already exists" },
+      { mutate: vi.fn(), setValidationErrors, onConflict },
+    );
+
+    expect(onConflict).toHaveBeenCalledWith("Already exists");
+    expect(setValidationErrors).not.toHaveBeenCalled();
+  });
+
+  it.each(["forbidden", "notFound", "error"] as const)(
+    "toasts the message by default for a %s outcome",
+    async (outcome) => {
+      await applyWriteOutcome(
+        { outcome, message: "Nope" },
+        { mutate: vi.fn(), setValidationErrors: vi.fn() },
+      );
+
+      expect(toast.error).toHaveBeenCalledWith("Nope");
+    },
+  );
+
+  it("passes the full outcome to onError so a caller can special-case forbidden", async () => {
+    const onError = vi.fn();
+
+    await applyWriteOutcome(
+      { outcome: "forbidden", message: "Locked" },
+      { mutate: vi.fn(), setValidationErrors: vi.fn(), onError },
+    );
+
+    expect(onError).toHaveBeenCalledWith("Locked", {
+      outcome: "forbidden",
+      message: "Locked",
+    });
+  });
+});

--- a/apps/frontend/lib/apply-write-outcome.ts
+++ b/apps/frontend/lib/apply-write-outcome.ts
@@ -83,3 +83,45 @@ export async function applyWriteOutcome<TResult>(
       return;
   }
 }
+
+export interface ApplyDeleteOutcomeOptions<TResult> {
+  /** Revalidates one SWR key — usually `useSWRConfig()`'s `mutate`. */
+  readonly mutate: (key: string) => void;
+  readonly onSuccess?: (data: TResult) => void | Promise<void>;
+  /** See `ApplyWriteOutcomeOptions.onError` — covers every delete failure. */
+  readonly onError?: (message: string, outcome: WriteOutcome<TResult>) => void;
+}
+
+/**
+ * `applyWriteOutcome` for a delete: there's no field to validate or key a
+ * conflict to (e.g. a 409 "still referenced" delete refusal), so every
+ * failure — `conflict` included — surfaces through `onError` alongside
+ * `forbidden`/`notFound`/`error`.
+ */
+export async function applyDeleteOutcome<TResult>(
+  result: WriteOutcome<TResult>,
+  options: ApplyDeleteOutcomeOptions<TResult>,
+): Promise<void> {
+  return applyWriteOutcome(result, {
+    ...options,
+    setValidationErrors: () => {},
+    conflictField: null,
+  });
+}
+
+/**
+ * The toast.info-for-forbidden, toast.error-otherwise split repeated across
+ * every form whose Shared-resource lock refusal reads as guidance, not a
+ * failure — the backend's message already says where the resource is
+ * actually managed (#570).
+ */
+export function toastGuidanceOrError(
+  message: string,
+  outcome: WriteOutcome<unknown>,
+): void {
+  if (outcome.outcome === "forbidden") {
+    toast.info(message);
+  } else {
+    toast.error(message);
+  }
+}

--- a/apps/frontend/lib/apply-write-outcome.ts
+++ b/apps/frontend/lib/apply-write-outcome.ts
@@ -1,0 +1,85 @@
+import { toast } from "sonner";
+import type { WriteOutcome } from "./api-write";
+
+export interface ApplyWriteOutcomeOptions<TResult> {
+  /** Revalidates one SWR key — usually `useSWRConfig()`'s `mutate`. */
+  readonly mutate: (key: string) => void;
+  readonly setValidationErrors: (errors: Record<string, string>) => void;
+  /**
+   * Field a `conflict` outcome's message is keyed to (default `"name"`).
+   * Pass `null` when there's no field to key it to (e.g. a delete dialog) —
+   * `conflict` then routes through `onError` like every other failure.
+   * Ignored if `onConflict` is given.
+   */
+  readonly conflictField?: string | null;
+  /** Whatever genuinely differs per caller: navigation, dialog close, side-effects. */
+  readonly onSuccess?: (data: TResult) => void | Promise<void>;
+  /** Overrides the default `setValidationErrors` + toast-if-no-field-errors handling. */
+  readonly onInvalid?: (
+    fieldErrors: Record<string, string>,
+    message: string,
+  ) => void;
+  /** Overrides the default `setValidationErrors({ [conflictField]: message })`. */
+  readonly onConflict?: (message: string) => void;
+  /**
+   * Covers `forbidden`, `notFound`, and `error`, plus an `invalid` outcome
+   * with no field errors to show. Defaults to `toast.error`. Receives the
+   * outcome so a caller can special-case `forbidden` (e.g. a Shared
+   * resource's lock refusal reads as guidance, not a failure — #570).
+   */
+  readonly onError?: (message: string, outcome: WriteOutcome<TResult>) => void;
+}
+
+/**
+ * The near-byte-identical `switch (result.outcome)` handler duplicated
+ * across the write-backed forms (#598): success revalidates and hands off to
+ * the caller, invalid/conflict route to field errors, and every other
+ * failure surfaces a message. Callers keep only what genuinely differs.
+ */
+export async function applyWriteOutcome<TResult>(
+  result: WriteOutcome<TResult>,
+  options: ApplyWriteOutcomeOptions<TResult>,
+): Promise<void> {
+  const {
+    mutate,
+    setValidationErrors,
+    conflictField = "name",
+    onSuccess,
+    onInvalid,
+    onConflict,
+    onError = (message) => toast.error(message),
+  } = options;
+
+  switch (result.outcome) {
+    case "success":
+      result.revalidateKeys.forEach((key) => mutate(key));
+      await onSuccess?.(result.data);
+      return;
+    case "invalid":
+      if (onInvalid) {
+        onInvalid(result.fieldErrors, result.message);
+        return;
+      }
+      setValidationErrors(result.fieldErrors);
+      if (Object.keys(result.fieldErrors).length === 0) {
+        onError(result.message, result);
+      }
+      return;
+    case "conflict":
+      if (onConflict) {
+        onConflict(result.message);
+        return;
+      }
+      if (conflictField === null) {
+        onError(result.message, result);
+        return;
+      }
+      setValidationErrors({ [conflictField]: result.message });
+      return;
+    case "forbidden":
+    case "notFound":
+    case "error":
+      onError(result.message, result);
+      return;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #598.

- **Part A** — `WriteOutcome` gains a `forbidden` member; a 403 no longer maps to `locked`, since ADR-0010 scopes that outcome to resource-state failures (`LockedError`), not authorization refusals. The wire envelope for both cases is identical (`{ error: string }`), so the fix is a neutral default message ("You do not have permission to do this.") rather than a heuristic — a backend message always passes through unchanged either way.
- **Part B** — extracts `applyWriteOutcome` (`lib/apply-write-outcome.ts`) to replace the near-identical `switch (result.outcome)` handler duplicated across the 11 write-backed forms (skill, organization, webhook, blueprint, provider, agent, mcp, workspace, trigger, kanban-board, invitation), plus `useDetachDialog` to replace the detach-error trio duplicated across `agents-list`, `mcp-list`, `skills-list`, `providers-list`.
- Follow-up from self-review: extracted `toastGuidanceOrError` (the toast.info-for-forbidden / toast.error-otherwise branch repeated across skill/agent/mcp/provider forms) and `applyDeleteOutcome` (a delete has no field to validate or key a conflict to, so every failure — including a 409 "still referenced" — now routes through `onError`).

No user-visible copy changes except the new 403 default message. `revalidateKeys` revalidation now lives in exactly one place.

## Test plan

- `pnpm typecheck` and `pnpm test` pass across the full monorepo (453 frontend tests, 1902 backend tests).
- New coverage: `api-write.test.ts` (403-with-message, 403-empty-body), `apply-write-outcome.test.ts`, `use-detach-dialog.test.tsx`.