### PR TITLE
fix(docs,frontend): sweep sub-agent prose to Sub-Agent casing

### DIFF
--- a/apps/docs/content/building-with-platypus/_meta.ts
+++ b/apps/docs/content/building-with-platypus/_meta.ts
@@ -7,7 +7,7 @@
 const meta = {
   index: "Overview",
   chat: "Chat",
-  agents: "Agents & sub-agents",
+  agents: "Agents & Sub-Agents",
   skills: "Skills",
   "tool-sets": "Tool sets",
   mcp: "MCP servers",

--- a/apps/docs/content/building-with-platypus/agents.mdx
+++ b/apps/docs/content/building-with-platypus/agents.mdx
@@ -1,16 +1,16 @@
 ---
-title: Agents & sub-agents
-description: Create and configure an Agent — pin a Provider and model, write its Instructions, tune generation parameters, grant tools and Skills, and compose sub-agents.
+title: Agents & Sub-Agents
+description: Create and configure an Agent — pin a Provider and model, write its Instructions, tune generation parameters, grant tools and Skills, and compose Sub-Agents.
 ---
 
 import { Callout, Steps } from "nextra/components";
 
-# Agents & sub-agents
+# Agents & Sub-Agents
 
 An **Agent** is a reusable preset for how the assistant behaves: a Provider and
 model, its Instructions, generation settings, and the tools, Skills, and
-sub-agents it's allowed to use. Build it once, then select it on any Chat. For
-the concept, see [Agents & sub-agents](/concepts/agents); this page is the
+Sub-Agents it's allowed to use. Build it once, then select it on any Chat. For
+the concept, see [Agents & Sub-Agents](/concepts/agents); this page is the
 build.
 
 ## Create an Agent
@@ -25,7 +25,7 @@ From your Workspace, go to the **Agents** section and click **Create agent**.
 
 - **Name** — what to call the Agent (3–30 characters).
 - **Description** — a short summary (1–128 characters). This is also what a
-  parent Agent sees when it considers delegating to this one as a sub-agent.
+  parent Agent sees when it considers delegating to this one as a Sub-Agent.
 - **Input Placeholder** _(optional)_ — custom placeholder text shown in the chat
   input when this Agent is selected.
 - **Avatar** _(optional)_ — click to upload or paste an image.
@@ -128,21 +128,21 @@ An Agent that can only talk is limited. Give it the ability to _act_:
   show them.
 </Callout>
 
-## Compose sub-agents
+## Compose Sub-Agents
 
-A **sub-agent** is just another Agent that this one can hand work to. In the
+A **Sub-Agent** is just another Agent that this one can hand work to. In the
 **Sub-Agents** card, flip a switch for each Agent you want this Agent to be able
 to delegate to.
 
-At run time each selected sub-agent is exposed to the parent as a **delegate
+At run time each selected Sub-Agent is exposed to the parent as a **delegate
 tool** named `delegateTo` plus the Agent's name in PascalCase — "Research Agent"
-becomes `delegateToResearchAgent`. Calling it runs the sub-agent (with its
+becomes `delegateToResearchAgent`. Calling it runs the Sub-Agent (with its
 own model, Instructions, and tools) and returns the result. This lets a coordinator
 Agent stay focused while specialists do the detailed work.
 
-### What a sub-agent run does and doesn't get
+### What a Sub-Agent run does and doesn't get
 
-A sub-agent run is not a Chat turn, and it gets far less than the same Agent
+A Sub-Agent run is not a Chat turn, and it gets far less than the same Agent
 would get if you selected it on a Chat. What it does get is everything that
 belongs to the Agent itself: its own **model**, its own **Instructions**
 verbatim, its granted **Tool sets**, its **Max steps** and **sampling
@@ -154,37 +154,37 @@ and a delegated run uses it, exactly as a Chat turn would.
 
 Everything else is absent:
 
-| Not passed to a sub-agent | Consequence                                                                                       |
+| Not passed to a Sub-Agent | Consequence                                                                                       |
 | ------------------------- | --------------------------------------------------------------------------------------------------- |
-| **Skills**                | Attaching a Skill to an Agent used as a sub-agent does nothing in that run — no catalogue is injected and `loadSkill` isn't offered. Fold the know-how into its Instructions instead. |
+| **Skills**                | Attaching a Skill to an Agent used as a Sub-Agent does nothing in that run — no catalogue is injected and `loadSkill` isn't offered. Fold the know-how into its Instructions instead. |
 | **Memories and Context**  | No user Context, no Workspace Context, no Memory summaries.                                       |
 | **Workspace / user identity** | No Workspace id or user name in the prompt. Tools needing one still work; the prompt won't mention it. |
-| **Chat history**          | The sub-agent sees only the `task` string, never the conversation it came from.                   |
-| **Its own sub-agents**    | Delegation is one level deep — see below.                                                         |
+| **Chat history**          | The Sub-Agent sees only the `task` string, never the conversation it came from.                   |
+| **Its own Sub-Agents**    | Delegation is one level deep — see below.                                                         |
 
 <Callout type="warning">
-  Because the parent's `task` string is the sub-agent's entire view of the
-  world, write sub-agent **Instructions so they stand alone**, and expect the
-  parent to restate context it wants carried across. A sub-agent that "forgets
+  Because the parent's `task` string is the Sub-Agent's entire view of the
+  world, write Sub-Agent **Instructions so they stand alone**, and expect the
+  parent to restate context it wants carried across. A Sub-Agent that "forgets
   what we were talking about" is working as designed.
 </Callout>
 
 <Callout type="warning">
-  Delegation is **one level deep**. An Agent running _as_ a sub-agent cannot
-  delegate further — its own sub-agents are not wired up in that context. Design
+  Delegation is **one level deep**. An Agent running _as_ a Sub-Agent cannot
+  delegate further — its own Sub-Agents are not wired up in that context. Design
   for a coordinator plus a flat set of specialists, not deep chains.
 </Callout>
 
-### When a sub-agent can't run
+### When a Sub-Agent can't run
 
-Selecting a sub-agent in the form is not a guarantee it will be there at run
+Selecting a Sub-Agent in the form is not a guarantee it will be there at run
 time. Each one is resolved and built fresh on every turn, and three things stop
 it:
 
-- The sub-agent is **not available in this Workspace** — it was deleted, or it
+- The Sub-Agent is **not available in this Workspace** — it was deleted, or it
   is a Shared Agent that was detached from this Workspace or never attached to
   it. A Shared Agent is only ever visible where it is attached, so a parent
-  attached to a second Workspace loses a sub-agent attached only to the first.
+  attached to a second Workspace loses a Sub-Agent attached only to the first.
 - Its **Provider** no longer resolves in this Workspace — a Shared Provider that
   was detached, say.
 - Its pinned **model** is gone from the Provider's model list.
@@ -196,30 +196,30 @@ can't be honoured right now. Re-attach the Agent, or fix its Provider or model,
 and the tool comes back on the next turn.
 
 <Callout type="warning">
-  "The Agent says it can't reach its sub-agent, but I can see the switch is on"
+  "The Agent says it can't reach its Sub-Agent, but I can see the switch is on"
   is the trap. The **Sub-Agents** card shows what you assigned, not what loaded.
-  Check the sub-agent is still attached to this Workspace, then open it and check
+  Check the Sub-Agent is still attached to this Workspace, then open it and check
   its Provider and model still resolve.
 </Callout>
 
-If the sub-agent builds but its run then fails part-way, the delegate tool
-reports an **error** rather than a short answer. Anything the sub-agent had
+If the Sub-Agent builds but its run then fails part-way, the delegate tool
+reports an **error** rather than a short answer. Anything the Sub-Agent had
 written before the failure comes back with it, so the parent can say what was
 done and what wasn't instead of passing a half-finished reply off as the result.
 
-### When a sub-agent answer stops early
+### When a Sub-Agent answer stops early
 
-A sub-agent writes against its own model's output ceiling, the same one that cuts
+A Sub-Agent writes against its own model's output ceiling, the same one that cuts
 a Chat reply short. Hit it and the delegated answer breaks off wherever it got
 to. That is not treated as a failure: the fragment comes back as the delegate's
 result, the parent Agent is told in the same breath that the answer is partial,
-and expanding the sub-agent's card in the Chat shows a muted line under the
-response reading **Sub-agent response cut short at the model's output limit.**
+and expanding the Sub-Agent's card in the Chat shows a muted line under the
+response reading **Sub-Agent response cut short at the model's output limit.**
 
 <Callout type="warning">
-  The ceiling that applies is the sub-agent's own model's, not the parent's — a
+  The ceiling that applies is the Sub-Agent's own model's, not the parent's — a
   parent on a large model can delegate to a small one and get a fragment back.
-  Split the work into narrower tasks, or pin the sub-agent to a model whose
+  Split the work into narrower tasks, or pin the Sub-Agent to a model whose
   output limit fits the answer you want.
 </Callout>
 

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -121,8 +121,8 @@ Read it against the reply as a whole: most Tools land in single milliseconds, so
 a turn that felt slow and shows nothing above `1.2s` spent its time in the
 model, not the Tools.
 
-A Sub-agent card carries a time too, covering the whole delegated run — every
-step that Sub-agent took, not just the handover. It is usually the largest
+A Sub-Agent card carries a time too, covering the whole delegated run — every
+step that Sub-Agent took, not just the handover. It is usually the largest
 number on the page and the first one to look at on a slow turn.
 
 <Callout type="warning">
@@ -317,7 +317,7 @@ cannot continue it.
 
 - **[Tool sets](/building-with-platypus/tool-sets)** — what the built-in tool
   sets let an Agent do while you watch.
-- **[Agents & sub-agents](/building-with-platypus/agents)** — turn a Chat's
+- **[Agents & Sub-Agents](/building-with-platypus/agents)** — turn a Chat's
   settings into a reusable Agent.
 - **[Memory & context](/concepts/memory-and-context)** — why the assistant knows
   things you didn't say in this Chat.

--- a/apps/docs/content/building-with-platypus/dashboards.mdx
+++ b/apps/docs/content/building-with-platypus/dashboards.mdx
@@ -98,7 +98,7 @@ live without anyone opening a Chat.
 
 ## Where to next
 
-- **[Agents & sub-agents](/building-with-platypus/agents)** — grant the
+- **[Agents & Sub-Agents](/building-with-platypus/agents)** — grant the
   Dashboards tool set to an Agent.
 - **[Triggers](/building-with-platypus/triggers)** — refresh a dashboard on a
   schedule.

--- a/apps/docs/content/building-with-platypus/index.mdx
+++ b/apps/docs/content/building-with-platypus/index.mdx
@@ -43,9 +43,9 @@ Workspace Owner can only manage their own where an Org Admin has switched that o
    time in. Worth reading even if it looks self-explanatory: File parts, web
    search, voice, per-message editing, and what happens when you close the tab
    mid-run.
-2. **[Agents & sub-agents](/building-with-platypus/agents)** — pin a Provider and
+2. **[Agents & Sub-Agents](/building-with-platypus/agents)** — pin a Provider and
    model, write Instructions, tune generation, grant tools. Compose specialists
-   as sub-agents.
+   as Sub-Agents.
 3. **[Skills](/building-with-platypus/skills)** — author named, on-demand know-how
    and attach it to an Agent.
 4. **[Tool sets](/building-with-platypus/tool-sets)** — the catalogue of what the

--- a/apps/docs/content/building-with-platypus/mcp.mdx
+++ b/apps/docs/content/building-with-platypus/mcp.mdx
@@ -111,6 +111,6 @@ unset.
 
 ## Where to next
 
-- **[Agents & sub-agents](/building-with-platypus/agents)** — grant the tool set
+- **[Agents & Sub-Agents](/building-with-platypus/agents)** — grant the tool set
   to an Agent.
 - **[Tools, tool sets & MCP](/concepts/tools)** — the underlying model.

--- a/apps/docs/content/building-with-platypus/skills.mdx
+++ b/apps/docs/content/building-with-platypus/skills.mdx
@@ -88,7 +88,7 @@ A Skill lives at exactly one scope:
 
 ## Where to next
 
-- **[Agents & sub-agents](/building-with-platypus/agents)** — the Agent that uses
+- **[Agents & Sub-Agents](/building-with-platypus/agents)** — the Agent that uses
   the Skills you author here.
 - **[Sharing across workspaces](/concepts/sharing)** — how a Skill becomes a
   Shared resource.

--- a/apps/docs/content/building-with-platypus/tool-sets.mdx
+++ b/apps/docs/content/building-with-platypus/tool-sets.mdx
@@ -70,7 +70,7 @@ above — it needs no code change and no Operator involvement.
 
 ## Where to next
 
-- **[Agents & sub-agents](/building-with-platypus/agents)** — the **Tools** card
+- **[Agents & Sub-Agents](/building-with-platypus/agents)** — the **Tools** card
   these appear on.
 - **[Build a standup bot](/building-with-platypus/standup-bot)** — a worked
   example that grants **Kanban** and puts it to work on a schedule.

--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -139,7 +139,7 @@ Worth checking before rewriting the Instruction.
 
 ## Where to next
 
-- **[Agents & sub-agents](/building-with-platypus/agents)** — the Agent a Trigger
+- **[Agents & Sub-Agents](/building-with-platypus/agents)** — the Agent a Trigger
   runs.
 - **[Boards](/building-with-platypus/boards)** — a common source of Trigger
   events and a common target for scheduled runs.

--- a/apps/docs/content/concepts/_meta.ts
+++ b/apps/docs/content/concepts/_meta.ts
@@ -3,7 +3,7 @@
 // meets while building, then how resources are shared across Workspaces.
 const meta = {
   index: "The big picture",
-  agents: "Agents & sub-agents",
+  agents: "Agents & Sub-Agents",
   providers: "Providers & models",
   tools: "Tools, tool sets & MCP",
   sandboxes: "Sandboxes",

--- a/apps/docs/content/concepts/agents.mdx
+++ b/apps/docs/content/concepts/agents.mdx
@@ -1,9 +1,9 @@
 ---
-title: Agents & sub-agents
-description: Agents are reusable presets that pin a model, Instructions, tools, and skills. Sub-agents let one agent delegate to another.
+title: Agents & Sub-Agents
+description: Agents are reusable presets that pin a model, Instructions, tools, and skills. Sub-Agents let one agent delegate to another.
 ---
 
-# Agents & sub-agents
+# Agents & Sub-Agents
 
 ## Agent
 
@@ -19,7 +19,7 @@ An Agent pins together:
 - **generation parameters** (such as temperature),
 - the **tools** it's allowed to use (see [Tools, tool sets & MCP](/concepts/tools)),
 - any **[Skills](/concepts/skills)** it can draw on,
-- and any **sub-agents** it can delegate to.
+- and any **Sub-Agents** it can delegate to.
 
 When you select an Agent on a Chat turn, that selection takes the place of
 choosing a Provider and model by hand — the Agent already carries those choices.
@@ -34,18 +34,18 @@ prompt](/concepts/system-prompt) lists every part in order.
 Instructions, model, and tools. Build them once, use them across many Chats, and
 tweak them in one place.
 
-## Sub-agent
+## Sub-Agent
 
 A **Sub-Agent** is simply an Agent that another Agent can call on. When you add an
-Agent as a sub-agent of a parent Agent, the parent gains the ability to hand off
-work to it — the sub-agent shows up to the parent as a tool it can invoke.
+Agent as a Sub-Agent of a parent Agent, the parent gains the ability to hand off
+work to it — the Sub-Agent shows up to the parent as a tool it can invoke.
 
 **Why you'd use one:** to break a big job into specialists. A top-level Agent can
-stay focused on coordinating, then delegate research to one sub-agent, drafting to
+stay focused on coordinating, then delegate research to one Sub-Agent, drafting to
 another, and fact-checking to a third.
 
-A sub-agent brings its own model, Instructions and tools — but **not** its
+A Sub-Agent brings its own model, Instructions and tools — but **not** its
 Skills, and none of the surrounding context. A delegated run receives the parent's
 task description and nothing else: no Memories, no Workspace or user Context, no
-Chat history, and no ability to delegate further. See [what a sub-agent run does
+Chat history, and no ability to delegate further. See [what a Sub-Agent run does
 and doesn't get](/building-with-platypus/agents#what-a-sub-agent-run-does-and-doesnt-get).

--- a/apps/docs/content/concepts/index.mdx
+++ b/apps/docs/content/concepts/index.mdx
@@ -69,14 +69,14 @@ once — its **Provider** and model, its **Instructions**, its tools, its
 Agent replaces choosing a Provider and model by hand.
 
 Agents are the heart of building with Platypus. The
-[Agents & sub-agents](/concepts/agents) page goes deeper.
+[Agents & Sub-Agents](/concepts/agents) page goes deeper.
 
 ## The core nouns
 
 Beyond the hierarchy, you'll meet a handful of building blocks. Each has its own
 page in this section:
 
-- **[Agents & sub-agents](/concepts/agents)** — the configurable presets that
+- **[Agents & Sub-Agents](/concepts/agents)** — the configurable presets that
   drive a conversation, and how one Agent can delegate to another.
 - **[Providers & models](/concepts/providers)** — your connections to AI vendors
   like OpenAI, Anthropic, or Google.

--- a/apps/docs/content/concepts/providers.mdx
+++ b/apps/docs/content/concepts/providers.mdx
@@ -178,7 +178,7 @@ backends](/extending/web-search-backends).
 A Provider carries an optional free-text **security guardrails** field. Whatever
 you write there is appended **last** in the system prompt — the final
 instructions the model reads before the conversation — for **every** run on that
-Provider, including sub-agent runs that resolve to it.
+Provider, including Sub-Agent runs that resolve to it.
 
 It is provider-scoped on purpose: how susceptible a model is to prompt injection
 is a property of the endpoint. Frontier hosted models resist most attacks

--- a/apps/docs/content/concepts/system-prompt.mdx
+++ b/apps/docs/content/concepts/system-prompt.mdx
@@ -33,7 +33,7 @@ Workspace produces a short prompt — only fragments 1, 4 and 5 are always prese
 | **7**  | **Memories**              | When there are Memories to recall               | The [Memory](/concepts/memory-and-context#memory) summaries retrieved for you in this Workspace.                                                                                                                                   |
 | **8**  | **Memory tools**          | When the Agent has the memory tool set          | A note that `memorySearch` and `memoryGet` are available for looking up memories beyond any summaries above.                                                                                                                       |
 | **9**  | **Skills**                | When the Agent has Skills                       | The name and description of each [Skill](/concepts/skills) — not its body, which the model requests on demand via `loadSkill`.                                                                                                     |
-| **10** | **Sub-Agents**            | When the Agent has sub-agents                   | Each [sub-agent](/concepts/agents#sub-agent) that loaded, its delegate tool name, its description, and the rule that a delegated task must be self-contained. Any sub-agent that failed to load is listed separately as unavailable, with the reason. |
+| **10** | **Sub-Agents**            | When the Agent has Sub-Agents                   | Each [Sub-Agent](/concepts/agents#sub-agent) that loaded, its delegate tool name, its description, and the rule that a delegated task must be self-contained. Any Sub-Agent that failed to load is listed separately as unavailable, with the reason. |
 | **11** | **Sandbox**               | When the Agent has the sandbox tool set         | How the [Sandbox](/concepts/sandboxes) works: the `/workspace` root, that files persist between turns, that each shell call starts fresh, output limits, timeouts, and the _names_ of any Workspace-default environment variables. |
 | **12** | **Security guardrails**   | When the run's Provider has guardrails          | The Provider's [security guardrails](/concepts/providers#security-guardrails), verbatim and last.                                                                                                                                  |
 
@@ -45,10 +45,10 @@ Workspace produces a short prompt — only fragments 1, 4 and 5 are always prese
 </Callout>
 
 <Callout type="warning">
-  This is the composition for a **Chat turn**. A sub-agent invoked through a
+  This is the composition for a **Chat turn**. A Sub-Agent invoked through a
   delegate tool is not a Chat turn: it receives its own Instructions plus its
   Provider's security guardrails, and none of the fragments in between. Write a
-  sub-agent's Instructions so they stand on their own.
+  Sub-Agent's Instructions so they stand on their own.
 </Callout>
 
 ## Why the order matters
@@ -70,7 +70,7 @@ guardrails live at opposite ends.
 Your Instructions are one input to a prompt Platypus owns. Two consequences:
 
 **You don't need to restate what's already there.** The Workspace Context, your
-name, your Context notes, your Memories, the Skills catalogue and the sub-agent
+name, your Context notes, your Memories, the Skills catalogue and the Sub-Agent
 catalogue all arrive on their own. Describing a Skill inside your Instructions, or
 writing "the user you're talking to is Sam", spends context on something Platypus
 supplies anyway — and goes stale the moment either changes.

--- a/apps/docs/content/self-hosting/providers-and-auth.mdx
+++ b/apps/docs/content/self-hosting/providers-and-auth.mdx
@@ -232,7 +232,7 @@ run is marked cut short at the model's output limit.
 Leave it empty and Platypus sends no ceiling at all, so whatever the vendor does
 by default applies. Set it to the model's published output maximum when you want
 long answers, or lower to hold replies (and spend) down. The same ceiling
-applies when that model runs as a sub-Agent.
+applies when that model runs as a Sub-Agent.
 
 <Callout type="warning">
   **On Amazon Bedrock, empty is not "the model's maximum".** Bedrock applies a
@@ -387,7 +387,7 @@ Before taking an irreversible or high-impact action — sending a message, delet
 
 <Callout type="warning">
   Guardrails are provider-scoped and apply to **every** run on that Provider,
-  including sub-agent runs. They are also non-suppressible: an Agent's own
+  including Sub-Agent runs. They are also non-suppressible: an Agent's own
   Instructions render first and cannot opt out of text that renders last. The
   escape hatch for an Agent that must not carry them is a different Provider.
 </Callout>

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -148,7 +148,7 @@ const AgentForm = ({
   );
   const skills = skillsData?.results || [];
 
-  // Fetch agents for sub-agent selection
+  // Fetch agents for Sub-Agent selection
   const { data: agentsData } = useSWR<{ results: Agent[] }>(
     backendUrl && user ? joinUrl(backendUrl, agentsBase) : null,
     fetcher,
@@ -866,7 +866,7 @@ const AgentForm = ({
             <CardContent>
               <FieldDescription className="mb-4">
                 Select agents that this agent can delegate tasks to. When
-                running as a sub-agent, these agents will not be able to
+                running as a Sub-Agent, these agents will not be able to
                 delegate further.
               </FieldDescription>
               <FieldGroup className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/apps/frontend/components/agents-list.tsx
+++ b/apps/frontend/components/agents-list.tsx
@@ -83,7 +83,7 @@ type PromoteBlocker = {
 const BLOCKER_LABEL: Record<PromoteBlocker["type"], string> = {
   provider: "Provider",
   skill: "Skill",
-  subAgent: "Sub-agent",
+  subAgent: "Sub-Agent",
   mcp: "MCP tool set",
 };
 

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -108,7 +108,7 @@ const specializedToolMatchers: Array<(part: MessagePart) => boolean> = [
  * that no specialised renderer above has already claimed.
  *
  * Exported so a test can assert the exclusion directly: a plugin web-search
- * or sub-agent part must never also satisfy this, or its raw JSON body would
+ * or Sub-Agent part must never also satisfy this, or its raw JSON body would
  * repeat what the specialised card (and, for search, the Sources row above
  * the parts loop) already shows.
  */

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -1377,7 +1377,7 @@ const ProviderForm = ({
                 <FieldDescription>
                   Free-text security directives appended to the end of the
                   system prompt for every run on this provider (including
-                  sub-agents). Recommended for self-hosted or open models, which
+                  Sub-Agents). Recommended for self-hosted or open models, which
                   are more susceptible to prompt injection. This is a
                   prompt-level floor, not a guarantee — see the docs for
                   paste-in starter snippets and the enforcement layers behind a

--- a/apps/frontend/components/sub-agent-tool.tsx
+++ b/apps/frontend/components/sub-agent-tool.tsx
@@ -45,14 +45,14 @@ type SubAgentActivity = {
 };
 
 /**
- * What the person reading a delegated run is told when the sub-agent stopped at
+ * What the person reading a delegated run is told when the Sub-Agent stopped at
  * its model's output ceiling rather than because it had finished. The Chat
  * counterpart of the marker a cut-short reply carries, one level down: the card
  * shows the delegate's answer verbatim, so an unmarked fragment reads as a
  * finished finding. A constant so tests assert the wording without restating it.
  */
 export const SUB_AGENT_CUT_SHORT_NOTICE =
-  "Sub-agent response cut short at the model's output limit.";
+  "Sub-Agent response cut short at the model's output limit.";
 
 const isSubAgentActivity = (output: unknown): output is SubAgentActivity =>
   typeof output === "object" &&

--- a/apps/frontend/components/turn-notice.tsx
+++ b/apps/frontend/components/turn-notice.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 
 /**
  * The muted warning row for a per-turn notice about how an answer was produced
- * or how it ended — under a Chat reply, under a delegated sub-agent response,
+ * or how it ended — under a Chat reply, under a delegated Sub-Agent response,
  * and in Trigger run history.
  *
  * It carries the output-ceiling notice and the search-was-unavailable notice,
@@ -12,7 +12,7 @@ import { cn } from "@/lib/utils";
  *
  * The row is shared; the wording is not. Each surface owns its own sentence as
  * an exported constant its tests assert against — the ceiling notices name
- * their subject ("Response", "Sub-agent response", "Run") per surface.
+ * their subject ("Response", "Sub-Agent response", "Run") per surface.
  */
 export const TurnNotice = ({
   children,


### PR DESCRIPTION
## Summary
- Brings prose, headings, nav labels, and UI strings across `apps/docs/content` and `apps/frontend` to the `Sub-Agent`/`Sub-Agents` capitalization codified in `VOICE.md` by #544
- Leaves filenames (`sub-agent-tool.tsx`), code identifiers (`subAgentIds`, `SubAgentTool`), DOM ids, and heading anchor slugs (`#sub-agent`) lowercase, unchanged
- Fixes the frontend stragglers named in the issue: the `agents-list.tsx` resource-type label and `sub-agent-tool.tsx`'s `SUB_AGENT_CUT_SHORT_NOTICE` string (the doc quoting that string verbatim is updated to match)
- Leaves `agents-list.tsx`'s "0 sub-agents" badge lowercase, matching its lowercase sibling badges ("0 skills", "0 tools")

Closes #545

## Test plan
- [x] `pnpm --filter docs test` — 28/28 passing, no anchor/link regressions
- [x] `pnpm --filter frontend test` — 458/458 passing
- [x] `pnpm --filter frontend typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)