### PR TITLE
feat: add card.moved event so triggers can fire on column entry

### DIFF
--- a/apps/backend/src/services/event-dispatch.test.ts
+++ b/apps/backend/src/services/event-dispatch.test.ts
@@ -228,6 +228,91 @@ describe("event-dispatch", () => {
       expect(mockExecuteTrigger).not.toHaveBeenCalled();
     });
 
+    it("should fire card.moved for a column filter matching the destination column", async () => {
+      const trigger = makeEventTrigger({
+        config: {
+          events: ["card.moved"],
+          filters: { columnId: "col-dest" },
+        },
+      });
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
+
+      dispatchEvent("org-1", "ws-1", "card.moved", {
+        id: "c1",
+        columnId: "col-dest",
+        previousColumnId: "col-source",
+      });
+      await flushMicrotasks();
+
+      expect(mockExecuteTrigger).toHaveBeenCalled();
+    });
+
+    it("should not fire card.moved for a column filter matching only the source column", async () => {
+      const trigger = makeEventTrigger({
+        config: {
+          events: ["card.moved"],
+          filters: { columnId: "col-source" },
+        },
+      });
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
+
+      dispatchEvent("org-1", "ws-1", "card.moved", {
+        id: "c1",
+        columnId: "col-dest",
+        previousColumnId: "col-source",
+      });
+      await flushMicrotasks();
+
+      expect(mockExecuteTrigger).not.toHaveBeenCalled();
+    });
+
+    it("should skip a card.moved trigger when its own agent caused the event", async () => {
+      const trigger = makeEventTrigger({
+        agentId: "agent-1",
+        config: { events: ["card.moved"], filters: undefined },
+      });
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
+
+      dispatchEvent(
+        "org-1",
+        "ws-1",
+        "card.moved",
+        { id: "c1", columnId: "col-dest", previousColumnId: "col-source" },
+        { actorAgentId: "agent-1" },
+      );
+      await flushMicrotasks();
+
+      expect(mockExecuteTrigger).not.toHaveBeenCalled();
+    });
+
+    it("should reach the debounce path for card.moved, coalescing rapid duplicates", async () => {
+      const trigger = makeEventTrigger({
+        config: { events: ["card.moved"], filters: undefined },
+      });
+      mockDb.where
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([trigger])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([trigger]);
+
+      dispatchEvent("org-1", "ws-1", "card.moved", {
+        id: "c1",
+        columnId: "col-dest",
+        previousColumnId: "col-source",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      dispatchEvent("org-1", "ws-1", "card.moved", {
+        id: "c1",
+        columnId: "col-dest",
+        previousColumnId: "col-source",
+      });
+      await flushMicrotasks();
+
+      // Both calls key onto the same trigger+card debounce entry, so they
+      // coalesce into a single execution — same as card.updated does.
+      expect(mockExecuteTrigger).toHaveBeenCalledTimes(1);
+    });
+
     it("should handle multiple webhooks and triggers", async () => {
       const webhook1 = makeWebhook({ id: "wh-1" });
       const webhook2 = makeWebhook({

--- a/apps/backend/src/services/kanban.test.ts
+++ b/apps/backend/src/services/kanban.test.ts
@@ -6,10 +6,12 @@ vi.mock("./event-dispatch.ts", () => ({
 }));
 
 import { NotFoundError, ValidationError } from "../errors.ts";
+import { dispatchEvent } from "./event-dispatch.ts";
 import {
   applyBodyDiff,
   bulkUpdateCards,
   keepKnownLabelIds,
+  moveCard,
   placeCardInColumn,
   rebalancedPositions,
   requireCard,
@@ -26,6 +28,7 @@ describe("kanban module", () => {
 
   beforeEach(() => {
     db = createMockDb();
+    vi.mocked(dispatchEvent).mockClear();
   });
 
   describe("requireCard", () => {
@@ -289,6 +292,79 @@ describe("kanban module", () => {
     });
   });
 
+  describe("moveCard", () => {
+    it("dispatches card.moved with the previous column when the column changes", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-old", boardId: "board-1" },
+        ]) // requireCard
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]); // requireColumn
+      db.orderBy.mockResolvedValue([]); // placeCardInColumn
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-new", position: 1 },
+      ]);
+
+      await moveCard(asDb(db), ctx, {
+        cardId: "card-1",
+        columnId: "col-new",
+        afterCardId: null,
+      });
+
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.moved",
+        expect.objectContaining({
+          id: "card-1",
+          columnId: "col-new",
+          previousColumnId: "col-old",
+          boardId: "board-1",
+        }),
+        expect.anything(),
+      );
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.updated",
+        expect.objectContaining({ id: "card-1", boardId: "board-1" }),
+        expect.anything(),
+      );
+    });
+
+    it("does not dispatch card.moved for a within-column reorder", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // requireCard
+        .mockResolvedValueOnce([{ id: "col-1", boardId: "board-1" }]); // requireColumn
+      db.orderBy.mockResolvedValue([]); // placeCardInColumn
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-1", position: 1 },
+      ]);
+
+      await moveCard(asDb(db), ctx, {
+        cardId: "card-1",
+        columnId: "col-1",
+        afterCardId: null,
+      });
+
+      expect(dispatchEvent).not.toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.moved",
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.updated",
+        expect.objectContaining({ id: "card-1", boardId: "board-1" }),
+        expect.anything(),
+      );
+    });
+  });
+
   describe("bulkUpdateCards", () => {
     it("reports the cards it could not reach and updates the rest", async () => {
       db.limit
@@ -321,6 +397,61 @@ describe("kanban module", () => {
         }),
       ).rejects.toThrow("Invalid user assignee");
       expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it("dispatches card.moved for a card whose column changes, but not for one that stays put", async () => {
+      db.limit
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]) // requireColumn (target)
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-old", boardId: "board-1" },
+        ]) // requireCard card-1
+        .mockResolvedValueOnce([
+          { id: "card-2", columnId: "col-new", boardId: "board-1" },
+        ]); // requireCard card-2, already in the target column
+      db.returning
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-new", position: 1 },
+        ])
+        .mockResolvedValueOnce([
+          { id: "card-2", columnId: "col-new", position: 2 },
+        ]);
+
+      await bulkUpdateCards(asDb(db), ctx, {
+        cardIds: ["card-1", "card-2"],
+        columnId: "col-new",
+      });
+
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.moved",
+        expect.objectContaining({
+          id: "card-1",
+          previousColumnId: "col-old",
+        }),
+        expect.anything(),
+      );
+      expect(dispatchEvent).not.toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.moved",
+        expect.objectContaining({ id: "card-2" }),
+        expect.anything(),
+      );
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.updated",
+        expect.objectContaining({ id: "card-1" }),
+        expect.anything(),
+      );
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.updated",
+        expect.objectContaining({ id: "card-2" }),
+        expect.anything(),
+      );
     });
   });
 });

--- a/apps/backend/src/services/kanban.ts
+++ b/apps/backend/src/services/kanban.ts
@@ -139,6 +139,24 @@ const dispatch = (ctx: KanbanContext, event: WebhookEvent, data: unknown) =>
     isAgent(ctx.actor) ? { actorAgentId: ctx.actor.agentId } : undefined,
   );
 
+/**
+ * Announces a card write that may have changed its column. Emits
+ * `card.moved` (with `previousColumnId`) only when the column actually
+ * changed, always followed by `card.updated` — a within-column reorder or
+ * a plain field edit emits `card.updated` alone.
+ */
+const dispatchCardWrite = (
+  ctx: KanbanContext,
+  row: CardRow,
+  boardId: string,
+  previousColumnId: string,
+) => {
+  if (previousColumnId !== row.columnId) {
+    dispatch(ctx, "card.moved", { ...row, boardId, previousColumnId });
+  }
+  dispatch(ctx, "card.updated", { ...row, boardId });
+};
+
 // --- Scope guards ---
 
 /** The board-side condition every guard joins through: Workspace, then board. */
@@ -657,7 +675,7 @@ export const moveCard = async (
   ctx: KanbanContext,
   input: { cardId: string; columnId: string; afterCardId: string | null },
 ): Promise<CardResult> => {
-  await requireCard(database, ctx, input.cardId);
+  const previous = await requireCard(database, ctx, input.cardId);
   const column = await requireColumn(database, ctx, input.columnId);
 
   const record = await database.transaction(async (tx) => {
@@ -681,7 +699,7 @@ export const moveCard = async (
     return rows[0];
   });
 
-  dispatch(ctx, "card.updated", { ...record, boardId: column.boardId });
+  dispatchCardWrite(ctx, record, column.boardId, previous.columnId);
   return { card: record, boardId: column.boardId };
 };
 
@@ -948,7 +966,7 @@ export const bulkUpdateCards = async (
   });
 
   for (const { card, row } of updated) {
-    dispatch(ctx, "card.updated", { ...row, boardId: card.boardId });
+    dispatchCardWrite(ctx, row, card.boardId, card.columnId);
   }
 
   return input.cardIds.map((id) => outcomes.get(id)!);

--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -53,9 +53,14 @@ Trigger** to run once and then disable itself.
 ### Or choose events (Event)
 
 For an Event trigger, select one or more **Events** (e.g. `card.created`,
-`card.updated`, `notification.created`). Optionally narrow with **Filter by
-Board** and **Filter by Column** so the Trigger only fires for activity on a
-specific board.
+`card.updated`, `card.moved`, `notification.created`). Optionally narrow with
+**Filter by Board** and **Filter by Column** so the Trigger only fires for
+activity on a specific board.
+
+`card.moved` fires only when a card's column actually changes, so a column
+filter on it matches the card's **destination** column — use it to run an
+Agent whenever a card enters a specific column, without re-firing on later
+edits to cards already sitting there.
 
 ### Finish
 

--- a/apps/docs/content/building-with-platypus/webhooks.mdx
+++ b/apps/docs/content/building-with-platypus/webhooks.mdx
@@ -26,6 +26,7 @@ A Webhook subscribes to one or more events. The available events are:
 | ------------------------ | ------------------------------------------------------------- |
 | `card.created`           | A card is added to a [Board](/building-with-platypus/boards). |
 | `card.updated`           | A card's fields, column, or position change.                  |
+| `card.moved`             | A card's column changes — fires alongside `card.updated`.     |
 | `card.deleted`           | A card is removed.                                            |
 | `notification.created`   | An Agent posts a notification.                                |
 | `notification.updated`   | A notification is edited.                                     |
@@ -128,8 +129,40 @@ the full notification record:
 }
 ```
 
-while lighter-weight events carry only the affected IDs. For example,
-`card.deleted`:
+`card.moved` carries the full card record plus `previousColumnId`, so a handler
+can tell where the card came from without a separate lookup:
+
+```json
+{
+  "event": "card.moved",
+  "timestamp": "2026-06-26T09:31:30.000Z",
+  "orgId": "g7Qw3pLm9xRt2nK5vB8dY",
+  "workspaceId": "k4Tn2pXqRf7Lm9sWvB3dY",
+  "data": {
+    "id": "V1StGXR8_Z5jdHi6B-myT",
+    "boardId": "lbfQ0p7xKmR2nT4vZ8wYs",
+    "columnId": "9zHcN3eW1qoP5rUaB7dKt",
+    "previousColumnId": "3mYtQ8vNc1RpZ7wLdB4sK",
+    "title": "Review onboarding flow",
+    "body": "Check the new sign-up steps.",
+    "labelIds": [],
+    "assignees": [],
+    "dueDate": null,
+    "priority": "none",
+    "position": 1024,
+    "createdByUserId": "x6Ym2Qp9LrT4nW8sVdB1k",
+    "createdByAgentId": null,
+    "createdAt": "2026-06-26T09:30:00.000Z",
+    "updatedAt": "2026-06-26T09:31:30.000Z"
+  }
+}
+```
+
+Moving a card to a different column always fires both `card.moved` and
+`card.updated`. Reordering a card within the same column fires only
+`card.updated` — `card.moved` means the card changed columns.
+
+Other events carry only the affected IDs. For example, `card.deleted`:
 
 ```json
 {

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -102,6 +102,7 @@ const AVAILABLE_EVENTS = [
   "notification.dismissed",
   "card.created",
   "card.updated",
+  "card.moved",
   "card.deleted",
 ] as const;
 

--- a/apps/frontend/components/webhook-form.tsx
+++ b/apps/frontend/components/webhook-form.tsx
@@ -58,6 +58,7 @@ const ALL_EVENTS = [
   "notification.dismissed",
   "card.created",
   "card.updated",
+  "card.moved",
   "card.deleted",
 ] as const;
 
@@ -68,6 +69,7 @@ const EVENT_LABELS: Record<string, string> = {
   "notification.dismissed": "Notification dismissed",
   "card.created": "Card created",
   "card.updated": "Card updated",
+  "card.moved": "Card moved",
   "card.deleted": "Card deleted",
 };
 

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -1536,6 +1536,7 @@ export const webhookEventSchema = z.enum([
   "notification.dismissed",
   "card.created",
   "card.updated",
+  "card.moved",
   "card.deleted",
 ]);
 


### PR DESCRIPTION
## Summary
- Adds `card.moved` to `webhookEventSchema`, emitted by `moveCard` and the bulk-update column path only when a card's column actually changes (compared before the write); a within-column reorder still emits `card.updated` only.
- `card.moved` carries the full card record plus `previousColumnId`, and is dispatched alongside the existing `card.updated` (dual emission — no breaking change for existing consumers).
- A trigger/webhook column filter on `card.moved` matches the destination column, giving true "fire on column entry" semantics; the self-actor guard and per-trigger+card debounce apply to it identically to other card events.
- Trigger/webhook event pickers in the frontend, and the `triggers.mdx`/`webhooks.mdx` docs pages, updated with the new event; the docs contract test still pins the webhooks table against the schema.

Closes #621

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (backend 1980 tests, frontend 458 tests, docs contract test)
- [x] `pnpm lint`
- [x] New tests: cross-column vs. same-column `moveCard`/`bulkUpdateCards` dispatch, destination-column filter matching for `card.moved`, self-actor guard and debounce behavior for `card.moved`
- [x] Ran `/code-review` (Standards + Spec axes) against `origin/main`; addressed the one duplicated-code smell and the missing self-actor-guard/debounce test coverage it flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)