### PR TITLE
feat(docs): document the event payload an Event trigger delivers

### DIFF
--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -33,8 +33,8 @@ In your Workspace, go to the **Triggers** section and click **Create trigger**.
 - **Name** and **Description** — label the Trigger (description optional).
 - **Agent** — which Agent to run.
 - **Instruction** — the message sent to the Agent every time the Trigger fires
-  (up to 10,000 characters). For Event triggers, the event's data is appended
-  automatically.
+  (up to 10,000 characters). For Event triggers, the event's data arrives
+  above it — see [Event payloads](#event-payloads).
 
 ### Set the cadence (Cron)
 
@@ -114,6 +114,61 @@ A few details worth knowing:
   whole step budget. (This guard is unattended-only; interactive Chats are never
   stopped this way.)
 - Older run records beyond **Max Runs to Keep** are pruned automatically.
+
+## Event payloads
+
+An Event trigger's Agent doesn't only get your **Instruction** — the event
+arrives first, above it:
+
+```
+Event: card.updated
+Event Data:
+{
+  "id": "V1StGXR8_Z5jdHi6B-myT",
+  "boardId": "lbfQ0p7xKmR2nT4vZ8wYs",
+  "columnId": "9zHcN3eW1qoP5rUaB7dKt",
+  "title": "Review onboarding flow",
+  "body": "Check the new sign-up steps and confirm the copy.",
+  "labelIds": [],
+  "assignees": [],
+  "dueDate": null,
+  "priority": "none",
+  "position": 1024,
+  "createdByUserId": "x6Ym2Qp9LrT4nW8sVdB1k",
+  "createdByAgentId": null,
+  "createdAt": "2026-06-26T09:30:00.000Z",
+  "updatedAt": "2026-06-26T09:31:30.000Z",
+  "changedFields": ["body"]
+}
+---
+Post a one-line summary of what changed on this card.
+```
+
+Because the event sits above your text, the Instruction can point at it — "the
+card in the event data above" — instead of describing where to look. It only
+appears for Event triggers; a Cron run gets the Instruction on its own.
+
+The JSON is the event's data and nothing more. There's no `event`, `timestamp`,
+`orgId`, or `workspaceId` wrapper — a Trigger already knows which Workspace it
+belongs to. Every event's shape is written up once, on the Webhooks page: see
+[`data` by event](/building-with-platypus/webhooks#data-by-event), and read the
+`data` object there as the whole of what your Agent gets.
+
+<Callout type="warning">
+  **Not every event carries a whole record.** `card.created`, `card.updated`,
+  and `card.moved` send the full card; `notification.created` and
+  `notification.updated` send the full notification. `card.deleted`,
+  `notification.read`, and `notification.dismissed` send only the IDs of what
+  changed. An Instruction that reads the card's title works on `card.updated`
+  and finds nothing on `card.deleted` — and an Agent handed a field that isn't
+  there will often invent one rather than stop. Put each shape on its own
+  Trigger, or write the Instruction to cope with both.
+</Callout>
+
+The runs view names the event type each run fired for, so you can confirm which
+shape reached the Agent — it does not show the payload itself. To read a real
+one, point a [Webhook](/building-with-platypus/webhooks) at the same event and
+inspect the delivery.
 
 ## Review run history
 

--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -129,15 +129,7 @@ Event Data:
   "columnId": "9zHcN3eW1qoP5rUaB7dKt",
   "title": "Review onboarding flow",
   "body": "Check the new sign-up steps and confirm the copy.",
-  "labelIds": [],
-  "assignees": [],
-  "dueDate": null,
-  "priority": "none",
-  "position": 1024,
-  "createdByUserId": "x6Ym2Qp9LrT4nW8sVdB1k",
-  "createdByAgentId": null,
-  "createdAt": "2026-06-26T09:30:00.000Z",
-  "updatedAt": "2026-06-26T09:31:30.000Z",
+  ... the rest of the card ...
   "changedFields": ["body"]
 }
 ---
@@ -165,10 +157,9 @@ belongs to. Every event's shape is written up once, on the Webhooks page: see
   Trigger, or write the Instruction to cope with both.
 </Callout>
 
-The runs view names the event type each run fired for, so you can confirm which
-shape reached the Agent — it does not show the payload itself. To read a real
-one, point a [Webhook](/building-with-platypus/webhooks) at the same event and
-inspect the delivery.
+Run history does not show the payload itself. To read a real one, point a
+[Webhook](/building-with-platypus/webhooks) at the same event and inspect the
+delivery — the `data` object it sends is what the Trigger received.
 
 ## Review run history
 

--- a/apps/docs/content/building-with-platypus/webhooks.mdx
+++ b/apps/docs/content/building-with-platypus/webhooks.mdx
@@ -90,6 +90,8 @@ is the same envelope for every event:
     "position": 1024,
     "createdByUserId": "x6Ym2Qp9LrT4nW8sVdB1k",
     "createdByAgentId": null,
+    "lastEditedByUserId": null,
+    "lastEditedByAgentId": null,
     "createdAt": "2026-06-26T09:30:00.000Z",
     "updatedAt": "2026-06-26T09:30:00.000Z"
   }
@@ -152,6 +154,8 @@ can tell where the card came from without a separate lookup:
     "position": 1024,
     "createdByUserId": "x6Ym2Qp9LrT4nW8sVdB1k",
     "createdByAgentId": null,
+    "lastEditedByUserId": "x6Ym2Qp9LrT4nW8sVdB1k",
+    "lastEditedByAgentId": null,
     "createdAt": "2026-06-26T09:30:00.000Z",
     "updatedAt": "2026-06-26T09:31:30.000Z"
   }
@@ -189,6 +193,8 @@ reorder within a column emits `card.updated` with `changedFields: []`.
     "position": 1024,
     "createdByUserId": "x6Ym2Qp9LrT4nW8sVdB1k",
     "createdByAgentId": null,
+    "lastEditedByUserId": "x6Ym2Qp9LrT4nW8sVdB1k",
+    "lastEditedByAgentId": null,
     "createdAt": "2026-06-26T09:30:00.000Z",
     "updatedAt": "2026-06-26T09:31:30.000Z",
     "changedFields": ["body"]

--- a/apps/docs/content/docs-contract.test.ts
+++ b/apps/docs/content/docs-contract.test.ts
@@ -126,6 +126,33 @@ const inlineCodeSpans = (content: string): Located[] => {
   return spans;
 };
 
+/**
+ * Every fenced block on the page, as raw text with its opening line number.
+ *
+ * The counterpart to `withoutCodeFences`: that one throws the fences away
+ * because a snippet is not a claim, and this one keeps them for the rare
+ * snippet that is — text the reader is told the product produces verbatim.
+ */
+const fencedBlocks = (content: string): Located[] => {
+  const blocks: Located[] = [];
+  let open: number | null = null;
+  let body: string[] = [];
+  content.split("\n").forEach((line, index) => {
+    if (!/^\s*```/.test(line)) {
+      if (open !== null) body.push(line);
+      return;
+    }
+    if (open === null) {
+      open = index + 1;
+      body = [];
+    } else {
+      blocks.push({ text: body.join("\n"), line: open });
+      open = null;
+    }
+  });
+  return blocks;
+};
+
 type MarkdownTable = { line: number; header: string[]; rows: string[][] };
 
 const splitRow = (line: string): string[] =>
@@ -464,27 +491,6 @@ const parseEventPrefixSegments = (): string[] => {
     .split(/\$\{[^}]*\}/)
     .map((segment) => segment.replace(/\\n/g, "\n").trim())
     .filter((segment) => segment.length > 0);
-};
-
-/** Every fenced block on the page, as raw text with its opening line number. */
-const fencedBlocks = (content: string): Located[] => {
-  const blocks: Located[] = [];
-  let open: number | null = null;
-  let body: string[] = [];
-  content.split("\n").forEach((line, index) => {
-    if (!/^\s*```/.test(line)) {
-      if (open !== null) body.push(line);
-      return;
-    }
-    if (open === null) {
-      open = index + 1;
-      body = [];
-    } else {
-      blocks.push({ text: body.join("\n"), line: open });
-      open = null;
-    }
-  });
-  return blocks;
 };
 
 describe("trigger event payloads", () => {

--- a/apps/docs/content/docs-contract.test.ts
+++ b/apps/docs/content/docs-contract.test.ts
@@ -435,6 +435,128 @@ describe("webhook events", () => {
   });
 });
 
+// --- trigger event payloads --------------------------------------------------
+
+/**
+ * The Triggers page reproduces the prefix an Event trigger's Agent actually
+ * receives, because there is no other way for a Workspace Owner to learn the
+ * shape short of firing an event and reading the run. That makes the prefix a
+ * quoted string with one authoritative source, so pin it: the docs show a
+ * worked example, and the example's scaffolding has to be the scaffolding the
+ * service builds.
+ */
+const TRIGGER_PREFIX_SOURCE = "apps/backend/src/services/trigger-execution.ts";
+
+/**
+ * The fixed text of the event prefix template, in order — the parts of the
+ * template literal that are not interpolations, with escapes resolved.
+ */
+const parseEventPrefixSegments = (): string[] => {
+  const source = readRepoFile(TRIGGER_PREFIX_SOURCE);
+  const template = source.match(/effectiveInstruction\s*=[\s\S]*?`([^`]*)`/);
+  if (!template) {
+    throw new Error(
+      `No \`effectiveInstruction = \` template literal in ${TRIGGER_PREFIX_SOURCE}. ` +
+        `The prefix moved or stopped being a template; re-anchor this test.`,
+    );
+  }
+  return template[1]
+    .split(/\$\{[^}]*\}/)
+    .map((segment) => segment.replace(/\\n/g, "\n").trim())
+    .filter((segment) => segment.length > 0);
+};
+
+/** Every fenced block on the page, as raw text with its opening line number. */
+const fencedBlocks = (content: string): Located[] => {
+  const blocks: Located[] = [];
+  let open: number | null = null;
+  let body: string[] = [];
+  content.split("\n").forEach((line, index) => {
+    if (!/^\s*```/.test(line)) {
+      if (open !== null) body.push(line);
+      return;
+    }
+    if (open === null) {
+      open = index + 1;
+      body = [];
+    } else {
+      blocks.push({ text: body.join("\n"), line: open });
+      open = null;
+    }
+  });
+  return blocks;
+};
+
+describe("trigger event payloads", () => {
+  const page = "building-with-platypus/triggers.mdx";
+  const content = readDoc(page);
+  const segments = parseEventPrefixSegments();
+
+  it("parsed the prefix template", () => {
+    expect(
+      segments.length,
+      `Parsed no fixed text out of the event prefix in ${TRIGGER_PREFIX_SOURCE}. ` +
+        `A test that checks nothing is worse than no test; re-anchor it.`,
+    ).toBeGreaterThan(0);
+  });
+
+  it("shows the prefix the service builds", () => {
+    const examples = fencedBlocks(content).filter((block) =>
+      /^Event: \S/.test(block.text),
+    );
+    expect(
+      examples.length,
+      `apps/docs/content/${page} has ${examples.length} fenced blocks starting with ` +
+        `"Event: ". This check reads one — it is the worked example of the prefix ` +
+        `built in ${TRIGGER_PREFIX_SOURCE}.`,
+    ).toBe(1);
+
+    const example = examples[0];
+    const violations: string[] = [];
+    for (const segment of segments) {
+      if (!example.text.includes(segment)) {
+        violations.push(
+          `apps/docs/content/${page}:${example.line} does not contain ${JSON.stringify(segment)}, ` +
+            `but ${TRIGGER_PREFIX_SOURCE} puts it in the prefix every Event trigger sends.\n` +
+            `An Instruction written against the wrong prefix refers to text the Agent never sees.`,
+        );
+      }
+    }
+    const named = example.text.match(/^Event: (\S+)/);
+    const events: readonly string[] = webhookEventSchema.options;
+    if (named && !events.includes(named[1])) {
+      violations.push(
+        `apps/docs/content/${page}:${example.line} works the example through \`${named[1]}\`, ` +
+          `which is not in packages/schemas/index.ts (webhookEventSchema).\n` +
+          `That event never fires.`,
+      );
+    }
+    expectNoViolations(violations);
+  });
+
+  it("names only events that exist", () => {
+    const namespaces = new Set(
+      webhookEventSchema.options.map((event) => event.split(".")[0]),
+    );
+    const looksLikeEvent = new RegExp(
+      `^(?:${[...namespaces].join("|")})\\.[A-Za-z.]+$`,
+    );
+    const events: readonly string[] = webhookEventSchema.options;
+
+    const violations: string[] = [];
+    for (const span of inlineCodeSpans(content)) {
+      if (!looksLikeEvent.test(span.text)) continue;
+      if (events.includes(span.text)) continue;
+      violations.push(
+        `apps/docs/content/${page}:${span.line} mentions \`${span.text}\`, which is not in ` +
+          `packages/schemas/index.ts (webhookEventSchema).\n` +
+          `A Trigger cannot subscribe to an event that never fires.`,
+      );
+    }
+    expectNoViolations(violations);
+  });
+});
+
 // --- core plugins ------------------------------------------------------------
 
 /**

--- a/apps/docs/turbo.json
+++ b/apps/docs/turbo.json
@@ -10,6 +10,7 @@
         "$TURBO_ROOT$/apps/frontend/.env.example",
         "$TURBO_ROOT$/apps/backend/src/plugins/builtin.ts",
         "$TURBO_ROOT$/apps/backend/src/tools/closers.ts",
+        "$TURBO_ROOT$/apps/backend/src/services/trigger-execution.ts",
         "$TURBO_ROOT$/packages/plugin-sdk/README.md",
         "$TURBO_ROOT$/docs/adr/0014-web-search-backend-extension-point.md",
         "$TURBO_ROOT$/package.json",


### PR DESCRIPTION
Closes #620

The Triggers page told readers an Event trigger's instruction gets "the event's data appended automatically" and then never said what that data was. Writing an event trigger instruction meant guessing at the payload, firing a real event, and reading the run to find out what you got.

## What changed

`triggers.mdx` gains an **Event payloads** section, between "What a run does" and "Review run history":

- The exact prefix the Agent receives — `Event: <type>`, `Event Data:`, the JSON, `---`, then your Instruction — with a worked `card.updated` example including `changedFields`, and the note that the Instruction can refer back to what sits above it.
- States that the JSON is the event's `data` object only, with no `event` / `timestamp` / `orgId` / `workspaceId` envelope, and links to `data` by event on the Webhooks page for the per-event shapes rather than duplicating them.
- A warning callout naming the trap: `card.created`, `card.updated`, `card.moved` and the two `notification` record events send a whole record, while `card.deleted`, `notification.read` and `notification.dismissed` send only the IDs of what changed — so an Instruction that reads a card's title silently gets nothing when the same Trigger fires for `card.deleted`.
- The **Instruction** bullet's stale "appended automatically" becomes "arrives above it", linked to the new section.

The event set and payload shapes were re-derived from `webhookEventSchema` and the dispatch call sites as they stand on `main`, so `card.moved` and `changedFields` are both covered.

## Contract test

`docs-contract.test.ts` gains a **trigger event payloads** suite, since an undocumented payload is how this gap arose:

- Parses the prefix template out of the trigger execution service and asserts the page's worked example contains each fixed segment — rename `Event Data:` in the service and the docs test fails (verified, then reverted).
- Asserts the event the example works through is in `webhookEventSchema`.
- Asserts every event name mentioned anywhere on the page is a real event.

`apps/docs/turbo.json` declares the new source file as a test input, per the coupling rule in the contract test's header.

## Two notes for review

**Acceptance criterion 4 was not implementable as written.** It asked to document that run history is a way to inspect real payloads. `eventData` is persisted and the runs API returns the whole row, but nothing renders it — the runs view shows only the event type. Documenting it as specified would have pointed a Workspace Owner at a page that does not have the payload. The section documents the accurate path instead: run history does not show it, so point a Webhook at the same event and read the delivery. Surfacing `eventData` in the runs view would make the original criterion true, and is a reasonable follow-up.

**Second commit fixes a pre-existing inaccuracy.** All three `card.*` examples on the Webhooks page read as complete payloads but omitted `lastEditedByUserId` and `lastEditedByAgentId`, which are on the card row and reach every handler. Fixed in all three; the triggers example is trimmed to the fields it is illustrating so it is not a second copy of the card shape that can rot on its own.

## Verification

- `pnpm typecheck` clean
- `pnpm test` — 2,639 tests pass, including the 38 docs-contract assertions
- `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)