### PR TITLE
feat: card.updated payload carries changedFields, with a matching trigger filter

### DIFF
--- a/apps/backend/src/routes/kanban.test.ts
+++ b/apps/backend/src/routes/kanban.test.ts
@@ -669,6 +669,9 @@ describe("Kanban Routes", () => {
       mockDb.limit.mockResolvedValueOnce([
         { id: "card-1", columnId: "col-1", boardId: "board-1" },
       ]); // card guard
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "card-1", columnId: "col-1", title: "Card" },
+      ]); // prior row, for the changedFields value-diff
 
       const mockCard = { id: "card-1", title: "Updated Card" };
       mockDb.returning.mockResolvedValueOnce([mockCard]);
@@ -714,6 +717,9 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]); // card guard
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", labelIds: [] },
+        ]); // prior row, for the changedFields value-diff
         mockBoardLabels([{ id: "lbl-a" }, { id: "lbl-b" }]);
         mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
 
@@ -738,6 +744,9 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]); // card guard
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", labelIds: [] },
+        ]); // prior row, for the changedFields value-diff
         mockBoardLabels([{ id: "lbl-new" }]);
         mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
 
@@ -770,6 +779,9 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]); // card guard
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", labelIds: [] },
+        ]); // prior row, for the changedFields value-diff
         mockBoardLabels([]);
         mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
 
@@ -796,10 +808,14 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]); // card guard
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1" },
+        ]); // prior row, for the changedFields value-diff
         // assignee validation: org member query then super admin query
         mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
+        mockDb.where.mockReturnValueOnce(mockDb); // currentCardRow chain
         mockDb.where.mockResolvedValueOnce([]); // org member lookup — not found
         mockDb.where.mockResolvedValueOnce([]); // super admin lookup — not found
 
@@ -829,9 +845,13 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]); // card guard
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1" },
+        ]); // prior row, for the changedFields value-diff
         // assignee validation queries
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
+        mockDb.where.mockReturnValueOnce(mockDb); // currentCardRow chain
         mockDb.where.mockResolvedValueOnce([]); // org member lookup — not found
         mockDb.where.mockResolvedValueOnce([{ id: "admin-user" }]); // super admin lookup — found
         mockDb.where.mockReturnValueOnce(mockDb); // card update chain
@@ -868,9 +888,13 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]); // card guard
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1" },
+        ]); // prior row, for the changedFields value-diff
         mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
+        mockDb.where.mockReturnValueOnce(mockDb); // currentCardRow chain
         // No user assignees, so the visibility lookup's two queries come first:
         // workspace-scoped agents, then org-scoped ones joined to an attachment.
         mockDb.where.mockResolvedValueOnce([]);
@@ -915,9 +939,13 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]); // card guard
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1" },
+        ]); // prior row, for the changedFields value-diff
         mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
+        mockDb.where.mockReturnValueOnce(mockDb); // currentCardRow chain
         mockDb.where.mockResolvedValueOnce([]); // no workspace-scoped match
         mockDb.where.mockResolvedValueOnce([]); // no attached org-scoped match
 
@@ -947,10 +975,14 @@ describe("Kanban Routes", () => {
         mockDb.limit.mockResolvedValueOnce([
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]); // card guard
+        mockDb.limit.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1" },
+        ]); // prior row, for the changedFields value-diff
         // assignee validation queries
         mockDb.where.mockReturnValueOnce(mockDb); // requireOrgAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // requireWorkspaceAccess chain
         mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
+        mockDb.where.mockReturnValueOnce(mockDb); // currentCardRow chain
         mockDb.where.mockResolvedValueOnce([{ userId: "user-1" }]); // org member lookup — found
         mockDb.where.mockResolvedValueOnce([]); // super admin lookup — not found
         mockDb.where.mockReturnValueOnce(mockDb); // card update chain

--- a/apps/backend/src/services/event-dispatch.test.ts
+++ b/apps/backend/src/services/event-dispatch.test.ts
@@ -228,6 +228,76 @@ describe("event-dispatch", () => {
       expect(mockExecuteTrigger).not.toHaveBeenCalled();
     });
 
+    it("should filter triggers by changedFields when the filter set does not intersect", async () => {
+      const trigger = makeEventTrigger({
+        config: {
+          events: ["card.updated"],
+          filters: { changedFields: ["assignees"] },
+        },
+      });
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
+
+      dispatchEvent("org-1", "ws-1", "card.updated", {
+        id: "c1",
+        changedFields: ["body"],
+      });
+      await flushMicrotasks();
+
+      expect(mockExecuteTrigger).not.toHaveBeenCalled();
+    });
+
+    it("should execute the trigger when the changedFields filter intersects the event", async () => {
+      const trigger = makeEventTrigger({
+        config: {
+          events: ["card.updated"],
+          filters: { changedFields: ["assignees"] },
+        },
+      });
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
+
+      dispatchEvent("org-1", "ws-1", "card.updated", {
+        id: "c1",
+        changedFields: ["assignees", "body"],
+      });
+      await flushMicrotasks();
+
+      expect(mockExecuteTrigger).toHaveBeenCalled();
+    });
+
+    it("should not fire a changedFields filter for an event that carries no changedFields", async () => {
+      const trigger = makeEventTrigger({
+        config: {
+          events: ["card.created"],
+          filters: { changedFields: ["assignees"] },
+        },
+      });
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
+
+      dispatchEvent("org-1", "ws-1", "card.created", { cardId: "c1" });
+      await flushMicrotasks();
+
+      expect(mockExecuteTrigger).not.toHaveBeenCalled();
+    });
+
+    it("should compose the changedFields filter with the boardId filter", async () => {
+      const trigger = makeEventTrigger({
+        config: {
+          events: ["card.updated"],
+          filters: { boardId: "board-1", changedFields: ["assignees"] },
+        },
+      });
+      mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
+
+      dispatchEvent("org-1", "ws-1", "card.updated", {
+        id: "c1",
+        boardId: "board-2",
+        changedFields: ["assignees"],
+      });
+      await flushMicrotasks();
+
+      expect(mockExecuteTrigger).not.toHaveBeenCalled();
+    });
+
     it("should fire card.moved for a column filter matching the destination column", async () => {
       const trigger = makeEventTrigger({
         config: {

--- a/apps/backend/src/services/event-dispatch.ts
+++ b/apps/backend/src/services/event-dispatch.ts
@@ -105,6 +105,20 @@ export function dispatchEvent(
           const eventData = data as Record<string, unknown>;
           if (eventData.columnId !== triggerConfig.filters.columnId) continue;
         }
+        if (triggerConfig.filters?.changedFields) {
+          const eventData = data as Record<string, unknown>;
+          const changedFields = eventData.changedFields;
+          const filterFields = triggerConfig.filters.changedFields;
+          if (
+            !Array.isArray(changedFields) ||
+            !changedFields.some(
+              (field): boolean =>
+                typeof field === "string" && filterFields.includes(field),
+            )
+          ) {
+            continue;
+          }
+        }
 
         // Debounce per trigger+entity to coalesce rapid events
         const entityId = (data as { id?: string | number })?.id ?? "unknown";

--- a/apps/backend/src/services/event-trigger-debounce.test.ts
+++ b/apps/backend/src/services/event-trigger-debounce.test.ts
@@ -65,6 +65,44 @@ describe("event-trigger-debounce", () => {
     expect(executeFn).toHaveBeenCalledWith(trigger, ctx3);
   });
 
+  it("should union changedFields across coalesced events rather than replacing them", () => {
+    const executeFn = vi
+      .fn<Parameters<typeof debounceTriggerExecution>[3]>()
+      .mockResolvedValue(undefined);
+    const trigger = makeTrigger("t-1");
+
+    const ctx1 = makeContext({ id: "card-1", changedFields: ["body"] });
+    const ctx2 = makeContext({ id: "card-1", changedFields: ["assignees"] });
+
+    debounceTriggerExecution("t-1:card-1", trigger, ctx1, executeFn);
+    vi.advanceTimersByTime(1_000);
+    debounceTriggerExecution("t-1:card-1", trigger, ctx2, executeFn);
+    vi.advanceTimersByTime(5_000);
+
+    expect(executeFn).toHaveBeenCalledOnce();
+    const deliveredCtx = executeFn.mock.calls[0][1];
+    const changedFields = (
+      deliveredCtx.eventData as { changedFields: string[] }
+    ).changedFields;
+    expect(changedFields.slice().sort()).toEqual(["assignees", "body"]);
+  });
+
+  it("does not union changedFields when only one of the two events carries it", () => {
+    const executeFn = vi.fn().mockResolvedValue(undefined);
+    const trigger = makeTrigger("t-1");
+
+    const ctx1 = makeContext({ id: "card-1" }); // e.g. card.created, no changedFields
+    const ctx2 = makeContext({ id: "card-1", changedFields: ["body"] });
+
+    debounceTriggerExecution("t-1:card-1", trigger, ctx1, executeFn);
+    vi.advanceTimersByTime(1_000);
+    debounceTriggerExecution("t-1:card-1", trigger, ctx2, executeFn);
+    vi.advanceTimersByTime(5_000);
+
+    expect(executeFn).toHaveBeenCalledOnce();
+    expect(executeFn).toHaveBeenCalledWith(trigger, ctx2);
+  });
+
   it("should fire independently for different debounce keys", () => {
     const executeFn = vi.fn().mockResolvedValue(undefined);
     const trigger1 = makeTrigger("t-1");

--- a/apps/backend/src/services/event-trigger-debounce.ts
+++ b/apps/backend/src/services/event-trigger-debounce.ts
@@ -14,6 +14,39 @@ const pendingTriggers = new Map<
 
 const DEBOUNCE_MS = 5_000;
 
+/**
+ * The event context a coalesced replacement delivers: the incoming context,
+ * except `changedFields` — when both the incoming and the pending context
+ * carry one — is the union of the two, so a trigger that eventually runs
+ * sees every field changed across the coalesced window, not just the last
+ * event's (see #622).
+ */
+/** The `changedFields` an event's data carries, or `undefined` if it has none. */
+const changedFieldsOf = (eventData: unknown): string[] | undefined => {
+  const fields = (eventData as { changedFields?: unknown } | undefined)
+    ?.changedFields;
+  return Array.isArray(fields) && fields.every((f) => typeof f === "string")
+    ? fields
+    : undefined;
+};
+
+const mergedEventContext = (
+  pending: EventContext | undefined,
+  incoming: EventContext,
+): EventContext => {
+  const pendingFields = changedFieldsOf(pending?.eventData);
+  const incomingFields = changedFieldsOf(incoming.eventData);
+  if (!pendingFields || !incomingFields) return incoming;
+
+  return {
+    ...incoming,
+    eventData: {
+      ...(incoming.eventData as Record<string, unknown>),
+      changedFields: [...new Set([...pendingFields, ...incomingFields])],
+    },
+  };
+};
+
 export function debounceTriggerExecution(
   key: string,
   trigger: Trigger,
@@ -25,12 +58,17 @@ export function debounceTriggerExecution(
     clearTimeout(existing.timer);
   }
 
+  const mergedContext = mergedEventContext(
+    existing?.eventContext,
+    eventContext,
+  );
+
   const timer = setTimeout(() => {
     pendingTriggers.delete(key);
-    void executeFn(trigger, eventContext);
+    void executeFn(trigger, mergedContext);
   }, DEBOUNCE_MS);
 
-  pendingTriggers.set(key, { timer, trigger, eventContext });
+  pendingTriggers.set(key, { timer, trigger, eventContext: mergedContext });
 }
 
 export function clearPendingTriggers(): void {

--- a/apps/backend/src/services/kanban.test.ts
+++ b/apps/backend/src/services/kanban.test.ts
@@ -10,6 +10,7 @@ import { dispatchEvent } from "./event-dispatch.ts";
 import {
   applyBodyDiff,
   bulkUpdateCards,
+  changedCardFields,
   keepKnownLabelIds,
   moveCard,
   placeCardInColumn,
@@ -17,6 +18,8 @@ import {
   requireCard,
   requireKnownLabelIds,
   requireValidAssignees,
+  updateCard,
+  type CardRow,
   type KanbanContext,
 } from "./kanban.ts";
 
@@ -292,6 +295,116 @@ describe("kanban module", () => {
     });
   });
 
+  describe("changedCardFields", () => {
+    const baseCard: CardRow = {
+      id: "card-1",
+      columnId: "col-1",
+      title: "Title",
+      body: "Body",
+      labelIds: ["lbl-a", "lbl-b"],
+      assignees: [
+        { type: "user", id: "user-1" },
+        { type: "agent", id: "agent-1" },
+      ],
+      dueDate: new Date("2026-01-01T00:00:00Z"),
+      priority: "medium",
+      position: 1,
+      createdByUserId: "user-1",
+      createdByAgentId: null,
+      lastEditedByUserId: null,
+      lastEditedByAgentId: null,
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+      updatedAt: new Date("2026-01-01T00:00:00Z"),
+    };
+
+    it("reports nothing when every value-bearing field is unchanged", () => {
+      expect(changedCardFields(baseCard, { ...baseCard })).toEqual([]);
+    });
+
+    it("ignores bookkeeping columns even when they differ", () => {
+      const next: CardRow = {
+        ...baseCard,
+        position: 99,
+        updatedAt: new Date("2026-02-01T00:00:00Z"),
+        lastEditedByUserId: "user-2",
+        lastEditedByAgentId: "agent-2",
+      };
+      expect(changedCardFields(baseCard, next)).toEqual([]);
+    });
+
+    it("reports body when only the body differs", () => {
+      expect(
+        changedCardFields(baseCard, { ...baseCard, body: "New body" }),
+      ).toEqual(["body"]);
+    });
+
+    it("does not report labelIds when the same set arrives in a different order", () => {
+      expect(
+        changedCardFields(baseCard, {
+          ...baseCard,
+          labelIds: ["lbl-b", "lbl-a"],
+        }),
+      ).toEqual([]);
+    });
+
+    it("reports labelIds when the set actually differs", () => {
+      expect(
+        changedCardFields(baseCard, { ...baseCard, labelIds: ["lbl-a"] }),
+      ).toEqual(["labelIds"]);
+    });
+
+    it("does not report assignees when the same set arrives in a different order", () => {
+      expect(
+        changedCardFields(baseCard, {
+          ...baseCard,
+          assignees: [
+            { type: "agent", id: "agent-1" },
+            { type: "user", id: "user-1" },
+          ],
+        }),
+      ).toEqual([]);
+    });
+
+    it("reports assignees when the set actually differs", () => {
+      expect(
+        changedCardFields(baseCard, {
+          ...baseCard,
+          assignees: [{ type: "user", id: "user-1" }],
+        }),
+      ).toEqual(["assignees"]);
+    });
+
+    it("compares dueDate by value, not by object identity", () => {
+      expect(
+        changedCardFields(baseCard, {
+          ...baseCard,
+          dueDate: new Date("2026-01-01T00:00:00Z"),
+        }),
+      ).toEqual([]);
+      expect(
+        changedCardFields(baseCard, {
+          ...baseCard,
+          dueDate: new Date("2026-03-01T00:00:00Z"),
+        }),
+      ).toEqual(["dueDate"]);
+    });
+
+    it("reports columnId when the column changes", () => {
+      expect(
+        changedCardFields(baseCard, { ...baseCard, columnId: "col-2" }),
+      ).toEqual(["columnId"]);
+    });
+
+    it("reports priority and title changes", () => {
+      expect(
+        changedCardFields(baseCard, { ...baseCard, priority: "urgent" }),
+      ).toEqual(["priority"]);
+      expect(
+        changedCardFields(baseCard, { ...baseCard, title: "New title" }),
+      ).toEqual(["title"]);
+    });
+  });
+
   describe("moveCard", () => {
     it("dispatches card.moved with the previous column when the column changes", async () => {
       db.limit
@@ -326,7 +439,11 @@ describe("kanban module", () => {
         "org-1",
         "ws-1",
         "card.updated",
-        expect.objectContaining({ id: "card-1", boardId: "board-1" }),
+        expect.objectContaining({
+          id: "card-1",
+          boardId: "board-1",
+          changedFields: ["columnId"],
+        }),
         expect.anything(),
       );
     });
@@ -359,7 +476,85 @@ describe("kanban module", () => {
         "org-1",
         "ws-1",
         "card.updated",
-        expect.objectContaining({ id: "card-1", boardId: "board-1" }),
+        expect.objectContaining({
+          id: "card-1",
+          boardId: "board-1",
+          changedFields: [],
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe("updateCard", () => {
+    it("emits an empty changedFields when the update echoes the card back unchanged", async () => {
+      const previous = {
+        id: "card-1",
+        columnId: "col-1",
+        title: "Title",
+        body: "Body",
+        priority: "medium",
+      };
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // requireCard
+        .mockResolvedValueOnce([previous]); // currentCardRow
+      db.returning.mockResolvedValue([{ ...previous }]);
+
+      await updateCard(asDb(db), ctx, "card-1", {
+        title: "Title",
+        body: "Body",
+        priority: "medium",
+      });
+
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.updated",
+        expect.objectContaining({ changedFields: [] }),
+        expect.anything(),
+      );
+    });
+
+    it("reports body when the change arrives as a plain edit", async () => {
+      const previous = { id: "card-1", columnId: "col-1", body: "Old body" };
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([previous]);
+      db.returning.mockResolvedValue([{ ...previous, body: "New body" }]);
+
+      await updateCard(asDb(db), ctx, "card-1", { body: "New body" });
+
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.updated",
+        expect.objectContaining({ changedFields: ["body"] }),
+        expect.anything(),
+      );
+    });
+
+    it("reports body when the change arrives as a bodyDiff", async () => {
+      const previous = { id: "card-1", columnId: "col-1", body: "Old body" };
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([previous]);
+      db.returning.mockResolvedValue([{ ...previous, body: "New body" }]);
+
+      await updateCard(asDb(db), ctx, "card-1", {
+        bodyDiff: [{ search: "Old", replace: "New" }],
+      });
+
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.updated",
+        expect.objectContaining({ changedFields: ["body"] }),
         expect.anything(),
       );
     });
@@ -371,7 +566,8 @@ describe("kanban module", () => {
         .mockResolvedValueOnce([
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ])
-        .mockResolvedValueOnce([]); // card-2 is out of scope
+        .mockResolvedValueOnce([]) // card-2 is out of scope
+        .mockResolvedValueOnce([{ id: "card-1", priority: "low" }]); // card-1's row before this write
       db.returning.mockResolvedValue([{ id: "card-1" }]);
 
       expect(
@@ -384,6 +580,13 @@ describe("kanban module", () => {
         { cardId: "card-2", success: false, error: "Card not found" },
       ]);
       expect(db.set).toHaveBeenCalledTimes(1);
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        "org-1",
+        "ws-1",
+        "card.updated",
+        expect.objectContaining({ changedFields: ["priority"] }),
+        expect.anything(),
+      );
     });
 
     it("refuses the whole batch when the assignee cannot work here", async () => {
@@ -407,7 +610,9 @@ describe("kanban module", () => {
         ]) // requireCard card-1
         .mockResolvedValueOnce([
           { id: "card-2", columnId: "col-new", boardId: "board-1" },
-        ]); // requireCard card-2, already in the target column
+        ]) // requireCard card-2, already in the target column
+        .mockResolvedValueOnce([{ id: "card-1", columnId: "col-old" }]) // card-1's row before this write
+        .mockResolvedValueOnce([{ id: "card-2", columnId: "col-new" }]); // card-2's row before this write
       db.returning
         .mockResolvedValueOnce([
           { id: "card-1", columnId: "col-new", position: 1 },
@@ -442,14 +647,14 @@ describe("kanban module", () => {
         "org-1",
         "ws-1",
         "card.updated",
-        expect.objectContaining({ id: "card-1" }),
+        expect.objectContaining({ id: "card-1", changedFields: ["columnId"] }),
         expect.anything(),
       );
       expect(dispatchEvent).toHaveBeenCalledWith(
         "org-1",
         "ws-1",
         "card.updated",
-        expect.objectContaining({ id: "card-2" }),
+        expect.objectContaining({ id: "card-2", changedFields: [] }),
         expect.anything(),
       );
     });

--- a/apps/backend/src/services/kanban.ts
+++ b/apps/backend/src/services/kanban.ts
@@ -140,6 +140,55 @@ const dispatch = (ctx: KanbanContext, event: WebhookEvent, data: unknown) =>
   );
 
 /**
+ * The card attributes a value-diff considers. Bookkeeping columns
+ * (`updatedAt`, the `lastEditedBy*` attribution, `position`) are excluded —
+ * every write touches them, so including them would make `changedFields`
+ * meaningless. `id`, `createdAt`, and `createdBy*` are left in for
+ * completeness but never differ between an old and new row.
+ */
+const CHANGED_FIELD_KEYS = [
+  "title",
+  "body",
+  "labelIds",
+  "assignees",
+  "dueDate",
+  "priority",
+  "columnId",
+] as const satisfies readonly (keyof CardRow)[];
+
+/** The set-like fields compared order-insensitively, not by array equality. */
+const SET_LIKE_FIELDS = new Set<string>(["labelIds", "assignees"]);
+
+/** A field's value, reduced to a form where `===`-by-JSON is the right test. */
+const comparableFieldValue = (key: string, value: unknown): unknown => {
+  if (value === undefined || value === null) return value;
+  if (key === "labelIds") return [...(value as string[])].sort();
+  if (key === "assignees") {
+    return (value as KanbanCardAssignee[])
+      .map((assignee) => `${assignee.type}:${assignee.id}`)
+      .sort();
+  }
+  if (value instanceof Date) return value.getTime();
+  return value;
+};
+
+/**
+ * The names of the fields whose values actually differ between the pre-write
+ * and post-write row — a value-diff, not a report of which input keys were
+ * supplied (see #622: an update that echoes a field back unchanged, or an
+ * agent that resends `labelIds`/`assignees` in a different order, must not
+ * report that field as changed).
+ */
+export const changedCardFields = (previous: CardRow, next: CardRow): string[] =>
+  CHANGED_FIELD_KEYS.filter((key) => {
+    const before = comparableFieldValue(key, previous[key]);
+    const after = comparableFieldValue(key, next[key]);
+    return SET_LIKE_FIELDS.has(key)
+      ? JSON.stringify(before) !== JSON.stringify(after)
+      : before !== after;
+  });
+
+/**
  * Announces a card write that may have changed its column. Emits
  * `card.moved` (with `previousColumnId`) only when the column actually
  * changed, always followed by `card.updated` — a within-column reorder or
@@ -150,11 +199,12 @@ const dispatchCardWrite = (
   row: CardRow,
   boardId: string,
   previousColumnId: string,
+  changedFields: string[],
 ) => {
   if (previousColumnId !== row.columnId) {
     dispatch(ctx, "card.moved", { ...row, boardId, previousColumnId });
   }
-  dispatch(ctx, "card.updated", { ...row, boardId });
+  dispatch(ctx, "card.updated", { ...row, boardId, changedFields });
 };
 
 // --- Scope guards ---
@@ -535,18 +585,24 @@ export const placeCardInColumn = async (
 
 // --- Card body ---
 
-/** The card's body as stored, or an empty string when it has none. */
-const currentBody = async (
-  database: Database,
+/**
+ * The card row as it stands before a write — the pre-write side of the
+ * `changedFields` value-diff, and (for a `bodyDiff` edit) what the diff
+ * applies against.
+ */
+const currentCardRow = async (
+  database: Executor,
   cardId: string,
-): Promise<string> => {
+): Promise<CardRow> => {
   const rows = await database
-    .select({ body: kanbanCardTable.body })
+    .select()
     .from(kanbanCardTable)
     .where(eq(kanbanCardTable.id, cardId))
     .limit(1);
 
-  return rows[0]?.body ?? "";
+  const row = rows[0];
+  if (!row) throw new NotFoundError("Card not found");
+  return row;
 };
 
 /**
@@ -635,6 +691,7 @@ export const updateCard = async (
   input: CardInput,
 ): Promise<CardResult> => {
   const card = await requireCard(database, ctx, cardId);
+  const previous = await currentCardRow(database, cardId);
 
   const labelIds =
     input.labelIds === undefined
@@ -645,7 +702,7 @@ export const updateCard = async (
   const body =
     input.bodyDiff === undefined
       ? input.body
-      : applyBodyDiff(await currentBody(database, cardId), input.bodyDiff);
+      : applyBodyDiff(previous.body ?? "", input.bodyDiff);
 
   const rows = await database
     .update(kanbanCardTable)
@@ -661,7 +718,11 @@ export const updateCard = async (
   const record = rows[0];
   if (!record) throw new NotFoundError("Card not found");
 
-  dispatch(ctx, "card.updated", { ...record, boardId: card.boardId });
+  dispatch(ctx, "card.updated", {
+    ...record,
+    boardId: card.boardId,
+    changedFields: changedCardFields(previous, record),
+  });
   return { card: record, boardId: card.boardId };
 };
 
@@ -699,7 +760,18 @@ export const moveCard = async (
     return rows[0];
   });
 
-  dispatchCardWrite(ctx, record, column.boardId, previous.columnId);
+  // A move only ever touches columnId and position (bookkeeping, excluded),
+  // so the changedFields diff is this one comparison rather than a
+  // `changedCardFields` call — `previous` here is a narrow `CardRef`
+  // (from `requireCard`), not a full `CardRow`, and doesn't carry the other
+  // fields a general diff would need.
+  dispatchCardWrite(
+    ctx,
+    record,
+    column.boardId,
+    previous.columnId,
+    previous.columnId !== record.columnId ? ["columnId"] : [],
+  );
   return { card: record, boardId: column.boardId };
 };
 
@@ -931,9 +1003,15 @@ export const bulkUpdateCards = async (
     : 0;
 
   const updated = await database.transaction(async (tx) => {
-    const records: { card: CardRef; row: CardRow }[] = [];
+    const records: { card: CardRef; row: CardRow; previous: CardRow }[] = [];
 
     for (const [index, card] of cards.entries()) {
+      // The value-diff each card's `card.updated` event carries is computed
+      // against the row as it stood right before this write. `card` (from
+      // `requireCard`) only carries id/columnId/boardId, not the field values
+      // a diff needs, so this is a genuine extra read rather than reuse.
+      const previous = await currentCardRow(tx, card.id);
+
       const labelIds = editsLabels
         ? filterKnownLabelIds(
             resolveBulkLabels(input, currentLabels.get(card.id) ?? []),
@@ -960,13 +1038,19 @@ export const bulkUpdateCards = async (
         .where(eq(kanbanCardTable.id, card.id))
         .returning();
 
-      records.push({ card, row: rows[0] });
+      records.push({ card, row: rows[0], previous });
     }
     return records;
   });
 
-  for (const { card, row } of updated) {
-    dispatchCardWrite(ctx, row, card.boardId, card.columnId);
+  for (const { card, row, previous } of updated) {
+    dispatchCardWrite(
+      ctx,
+      row,
+      card.boardId,
+      card.columnId,
+      changedCardFields(previous, row),
+    );
   }
 
   return input.cardIds.map((id) => outcomes.get(id)!);

--- a/apps/backend/src/tools/kanban.test.ts
+++ b/apps/backend/src/tools/kanban.test.ts
@@ -291,6 +291,7 @@ describe("createKanbanTools", () => {
         .mockResolvedValueOnce([
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]) // card guard
+        .mockResolvedValueOnce([{ id: "card-1", columnId: "col-1" }]) // prior row, for the changedFields value-diff
         .mockResolvedValueOnce([{ labels: [{ id: "lbl-a" }] }]); // board labels
       mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
 
@@ -309,10 +310,13 @@ describe("createKanbanTools", () => {
     });
 
     it("rejects an invalid assignee when updating", async () => {
-      mockDb.limit.mockResolvedValueOnce([
-        { id: "card-1", columnId: "col-1", boardId: "board-1" },
-      ]); // card guard
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard
+        .mockResolvedValueOnce([{ id: "card-1", columnId: "col-1" }]); // prior row, for the changedFields value-diff
       mockDb.where.mockReturnValueOnce(mockDb); // card guard chain
+      mockDb.where.mockReturnValueOnce(mockDb); // currentCardRow chain
       mockDb.where.mockResolvedValueOnce([]); // org member lookup — not found
       mockDb.where.mockResolvedValueOnce([]); // super admin lookup — not found
 
@@ -337,6 +341,7 @@ describe("createKanbanTools", () => {
         .mockResolvedValueOnce([
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]) // card guard
+        .mockResolvedValueOnce([{ id: "card-1", columnId: "col-1" }]) // prior row, for the changedFields value-diff
         .mockResolvedValueOnce([{ labels: [{ id: "lbl-a" }] }]); // board labels
       mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
 

--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -62,13 +62,21 @@ filter on it matches the card's **destination** column — use it to run an
 Agent whenever a card enters a specific column, without re-firing on later
 edits to cards already sitting there.
 
-A Trigger listening for `card.updated` can also be narrowed to specific
-attributes with a `changedFields` filter, so it fires only when one of the
-named fields actually changed — not on every write to a matching card. It
+When `card.updated` is among the selected events, a **Filter by Changed
+Fields** control appears — pick one or more card attributes (Title, Body,
+Labels, Assignees, Due date, Priority, Column) and the Trigger fires only when
+one of them actually changed, not on every write to a matching card. It
 composes with the Board and Column filters: every filter set on the Trigger
 must match. See [Webhooks: the
 payload](/building-with-platypus/webhooks#the-payload) for what counts as a
 changed field.
+
+<Callout type="warning">
+  This filter only applies to `card.updated` — `card.created`, `card.moved`,
+  and `card.deleted` carry no changed fields, so a Trigger that also
+  subscribes to one of those alongside a Changed Fields filter never fires for
+  it. Give a Trigger that needs both its own copy without the filter.
+</Callout>
 
 ### Finish
 

--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -62,6 +62,14 @@ filter on it matches the card's **destination** column — use it to run an
 Agent whenever a card enters a specific column, without re-firing on later
 edits to cards already sitting there.
 
+A Trigger listening for `card.updated` can also be narrowed to specific
+attributes with a `changedFields` filter, so it fires only when one of the
+named fields actually changed — not on every write to a matching card. It
+composes with the Board and Column filters: every filter set on the Trigger
+must match. See [Webhooks: the
+payload](/building-with-platypus/webhooks#the-payload) for what counts as a
+changed field.
+
 ### Finish
 
 Set **Max Runs to Keep** (how many run records to retain), optionally enable

--- a/apps/docs/content/building-with-platypus/webhooks.mdx
+++ b/apps/docs/content/building-with-platypus/webhooks.mdx
@@ -162,6 +162,40 @@ Moving a card to a different column always fires both `card.moved` and
 `card.updated`. Reordering a card within the same column fires only
 `card.updated` — `card.moved` means the card changed columns.
 
+`card.updated` also carries `changedFields` — the names of the attributes that
+actually changed, e.g. `["body"]` for a body edit or `["columnId"]` for a
+cross-column move. It's a value comparison, not a report of which fields the
+update submitted: resending a field with the same value (an Agent that echoes
+the whole card back) doesn't add it to `changedFields`, and re-ordering
+`labelIds` or `assignees` without changing the set doesn't either. A pure
+reorder within a column emits `card.updated` with `changedFields: []`.
+
+```json
+{
+  "event": "card.updated",
+  "timestamp": "2026-06-26T09:31:30.000Z",
+  "orgId": "g7Qw3pLm9xRt2nK5vB8dY",
+  "workspaceId": "k4Tn2pXqRf7Lm9sWvB3dY",
+  "data": {
+    "id": "V1StGXR8_Z5jdHi6B-myT",
+    "boardId": "lbfQ0p7xKmR2nT4vZ8wYs",
+    "columnId": "9zHcN3eW1qoP5rUaB7dKt",
+    "title": "Review onboarding flow",
+    "body": "Check the new sign-up steps and confirm the copy.",
+    "labelIds": [],
+    "assignees": [],
+    "dueDate": null,
+    "priority": "none",
+    "position": 1024,
+    "createdByUserId": "x6Ym2Qp9LrT4nW8sVdB1k",
+    "createdByAgentId": null,
+    "createdAt": "2026-06-26T09:30:00.000Z",
+    "updatedAt": "2026-06-26T09:31:30.000Z",
+    "changedFields": ["body"]
+  }
+}
+```
+
 Other events carry only the affected IDs. For example, `card.deleted`:
 
 ```json

--- a/apps/frontend/components/trigger-form.test.tsx
+++ b/apps/frontend/components/trigger-form.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// --- Module mocks ------------------------------------------------------------
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://test",
+}));
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "u1" } }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+const agents = [{ id: "agent-1", name: "Agent One" }];
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: (key: string | null) => {
+    if (key?.includes("/agents")) {
+      return { data: { results: agents }, isLoading: false, mutate: vi.fn() };
+    }
+    if (key?.includes("/boards")) {
+      return { data: { results: [] }, isLoading: false, mutate: vi.fn() };
+    }
+    return { data: undefined, isLoading: false, mutate: vi.fn() };
+  },
+  useSWRConfig: () => ({ mutate: vi.fn() }),
+}));
+
+import { TriggerForm } from "./trigger-form";
+
+// --- Helpers -----------------------------------------------------------------
+
+/** An accepted save, so the payload the form sent can be read back. */
+function stubAcceptedSave() {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ id: "trigger-1" }),
+  } as unknown as Response);
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+/** The `config` the form put on the wire for the last save. */
+function savedConfig(fetchMock: ReturnType<typeof vi.fn>) {
+  const [, init] = fetchMock.mock.calls.at(-1) as [string, RequestInit];
+  return JSON.parse(String(init.body)).config;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+async function renderEventTriggerForm() {
+  render(<TriggerForm orgId="org1" workspaceId="ws1" />);
+  await waitFor(() => expect(screen.getByText("Agent")).toBeInTheDocument());
+
+  // Trigger Type is a Radix Select defaulting to "Cron" — open it and pick
+  // "Event" the same way provider-form's tests drive Radix Select controls.
+  const triggerTypeSelect = screen
+    .getAllByRole("combobox")
+    .find((el) => el.textContent === "Cron")!;
+  const scrollIntoView = Element.prototype.scrollIntoView;
+  Element.prototype.scrollIntoView = vi.fn();
+  try {
+    fireEvent.keyDown(triggerTypeSelect, { key: "ArrowDown" });
+    const event = await screen.findByRole("option", { name: "Event" });
+    fireEvent.keyDown(event, { key: "Enter" });
+  } finally {
+    Element.prototype.scrollIntoView = scrollIntoView;
+  }
+}
+
+describe("TriggerForm — changed-fields filter", () => {
+  it("hides the changed-fields filter until card.updated is selected", async () => {
+    await renderEventTriggerForm();
+
+    expect(screen.queryByText("Filter by Changed Fields")).toBeNull();
+
+    fireEvent.click(screen.getByLabelText("card.updated"));
+
+    expect(screen.getByText("Filter by Changed Fields")).toBeInTheDocument();
+  });
+
+  it("clears the changed-fields filter when card.updated is deselected", async () => {
+    await renderEventTriggerForm();
+
+    fireEvent.click(screen.getByLabelText("card.updated"));
+    fireEvent.click(screen.getByLabelText("Assignees"));
+    fireEvent.click(screen.getByLabelText("card.updated"));
+    fireEvent.click(screen.getByLabelText("card.updated"));
+
+    expect(screen.getByLabelText("Assignees")).not.toBeChecked();
+  });
+
+  it("submits the selected changed fields as the trigger filter", async () => {
+    const fetchMock = stubAcceptedSave();
+    await renderEventTriggerForm();
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "My Trigger" },
+    });
+    fireEvent.change(screen.getByLabelText("Instruction"), {
+      target: { value: "Do something" },
+    });
+    fireEvent.click(screen.getByLabelText("card.updated"));
+    fireEvent.click(screen.getByLabelText("Assignees"));
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(savedConfig(fetchMock)).toMatchObject({
+      events: ["card.updated"],
+      filters: { changedFields: ["assignees"] },
+    });
+  });
+});

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -106,6 +106,18 @@ const AVAILABLE_EVENTS = [
   "card.deleted",
 ] as const;
 
+// Mirrors the fields kanban.ts's changedCardFields diffs (updatedAt,
+// lastEditedBy*, and position are bookkeeping and never appear there).
+const CHANGED_FIELD_OPTIONS = [
+  { value: "title", label: "Title" },
+  { value: "body", label: "Body" },
+  { value: "labelIds", label: "Labels" },
+  { value: "assignees", label: "Assignees" },
+  { value: "dueDate", label: "Due date" },
+  { value: "priority", label: "Priority" },
+  { value: "columnId", label: "Column" },
+] as const;
+
 const buildCronExpression = (
   frequency: Frequency,
   minute: string,
@@ -349,6 +361,7 @@ const TriggerForm = ({
   const [selectedEvents, setSelectedEvents] = useState<string[]>([]);
   const [filterBoardId, setFilterBoardId] = useState<string>("");
   const [filterColumnId, setFilterColumnId] = useState<string>("");
+  const [filterChangedFields, setFilterChangedFields] = useState<string[]>([]);
 
   const { data: boardStateData } = useSWR<KanbanBoardState>(
     backendUrl && user && filterBoardId
@@ -437,6 +450,7 @@ const TriggerForm = ({
         setSelectedEvents(eventConfig.events);
         setFilterBoardId(eventConfig.filters?.boardId || "");
         setFilterColumnId(eventConfig.filters?.columnId || "");
+        setFilterChangedFields(eventConfig.filters?.changedFields || []);
       }
     }
   });
@@ -519,8 +533,18 @@ const TriggerForm = ({
         setFilterBoardId("");
         setFilterColumnId("");
       }
+      // The changed-fields filter only makes sense against card.updated
+      if (!next.includes("card.updated")) {
+        setFilterChangedFields([]);
+      }
       return next;
     });
+  };
+
+  const handleChangedFieldToggle = (field: string) => {
+    setFilterChangedFields((prev) =>
+      prev.includes(field) ? prev.filter((f) => f !== field) : [...prev, field],
+    );
   };
 
   const handleSubmit = async () => {
@@ -554,11 +578,16 @@ const TriggerForm = ({
               type: "event" as const,
               config: {
                 events: selectedEvents,
-                ...(filterBoardId
+                ...(filterBoardId || filterChangedFields.length > 0
                   ? {
                       filters: {
-                        boardId: filterBoardId,
-                        ...(filterColumnId ? { columnId: filterColumnId } : {}),
+                        ...(filterBoardId ? { boardId: filterBoardId } : {}),
+                        ...(filterBoardId && filterColumnId
+                          ? { columnId: filterColumnId }
+                          : {}),
+                        ...(filterChangedFields.length > 0
+                          ? { changedFields: filterChangedFields }
+                          : {}),
                       },
                     }
                   : {}),
@@ -1088,6 +1117,46 @@ const TriggerForm = ({
                   </FieldDescription>
                 </Field>
               </div>
+            )}
+
+          {/* Changed-fields filter — only meaningful against card.updated */}
+          {triggerType === "event" &&
+            selectedEvents.includes("card.updated") && (
+              <Field>
+                <FieldLabel>Filter by Changed Fields</FieldLabel>
+                <FieldDescription>
+                  Only fire on a card update when one of these fields actually
+                  changed. Leave all off to fire on any change.
+                  {selectedEvents.some(
+                    (e) => e !== "card.updated" && e.startsWith("card."),
+                  ) && (
+                    <>
+                      {" "}
+                      Setting this also stops the other selected card events
+                      from firing, since only card.updated reports changed
+                      fields.
+                    </>
+                  )}
+                </FieldDescription>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-2">
+                  {CHANGED_FIELD_OPTIONS.map((field) => (
+                    <Field key={field.value} orientation="horizontal">
+                      <Switch
+                        id={`changed-field-${field.value}`}
+                        className="cursor-pointer"
+                        checked={filterChangedFields.includes(field.value)}
+                        onCheckedChange={() =>
+                          handleChangedFieldToggle(field.value)
+                        }
+                        disabled={isSubmitting}
+                      />
+                      <FieldLabel htmlFor={`changed-field-${field.value}`}>
+                        {field.label}
+                      </FieldLabel>
+                    </Field>
+                  ))}
+                </div>
+              </Field>
             )}
 
           <Field className="w-1/2">

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -1559,6 +1559,7 @@ export type CronTriggerConfig = z.infer<typeof cronTriggerConfigSchema>;
 export const eventTriggerFiltersSchema = z.object({
   boardId: z.string().optional(),
   columnId: z.string().optional(),
+  changedFields: z.array(z.string()).optional(),
 });
 
 export type EventTriggerFilters = z.infer<typeof eventTriggerFiltersSchema>;


### PR DESCRIPTION
## Summary

- `card.updated` (single-card update, move, bulk update) now carries `changedFields: string[]` — a value-diff between the pre-write and post-write row, not a report of which input keys the update supplied. Bookkeeping columns (`updatedAt`, `lastEditedBy*`, `position`) are excluded; `labelIds`/`assignees` compare as sets, order-insensitively.
- `EventTriggerFilters` (`@platypus/schemas`) gains an optional `changedFields: string[]`; a Trigger with the filter set fires only when the event's `changedFields` intersects it, composing (AND) with the existing `boardId`/`columnId` filters. An event without `changedFields` (e.g. `card.created`/`card.deleted`) never matches this filter.
- The per-trigger+card debounce now **unions** `changedFields` across coalesced events instead of the later event replacing the earlier one's, so a trigger that eventually runs sees every field changed across the coalesced window.
- Purely additive — existing webhook consumers and triggers without the filter are unaffected.
- Docs: `webhooks.mdx` documents the new payload field; `triggers.mdx` documents the new filter.

Closes #622.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass (backend 1999 tests, frontend 458 tests, docs contract test)
- [x] Unit tests for `changedCardFields` covering: unchanged echo, body edit (direct + `bodyDiff`), reordered `labelIds`/`assignees` (no change reported), real set changes, `dueDate` value comparison, `columnId` change, bookkeeping exclusion
- [x] `updateCard`/`moveCard`/`bulkUpdateCards` integration tests asserting `changedFields` on the dispatched `card.updated` event
- [x] `event-dispatch` tests for the `changedFields` filter: no-intersect skip, intersect fires, no match on an event without `changedFields`, composes with `boardId`
- [x] `event-trigger-debounce` tests for the union behavior, and the case where only one of two coalesced events carries `changedFields`
- [x] Standards + Spec code review passed (both axes) prior to commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)