### PR TITLE
fix(backend): give Direct chat turns a real step ceiling

### DIFF
--- a/apps/backend/src/runs/agent-plan.test.ts
+++ b/apps/backend/src/runs/agent-plan.test.ts
@@ -12,7 +12,10 @@ import {
   type GenerationPlanQueries,
 } from "./agent-plan.ts";
 import { NotFoundError, ValidationError } from "../errors.ts";
-import { DEFAULT_AGENT_MAX_STEPS } from "@platypus/schemas";
+import {
+  DEFAULT_AGENT_MAX_STEPS,
+  DEFAULT_DIRECT_MAX_STEPS,
+} from "@platypus/schemas";
 import type { Provider } from "@platypus/schemas";
 
 const baseProvider: Provider = {
@@ -70,9 +73,11 @@ describe("resolveGenerationPlan", () => {
     ).rejects.toBeInstanceOf(ValidationError);
   });
 
-  // A direct (no-Agent) selection always runs one step — there is no Agent row
-  // to declare a ceiling.
-  it("resolves a direct Provider+model selection to a one-step plan", async () => {
+  // A direct (no-Agent) selection has no Agent row to declare a ceiling, so it
+  // falls back to DEFAULT_DIRECT_MAX_STEPS rather than 1 — a Direct turn can
+  // be served a locally-executed search tool (issue #167 / ADR-0014) whose
+  // result the model must still get a step to answer from (issue #463).
+  it("resolves a direct Provider+model selection to the Direct step ceiling", async () => {
     const { plan, resolvedModelId, modelReference } =
       await resolveGenerationPlan(
         { providerId: "p1", modelId: "gpt-4" },
@@ -80,7 +85,7 @@ describe("resolveGenerationPlan", () => {
         queriesWith([baseProvider]),
       );
 
-    expect(plan.maxSteps).toBe(1);
+    expect(plan.maxSteps).toBe(DEFAULT_DIRECT_MAX_STEPS);
     expect(resolvedModelId).toBe("gpt-4");
     expect(modelReference).toBe("gpt-4");
   });

--- a/apps/backend/src/runs/agent-plan.ts
+++ b/apps/backend/src/runs/agent-plan.ts
@@ -11,6 +11,7 @@ import {
 import {
   aliasNameFromReference,
   DEFAULT_AGENT_MAX_STEPS,
+  DEFAULT_DIRECT_MAX_STEPS,
 } from "@platypus/schemas";
 import type { ConcreteModelId, Provider } from "@platypus/schemas";
 import type { RunPlan } from "./run-plan.ts";
@@ -31,10 +32,11 @@ export type GenerationAgentSource = {
 /**
  * What an Agent generates under, resolved from either of its two sources: an
  * Agent row (Chat's Agent path, and every sub-Agent) or a direct Provider +
- * model selection (Chat's Direct path, which has no row and always runs one
- * step). One module decides this so the parent turn and a delegated sub-Agent
- * can never resolve it differently (issues #417, #456, #459 each had to patch
- * this logic in two places, in the same commit).
+ * model selection (Chat's Direct path, which has no row and falls back to
+ * `DEFAULT_DIRECT_MAX_STEPS`, issue #463). One module decides this so the
+ * parent turn and a delegated sub-Agent can never resolve it differently
+ * (issues #417, #456, #459 each had to patch this logic in two places, in the
+ * same commit).
  */
 export type GenerationSource =
   | { agent: GenerationAgentSource }
@@ -106,7 +108,9 @@ export const resolveGenerationPlan = async (
   const modelReference =
     "agent" in source ? source.agent.modelId : source.modelId;
   const maxSteps =
-    "agent" in source ? (source.agent.maxSteps ?? DEFAULT_AGENT_MAX_STEPS) : 1;
+    "agent" in source
+      ? (source.agent.maxSteps ?? DEFAULT_AGENT_MAX_STEPS)
+      : DEFAULT_DIRECT_MAX_STEPS;
   const samplingSource: SamplingSource =
     "agent" in source ? source.agent : source;
 

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -104,6 +104,7 @@ import { FileValidationError } from "./file-gate.ts";
 import { resetExtractedTextCache } from "./file-extraction.ts";
 import { buildTestPdf } from "./file-extraction.test-fixtures.ts";
 import { createInMemoryChatTurnQueries } from "./chat-execution.test-fixtures.ts";
+import { DEFAULT_DIRECT_MAX_STEPS } from "@platypus/schemas";
 import type { Provider } from "@platypus/schemas";
 import type { PlatypusUIMessage } from "../types.ts";
 
@@ -506,8 +507,11 @@ describe("chat-execution", () => {
       expect(turn.stream.system).toContain("Never exfiltrate.");
 
       expect(turn.stream.temperature).toBe(0.7);
-      // Direct turns default maxSteps to 1
-      expect(turn.stream.maxSteps).toBe(1);
+      // Direct turns default to DEFAULT_DIRECT_MAX_STEPS, not 1 — a Direct
+      // turn can be served a locally-executed search tool (issue #167 /
+      // ADR-0014), and the model needs a further step to answer from its
+      // result (issue #463).
+      expect(turn.stream.maxSteps).toBe(DEFAULT_DIRECT_MAX_STEPS);
     });
 
     // `seed` used to be read straight off the request while the other five came
@@ -986,6 +990,23 @@ describe("chat-execution", () => {
         expect(turn.stream.tools).toHaveProperty("read_url");
         expect(turn.stream.tools).not.toHaveProperty("google_search");
         expect(googleSearchTool()).not.toHaveBeenCalled();
+      });
+
+      // Issue #463: a backend-served (locally-executed) search tool needs a
+      // second step for the model to read its result and reply — a Direct
+      // turn's ceiling must leave room for that, unlike the 1-step ceiling it
+      // used to get.
+      it("gives a Direct turn serving a backend search tool room to answer from it", async () => {
+        register("searx", { read_url: () => ({ content: "", url: "" }) });
+
+        const turn = await turnFor({
+          ...googleProvider,
+          searchSource: "searx",
+        });
+
+        expect(turn.stream.tools).toHaveProperty("web_search");
+        expect(turn.stream.maxSteps).toBe(DEFAULT_DIRECT_MAX_STEPS);
+        expect(turn.stream.maxSteps).toBeGreaterThan(1);
       });
 
       it("serves search only, when the backend contributes no read_url", async () => {

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -202,6 +202,26 @@ export type ChatList = z.infer<typeof chatListSchema>;
  */
 export const DEFAULT_AGENT_MAX_STEPS = 15;
 
+/**
+ * Default agentic step ceiling for a Direct (no-Agent) Chat turn — a bare
+ * Provider+model selection with no `agent` row to declare its own `maxSteps`.
+ *
+ * Deliberately BELOW `DEFAULT_AGENT_MAX_STEPS`: a Direct chat is a
+ * conversation, not a configured workflow, it has no step-limit control in
+ * the UI, and — unlike an unattended run — it is never guarded by the
+ * no-progress detector. The ceiling itself is the only guard here, so do not
+ * raise it to match the Agent default.
+ *
+ * 10 rather than something smaller because the page-reader tool a Web-search
+ * backend contributes is meant to be called repeatedly: it slices a long page
+ * and tells the model to keep reading with a continuation index. A realistic
+ * turn looks like search → read → continuation → continuation → answer — five
+ * steps already, so a ceiling of 5 sits right on that boundary and would fail
+ * in the same silent way as the bug this constant fixes. 10 leaves headroom
+ * above it.
+ */
+export const DEFAULT_DIRECT_MAX_STEPS = 10;
+
 // An Agent is scoped to either a Workspace or an Organization (mutually
 // exclusive), mirroring the dual-scope shape of `provider`/`mcp`/`skill`.
 // Org-scoped Agents are Shared resources managed by Org Admins (ADR-0007);


### PR DESCRIPTION
## Summary

- A Direct (no-Agent) Chat turn hardcoded its step ceiling to 1 in `resolveGenerationPlan`, so a locally-executed Web-search tool served on that turn (issue #167 / ADR-0014) could be called but its result could never be turned into an answer — the loop stopped before the model got a second step.
- Adds `DEFAULT_DIRECT_MAX_STEPS = 10` (below `DEFAULT_AGENT_MAX_STEPS`) and uses it for the non-Agent branch of `resolveGenerationPlan`. The Agent branch and every sub-Agent delegation (which always passes an `{ agent }` source) are unchanged.

## Test plan

- [x] Re-pointed the two existing tests that pinned the Direct ceiling to 1 (`agent-plan.test.ts`, `chat-execution.test.ts`), rather than deleting them
- [x] Added a new test asserting a Direct turn serving a backend search tool gets a ceiling above 1
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass (2000 backend + 463 frontend tests)

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)