### PR TITLE
fix: scope the changed-fields trigger filter to card.updated

### DIFF
--- a/apps/backend/src/services/event-dispatch.test.ts
+++ b/apps/backend/src/services/event-dispatch.test.ts
@@ -264,19 +264,24 @@ describe("event-dispatch", () => {
       expect(mockExecuteTrigger).toHaveBeenCalled();
     });
 
-    it("should not fire a changedFields filter for an event that carries no changedFields", async () => {
+    it("should ignore the changedFields filter for an event other than card.updated", async () => {
       const trigger = makeEventTrigger({
         config: {
-          events: ["card.created"],
+          events: ["card.moved", "card.updated"],
           filters: { changedFields: ["assignees"] },
         },
       });
       mockDb.where.mockResolvedValueOnce([]).mockResolvedValueOnce([trigger]);
 
-      dispatchEvent("org-1", "ws-1", "card.created", { cardId: "c1" });
+      // A move emits card.moved (no changedFields) then card.updated. Only
+      // card.updated answers to the filter, so the move still fires.
+      dispatchEvent("org-1", "ws-1", "card.moved", {
+        id: "c1",
+        previousColumnId: "col-1",
+      });
       await flushMicrotasks();
 
-      expect(mockExecuteTrigger).not.toHaveBeenCalled();
+      expect(mockExecuteTrigger).toHaveBeenCalled();
     });
 
     it("should compose the changedFields filter with the boardId filter", async () => {

--- a/apps/backend/src/services/event-dispatch.ts
+++ b/apps/backend/src/services/event-dispatch.ts
@@ -105,7 +105,10 @@ export function dispatchEvent(
           const eventData = data as Record<string, unknown>;
           if (eventData.columnId !== triggerConfig.filters.columnId) continue;
         }
-        if (triggerConfig.filters?.changedFields) {
+        // Only `card.updated` reports a changed-fields diff, so the filter is
+        // scoped to it: a `card.moved`/`card.created`/`card.deleted` selected
+        // alongside it keeps firing rather than being silently suppressed.
+        if (event === "card.updated" && triggerConfig.filters?.changedFields) {
           const eventData = data as Record<string, unknown>;
           const changedFields = eventData.changedFields;
           const filterFields = triggerConfig.filters.changedFields;

--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -54,29 +54,27 @@ Trigger** to run once and then disable itself.
 
 For an Event trigger, select one or more **Events** (e.g. `card.created`,
 `card.updated`, `card.moved`, `notification.created`). Optionally narrow with
-**Filter by Board** and **Filter by Column** so the Trigger only fires for
-activity on a specific board.
+**Only cards in this Board** and **Only cards in this Column** so the Trigger
+only fires for activity in one place.
 
 `card.moved` fires only when a card's column actually changes, so a column
 filter on it matches the card's **destination** column — use it to run an
 Agent whenever a card enters a specific column, without re-firing on later
 edits to cards already sitting there.
 
-When `card.updated` is among the selected events, a **Filter by Changed
-Fields** control appears — pick one or more card attributes (Title, Body,
-Labels, Assignees, Due date, Priority, Column) and the Trigger fires only when
-one of them actually changed, not on every write to a matching card. It
-composes with the Board and Column filters: every filter set on the Trigger
-must match. See [Webhooks: the
+When `card.updated` is among the selected events, an **Only when these fields
+change** control appears — pick one or more card attributes (Title, Body,
+Labels, Assignees, Due date, Priority) and `card.updated` fires only when one
+of them actually changed, not on every write to a matching card. Leave them all
+off to fire on any change. It composes with the Board and Column filters: every
+filter set on the Trigger must match. See [Webhooks: the
 payload](/building-with-platypus/webhooks#the-payload) for what counts as a
 changed field.
 
-<Callout type="warning">
-  This filter only applies to `card.updated` — `card.created`, `card.moved`,
-  and `card.deleted` carry no changed fields, so a Trigger that also
-  subscribes to one of those alongside a Changed Fields filter never fires for
-  it. Give a Trigger that needs both its own copy without the filter.
-</Callout>
+The control applies to `card.updated` alone. Other events you selected are
+unaffected — a Trigger on both `card.moved` and `card.updated` still fires on
+every move, whatever fields the control names. To act on a column change, use
+`card.moved`: it is the event for that, and it carries the previous column.
 
 ### Finish
 

--- a/apps/frontend/components/trigger-form.test.tsx
+++ b/apps/frontend/components/trigger-form.test.tsx
@@ -21,6 +21,7 @@ vi.mock("sonner", () => ({
 }));
 
 const agents = [{ id: "agent-1", name: "Agent One" }];
+const boards = [{ id: "board-1", name: "Board One" }];
 
 vi.mock("swr", () => ({
   __esModule: true,
@@ -29,7 +30,7 @@ vi.mock("swr", () => ({
       return { data: { results: agents }, isLoading: false, mutate: vi.fn() };
     }
     if (key?.includes("/boards")) {
-      return { data: { results: [] }, isLoading: false, mutate: vi.fn() };
+      return { data: { results: boards }, isLoading: false, mutate: vi.fn() };
     }
     return { data: undefined, isLoading: false, mutate: vi.fn() };
   },
@@ -62,25 +63,43 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-async function renderEventTriggerForm() {
-  render(<TriggerForm orgId="org1" workspaceId="ws1" />);
-  await waitFor(() => expect(screen.getByText("Agent")).toBeInTheDocument());
-
-  // Trigger Type is a Radix Select defaulting to "Cron" — open it and pick
-  // "Event" the same way provider-form's tests drive Radix Select controls.
-  const triggerTypeSelect = screen
+/** Picks an option on the Radix Select currently reading `from`. */
+async function selectOption(from: string, option: string) {
+  const combobox = screen
     .getAllByRole("combobox")
-    .find((el) => el.textContent === "Cron")!;
+    .find((el) => el.textContent === from)!;
   const scrollIntoView = Element.prototype.scrollIntoView;
   Element.prototype.scrollIntoView = vi.fn();
   try {
-    fireEvent.keyDown(triggerTypeSelect, { key: "ArrowDown" });
-    const event = await screen.findByRole("option", { name: "Event" });
-    fireEvent.keyDown(event, { key: "Enter" });
+    fireEvent.keyDown(combobox, { key: "ArrowDown" });
+    const item = await screen.findByRole("option", { name: option });
+    fireEvent.keyDown(item, { key: "Enter" });
   } finally {
     Element.prototype.scrollIntoView = scrollIntoView;
   }
 }
+
+async function renderEventTriggerForm() {
+  render(<TriggerForm orgId="org1" workspaceId="ws1" />);
+  await waitFor(() => expect(screen.getByText("Agent")).toBeInTheDocument());
+
+  // Trigger Type is a Radix Select defaulting to "Cron".
+  await selectOption("Cron", "Event");
+}
+
+describe("TriggerForm — board and column filters", () => {
+  it("hides the column filter until a board is selected", async () => {
+    await renderEventTriggerForm();
+
+    fireEvent.click(screen.getByLabelText("card.updated"));
+
+    expect(screen.queryByText("Only cards in this Column")).toBeNull();
+
+    await selectOption("All boards", "Board One");
+
+    expect(screen.getByText("Only cards in this Column")).toBeInTheDocument();
+  });
+});
 
 describe("TriggerForm — changed-fields filter", () => {
   it("hides the changed-fields filter until card.updated is selected", async () => {

--- a/apps/frontend/components/trigger-form.test.tsx
+++ b/apps/frontend/components/trigger-form.test.tsx
@@ -86,11 +86,23 @@ describe("TriggerForm — changed-fields filter", () => {
   it("hides the changed-fields filter until card.updated is selected", async () => {
     await renderEventTriggerForm();
 
-    expect(screen.queryByText("Filter by Changed Fields")).toBeNull();
+    expect(
+      screen.queryByText("Only when these fields change (card.updated)"),
+    ).toBeNull();
 
     fireEvent.click(screen.getByLabelText("card.updated"));
 
-    expect(screen.getByText("Filter by Changed Fields")).toBeInTheDocument();
+    expect(
+      screen.getByText("Only when these fields change (card.updated)"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not offer Column as a changed field — card.moved is that event", async () => {
+    await renderEventTriggerForm();
+
+    fireEvent.click(screen.getByLabelText("card.updated"));
+
+    expect(screen.queryByLabelText("Column")).toBeNull();
   });
 
   it("clears the changed-fields filter when card.updated is deselected", async () => {

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -1086,9 +1086,6 @@ const TriggerForm = ({
                       ))}
                     </SelectContent>
                   </Select>
-                  <FieldDescription>
-                    Optionally restrict card events to a specific board.
-                  </FieldDescription>
                 </Field>
                 <Field className="flex-1">
                   <FieldLabel>Only cards in this Column</FieldLabel>
@@ -1111,9 +1108,9 @@ const TriggerForm = ({
                       ))}
                     </SelectContent>
                   </Select>
-                  <FieldDescription>
-                    Optionally restrict card events to a specific column.
-                  </FieldDescription>
+                  {!filterBoardId && (
+                    <FieldDescription>Pick a Board first.</FieldDescription>
+                  )}
                 </Field>
               </div>
             )}

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -115,7 +115,6 @@ const CHANGED_FIELD_OPTIONS = [
   { value: "assignees", label: "Assignees" },
   { value: "dueDate", label: "Due date" },
   { value: "priority", label: "Priority" },
-  { value: "columnId", label: "Column" },
 ] as const;
 
 const buildCronExpression = (
@@ -1066,7 +1065,7 @@ const TriggerForm = ({
             selectedEvents.some((e) => e.startsWith("card.")) && (
               <div className="flex flex-col sm:flex-row gap-4">
                 <Field className="flex-1">
-                  <FieldLabel>Filter by Board</FieldLabel>
+                  <FieldLabel>Only cards in this Board</FieldLabel>
                   <Select
                     value={filterBoardId || "__all__"}
                     onValueChange={(value) => {
@@ -1092,7 +1091,7 @@ const TriggerForm = ({
                   </FieldDescription>
                 </Field>
                 <Field className="flex-1">
-                  <FieldLabel>Filter by Column</FieldLabel>
+                  <FieldLabel>Only cards in this Column</FieldLabel>
                   <Select
                     value={filterColumnId || "__all__"}
                     onValueChange={(value) =>
@@ -1123,20 +1122,14 @@ const TriggerForm = ({
           {triggerType === "event" &&
             selectedEvents.includes("card.updated") && (
               <Field>
-                <FieldLabel>Filter by Changed Fields</FieldLabel>
+                <FieldLabel>
+                  Only when these fields change (card.updated)
+                </FieldLabel>
                 <FieldDescription>
                   Only fire on a card update when one of these fields actually
-                  changed. Leave all off to fire on any change.
-                  {selectedEvents.some(
-                    (e) => e !== "card.updated" && e.startsWith("card."),
-                  ) && (
-                    <>
-                      {" "}
-                      Setting this also stops the other selected card events
-                      from firing, since only card.updated reports changed
-                      fields.
-                    </>
-                  )}
+                  changed. Leave all off to fire on any change. Other selected
+                  events are unaffected — to fire on a column change, select
+                  card.moved.
                 </FieldDescription>
                 <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-2">
                   {CHANGED_FIELD_OPTIONS.map((field) => (

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -1063,8 +1063,8 @@ const TriggerForm = ({
           {/* Board and column filters for card events */}
           {triggerType === "event" &&
             selectedEvents.some((e) => e.startsWith("card.")) && (
-              <div className="flex flex-col sm:flex-row gap-4">
-                <Field className="flex-1">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <Field>
                   <FieldLabel>Only cards in this Board</FieldLabel>
                   <Select
                     value={filterBoardId || "__all__"}
@@ -1087,31 +1087,30 @@ const TriggerForm = ({
                     </SelectContent>
                   </Select>
                 </Field>
-                <Field className="flex-1">
-                  <FieldLabel>Only cards in this Column</FieldLabel>
-                  <Select
-                    value={filterColumnId || "__all__"}
-                    onValueChange={(value) =>
-                      setFilterColumnId(value === "__all__" ? "" : value)
-                    }
-                    disabled={isSubmitting || !filterBoardId}
-                  >
-                    <SelectTrigger disabled={isSubmitting || !filterBoardId}>
-                      <SelectValue placeholder="All columns" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__all__">All columns</SelectItem>
-                      {columns.map((col) => (
-                        <SelectItem key={col.id} value={col.id}>
-                          {col.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {!filterBoardId && (
-                    <FieldDescription>Pick a Board first.</FieldDescription>
-                  )}
-                </Field>
+                {filterBoardId && (
+                  <Field>
+                    <FieldLabel>Only cards in this Column</FieldLabel>
+                    <Select
+                      value={filterColumnId || "__all__"}
+                      onValueChange={(value) =>
+                        setFilterColumnId(value === "__all__" ? "" : value)
+                      }
+                      disabled={isSubmitting}
+                    >
+                      <SelectTrigger disabled={isSubmitting}>
+                        <SelectValue placeholder="All columns" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__all__">All columns</SelectItem>
+                        {columns.map((col) => (
+                          <SelectItem key={col.id} value={col.id}>
+                            {col.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
## Problem

The changed-fields filter on an Event trigger ran against **every** event delivered to that trigger, but only `card.updated` carries a `changedFields` diff. Select `card.moved` + `card.updated`, toggle any field, and the move stopped firing — the event data had no `changedFields` array, so the filter rejected it.

Nothing in the UI admitted this. The `card.moved` switch stayed on, the event stayed in the saved config, the trigger list still rendered its badge, and reopening the form rehydrated both switches. The only signal was a sentence in the field description, which also under-reported the blast radius: it warned about other *card* events, while the `notification.*` events were suppressed the same way with no warning at all.

Separately, "Filter by Column" and the "Column" changed-field toggle read as the same control but aren't: one is *where the card is*, the other is *that its column changed*.

## Change

- **Backend** — gate the filter on `event === "card.updated"`. Other selected events pass through untouched. A move now fires `card.moved`, and fires `card.updated` only if the named fields changed.
- **Frontend** — `Filter by Board` / `Filter by Column` → **Only cards in this Board** / **Only cards in this Column**; `Filter by Changed Fields` → **Only when these fields change (card.updated)**. The description now states that other events are unaffected and points at `card.moved` for a column change.
- **Frontend** — drop `Column` from the changed-field options. `card.moved` is the event for a column change and it carries `previousColumnId`; the toggle offered the same fact through a channel that says less.
- **Docs** — `triggers.mdx` updated for the new labels and the removed option; the warning Callout is replaced by a plain statement of the scope.

`columnId` stays in the backend's `CHANGED_FIELD_KEYS`, so `card.updated` payloads still report it — only the form option is gone, and `webhooks.mdx` stays accurate as written.

## Compatibility

`card.moved` and the changed-fields filter have not shipped in a release, so the behaviour change needs no migration path.

## Testing

- The backend test that pinned the old suppression now pins the opposite: a trigger on `card.moved` + `card.updated` with a changed-fields filter still fires on a move.
- Added a frontend test asserting `Column` is not offered as a changed field.
- Full suite green (2,640 tests), `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)