### PR TITLE
fix: reject a core web backend that claims the searchSource reserved ids

### DIFF
--- a/apps/backend/src/plugins/extension-points.ts
+++ b/apps/backend/src/plugins/extension-points.ts
@@ -3,6 +3,7 @@ import type {
   ToolSetContribution,
   WebBackendContribution,
 } from "@platypuschat/plugin-sdk";
+import { SEARCH_SOURCE_NATIVE, SEARCH_SOURCE_NONE } from "@platypus/schemas";
 import type { SandboxBackendRegistration } from "../sandbox/index.ts";
 import { composeToolSet, type ToolSetRegistration } from "../tools/index.ts";
 import {
@@ -171,6 +172,17 @@ export const webBackendPoint = (
   idField: "backend",
   prepare: (raw, { pluginName, id, plugin }) => {
     const contribution = raw as unknown as WebBackendContribution;
+
+    // Checked against the *namespaced* id, not the raw one: `provider.searchSource`
+    // reserves these two literals ahead of any backend id (`resolveSearchMode`
+    // checks them first), and only a bare — i.e. core — id can ever collide with
+    // them, since a third-party id is always prefixed with the plugin's name. A
+    // backend registered under either would silently never serve a turn.
+    if (id === SEARCH_SOURCE_NONE || id === SEARCH_SOURCE_NATIVE) {
+      throw new Error(
+        `Plugin "${pluginName}": web backend "${id}" is reserved by provider.searchSource and can never serve a turn — choose a different id.`,
+      );
+    }
 
     // A web backend supplies executors only — core builds the Tools — so a
     // missing factory means the contribution can never serve a turn. The TS type

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -898,6 +898,58 @@ describe("loadPlugins — web-search backends", () => {
     expect(calls).toHaveLength(1);
   });
 
+  it('aborts (fail-loud) when a core web backend claims the reserved id "none"', async () => {
+    const { register } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@platypus/searx"],
+        builtinPlugins: {
+          "@platypus/searx": () =>
+            Promise.resolve({
+              plugin: webManifest("@platypus/searx", [webBackend("none")]),
+            }),
+        },
+        register,
+        registerWeb: () => {},
+      }),
+    ).rejects.toThrow(/@platypus\/searx.*"none".*reserved/s);
+  });
+
+  it('aborts (fail-loud) when a core web backend claims the reserved id "native"', async () => {
+    const { register } = makeRegister();
+    await expect(
+      loadPlugins({
+        pluginNames: ["@platypus/searx"],
+        builtinPlugins: {
+          "@platypus/searx": () =>
+            Promise.resolve({
+              plugin: webManifest("@platypus/searx", [webBackend("native")]),
+            }),
+        },
+        register,
+        registerWeb: () => {},
+      }),
+    ).rejects.toThrow(/@platypus\/searx.*"native".*reserved/s);
+  });
+
+  it('still loads a third-party plugin\'s bare "none" id, namespaced and unaffected', async () => {
+    const { register } = makeRegister();
+    const { registerWeb, calls } = makeWebRegister();
+    const { plugins: loaded } = await loadPlugins({
+      pluginNames: ["@acme/platypus-search"],
+      builtinPlugins: {},
+      importPlugin: () =>
+        Promise.resolve({
+          plugin: webManifest("acme", [webBackend("none")]),
+        }),
+      register,
+      registerWeb,
+    });
+
+    expect(calls.map((c) => c.backend)).toEqual(["acme.none"]);
+    expect(loaded[0].webBackendIds).toEqual(["acme.none"]);
+  });
+
   it("injects the shared plugin config block into createExecutors", async () => {
     const { register } = makeRegister();
     const { registerWeb, calls } = makeWebRegister();


### PR DESCRIPTION
## Summary
- `provider.searchSource` reserves the literals `none`/`native` ahead of any backend id (`resolveSearchMode` checks them first), so a core-authored Web-search backend registered under either name would register successfully at boot but never serve a turn — silently unreachable rather than a boot error.
- Refuses the two reserved ids in `webBackendPoint`'s `prepare` hook, checked against the **namespaced** id (not the raw one), so only a bare/core id can match — a third-party plugin's namespaced `acme.none` still loads and registers fine, unaffected.
- Compares against the exported `SEARCH_SOURCE_NONE`/`SEARCH_SOURCE_NATIVE` constants rather than inline string literals. `resolveSearchMode`, the `SearchResolution` union, and the shared `owners` map are all untouched.

## Docs
No docs change. `web-search-backends.mdx` already documents `backend` as namespaced with the plugin's name automatically, and its audience is third-party plugin authors — whose ids can never take a bare reserved id, so the constraint this PR adds doesn't affect what that page describes.

## Test plan
- [x] `pnpm typecheck` passes
- [x] New tests: a core backend claiming `none` aborts boot naming the plugin and id; same for `native`; a third-party plugin's bare `none` still registers under its namespaced id, unaffected
- [x] Existing `owners.webBackends` assertions in `loader.test.ts` pass unchanged
- [x] Full `pnpm test` passes (2002 backend + 463 frontend tests)

Fixes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)