### PR TITLE
fix(docs): read the docs contract's inputs with normalised line endings

### DIFF
--- a/apps/docs/content/docs-contract.test.ts
+++ b/apps/docs/content/docs-contract.test.ts
@@ -51,11 +51,24 @@ const REPO_ROOT = join(CONTENT_DIR, "..", "..", "..");
 
 // --- reading -----------------------------------------------------------------
 
+/**
+ * Normalise CRLF to LF at the point of reading.
+ *
+ * Git can check out CRLF on Windows. Everything downstream splits on `"\n"` and
+ * several patterns anchor with `$`, and a trailing `"\r"` defeats both — most
+ * sharply the heading pattern, which then matches nothing and leaves the
+ * internal-link check with no anchors to resolve against. One normalisation
+ * here rather than a tolerance every future pattern has to remember.
+ */
+const normalizeNewlines = (text: string): string => text.replace(/\r\n/g, "\n");
+
 const readRepoFile = (repoRelativePath: string): string =>
-  readFileSync(join(REPO_ROOT, repoRelativePath), "utf8");
+  normalizeNewlines(readFileSync(join(REPO_ROOT, repoRelativePath), "utf8"));
 
 const readDoc = (contentRelativePath: string): string =>
-  readFileSync(join(CONTENT_DIR, contentRelativePath), "utf8");
+  normalizeNewlines(
+    readFileSync(join(CONTENT_DIR, contentRelativePath), "utf8"),
+  );
 
 /** Every `.mdx` page under `content/`, as paths relative to `content/`. */
 const listDocs = (dir = CONTENT_DIR): string[] => {
@@ -1050,6 +1063,29 @@ const headingSlugs = (content: string): Set<string> => {
   }
   return slugs;
 };
+
+// Git can check out CRLF on Windows, and every reader here splits on "\n" and
+// anchors patterns with `$`. A trailing "\r" defeats both: the heading pattern
+// matches nothing, the internal-link check collects no anchors, and every link
+// is then reported as broken. Pinned because that failure names the links
+// rather than the line endings, which sends a reader to the wrong place.
+describe("line endings", () => {
+  it("normalises CRLF, so heading anchors survive a Windows checkout", () => {
+    const lf = readDoc("extending/web-search-backends.mdx");
+    const crlf = lf.replace(/\n/g, "\r\n");
+
+    expect(normalizeNewlines(crlf)).toBe(lf);
+    expect([...headingSlugs(normalizeNewlines(crlf))]).toEqual([
+      ...headingSlugs(lf),
+    ]);
+  });
+
+  // Trivially true on an LF checkout, and that is the point: on a CRLF one this
+  // is what fails if a reader stops normalising, instead of every link check.
+  it("hands the checks below no carriage returns", () => {
+    for (const doc of DOCS) expect(readDoc(doc)).not.toContain("\r");
+  });
+});
 
 describe("internal links", () => {
   const slugsByRoute = new Map<string, Set<string>>();


### PR DESCRIPTION
Found while reviewing #629, and noted in that PR as unrelated to it. Split out rather than folded in.

## The symptom

On a Windows checkout, `docs-contract.test.ts` fails with **every internal link reported as broken**. On Linux and macOS it passes, so CI never saw it.

## The cause

Not the links. Git can check out CRLF, and each reader splits on `"\n"`, which leaves a trailing `"\r"` on every line. The heading pattern anchors with `$`:

```js
/^#{1,6}\s+(.*)$/
```

`.` does not match a carriage return, so `.*` stops before it and `$` cannot reach the end of the string. The line does not match at all:

```
LF   match: "Releasing what you opened"
CRLF match: null
```

`headingSlugs` therefore collects nothing from any page, and the internal-link check has no anchors left to resolve against — so it reports every link and anchor as broken. The failure names the links, which sends a reader looking in entirely the wrong place.

## The fix

Normalised at the two readers, not in the heading pattern. Nine call sites in this file split on `"\n"` and several anchor with `$`; the heading pattern is only the one that fails loudest. Putting the tolerance at the single point where content enters means no future pattern has to remember it.

## Tests

Two, and they do different jobs:

- The first pins the composition a reader depends on — CRLF content normalises to exactly the LF text, and yields identical heading anchors.
- The second asserts the readers hand the checks no carriage returns. This is **trivially true on an LF checkout, and that is the point**: on a CRLF one it is what fails if a reader stops normalising, naming the cause instead of the links.

## Verification

Beyond the unit tests, I converted every `.mdx` under `apps/docs/content` to CRLF on disk and ran the suite against it:

- With the fix: **35 pass**.
- Without it (readers not normalising, same CRLF tree): the internal-link check **fails**, reproducing the reported symptom.

`pnpm typecheck`, `pnpm lint` and `pnpm test` all pass — 8/8 tasks.

## Scope

One file. No behaviour change for anyone on LF, and no docs content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)