### PR TITLE
chore(backend): org-agent becomes a third adapter of the Agent write model

### DIFF
--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -28,17 +28,8 @@ import {
 } from "../services/scoped-resource.ts";
 import { NotFoundError } from "../errors.ts";
 import { storeAvatar, deleteAvatar } from "../services/avatar.ts";
-import { avatarKeyToUrl } from "../utils/avatar-url.ts";
+import { agentWithAvatarUrl } from "../utils/avatar-url.ts";
 import { getOrigin } from "../utils/get-origin.ts";
-
-function agentWithAvatarUrl(
-  agent: Record<string, unknown>,
-  baseUrl: string,
-): Record<string, unknown> {
-  const key = agent.avatarKey as string | null | undefined;
-  const { avatarKey: _avatarKey, ...rest } = agent;
-  return { ...rest, avatarUrl: avatarKeyToUrl(key, baseUrl) ?? undefined };
-}
 
 const agent = new Hono<{ Variables: Variables }>();
 
@@ -119,7 +110,11 @@ agent.put(
     // A Shared Agent is a single source of truth edited only on the Organization
     // surface (ADR-0007); `updateAgentRow` throws NotFound (→404) when the
     // Agent is not visible here, then Locked (→403) when it is org-scoped.
-    const result = await updateAgentRow(scope, agentId, data);
+    const result = await updateAgentRow(
+      { kind: "workspace", ctx: scope },
+      agentId,
+      data,
+    );
     if ("error" in result) {
       return c.json({ error: result.error }, 400);
     }
@@ -200,7 +195,7 @@ agent.delete(
     // A Shared Agent is deleted only from the Organization surface (ADR-0007):
     // `deleteAgentRow` throws NotFound (→404) when the Agent is not visible
     // here, then Locked (→403) when it is org-scoped.
-    await deleteAgentRow(scope, agentId);
+    await deleteAgentRow({ kind: "workspace", ctx: scope }, agentId);
 
     return c.json({ message: "Agent deleted" });
   },

--- a/apps/backend/src/routes/org-agent.test.ts
+++ b/apps/backend/src/routes/org-agent.test.ts
@@ -64,10 +64,15 @@ describe("Organization Agent Routes", () => {
   describe("PUT /:agentId", () => {
     it("updates an org agent if org admin and references stay shared", async () => {
       mockSession();
-      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([
+          { id: "agent-1", organizationId: orgId, workspaceId: null },
+        ]); // requireOrgScoped
 
       mockDb.where
         .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // requireOrgScoped
         .mockResolvedValueOnce([
           { id: "p1", name: "Shared Provider", organizationId: orgId },
         ]); // provider validation → org-scoped
@@ -100,10 +105,15 @@ describe("Organization Agent Routes", () => {
 
     it("blocks an update that references a workspace-private resource", async () => {
       mockSession();
-      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([
+          { id: "agent-1", organizationId: orgId, workspaceId: null },
+        ]); // requireOrgScoped
 
       mockDb.where
         .mockReturnValueOnce(mockDb) // requireOrgAccess
+        .mockReturnValueOnce(mockDb) // requireOrgScoped
         .mockResolvedValueOnce([
           { id: "p1", name: "WS Provider", organizationId: null },
         ]); // provider validation → workspace-private, blocker
@@ -124,6 +134,54 @@ describe("Organization Agent Routes", () => {
       expect(body.blockers).toEqual([
         { type: "provider", id: "p1", name: "WS Provider" },
       ]);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the agent is not visible here", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([]); // requireOrgScoped: not found
+
+      mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess
+
+      const res = await app.request(`${baseUrl}/missing`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "Renamed",
+          description: "A shared agent",
+          providerId: "p1",
+          modelId: "m1",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("rejects a self-assigned sub-agent", async () => {
+      mockSession();
+      mockDb.limit
+        .mockResolvedValueOnce([{ role: "admin" }]) // requireOrgAccess
+        .mockResolvedValueOnce([
+          { id: "agent-1", organizationId: orgId, workspaceId: null },
+        ]); // requireOrgScoped
+
+      mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess
+
+      const res = await app.request(`${baseUrl}/agent-1`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "Renamed",
+          description: "A shared agent",
+          providerId: "p1",
+          modelId: "m1",
+          subAgentIds: ["agent-1"],
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(400);
       expect(mockDb.update).not.toHaveBeenCalled();
     });
 

--- a/apps/backend/src/routes/org-agent.ts
+++ b/apps/backend/src/routes/org-agent.ts
@@ -3,22 +3,20 @@ import { sValidator } from "@hono/standard-validator";
 import { db } from "../index.ts";
 import { agent as agentTable } from "../db/schema.ts";
 import { agentUpdateSchema } from "@platypus/schemas";
-import { dedupeArray } from "../utils.ts";
 import { requireAuth } from "../middleware/authentication.ts";
 import { orgScopeOf, requireOrgAccess } from "../middleware/authorization.ts";
-import { findNonSharedReferences } from "../services/agent-scope-validation.ts";
-import { SUB_AGENT_SELF_ASSIGNMENT_ERROR } from "../services/sub-agent-validation.ts";
-import { scrubDeletedAgentReference } from "../services/agent-references.ts";
+import {
+  updateAgent as updateAgentRow,
+  deleteAgent as deleteAgentRow,
+} from "../services/agent.ts";
 import {
   listOrgScoped,
   orgScopedWhere,
   requireOrgScoped,
-  requireSharedDeletable,
 } from "../services/scoped-resource.ts";
 import { storeAvatar, deleteAvatar } from "../services/avatar.ts";
-import { avatarKeyToUrl } from "../utils/avatar-url.ts";
+import { agentWithAvatarUrl } from "../utils/avatar-url.ts";
 import { getOrigin } from "../utils/get-origin.ts";
-import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
 // Org-scoped Agents are Shared resources (ADR-0007): a single source of truth
@@ -26,15 +24,6 @@ import type { Variables } from "../server.ts";
 // through an Attachment. They are managed only by Org Admins on the Organization
 // surface, so all mutations are org-admin-only; any member may read them.
 const orgAgent = new Hono<{ Variables: Variables }>();
-
-function agentWithAvatarUrl(
-  agent: Record<string, unknown>,
-  baseUrl: string,
-): Record<string, unknown> {
-  const key = agent.avatarKey as string | null | undefined;
-  const { avatarKey: _avatarKey, ...rest } = agent;
-  return { ...rest, avatarUrl: avatarKeyToUrl(key, baseUrl) ?? undefined };
-}
 
 /** List org-scoped Agents */
 orgAgent.get("/", requireAuth, requireOrgAccess(), async (c) => {
@@ -67,43 +56,24 @@ orgAgent.put(
     const data = c.req.valid("json");
     const baseUrl = getOrigin(c);
 
-    if (data.toolSetIds) data.toolSetIds = dedupeArray(data.toolSetIds);
-    if (data.skillIds) data.skillIds = dedupeArray(data.skillIds);
-    if (data.subAgentIds) data.subAgentIds = dedupeArray(data.subAgentIds);
-
-    if (data.subAgentIds?.includes(agentId)) {
-      return c.json({ error: SUB_AGENT_SELF_ASSIGNMENT_ERROR }, 400);
-    }
-
-    // A Shared Agent may reference only other Shared resources (ADR-0007).
-    const blockers = await findNonSharedReferences(orgId, {
-      providerId: data.providerId,
-      skillIds: data.skillIds,
-      subAgentIds: data.subAgentIds,
-      toolSetIds: data.toolSetIds,
-    });
-    if (blockers.length > 0) {
+    // `updateAgentRow` throws NotFound (→404) when the Agent is not visible
+    // here; a duplicate name surfaces as a Postgres unique violation, mapped
+    // to 409 by the central onError (ADR-0010).
+    const result = await updateAgentRow(
+      { kind: "organization", orgId },
+      agentId,
+      data,
+    );
+    if ("error" in result) {
       return c.json(
         {
-          error:
-            "A shared agent may only reference other shared (organization-scoped) resources",
-          blockers,
+          error: result.error,
+          ...(result.blockers && { blockers: result.blockers }),
         },
-        422,
+        result.blockers ? 422 : 400,
       );
     }
-
-    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
-    // by the central onError (ADR-0010).
-    const record = await db
-      .update(agentTable)
-      .set({ ...data, updatedAt: new Date() })
-      .where(orgScopedWhere("agent", agentId, orgId))
-      .returning();
-    if (record.length === 0) {
-      throw new NotFoundError("Agent not found");
-    }
-    return c.json(agentWithAvatarUrl(record[0], baseUrl), 200);
+    return c.json(agentWithAvatarUrl(result.row, baseUrl), 200);
   },
 );
 
@@ -166,32 +136,10 @@ orgAgent.delete(
     const { orgId } = orgScopeOf(c);
     const agentId = c.req.param("agentId");
 
-    // A Shared resource cannot be deleted while anything still points at it —
-    // an Attachment (ADR-0007) or a Blueprint (ADR-0008). Throws ConflictError
-    // → 409 via the central onError (ADR-0010).
-    await requireSharedDeletable(db, "agent", agentId);
-
-    // Delete the Agent and scrub its (now-dead) id from any Agent's subAgentIds
-    // in the same transaction, so deletion never leaves dangling references.
-    const result = await db.transaction(async (tx) => {
-      const rows = await tx
-        .delete(agentTable)
-        .where(orgScopedWhere("agent", agentId, orgId))
-        .returning();
-      if (rows.length > 0) {
-        await scrubDeletedAgentReference(tx, "subAgentIds", agentId);
-      }
-      return rows;
-    });
-    if (result.length === 0) {
-      throw new NotFoundError("Agent not found");
-    }
-
-    // Clean up the (now-orphaned) avatar, matching the Workspace surface — the
-    // avatar is keyed by the Agent id alone, so nothing else can reference it
-    // once the row is gone. Best-effort: a storage miss must not fail the
-    // delete that already committed.
-    await deleteAvatar(result[0].avatarKey);
+    // `deleteAgentRow` throws ConflictError (→409, ADR-0007/0008) while an
+    // Attachment or Blueprint still references the Agent, and NotFound (→404)
+    // when it is not visible here.
+    await deleteAgentRow({ kind: "organization", orgId }, agentId);
 
     return c.json({ message: "Agent deleted" });
   },

--- a/apps/backend/src/services/agent.test.ts
+++ b/apps/backend/src/services/agent.test.ts
@@ -3,6 +3,16 @@ import { mockDb, resetMockDb } from "../test-utils.ts";
 
 vi.mock("./sub-agent-validation.ts", () => ({
   validateSubAgentAssignment: vi.fn().mockResolvedValue({ valid: true }),
+  SUB_AGENT_SELF_ASSIGNMENT_ERROR:
+    "An agent cannot assign itself as a sub-agent",
+}));
+
+vi.mock("./agent-scope-validation.ts", () => ({
+  findNonSharedReferences: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("./agent-references.ts", () => ({
+  scrubDeletedAgentReference: vi.fn().mockResolvedValue(undefined),
 }));
 
 // deleteAgent's avatar cleanup goes through avatar.ts's own getStorage() call,
@@ -15,15 +25,21 @@ vi.mock("../storage/index.ts", () => ({
 
 import { createAgent, updateAgent, deleteAgent } from "./agent.ts";
 import { validateSubAgentAssignment } from "./sub-agent-validation.ts";
+import { findNonSharedReferences } from "./agent-scope-validation.ts";
+import { scrubDeletedAgentReference } from "./agent-references.ts";
 import { LockedError, NotFoundError } from "../errors.ts";
 
 const ctx = { orgId: "org-1", workspaceId: "ws-1" };
+const workspaceScope = { kind: "workspace" as const, ctx };
+const orgScope = { kind: "organization" as const, orgId: "org-1" };
 
 describe("agent module", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetMockDb();
     vi.mocked(validateSubAgentAssignment).mockResolvedValue({ valid: true });
+    vi.mocked(findNonSharedReferences).mockResolvedValue([]);
+    vi.mocked(scrubDeletedAgentReference).mockResolvedValue(undefined);
   });
 
   describe("createAgent", () => {
@@ -92,7 +108,9 @@ describe("agent module", () => {
       const updated = { id: "a1", workspaceId: "ws-1", name: "Renamed" };
       mockDb.returning.mockResolvedValueOnce([updated]);
 
-      const result = await updateAgent(ctx, "a1", { name: "Renamed" });
+      const result = await updateAgent(workspaceScope, "a1", {
+        name: "Renamed",
+      });
 
       expect(result).toEqual({ row: updated });
       expect(mockDb.update).toHaveBeenCalled();
@@ -105,7 +123,7 @@ describe("agent module", () => {
       mockDb.limit.mockResolvedValueOnce([{ id: "a1", workspaceId: "ws-1" }]);
       mockDb.returning.mockResolvedValueOnce([{ id: "a1", temperature: null }]);
 
-      await updateAgent(ctx, "a1", { temperature: null });
+      await updateAgent(workspaceScope, "a1", { temperature: null });
 
       expect(mockDb.set).toHaveBeenCalledWith(
         expect.objectContaining({ temperature: null }),
@@ -115,9 +133,9 @@ describe("agent module", () => {
     it("throws NotFoundError when the agent is not visible here", async () => {
       mockDb.limit.mockResolvedValueOnce([]);
 
-      await expect(updateAgent(ctx, "missing", { name: "x" })).rejects.toThrow(
-        NotFoundError,
-      );
+      await expect(
+        updateAgent(workspaceScope, "missing", { name: "x" }),
+      ).rejects.toThrow(NotFoundError);
       expect(mockDb.update).not.toHaveBeenCalled();
     });
 
@@ -128,9 +146,9 @@ describe("agent module", () => {
         ])
         .mockResolvedValueOnce([{ id: "att-1" }]);
 
-      await expect(updateAgent(ctx, "a1", { name: "x" })).rejects.toThrow(
-        LockedError,
-      );
+      await expect(
+        updateAgent(workspaceScope, "a1", { name: "x" }),
+      ).rejects.toThrow(LockedError);
       expect(mockDb.update).not.toHaveBeenCalled();
     });
 
@@ -141,7 +159,9 @@ describe("agent module", () => {
         error: "An agent cannot assign itself as a sub-agent",
       });
 
-      const result = await updateAgent(ctx, "a1", { subAgentIds: ["a1"] });
+      const result = await updateAgent(workspaceScope, "a1", {
+        subAgentIds: ["a1"],
+      });
 
       expect(result).toEqual({
         error: "An agent cannot assign itself as a sub-agent",
@@ -153,7 +173,9 @@ describe("agent module", () => {
       mockDb.limit.mockResolvedValueOnce([{ id: "a1", workspaceId: "ws-1" }]);
       mockDb.returning.mockResolvedValueOnce([{ id: "a1" }]);
 
-      await updateAgent(ctx, "a1", { subAgentIds: ["sub1", "sub1"] });
+      await updateAgent(workspaceScope, "a1", {
+        subAgentIds: ["sub1", "sub1"],
+      });
 
       expect(validateSubAgentAssignment).toHaveBeenCalledWith(ctx, "a1", [
         "sub1",
@@ -161,6 +183,69 @@ describe("agent module", () => {
       expect(mockDb.set).toHaveBeenCalledWith(
         expect.objectContaining({ subAgentIds: ["sub1"] }),
       );
+    });
+
+    it("updates an organization-scoped agent after checking it is visible here (#605)", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "a1", organizationId: "org-1", workspaceId: null },
+      ]); // requireOrgScoped
+      const updated = { id: "a1", organizationId: "org-1", name: "Renamed" };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const result = await updateAgent(orgScope, "a1", {
+        providerId: "p1",
+        name: "Renamed",
+      });
+
+      expect(result).toEqual({ row: updated });
+      expect(findNonSharedReferences).toHaveBeenCalledWith(
+        "org-1",
+        expect.objectContaining({ providerId: "p1" }),
+      );
+    });
+
+    it("throws NotFoundError for an organization-scoped agent that is not Shared here", async () => {
+      mockDb.limit.mockResolvedValueOnce([]); // requireOrgScoped: not found
+
+      await expect(
+        updateAgent(orgScope, "missing", { providerId: "p1" }),
+      ).rejects.toThrow(NotFoundError);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("rejects an organization-scoped self-assignment before checking references", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "a1", organizationId: "org-1", workspaceId: null },
+      ]); // requireOrgScoped
+
+      const result = await updateAgent(orgScope, "a1", {
+        providerId: "p1",
+        subAgentIds: ["a1"],
+      });
+
+      expect(result).toEqual({
+        error: "An agent cannot assign itself as a sub-agent",
+      });
+      expect(findNonSharedReferences).not.toHaveBeenCalled();
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("blocks an organization-scoped update that references a workspace-private resource", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "a1", organizationId: "org-1", workspaceId: null },
+      ]); // requireOrgScoped
+      vi.mocked(findNonSharedReferences).mockResolvedValueOnce([
+        { type: "provider", id: "p1", name: "WS Provider" },
+      ]);
+
+      const result = await updateAgent(orgScope, "a1", { providerId: "p1" });
+
+      expect(result).toEqual({
+        error:
+          "A shared agent may only reference other shared (organization-scoped) resources",
+        blockers: [{ type: "provider", id: "p1", name: "WS Provider" }],
+      });
+      expect(mockDb.update).not.toHaveBeenCalled();
     });
   });
 
@@ -170,7 +255,7 @@ describe("agent module", () => {
         { id: "a1", workspaceId: "ws-1", avatarKey: "agents/a1/avatar.webp" },
       ]);
 
-      await deleteAgent(ctx, "a1");
+      await deleteAgent(workspaceScope, "a1");
 
       expect(mockDb.delete).toHaveBeenCalled();
     });
@@ -180,7 +265,7 @@ describe("agent module", () => {
         { id: "a1", workspaceId: "ws-1", avatarKey: null },
       ]);
 
-      await deleteAgent(ctx, "a1");
+      await deleteAgent(workspaceScope, "a1");
 
       expect(mockDb.delete).toHaveBeenCalled();
     });
@@ -188,7 +273,9 @@ describe("agent module", () => {
     it("throws NotFoundError when the agent is not visible here", async () => {
       mockDb.limit.mockResolvedValueOnce([]);
 
-      await expect(deleteAgent(ctx, "missing")).rejects.toThrow(NotFoundError);
+      await expect(deleteAgent(workspaceScope, "missing")).rejects.toThrow(
+        NotFoundError,
+      );
       expect(mockDb.delete).not.toHaveBeenCalled();
     });
 
@@ -199,8 +286,47 @@ describe("agent module", () => {
         ])
         .mockResolvedValueOnce([{ id: "att-1" }]);
 
-      await expect(deleteAgent(ctx, "a1")).rejects.toThrow(LockedError);
+      await expect(deleteAgent(workspaceScope, "a1")).rejects.toThrow(
+        LockedError,
+      );
       expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("deletes an organization-scoped agent and scrubs it from other agents' subAgentIds", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([]) // requireSharedDeletable: no attachment
+        .mockResolvedValueOnce([]); // requireSharedDeletable: no blueprint
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "a1", avatarKey: "agents/a1/avatar.webp" },
+      ]);
+
+      await deleteAgent(orgScope, "a1");
+
+      expect(mockDb.delete).toHaveBeenCalled();
+      expect(scrubDeletedAgentReference).toHaveBeenCalledWith(
+        expect.anything(),
+        "subAgentIds",
+        "a1",
+      );
+    });
+
+    it("throws ConflictError while an Attachment still references the organization-scoped agent", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]); // attached
+
+      await expect(deleteAgent(orgScope, "a1")).rejects.toThrow();
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("throws NotFoundError when the organization-scoped delete matches no row", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([]) // requireSharedDeletable: no attachment
+        .mockResolvedValueOnce([]); // requireSharedDeletable: no blueprint
+      mockDb.returning.mockResolvedValueOnce([]); // delete matched nothing
+
+      await expect(deleteAgent(orgScope, "missing")).rejects.toThrow(
+        NotFoundError,
+      );
+      expect(scrubDeletedAgentReference).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/services/agent.ts
+++ b/apps/backend/src/services/agent.ts
@@ -5,8 +5,20 @@ import { db } from "../index.ts";
 import { agent as agentTable } from "../db/schema.ts";
 import { dedupeArray } from "../utils.ts";
 import type { ScopeContext } from "../scope.ts";
-import { validateSubAgentAssignment } from "./sub-agent-validation.ts";
 import {
+  validateSubAgentAssignment,
+  SUB_AGENT_SELF_ASSIGNMENT_ERROR,
+} from "./sub-agent-validation.ts";
+import {
+  findNonSharedReferences,
+  type ReferenceBlocker,
+} from "./agent-scope-validation.ts";
+import { scrubDeletedAgentReference } from "./agent-references.ts";
+import { NotFoundError } from "../errors.ts";
+import {
+  orgScopedWhere,
+  requireOrgScoped,
+  requireSharedDeletable,
   requireWorkspaceMutable,
   workspaceScopedWhere,
 } from "./scoped-resource.ts";
@@ -21,13 +33,21 @@ import { deleteAvatar } from "./avatar.ts";
  * the sampling params was non-nullable, so an Agent could not clear a
  * temperature it had set, while the route's schema-driven copy could (#263).
  *
+ * `updateAgent`/`deleteAgent` also answer the Organization surface
+ * (`routes/org-agent.ts`), which used to carry its own copy of the dedupe,
+ * self-assignment check, and `findNonSharedReferences` blockers inline (#605).
+ *
  * "Not visible here" and "visible but locked" (a Shared Agent, a single
  * source of truth edited only on the Organization surface — ADR-0007) are the
- * cross-cutting errors of ADR-0010: `updateAgent`/`deleteAgent` throw them via
- * `requireWorkspaceMutable`, for the route to let bubble to `app.onError` and
- * the Tool to catch and translate to an `{ error }` result. A rejected
- * sub-agent assignment is surface-specific validation (errors.ts) and so
- * answers inline instead, as `{ error }`.
+ * cross-cutting errors of ADR-0010: at Workspace scope, `updateAgent`/
+ * `deleteAgent` throw them via `requireWorkspaceMutable`, for the route to let
+ * bubble to `app.onError` and the Tool to catch and translate to an `{ error
+ * }` result. At Organization scope, "not visible here" throws `NotFoundError`
+ * via `requireOrgScoped`/`requireSharedDeletable` the same way; there is no
+ * "locked" case, since the Organization surface is where a Shared Agent is
+ * always editable. A rejected sub-agent assignment or reference-blocker check
+ * is surface-specific validation (errors.ts) and so answers inline instead, as
+ * `{ error }`.
  */
 
 export type AgentRow = typeof agentTable.$inferSelect;
@@ -46,10 +66,24 @@ export type AgentCreateFields = Omit<
 /** The fields an update may carry — a partial edit of the same set. */
 export type AgentUpdateFields = Partial<AgentCreateFields>;
 
-/** What a rejected write carries — shared with the Tool adapter's own result shape. */
-export type AgentWriteError = { error: string };
+/**
+ * What a rejected write carries — shared with the Tool adapter's own result
+ * shape. `blockers` is present only for an Organization-scope rejection: the
+ * Agent references a Workspace-private resource a Shared Agent may not
+ * reference (ADR-0007), named so the UI can render a fix-this checklist.
+ */
+export type AgentWriteError = { error: string; blockers?: ReferenceBlocker[] };
 
 export type AgentWriteResult = { row: AgentRow } | AgentWriteError;
+
+/**
+ * Which scope a write targets — the Workspace surface (ADR-0006 delegation
+ * applies, a Shared row is locked) or the Organization surface (admin-only,
+ * writes a Shared row directly). Mirrors `ProviderScope`.
+ */
+export type AgentScope =
+  | { kind: "workspace"; ctx: ScopeContext }
+  | { kind: "organization"; orgId: string };
 
 /** The id-array fields both a create and an update may carry, for deduping. */
 type IdArrayFields = Pick<
@@ -103,52 +137,124 @@ export async function createAgent(
 }
 
 /**
- * Updates a Workspace-scoped Agent. Throws `NotFoundError`/`LockedError` (via
- * `requireWorkspaceMutable`) when the Agent is not visible here or is a
- * Shared Agent edited only on the Organization surface (ADR-0007).
+ * Updates an Agent at the given scope. At Workspace scope, throws
+ * `NotFoundError`/`LockedError` (via `requireWorkspaceMutable`) when the Agent
+ * is not visible here or is a Shared Agent edited only on the Organization
+ * surface (ADR-0007), then validates `subAgentIds` against what this
+ * Workspace can see. At Organization scope, throws `NotFoundError` (via
+ * `requireOrgScoped`) when the Agent is not visible, then rejects with
+ * `blockers` when the update would leave a Shared Agent referencing a
+ * Workspace-private resource (ADR-0007's no-cascade rule).
  */
 export async function updateAgent(
-  ctx: ScopeContext,
+  scope: AgentScope,
   agentId: string,
   fields: AgentUpdateFields,
 ): Promise<AgentWriteResult> {
   const data = dedupeIdArrays(fields);
 
-  await requireWorkspaceMutable(db, "agent", agentId, ctx);
+  if (scope.kind === "workspace") {
+    await requireWorkspaceMutable(db, "agent", agentId, scope.ctx);
 
-  if (data.subAgentIds) {
-    const validation = await validateSubAgentAssignment(
-      ctx,
-      agentId,
-      data.subAgentIds,
-    );
-    if (!validation.valid) {
-      return { error: validation.error! };
+    if (data.subAgentIds) {
+      const validation = await validateSubAgentAssignment(
+        scope.ctx,
+        agentId,
+        data.subAgentIds,
+      );
+      if (!validation.valid) {
+        return { error: validation.error! };
+      }
     }
+
+    const [row] = await db
+      .update(agentTable)
+      .set({ ...data, updatedAt: new Date() })
+      .where(workspaceScopedWhere("agent", agentId, scope.ctx.workspaceId))
+      .returning();
+    return { row };
+  }
+
+  await requireOrgScoped(db, "agent", agentId, scope.orgId);
+
+  if (data.subAgentIds?.includes(agentId)) {
+    return { error: SUB_AGENT_SELF_ASSIGNMENT_ERROR };
+  }
+
+  // A Shared Agent may reference only other Shared resources (ADR-0007).
+  // `providerId` is required by `agentUpdateSchema` on this surface (unlike
+  // the Workspace surface's Tool adapter, which allows a partial update), so
+  // it is always present here despite `AgentUpdateFields` widening it to
+  // optional for that other caller.
+  const blockers = await findNonSharedReferences(scope.orgId, {
+    providerId: data.providerId!,
+    skillIds: data.skillIds,
+    subAgentIds: data.subAgentIds,
+    toolSetIds: data.toolSetIds,
+  });
+  if (blockers.length > 0) {
+    return {
+      error:
+        "A shared agent may only reference other shared (organization-scoped) resources",
+      blockers,
+    };
   }
 
   const [row] = await db
     .update(agentTable)
     .set({ ...data, updatedAt: new Date() })
-    .where(workspaceScopedWhere("agent", agentId, ctx.workspaceId))
+    .where(orgScopedWhere("agent", agentId, scope.orgId))
     .returning();
   return { row };
 }
 
 /**
- * Deletes a Workspace-scoped Agent, cleaning up its avatar. Throws
- * `NotFoundError`/`LockedError` (via `requireWorkspaceMutable`) under the same
- * rule as {@link updateAgent}.
+ * Deletes an Agent at the given scope, cleaning up its avatar. At Workspace
+ * scope, throws `NotFoundError`/`LockedError` (via `requireWorkspaceMutable`)
+ * under the same rule as {@link updateAgent}. At Organization scope, throws
+ * `ConflictError` (via `requireSharedDeletable`) while an Attachment or
+ * Blueprint still references the Agent (ADR-0007/0008), and — because
+ * deleting a Shared Agent can orphan another Agent's `subAgentIds` reference
+ * to it — scrubs that reference in the same transaction as the delete.
  */
 export async function deleteAgent(
-  ctx: ScopeContext,
+  scope: AgentScope,
   agentId: string,
 ): Promise<void> {
-  const found = await requireWorkspaceMutable(db, "agent", agentId, ctx);
+  if (scope.kind === "workspace") {
+    const found = await requireWorkspaceMutable(
+      db,
+      "agent",
+      agentId,
+      scope.ctx,
+    );
 
-  await deleteAvatar(found.row.avatarKey);
+    await deleteAvatar(found.row.avatarKey);
 
-  await db
-    .delete(agentTable)
-    .where(workspaceScopedWhere("agent", agentId, ctx.workspaceId));
+    await db
+      .delete(agentTable)
+      .where(workspaceScopedWhere("agent", agentId, scope.ctx.workspaceId));
+    return;
+  }
+
+  await requireSharedDeletable(db, "agent", agentId);
+
+  // requireSharedDeletable only checks referencing Attachments/Blueprints, not
+  // existence, so the delete itself is where a missing Agent 404s.
+  const result = await db.transaction(async (tx) => {
+    const rows = await tx
+      .delete(agentTable)
+      .where(orgScopedWhere("agent", agentId, scope.orgId))
+      .returning();
+    if (rows.length > 0) {
+      await scrubDeletedAgentReference(tx, "subAgentIds", agentId);
+    }
+    return rows;
+  });
+  if (result.length === 0) {
+    throw new NotFoundError("Agent not found");
+  }
+
+  // Best-effort: a storage miss must not fail the delete that already committed.
+  await deleteAvatar(result[0].avatarKey);
 }

--- a/apps/backend/src/tools/agent-management.ts
+++ b/apps/backend/src/tools/agent-management.ts
@@ -35,6 +35,7 @@ export function createAgentManagementTools(
   frontendUrl: string | undefined,
 ): Record<string, Tool> {
   const ctx: ScopeContext = { orgId, workspaceId };
+  const scope = { kind: "workspace" as const, ctx };
 
   /**
    * Turns `updateAgent`/`deleteAgent`'s thrown `NotFoundError`/`LockedError`
@@ -127,7 +128,7 @@ export function createAgentManagementTools(
     }),
     execute: async ({ agentId, label: _label, ...data }) =>
       asToolResult(async () => {
-        const result = await updateAgentRow(ctx, agentId, data);
+        const result = await updateAgentRow(scope, agentId, data);
         if ("error" in result) return result;
 
         const { avatarKey: _, ...rest } = result.row;
@@ -149,7 +150,7 @@ export function createAgentManagementTools(
     }),
     execute: async ({ agentId }) =>
       asToolResult(async () => {
-        await deleteAgentRow(ctx, agentId);
+        await deleteAgentRow(scope, agentId);
         return { success: true };
       }),
   });

--- a/apps/backend/src/utils/avatar-url.ts
+++ b/apps/backend/src/utils/avatar-url.ts
@@ -12,3 +12,17 @@ export function avatarKeyToUrl(
     ? `${publicUrl}/${avatarKey}`
     : `${baseUrl}/files/${avatarKey}`;
 }
+
+/**
+ * Replaces an Agent row's stored `avatarKey` with a resolved `avatarUrl` for
+ * the response — shared by the Workspace and Organization Agent routes so the
+ * two surfaces cannot drift on the shape (#605).
+ */
+export function agentWithAvatarUrl(
+  agent: Record<string, unknown>,
+  baseUrl: string,
+): Record<string, unknown> {
+  const key = agent.avatarKey as string | null | undefined;
+  const { avatarKey: _avatarKey, ...rest } = agent;
+  return { ...rest, avatarUrl: avatarKeyToUrl(key, baseUrl) ?? undefined };
+}


### PR DESCRIPTION
## Summary
- Extends `services/agent.ts`'s `updateAgent`/`deleteAgent` with an `AgentScope` (`workspace` | `organization`), mirroring `ProviderScope` from #615, so `routes/org-agent.ts` is now a thin adapter instead of re-implementing the dedupe/self-assignment/reference-blocker/write pipeline inline (#605).
- The org-side existence check (`requireOrgScoped`) now runs before self-assignment/blocker validation, matching the Workspace-side ordering — previously it only surfaced implicitly, last, via the update's row count.
- Dedupes the `agentWithAvatarUrl` helper (previously copy-defined in `routes/agent.ts` and `routes/org-agent.ts`) into `utils/avatar-url.ts`.
- Files #617 as a follow-up for the issue's remaining stage 4 (Skill write model, Attachment module).

Closes #605 (Agent stage; Provider stage and the `scoped-resource.ts` workspace-write-predicate landed earlier in #615/#616).

## Test plan
- [x] `pnpm typecheck` (backend)
- [x] `pnpm lint` (backend)
- [x] `pnpm test` (backend) — 1931 tests passing
- [x] Reviewed via `/code-review` (standards + spec sub-agents) — no hard violations; one intentional behavior change (existence-check ordering) called out and defensible

🤖 Generated with [Claude Code](https://claude.com/claude-code)