### PR TITLE
chore(backend): skill write model and attachment module (#617)

### DIFF
--- a/apps/backend/src/routes/attachment.ts
+++ b/apps/backend/src/routes/attachment.ts
@@ -52,12 +52,11 @@ attachment.post(
     // Organization by requireWorkspaceAccess); the module checks the resource
     // is a Shared one of this Organization (→404) and that it is not already
     // attached (→409, ADR-0007/ADR-0010).
-    const record = await attachResource(
-      orgId,
+    const record = await attachResource({ kind: "workspace" }, orgId, {
       resourceType,
       resourceId,
       workspaceId,
-    );
+    });
     return c.json(record, 201);
   },
 );
@@ -69,13 +68,17 @@ attachment.delete(
   requireOrgAccess(["admin"]),
   requireWorkspaceAccess,
   async (c) => {
-    const { workspaceId } = workspaceScopeOf(c);
+    const { orgId, workspaceId } = workspaceScopeOf(c);
     const resourceType = c.req.param("resourceType");
     const resourceId = c.req.param("resourceId");
 
     // `detachResource` validates the path-typed resourceType and throws
     // NotFound (→404) when no such Attachment exists (ADR-0010).
-    await detachResource(resourceType, resourceId, workspaceId);
+    await detachResource({ kind: "workspace" }, orgId, {
+      resourceType,
+      resourceId,
+      workspaceId,
+    });
 
     return c.json({ message: "Detached" });
   },

--- a/apps/backend/src/routes/attachment.ts
+++ b/apps/backend/src/routes/attachment.ts
@@ -1,24 +1,24 @@
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
-import { nanoid } from "nanoid";
 import { db } from "../index.ts";
 import { attachment as attachmentTable } from "../db/schema.ts";
 import { attachmentCreateSchema } from "@platypus/schemas";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
   requireWorkspaceAccess,
   workspaceScopeOf,
 } from "../middleware/authorization.ts";
-import { isUniqueViolation, NotFoundError } from "../errors.ts";
-import { resolveOrgScoped } from "../services/scoped-resource.ts";
+import { attachResource, detachResource } from "../services/attachment.ts";
 import type { Variables } from "../server.ts";
 
 // Attachment is the explicit reference that surfaces an org-scoped Shared
 // resource inside a Workspace (ADR-0007). Managing attachments is an Org Admin
 // action — `requireOrgAccess(["admin"])` rejects non-admins with 403 — scoped
-// to a specific Workspace via `requireWorkspaceAccess`.
+// to a specific Workspace via `requireWorkspaceAccess`. The attach/detach rules
+// (resource-is-Shared, already-attached → 409) live in the Attachment module;
+// this route is a thin adapter over it.
 const attachment = new Hono<{ Variables: Variables }>();
 
 /** List attachments for this workspace (admin only) */
@@ -48,35 +48,17 @@ attachment.post(
     const { orgId, workspaceId } = workspaceScopeOf(c);
     const { resourceType, resourceId } = c.req.valid("json");
 
-    // The resource must be org-scoped and belong to this organization — you can
-    // only attach a Shared resource, never a workspace-scoped one.
-    const resource = await resolveOrgScoped(
-      db,
+    // The target Workspace is this route's own (already proved to belong to the
+    // Organization by requireWorkspaceAccess); the module checks the resource
+    // is a Shared one of this Organization (→404) and that it is not already
+    // attached (→409, ADR-0007/ADR-0010).
+    const record = await attachResource(
+      orgId,
       resourceType,
       resourceId,
-      orgId,
+      workspaceId,
     );
-    if (!resource) {
-      throw new NotFoundError(
-        "Org-scoped resource not found in this organization",
-      );
-    }
-
-    try {
-      const record = await db
-        .insert(attachmentTable)
-        .values({ id: nanoid(), workspaceId, resourceType, resourceId })
-        .returning();
-      return c.json(record[0], 201);
-    } catch (error) {
-      if (isUniqueViolation(error)) {
-        return c.json(
-          { error: "This resource is already attached to this workspace" },
-          409,
-        );
-      }
-      throw error;
-    }
+    return c.json(record, 201);
   },
 );
 
@@ -91,22 +73,10 @@ attachment.delete(
     const resourceType = c.req.param("resourceType");
     const resourceId = c.req.param("resourceId");
 
-    const result = await db
-      .delete(attachmentTable)
-      .where(
-        and(
-          eq(attachmentTable.workspaceId, workspaceId),
-          eq(
-            attachmentTable.resourceType,
-            resourceType as "mcp" | "provider" | "skill" | "agent",
-          ),
-          eq(attachmentTable.resourceId, resourceId),
-        ),
-      )
-      .returning();
-    if (result.length === 0) {
-      throw new NotFoundError("Attachment not found");
-    }
+    // `detachResource` validates the path-typed resourceType and throws
+    // NotFound (→404) when no such Attachment exists (ADR-0010).
+    await detachResource(resourceType, resourceId, workspaceId);
+
     return c.json({ message: "Detached" });
   },
 );

--- a/apps/backend/src/routes/org-attachment.ts
+++ b/apps/backend/src/routes/org-attachment.ts
@@ -1,18 +1,18 @@
 import { Hono } from "hono";
-import { nanoid } from "nanoid";
+import { and, eq } from "drizzle-orm";
 import { db } from "../index.ts";
 import {
   attachment as attachmentTable,
   workspace as workspaceTable,
 } from "../db/schema.ts";
-import { and, eq } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { orgScopeOf, requireOrgAccess } from "../middleware/authorization.ts";
-import { isUniqueViolation } from "../errors.ts";
+import { isScopedResourceType } from "../services/scoped-resource.ts";
 import {
-  isScopedResourceType,
-  resolveOrgScoped,
-} from "../services/scoped-resource.ts";
+  attachResource,
+  detachResource,
+  requireWorkspaceInOrg,
+} from "../services/attachment.ts";
 import type { Variables } from "../server.ts";
 
 // Org-surface management of where a Shared resource is attached (ADR-0007).
@@ -20,6 +20,9 @@ import type { Variables } from "../server.ts";
 // workspace?", this route answers "which workspaces is THIS resource shared
 // with?" and lets an Org Admin attach/detach workspaces centrally — the natural
 // place to manage sharing across many workspaces. All routes are admin-only.
+// The attach/detach rules (workspace-in-org, resource-is-Shared,
+// already-attached → 409) live in the Attachment module; this route is a thin
+// adapter over it, supplying an arbitrary `workspaceId` from the request body.
 const orgAttachment = new Hono<{ Variables: Variables }>();
 
 /**
@@ -73,53 +76,21 @@ orgAttachment.post("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
   };
   const { resourceType, resourceId, workspaceId } = body;
 
-  if (!isScopedResourceType(resourceType)) {
-    return c.json({ error: "Invalid resourceType" }, 400);
-  }
   if (!resourceId || !workspaceId) {
     return c.json({ error: "resourceId and workspaceId are required" }, 400);
   }
 
-  // The target workspace must belong to this organization.
-  const [ws] = await db
-    .select({ id: workspaceTable.id })
-    .from(workspaceTable)
-    .where(
-      and(
-        eq(workspaceTable.id, workspaceId),
-        eq(workspaceTable.organizationId, orgId),
-      ),
-    )
-    .limit(1);
-  if (!ws) {
-    return c.json({ error: "Workspace not found in this organization" }, 404);
-  }
-
-  // You can only manage sharing for a Shared resource, never a
-  // Workspace-private one (ADR-0007) — the same check the Workspace-surface
-  // attach route makes.
-  if (!(await resolveOrgScoped(db, resourceType, resourceId, orgId))) {
-    return c.json(
-      { error: "Org-scoped resource not found in this organization" },
-      404,
-    );
-  }
-
-  try {
-    const record = await db
-      .insert(attachmentTable)
-      .values({ id: nanoid(), workspaceId, resourceType, resourceId })
-      .returning();
-    return c.json(record[0], 201);
-  } catch (error) {
-    if (isUniqueViolation(error)) {
-      return c.json(
-        { error: "This resource is already attached to that workspace" },
-        409,
-      );
-    }
-    throw error;
-  }
+  // The target workspace must belong to this organization; the resource must be
+  // a Shared resource of this Organization (ADR-0007). Both rules and the
+  // already-attached → 409 live in the Attachment module.
+  await requireWorkspaceInOrg(orgId, workspaceId);
+  const record = await attachResource(
+    orgId,
+    resourceType,
+    resourceId,
+    workspaceId,
+  );
+  return c.json(record, 201);
 });
 
 /** Detach an org-scoped Shared resource from a workspace (admin only) */
@@ -133,38 +104,11 @@ orgAttachment.delete(
     const resourceId = c.req.param("resourceId");
     const workspaceId = c.req.param("workspaceId");
 
-    if (!isScopedResourceType(resourceType)) {
-      return c.json({ error: "Invalid resourceType" }, 400);
-    }
+    // Guard against detaching across orgs, and let the module throw NotFound
+    // (→404) when no such Attachment exists (ADR-0010).
+    await requireWorkspaceInOrg(orgId, workspaceId);
+    await detachResource(resourceType, resourceId, workspaceId);
 
-    // Guard against detaching across orgs: the workspace must be in this org.
-    const [ws] = await db
-      .select({ id: workspaceTable.id })
-      .from(workspaceTable)
-      .where(
-        and(
-          eq(workspaceTable.id, workspaceId),
-          eq(workspaceTable.organizationId, orgId),
-        ),
-      )
-      .limit(1);
-    if (!ws) {
-      return c.json({ error: "Workspace not found in this organization" }, 404);
-    }
-
-    const result = await db
-      .delete(attachmentTable)
-      .where(
-        and(
-          eq(attachmentTable.workspaceId, workspaceId),
-          eq(attachmentTable.resourceType, resourceType),
-          eq(attachmentTable.resourceId, resourceId),
-        ),
-      )
-      .returning();
-    if (result.length === 0) {
-      return c.json({ error: "Attachment not found" }, 404);
-    }
     return c.json({ message: "Detached" });
   },
 );

--- a/apps/backend/src/routes/org-attachment.ts
+++ b/apps/backend/src/routes/org-attachment.ts
@@ -8,11 +8,7 @@ import {
 import { requireAuth } from "../middleware/authentication.ts";
 import { orgScopeOf, requireOrgAccess } from "../middleware/authorization.ts";
 import { isScopedResourceType } from "../services/scoped-resource.ts";
-import {
-  attachResource,
-  detachResource,
-  requireWorkspaceInOrg,
-} from "../services/attachment.ts";
+import { attachResource, detachResource } from "../services/attachment.ts";
 import type { Variables } from "../server.ts";
 
 // Org-surface management of where a Shared resource is attached (ADR-0007).
@@ -76,20 +72,15 @@ orgAttachment.post("/", requireAuth, requireOrgAccess(["admin"]), async (c) => {
   };
   const { resourceType, resourceId, workspaceId } = body;
 
-  if (!resourceId || !workspaceId) {
-    return c.json({ error: "resourceId and workspaceId are required" }, 400);
-  }
-
-  // The target workspace must belong to this organization; the resource must be
-  // a Shared resource of this Organization (ADR-0007). Both rules and the
-  // already-attached → 409 live in the Attachment module.
-  await requireWorkspaceInOrg(orgId, workspaceId);
-  const record = await attachResource(
-    orgId,
+  // Every rule — well-formed resourceType, the target workspace belonging to
+  // this organization, the resource being a Shared one of it (ADR-0007), and
+  // already-attached → 409 — lives in the Attachment module, which also owns
+  // the order they fail in.
+  const record = await attachResource({ kind: "organization" }, orgId, {
     resourceType,
     resourceId,
     workspaceId,
-  );
+  });
   return c.json(record, 201);
 });
 
@@ -106,8 +97,11 @@ orgAttachment.delete(
 
     // Guard against detaching across orgs, and let the module throw NotFound
     // (→404) when no such Attachment exists (ADR-0010).
-    await requireWorkspaceInOrg(orgId, workspaceId);
-    await detachResource(resourceType, resourceId, workspaceId);
+    await detachResource({ kind: "organization" }, orgId, {
+      resourceType,
+      resourceId,
+      workspaceId,
+    });
 
     return c.json({ message: "Detached" });
   },

--- a/apps/backend/src/routes/org-skill.test.ts
+++ b/apps/backend/src/routes/org-skill.test.ts
@@ -117,6 +117,10 @@ describe("Organization Skill Routes", () => {
     it("updates an org skill if org admin", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      // requireOrgScoped: the Skill is a Shared resource of this org
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "skill-1", organizationId: orgId },
+      ]);
       const updated = {
         id: "skill-1",
         name: "org-skill",
@@ -136,6 +140,27 @@ describe("Organization Skill Routes", () => {
 
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual(updated);
+    });
+
+    // #605: the org surface used to skip the existence pre-check, discovering a
+    // missing Skill only when the UPDATE matched no row.
+    it("404s a skill that is not a Shared resource of this org, without touching the write", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([]); // requireOrgScoped: not found
+
+      const res = await app.request(`${baseUrl}/missing`, {
+        method: "PUT",
+        body: JSON.stringify({
+          name: "org-skill",
+          description: "This is a long enough description for the skill.",
+          body: "This is a long enough body for the skill to pass the validation requirements.",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(404);
+      expect(mockDb.update).not.toHaveBeenCalled();
     });
 
     it("returns 403 for a non-admin", async () => {

--- a/apps/backend/src/routes/org-skill.ts
+++ b/apps/backend/src/routes/org-skill.ts
@@ -1,19 +1,14 @@
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
-import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import { skill as skillTable } from "../db/schema.ts";
 import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
 import { requireAuth } from "../middleware/authentication.ts";
 import { orgScopeOf, requireOrgAccess } from "../middleware/authorization.ts";
-import { scrubDeletedAgentReference } from "../services/agent-references.ts";
 import {
   listOrgScoped,
-  orgScopedWhere,
   requireOrgScoped,
-  requireSharedDeletable,
 } from "../services/scoped-resource.ts";
-import { NotFoundError } from "../errors.ts";
+import { createSkill, deleteSkill, updateSkill } from "../services/skill.ts";
 import type { Variables } from "../server.ts";
 
 // Org-scoped Skills are Shared resources (ADR-0007): a single source of truth
@@ -30,23 +25,13 @@ orgSkill.post(
   sValidator("json", skillCreateSchema),
   async (c) => {
     const { orgId } = orgScopeOf(c);
-    // Agent associations are a workspace concern; org-scoped Skills carry none.
-    const { agentIds: _agentIds, ...data } = c.req.valid("json");
+    const data = c.req.valid("json");
 
-    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
-    // by the central onError (ADR-0010).
-    const record = await db
-      .insert(skillTable)
-      .values({
-        id: nanoid(),
-        name: data.name,
-        description: data.description,
-        body: data.body,
-        organizationId: orgId,
-        workspaceId: null,
-      })
-      .returning();
-    return c.json(record[0], 201);
+    // Agent associations are a workspace concern; `createSkill` ignores any
+    // `agentIds` at Organization scope. A duplicate name surfaces as a Postgres
+    // unique violation, mapped to 409 by the central onError (ADR-0010).
+    const row = await createSkill({ kind: "organization", orgId }, data);
+    return c.json(row, 201);
   },
 );
 
@@ -74,24 +59,19 @@ orgSkill.put(
   async (c) => {
     const { orgId } = orgScopeOf(c);
     const skillId = c.req.param("skillId");
-    const { agentIds: _agentIds, ...data } = c.req.valid("json");
+    const data = c.req.valid("json");
 
-    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
-    // by the central onError (ADR-0010).
-    const record = await db
-      .update(skillTable)
-      .set({
-        name: data.name,
-        description: data.description,
-        body: data.body,
-        updatedAt: new Date(),
-      })
-      .where(orgScopedWhere("skill", skillId, orgId))
-      .returning();
-    if (record.length === 0) {
-      throw new NotFoundError("Skill not found");
-    }
-    return c.json(record[0], 200);
+    // `updateSkill` throws NotFound (→404) via requireOrgScoped when the Skill
+    // is not a Shared resource of this Organization, before the write ever
+    // runs (#605). Agent associations are a workspace concern and are ignored. A
+    // duplicate name surfaces as a Postgres unique violation, mapped to 409 by
+    // the central onError (ADR-0010).
+    const row = await updateSkill(
+      { kind: "organization", orgId },
+      skillId,
+      data,
+    );
+    return c.json(row, 200);
   },
 );
 
@@ -104,26 +84,11 @@ orgSkill.delete(
     const { orgId } = orgScopeOf(c);
     const skillId = c.req.param("skillId");
 
-    // A Shared resource cannot be deleted while anything still points at it —
-    // an Attachment (ADR-0007) or a Blueprint (ADR-0008). Throws ConflictError
-    // → 409 via the central onError (ADR-0010).
-    await requireSharedDeletable(db, "skill", skillId);
+    // `deleteSkill` throws ConflictError (→409, ADR-0007/0008) while an
+    // Attachment or Blueprint still references the Skill, and NotFound (→404)
+    // when it is not visible here.
+    await deleteSkill({ kind: "organization", orgId }, skillId);
 
-    // Delete the Skill and scrub its (now-dead) id from any Agent's skillIds in
-    // the same transaction, so deletion never leaves dangling references.
-    const result = await db.transaction(async (tx) => {
-      const rows = await tx
-        .delete(skillTable)
-        .where(orgScopedWhere("skill", skillId, orgId))
-        .returning();
-      if (rows.length > 0) {
-        await scrubDeletedAgentReference(tx, "skillIds", skillId);
-      }
-      return rows;
-    });
-    if (result.length === 0) {
-      throw new NotFoundError("Skill not found");
-    }
     return c.json({ message: "Skill deleted" });
   },
 );

--- a/apps/backend/src/routes/skill.ts
+++ b/apps/backend/src/routes/skill.ts
@@ -8,7 +8,7 @@ import {
   attachment as attachmentTable,
 } from "../db/schema.ts";
 import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
-import { eq, and, sql, inArray, notInArray } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
   requireOrgAccess,
@@ -18,9 +18,9 @@ import {
 import {
   listScoped,
   requireScoped,
-  requireWorkspaceMutable,
   workspaceScopedWhere,
 } from "../services/scoped-resource.ts";
+import { createSkill, deleteSkill, updateSkill } from "../services/skill.ts";
 import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 
@@ -83,45 +83,16 @@ skill.post(
   requireWorkspaceAccess,
   sValidator("json", skillCreateSchema),
   async (c) => {
-    const { workspaceId } = workspaceScopeOf(c);
-    const { agentIds, ...data } = c.req.valid("json");
+    const scope = workspaceScopeOf(c);
+    const data = c.req.valid("json");
 
-    const newId = nanoid();
     // The workspace route only ever creates workspace-scoped Skills; the scope
-    // is taken from the route, never the body (org-scoped Skills are created via
-    // the Organization surface or by Promote). A duplicate name surfaces as a
-    // Postgres unique violation, mapped to 409 by the central onError (ADR-0010).
-    const record = await db
-      .insert(skillTable)
-      .values({
-        id: newId,
-        name: data.name,
-        description: data.description,
-        body: data.body,
-        workspaceId,
-        organizationId: null,
-      })
-      .returning();
-
-    // Add skill to specified agents
-    if (agentIds && agentIds.length > 0) {
-      const newIdJson = JSON.stringify([newId]);
-      await db
-        .update(agentTable)
-        .set({
-          skillIds: sql`${agentTable.skillIds} || ${newIdJson}::jsonb`,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(agentTable.workspaceId, workspaceId),
-            inArray(agentTable.id, agentIds),
-            sql`NOT ${agentTable.skillIds} @> ${newIdJson}::jsonb`,
-          ),
-        );
-    }
-
-    return c.json(record[0], 201);
+    // is taken from the route, never the body (org-scoped Skills are created
+    // via the Organization surface or by Promote). A duplicate name surfaces as
+    // a Postgres unique violation, mapped to 409 by the central onError
+    // (ADR-0010).
+    const row = await createSkill({ kind: "workspace", ctx: scope }, data);
+    return c.json(row, 201);
   },
 );
 
@@ -135,64 +106,19 @@ skill.put(
   async (c) => {
     const scope = workspaceScopeOf(c);
     const skillId = c.req.param("skillId");
-    const { agentIds, ...data } = c.req.valid("json");
+    const data = c.req.valid("json");
 
     // A Shared Skill is a single source of truth edited only on the Organization
-    // surface (ADR-0007); requireWorkspaceMutable throws NotFound (→404) when the
-    // Skill is not visible here, then Locked (→403) when it is org-scoped.
-    await requireWorkspaceMutable(db, "skill", skillId, scope);
-
-    // A duplicate name surfaces as a Postgres unique violation, mapped to 409
-    // by the central onError (ADR-0010).
-    const record = await db
-      .update(skillTable)
-      .set({
-        ...data,
-        updatedAt: new Date(),
-      })
-      .where(workspaceScopedWhere("skill", skillId, scope.workspaceId))
-      .returning();
-
-    // Update agent associations if agentIds was provided
-    if (agentIds !== undefined) {
-      const now = new Date();
-      const skillIdJson = JSON.stringify([skillId]);
-
-      // Remove skill from agents not in the new list
-      const removeWhere = [
-        eq(agentTable.workspaceId, scope.workspaceId),
-        sql`${agentTable.skillIds} @> ${skillIdJson}::jsonb`,
-      ];
-      if (agentIds.length > 0) {
-        removeWhere.push(notInArray(agentTable.id, agentIds));
-      }
-      await db
-        .update(agentTable)
-        .set({
-          skillIds: sql`(${agentTable.skillIds})::jsonb - ${skillId}::text`,
-          updatedAt: now,
-        })
-        .where(and(...removeWhere));
-
-      // Add skill to agents in the new list that don't already have it
-      if (agentIds.length > 0) {
-        await db
-          .update(agentTable)
-          .set({
-            skillIds: sql`${agentTable.skillIds} || ${skillIdJson}::jsonb`,
-            updatedAt: now,
-          })
-          .where(
-            and(
-              eq(agentTable.workspaceId, scope.workspaceId),
-              inArray(agentTable.id, agentIds),
-              sql`NOT ${agentTable.skillIds} @> ${skillIdJson}::jsonb`,
-            ),
-          );
-      }
-    }
-
-    return c.json(record[0], 200);
+    // surface (ADR-0007); `updateSkill` throws NotFound (→404) when the Skill is
+    // not visible here, then Locked (→403) when it is org-scoped. A duplicate
+    // name surfaces as a Postgres unique violation, mapped to 409 by the
+    // central onError (ADR-0010).
+    const row = await updateSkill(
+      { kind: "workspace", ctx: scope },
+      skillId,
+      data,
+    );
+    return c.json(row, 200);
   },
 );
 
@@ -207,35 +133,10 @@ skill.delete(
     const skillId = c.req.param("skillId");
 
     // A Shared Skill is deleted only from the Organization surface (ADR-0007):
-    // requireWorkspaceMutable throws NotFound (→404) when the Skill is not
-    // visible here, then Locked (→403) when it is org-scoped.
-    await requireWorkspaceMutable(db, "skill", skillId, scope);
-
-    // Check if skill is referenced by any agent
-    const referencingAgents = await db
-      .select()
-      .from(agentTable)
-      .where(
-        and(
-          eq(agentTable.workspaceId, scope.workspaceId),
-          sql`${agentTable.skillIds} @> ${JSON.stringify([skillId])}::jsonb`,
-        ),
-      )
-      .limit(1);
-
-    if (referencingAgents.length > 0) {
-      return c.json(
-        {
-          error:
-            "Cannot delete skill because it is referenced by one or more agents",
-        },
-        409,
-      );
-    }
-
-    await db
-      .delete(skillTable)
-      .where(workspaceScopedWhere("skill", skillId, scope.workspaceId));
+    // `deleteSkill` throws NotFound (→404) when the Skill is not visible here,
+    // then Locked (→403) when it is org-scoped, and Conflict (→409) while a
+    // Workspace agent still references it.
+    await deleteSkill({ kind: "workspace", ctx: scope }, skillId);
 
     return c.json({ message: "Skill deleted" });
   },

--- a/apps/backend/src/services/attachment.test.ts
+++ b/apps/backend/src/services/attachment.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDb, resetMockDb } from "../test-utils.ts";
+
+import {
+  attachResource,
+  detachResource,
+  requireWorkspaceInOrg,
+} from "./attachment.ts";
+import { ConflictError, NotFoundError, ValidationError } from "../errors.ts";
+
+describe("attachment module", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockDb();
+  });
+
+  describe("requireWorkspaceInOrg", () => {
+    it("resolves when the workspace belongs to the org", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "ws-1", organizationId: "org-1" },
+      ]);
+
+      await expect(
+        requireWorkspaceInOrg("org-1", "ws-1"),
+      ).resolves.toBeUndefined();
+    });
+
+    it("throws NotFoundError for a workspace outside the org", async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      await expect(requireWorkspaceInOrg("org-1", "other-ws")).rejects.toThrow(
+        NotFoundError,
+      );
+    });
+  });
+
+  describe("attachResource", () => {
+    it("throws ValidationError for an invalid resourceType, before any lookup", async () => {
+      await expect(
+        attachResource("org-1", "garbage", "r-1", "ws-1"),
+      ).rejects.toThrow(ValidationError);
+      expect(mockDb.select).not.toHaveBeenCalled();
+    });
+
+    it("attaches a Shared resource of the org", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "mcp-1", organizationId: "org-1" },
+      ]); // resolveOrgScoped
+      const record = {
+        id: "att-1",
+        workspaceId: "ws-1",
+        resourceType: "mcp",
+        resourceId: "mcp-1",
+      };
+      mockDb.returning.mockResolvedValueOnce([record]);
+
+      const row = await attachResource("org-1", "mcp", "mcp-1", "ws-1");
+
+      expect(row).toEqual(record);
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.workspaceId).toBe("ws-1");
+      expect(values.resourceType).toBe("mcp");
+    });
+
+    it("throws NotFoundError when the resource is not a Shared resource of this org", async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      await expect(
+        attachResource("org-1", "provider", "p-x", "ws-1"),
+      ).rejects.toThrow(NotFoundError);
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("throws ConflictError when already attached (unique violation)", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "mcp-1", organizationId: "org-1" },
+      ]);
+      mockDb.returning.mockRejectedValueOnce(
+        Object.assign(new Error("DrizzleQueryError"), {
+          cause: { code: "23505" },
+        }),
+      );
+
+      await expect(
+        attachResource("org-1", "mcp", "mcp-1", "ws-1"),
+      ).rejects.toThrow(ConflictError);
+    });
+
+    it("re-throws non-unique insert errors", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "mcp-1", organizationId: "org-1" },
+      ]);
+      const boom = new Error("boom");
+      mockDb.returning.mockRejectedValueOnce(boom);
+
+      await expect(
+        attachResource("org-1", "mcp", "mcp-1", "ws-1"),
+      ).rejects.toThrow(boom);
+    });
+  });
+
+  describe("detachResource", () => {
+    it("throws ValidationError for an invalid resourceType, before any delete", async () => {
+      await expect(detachResource("garbage", "r-1", "ws-1")).rejects.toThrow(
+        ValidationError,
+      );
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("deletes the matching attachment", async () => {
+      mockDb.returning.mockResolvedValueOnce([{ id: "att-1" }]);
+
+      await expect(
+        detachResource("mcp", "mcp-1", "ws-1"),
+      ).resolves.toBeUndefined();
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+
+    it("throws NotFoundError when no such attachment exists", async () => {
+      mockDb.returning.mockResolvedValueOnce([]);
+
+      await expect(detachResource("mcp", "mcp-1", "ws-1")).rejects.toThrow(
+        NotFoundError,
+      );
+    });
+  });
+});

--- a/apps/backend/src/services/attachment.test.ts
+++ b/apps/backend/src/services/attachment.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mockDb, resetMockDb } from "../test-utils.ts";
 
-import {
-  attachResource,
-  detachResource,
-  requireWorkspaceInOrg,
-} from "./attachment.ts";
+import { attachResource, detachResource } from "./attachment.ts";
 import { ConflictError, NotFoundError, ValidationError } from "../errors.ts";
+
+const WORKSPACE = { kind: "workspace" } as const;
+const ORGANIZATION = { kind: "organization" } as const;
+
+const target = (overrides: Record<string, unknown> = {}) => ({
+  resourceType: "mcp",
+  resourceId: "mcp-1",
+  workspaceId: "ws-1",
+  ...overrides,
+});
 
 describe("attachment module", () => {
   beforeEach(() => {
@@ -14,32 +20,63 @@ describe("attachment module", () => {
     resetMockDb();
   });
 
-  describe("requireWorkspaceInOrg", () => {
-    it("resolves when the workspace belongs to the org", async () => {
-      mockDb.limit.mockResolvedValueOnce([
-        { id: "ws-1", organizationId: "org-1" },
-      ]);
-
-      await expect(
-        requireWorkspaceInOrg("org-1", "ws-1"),
-      ).resolves.toBeUndefined();
-    });
-
-    it("throws NotFoundError for a workspace outside the org", async () => {
-      mockDb.limit.mockResolvedValueOnce([]);
-
-      await expect(requireWorkspaceInOrg("org-1", "other-ws")).rejects.toThrow(
-        NotFoundError,
-      );
-    });
-  });
-
   describe("attachResource", () => {
     it("throws ValidationError for an invalid resourceType, before any lookup", async () => {
       await expect(
-        attachResource("org-1", "garbage", "r-1", "ws-1"),
+        attachResource(WORKSPACE, "org-1", target({ resourceType: "garbage" })),
       ).rejects.toThrow(ValidationError);
       expect(mockDb.select).not.toHaveBeenCalled();
+    });
+
+    it("throws ValidationError when resourceId or workspaceId is missing", async () => {
+      await expect(
+        attachResource(
+          ORGANIZATION,
+          "org-1",
+          target({ resourceId: undefined }),
+        ),
+      ).rejects.toThrow(ValidationError);
+      await expect(
+        attachResource(
+          ORGANIZATION,
+          "org-1",
+          target({ workspaceId: undefined }),
+        ),
+      ).rejects.toThrow(ValidationError);
+      expect(mockDb.select).not.toHaveBeenCalled();
+    });
+
+    // The rule order is part of the contract: a request that trips both must
+    // still fail on the type, the way both surfaces answered before the module.
+    it("reports an invalid resourceType before an out-of-org workspace", async () => {
+      await expect(
+        attachResource(
+          ORGANIZATION,
+          "org-1",
+          target({ resourceType: "garbage", workspaceId: "other-ws" }),
+        ),
+      ).rejects.toThrow(ValidationError);
+      expect(mockDb.select).not.toHaveBeenCalled();
+    });
+
+    it("throws NotFoundError at org scope when the workspace is outside the org", async () => {
+      mockDb.limit.mockResolvedValueOnce([]); // requireWorkspaceInOrg
+
+      await expect(
+        attachResource(ORGANIZATION, "org-1", target({ workspaceId: "ws-x" })),
+      ).rejects.toThrow(NotFoundError);
+      expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it("skips the workspace-in-org check at workspace scope", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "mcp-1", organizationId: "org-1" },
+      ]); // resolveOrgScoped is the only lookup
+      mockDb.returning.mockResolvedValueOnce([{ id: "att-1" }]);
+
+      await attachResource(WORKSPACE, "org-1", target());
+
+      expect(mockDb.limit).toHaveBeenCalledTimes(1);
     });
 
     it("attaches a Shared resource of the org", async () => {
@@ -54,7 +91,7 @@ describe("attachment module", () => {
       };
       mockDb.returning.mockResolvedValueOnce([record]);
 
-      const row = await attachResource("org-1", "mcp", "mcp-1", "ws-1");
+      const row = await attachResource(WORKSPACE, "org-1", target());
 
       expect(row).toEqual(record);
       const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
@@ -66,7 +103,11 @@ describe("attachment module", () => {
       mockDb.limit.mockResolvedValueOnce([]);
 
       await expect(
-        attachResource("org-1", "provider", "p-x", "ws-1"),
+        attachResource(
+          WORKSPACE,
+          "org-1",
+          target({ resourceType: "provider", resourceId: "p-x" }),
+        ),
       ).rejects.toThrow(NotFoundError);
       expect(mockDb.insert).not.toHaveBeenCalled();
     });
@@ -82,7 +123,7 @@ describe("attachment module", () => {
       );
 
       await expect(
-        attachResource("org-1", "mcp", "mcp-1", "ws-1"),
+        attachResource(WORKSPACE, "org-1", target()),
       ).rejects.toThrow(ConflictError);
     });
 
@@ -94,16 +135,37 @@ describe("attachment module", () => {
       mockDb.returning.mockRejectedValueOnce(boom);
 
       await expect(
-        attachResource("org-1", "mcp", "mcp-1", "ws-1"),
+        attachResource(WORKSPACE, "org-1", target()),
       ).rejects.toThrow(boom);
     });
   });
 
   describe("detachResource", () => {
     it("throws ValidationError for an invalid resourceType, before any delete", async () => {
-      await expect(detachResource("garbage", "r-1", "ws-1")).rejects.toThrow(
-        ValidationError,
-      );
+      await expect(
+        detachResource(WORKSPACE, "org-1", target({ resourceType: "garbage" })),
+      ).rejects.toThrow(ValidationError);
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("reports an invalid resourceType before an out-of-org workspace", async () => {
+      await expect(
+        detachResource(
+          ORGANIZATION,
+          "org-1",
+          target({ resourceType: "garbage", workspaceId: "other-ws" }),
+        ),
+      ).rejects.toThrow(ValidationError);
+      expect(mockDb.select).not.toHaveBeenCalled();
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("throws NotFoundError at org scope when the workspace is outside the org", async () => {
+      mockDb.limit.mockResolvedValueOnce([]); // requireWorkspaceInOrg
+
+      await expect(
+        detachResource(ORGANIZATION, "org-1", target({ workspaceId: "ws-x" })),
+      ).rejects.toThrow(NotFoundError);
       expect(mockDb.delete).not.toHaveBeenCalled();
     });
 
@@ -111,7 +173,7 @@ describe("attachment module", () => {
       mockDb.returning.mockResolvedValueOnce([{ id: "att-1" }]);
 
       await expect(
-        detachResource("mcp", "mcp-1", "ws-1"),
+        detachResource(WORKSPACE, "org-1", target()),
       ).resolves.toBeUndefined();
       expect(mockDb.delete).toHaveBeenCalled();
     });
@@ -119,9 +181,9 @@ describe("attachment module", () => {
     it("throws NotFoundError when no such attachment exists", async () => {
       mockDb.returning.mockResolvedValueOnce([]);
 
-      await expect(detachResource("mcp", "mcp-1", "ws-1")).rejects.toThrow(
-        NotFoundError,
-      );
+      await expect(
+        detachResource(WORKSPACE, "org-1", target()),
+      ).rejects.toThrow(NotFoundError);
     });
   });
 });

--- a/apps/backend/src/services/attachment.ts
+++ b/apps/backend/src/services/attachment.ts
@@ -1,0 +1,135 @@
+import { and, eq } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { db } from "../index.ts";
+import {
+  attachment as attachmentTable,
+  workspace as workspaceTable,
+} from "../db/schema.ts";
+import {
+  ConflictError,
+  isUniqueViolation,
+  NotFoundError,
+  ValidationError,
+} from "../errors.ts";
+import { isScopedResourceType, resolveOrgScoped } from "./scoped-resource.ts";
+
+/**
+ * The Attachment module: the rules for attaching and detaching a Shared
+ * resource to a Workspace (ADR-0007), owned once and adapted over by both HTTP
+ * surfaces — `routes/attachment.ts` (per-Workspace) and
+ * `routes/org-attachment.ts` (Organization surface). They used to each carry
+ * their own copy of the attach/detach insert and diverged on every axis (#605):
+ * schema validation vs manual field checks, typed `NotFoundError` vs inline 404
+ * JSON, an unguarded path-param cast vs a guard.
+ *
+ * Three rules live here, in the shapes ADR-0007 states:
+ * - **resource-is-Shared**: you can only attach a Shared resource of this
+ *   Organization, never a Workspace-private one — `resolveOrgScoped` enforces
+ *   it, and a miss is a `NotFoundError` (→404).
+ * - **workspace-in-org**: `requireWorkspaceInOrg` — a workspace outside the
+ *   Organization is as absent as a missing one (→404). The per-Workspace
+ *   surface never calls it directly: `requireWorkspaceAccess` already answers
+ *   the same question for a workspace the URL named, so only the Organization
+ *   surface (which takes an arbitrary `workspaceId` from the body) needs it.
+ * - **already-attached**: the `(workspaceId, resourceType, resourceId)` unique
+ *   constraint is the authority; a violation surfaces as a `ConflictError`
+ *   (→409) instead of leaking the driver error.
+ */
+
+export type AttachmentRow = typeof attachmentTable.$inferSelect;
+
+/**
+ * Throws `NotFoundError` when `workspaceId` is not a Workspace of `orgId` —
+ * the workspace-in-org rule. Exported so the Organization surface can name it
+ * for both its attach and detach routes without duplicating the query.
+ */
+export const requireWorkspaceInOrg = async (
+  orgId: string,
+  workspaceId: string,
+): Promise<void> => {
+  const [ws] = await db
+    .select({ id: workspaceTable.id })
+    .from(workspaceTable)
+    .where(
+      and(
+        eq(workspaceTable.id, workspaceId),
+        eq(workspaceTable.organizationId, orgId),
+      ),
+    )
+    .limit(1);
+  if (!ws) {
+    throw new NotFoundError("Workspace not found in this organization");
+  }
+};
+
+/**
+ * Attaches a Shared resource to a Workspace. The resource must be a Shared
+ * resource of this Organization (ADR-0007) — a miss is a `NotFoundError`; an
+ * insert colliding on the `(workspaceId, resourceType, resourceId)` unique
+ * constraint is a `ConflictError` (→409). `resourceType` is untrusted input
+ * from the body, so it is validated rather than cast.
+ */
+export async function attachResource(
+  orgId: string,
+  resourceType: string | undefined,
+  resourceId: string,
+  workspaceId: string,
+): Promise<AttachmentRow> {
+  if (!isScopedResourceType(resourceType)) {
+    throw new ValidationError("Invalid resourceType");
+  }
+
+  // The resource must be org-scoped and belong to this organization — you can
+  // only attach a Shared resource, never a workspace-scoped one.
+  const resource = await resolveOrgScoped(db, resourceType, resourceId, orgId);
+  if (!resource) {
+    throw new NotFoundError(
+      "Org-scoped resource not found in this organization",
+    );
+  }
+
+  try {
+    const [row] = await db
+      .insert(attachmentTable)
+      .values({ id: nanoid(), workspaceId, resourceType, resourceId })
+      .returning();
+    return row;
+  } catch (error) {
+    // Already attached → the unique constraint refuses the duplicate pair.
+    if (isUniqueViolation(error)) {
+      throw new ConflictError(
+        "This resource is already attached to this workspace",
+      );
+    }
+    throw error;
+  }
+}
+
+/**
+ * Detaches a Shared resource from a Workspace. Throws `NotFoundError` when no
+ * such Attachment exists. `resourceType` is untrusted input from the path, so
+ * it's validated rather than cast.
+ */
+export async function detachResource(
+  resourceType: string | undefined,
+  resourceId: string,
+  workspaceId: string,
+): Promise<void> {
+  if (!isScopedResourceType(resourceType)) {
+    throw new ValidationError("Invalid resourceType");
+  }
+
+  const result = await db
+    .delete(attachmentTable)
+    .where(
+      and(
+        eq(attachmentTable.workspaceId, workspaceId),
+        eq(attachmentTable.resourceType, resourceType),
+        eq(attachmentTable.resourceId, resourceId),
+      ),
+    )
+    .returning();
+  if (result.length === 0) {
+    throw new NotFoundError("Attachment not found");
+  }
+}

--- a/apps/backend/src/services/attachment.ts
+++ b/apps/backend/src/services/attachment.ts
@@ -26,24 +26,49 @@ import { isScopedResourceType, resolveOrgScoped } from "./scoped-resource.ts";
  * - **resource-is-Shared**: you can only attach a Shared resource of this
  *   Organization, never a Workspace-private one — `resolveOrgScoped` enforces
  *   it, and a miss is a `NotFoundError` (→404).
- * - **workspace-in-org**: `requireWorkspaceInOrg` — a workspace outside the
- *   Organization is as absent as a missing one (→404). The per-Workspace
- *   surface never calls it directly: `requireWorkspaceAccess` already answers
- *   the same question for a workspace the URL named, so only the Organization
- *   surface (which takes an arbitrary `workspaceId` from the body) needs it.
+ * - **workspace-in-org**: a workspace outside the Organization is as absent as
+ *   a missing one (→404). Only the Organization surface needs it, since it
+ *   takes an arbitrary `workspaceId` from the request; the per-Workspace
+ *   surface has already had `requireWorkspaceAccess` answer the same question.
+ *   `AttachmentScope` is how a caller says which of the two it is.
  * - **already-attached**: the `(workspaceId, resourceType, resourceId)` unique
  *   constraint is the authority; a violation surfaces as a `ConflictError`
  *   (→409) instead of leaking the driver error.
+ *
+ * The *order* those rules run in is part of the contract, not the caller's to
+ * remember: a request that trips more than one must fail on the same rule it
+ * always did (an invalid `resourceType` is a 400 even when the workspace is
+ * also out of org). Keeping the sequence here is what stops the two surfaces
+ * drifting on precedence the way they drifted on everything else.
  */
 
 export type AttachmentRow = typeof attachmentTable.$inferSelect;
 
 /**
- * Throws `NotFoundError` when `workspaceId` is not a Workspace of `orgId` —
- * the workspace-in-org rule. Exported so the Organization surface can name it
- * for both its attach and detach routes without duplicating the query.
+ * Which surface a write comes from — the per-Workspace route, whose
+ * `workspaceId` the middleware already proved belongs to the Organization, or
+ * the Organization route, which names an arbitrary workspace and must have it
+ * checked. Mirrors `SkillScope`/`ProviderScope`.
  */
-export const requireWorkspaceInOrg = async (
+export type AttachmentScope = { kind: "workspace" } | { kind: "organization" };
+
+/**
+ * The resource an attach or detach names. `resourceType` is untrusted input
+ * from a body or a path on both surfaces, so it is validated rather than cast;
+ * the Organization attach surface reads the whole triple from an unvalidated
+ * body, so every field arrives possibly absent.
+ */
+export type AttachmentTarget = {
+  resourceType: string | undefined;
+  resourceId: string | undefined;
+  workspaceId: string | undefined;
+};
+
+/**
+ * Throws `NotFoundError` when `workspaceId` is not a Workspace of `orgId` —
+ * the workspace-in-org rule.
+ */
+const requireWorkspaceInOrg = async (
   orgId: string,
   workspaceId: string,
 ): Promise<void> => {
@@ -63,20 +88,25 @@ export const requireWorkspaceInOrg = async (
 };
 
 /**
- * Attaches a Shared resource to a Workspace. The resource must be a Shared
- * resource of this Organization (ADR-0007) — a miss is a `NotFoundError`; an
- * insert colliding on the `(workspaceId, resourceType, resourceId)` unique
- * constraint is a `ConflictError` (→409). `resourceType` is untrusted input
- * from the body, so it is validated rather than cast.
+ * Attaches a Shared resource to a Workspace, applying the three rules in the
+ * order described above. Returns the new Attachment row.
  */
 export async function attachResource(
+  scope: AttachmentScope,
   orgId: string,
-  resourceType: string | undefined,
-  resourceId: string,
-  workspaceId: string,
+  target: AttachmentTarget,
 ): Promise<AttachmentRow> {
+  const { resourceType, resourceId, workspaceId } = target;
+
   if (!isScopedResourceType(resourceType)) {
     throw new ValidationError("Invalid resourceType");
+  }
+  if (!resourceId || !workspaceId) {
+    throw new ValidationError("resourceId and workspaceId are required");
+  }
+
+  if (scope.kind === "organization") {
+    await requireWorkspaceInOrg(orgId, workspaceId);
   }
 
   // The resource must be org-scoped and belong to this organization — you can
@@ -106,17 +136,27 @@ export async function attachResource(
 }
 
 /**
- * Detaches a Shared resource from a Workspace. Throws `NotFoundError` when no
- * such Attachment exists. `resourceType` is untrusted input from the path, so
- * it's validated rather than cast.
+ * Detaches a Shared resource from a Workspace. Both identifying fields reach
+ * this from a path, so only `resourceType` needs validating; the rules run in
+ * the same order as `attachResource` — bad type before out-of-org workspace.
+ * Throws `NotFoundError` when no such Attachment exists.
  */
 export async function detachResource(
-  resourceType: string | undefined,
-  resourceId: string,
-  workspaceId: string,
+  scope: AttachmentScope,
+  orgId: string,
+  target: AttachmentTarget,
 ): Promise<void> {
+  const { resourceType, resourceId, workspaceId } = target;
+
   if (!isScopedResourceType(resourceType)) {
     throw new ValidationError("Invalid resourceType");
+  }
+  if (!resourceId || !workspaceId) {
+    throw new ValidationError("resourceId and workspaceId are required");
+  }
+
+  if (scope.kind === "organization") {
+    await requireWorkspaceInOrg(orgId, workspaceId);
   }
 
   const result = await db

--- a/apps/backend/src/services/skill.test.ts
+++ b/apps/backend/src/services/skill.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDb, resetMockDb } from "../test-utils.ts";
+
+import {
+  createSkill,
+  updateSkill,
+  upsertSkill,
+  deleteSkill,
+  type SkillCreateFields,
+} from "./skill.ts";
+import { ConflictError, LockedError, NotFoundError } from "../errors.ts";
+
+const workspaceCtx = { orgId: "org-1", workspaceId: "ws-1" };
+
+const createFields = (): SkillCreateFields => ({
+  name: "my-skill",
+  description: "A skill used in tests",
+  body: "The skill body",
+});
+
+const updateFields = () => ({
+  name: "Renamed",
+  description: "Renamed description",
+  body: "Renamed body",
+});
+
+describe("skill write model", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetMockDb();
+  });
+
+  describe("createSkill", () => {
+    it("inserts a workspace-scoped skill with a generated id", async () => {
+      const inserted = { id: "s1", workspaceId: "ws-1" };
+      mockDb.returning.mockResolvedValueOnce([inserted]);
+
+      const row = await createSkill(
+        { kind: "workspace", ctx: workspaceCtx },
+        createFields(),
+      );
+
+      expect(row).toEqual(inserted);
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.workspaceId).toBe("ws-1");
+      expect(values.organizationId).toBeNull();
+      expect(typeof values.id).toBe("string");
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("inserts an organization-scoped skill with no workspace, ignoring agentIds", async () => {
+      const inserted = { id: "s1", organizationId: "org-1" };
+      mockDb.returning.mockResolvedValueOnce([inserted]);
+
+      const row = await createSkill(
+        { kind: "organization", orgId: "org-1" },
+        { ...createFields(), agentIds: ["agent-1"] },
+      );
+
+      expect(row).toEqual(inserted);
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.organizationId).toBe("org-1");
+      expect(values.workspaceId).toBeNull();
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("assigns the new skill to the requested agents on the workspace surface", async () => {
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "s1", workspaceId: "ws-1" },
+      ]);
+
+      await createSkill(
+        { kind: "workspace", ctx: workspaceCtx },
+        { ...createFields(), agentIds: ["agent-1", "agent-2"] },
+      );
+
+      expect(mockDb.update).toHaveBeenCalledTimes(1);
+      const set = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(set.skillIds).toBeDefined();
+    });
+  });
+
+  describe("updateSkill", () => {
+    it("updates a workspace-scoped skill after proving it mutable", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "s1", workspaceId: "ws-1" }]);
+      const updated = { id: "s1", workspaceId: "ws-1", name: "Renamed" };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const row = await updateSkill(
+        { kind: "workspace", ctx: workspaceCtx },
+        "s1",
+        updateFields(),
+      );
+
+      expect(row).toEqual(updated);
+    });
+
+    it("throws NotFoundError for a workspace skill not visible here, before the write", async () => {
+      mockDb.limit.mockResolvedValueOnce([]); // resolveScoped: no row
+
+      await expect(
+        updateSkill(
+          { kind: "workspace", ctx: workspaceCtx },
+          "missing",
+          updateFields(),
+        ),
+      ).rejects.toThrow(NotFoundError);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("throws LockedError for an attached Shared skill on the workspace surface", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "s1", organizationId: "org-1", workspaceId: null },
+        ])
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attached
+
+      await expect(
+        updateSkill(
+          { kind: "workspace", ctx: workspaceCtx },
+          "s1",
+          updateFields(),
+        ),
+      ).rejects.toThrow(LockedError);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("updates an organization-scoped skill after checking it is a Shared resource here", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "s1", organizationId: "org-1", workspaceId: null },
+      ]); // requireOrgScoped
+      const updated = { id: "s1", organizationId: "org-1" };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const row = await updateSkill(
+        { kind: "organization", orgId: "org-1" },
+        "s1",
+        updateFields(),
+      );
+
+      expect(row).toEqual(updated);
+    });
+
+    it("throws NotFoundError for an org skill that is not Shared here, before the write", async () => {
+      mockDb.limit.mockResolvedValueOnce([]); // requireOrgScoped: not found
+
+      await expect(
+        updateSkill(
+          { kind: "organization", orgId: "org-1" },
+          "missing",
+          updateFields(),
+        ),
+      ).rejects.toThrow(NotFoundError);
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it("throws NotFoundError when a concurrently-deleted org skill is gone by the write", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "s1", organizationId: "org-1", workspaceId: null },
+      ]); // requireOrgScoped
+      mockDb.returning.mockResolvedValueOnce([]); // UPDATE matched nothing
+
+      await expect(
+        updateSkill(
+          { kind: "organization", orgId: "org-1" },
+          "s1",
+          updateFields(),
+        ),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("rewrites the agent set only when the workspace update carries agentIds", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "s1", workspaceId: "ws-1" }]);
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "s1", workspaceId: "ws-1" },
+      ]);
+
+      await updateSkill({ kind: "workspace", ctx: workspaceCtx }, "s1", {
+        ...updateFields(),
+        agentIds: ["agent-1"],
+      });
+
+      // Skill row update, then agent removal + append.
+      expect(mockDb.update).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("upsertSkill", () => {
+    it("writes a workspace-scoped row keyed on (workspaceId, name)", async () => {
+      mockDb.returning.mockResolvedValueOnce([{ id: "s1", name: "my-skill" }]);
+
+      const row = await upsertSkill(workspaceCtx, {
+        name: "my-skill",
+        description: "A skill used in tests",
+        body: "The skill body",
+      });
+
+      expect(row.id).toBe("s1");
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.workspaceId).toBe("ws-1");
+      const conflict = mockDb.onConflictDoUpdate.mock.calls[0][0] as {
+        target: unknown[];
+        set: Record<string, unknown>;
+      };
+      expect(conflict.target).toHaveLength(2);
+      expect(conflict.set.description).toBe("A skill used in tests");
+    });
+  });
+
+  describe("deleteSkill", () => {
+    it("deletes a workspace-scoped skill when no agent references it", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([{ id: "s1", workspaceId: "ws-1" }]) // requireWorkspaceMutable
+        .mockResolvedValueOnce([]); // referencing agents: none
+
+      await deleteSkill({ kind: "workspace", ctx: workspaceCtx }, "s1");
+
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+
+    it("throws ConflictError while a workspace agent references the skill", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([{ id: "s1", workspaceId: "ws-1" }]) // requireWorkspaceMutable
+        .mockResolvedValueOnce([{ id: "agent-1" }]); // referencing agents
+
+      await expect(
+        deleteSkill({ kind: "workspace", ctx: workspaceCtx }, "s1"),
+      ).rejects.toThrow(ConflictError);
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("throws LockedError for an attached Shared skill on the workspace surface", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "s1", organizationId: "org-1", workspaceId: null },
+        ])
+        .mockResolvedValueOnce([{ id: "att-1" }]); // attached
+
+      await expect(
+        deleteSkill({ kind: "workspace", ctx: workspaceCtx }, "s1"),
+      ).rejects.toThrow(LockedError);
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("deletes an org skill once it is confirmed deletable, scrubbing dead references in the same transaction", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([]) // requireSharedDeletable: no attachment
+        .mockResolvedValueOnce([]); // requireSharedDeletable: no blueprint
+      mockDb.returning.mockResolvedValueOnce([{ id: "s1" }]);
+
+      await deleteSkill({ kind: "organization", orgId: "org-1" }, "s1");
+
+      expect(mockDb.delete).toHaveBeenCalled();
+      // The dead id is scrubbed from the same transaction's agent update.
+      expect(mockDb.update).toHaveBeenCalled();
+    });
+
+    it("throws ConflictError while an Attachment still references the org skill", async () => {
+      mockDb.limit.mockResolvedValueOnce([{ id: "att-1" }]); // attached
+
+      await expect(
+        deleteSkill({ kind: "organization", orgId: "org-1" }, "s1"),
+      ).rejects.toThrow(ConflictError);
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("throws NotFoundError when the org delete matches no row", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([]) // requireSharedDeletable: no attachment
+        .mockResolvedValueOnce([]); // requireSharedDeletable: no blueprint
+      mockDb.returning.mockResolvedValueOnce([]); // delete matched nothing
+
+      await expect(
+        deleteSkill({ kind: "organization", orgId: "org-1" }, "missing"),
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+});

--- a/apps/backend/src/services/skill.ts
+++ b/apps/backend/src/services/skill.ts
@@ -1,0 +1,297 @@
+import type { z } from "zod";
+import type { SQL } from "drizzle-orm";
+import { and, eq, inArray, notInArray, sql } from "drizzle-orm";
+import { nanoid } from "nanoid";
+import { db } from "../index.ts";
+import { skill as skillTable, agent as agentTable } from "../db/schema.ts";
+import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
+import type { ScopeContext } from "../scope.ts";
+import { ConflictError, NotFoundError } from "../errors.ts";
+import { scrubDeletedAgentReference } from "./agent-references.ts";
+import {
+  orgScopedWhere,
+  requireOrgScoped,
+  requireSharedDeletable,
+  requireWorkspaceMutable,
+  workspaceScopedWhere,
+} from "./scoped-resource.ts";
+
+/**
+ * The Skill write model: create/update/delete that both route surfaces adapt
+ * over — `routes/skill.ts` (Workspace surface) and `routes/org-skill.ts`
+ * (Organization surface). They used to each carry a verbatim copy of the
+ * insert/update column set (name/description/body) and the agent-association
+ * SQL and had already drifted apart (#605): the Workspace copy owns `agentIds`
+ * while the Organization copy re-lists the fields to discard them.
+ *
+ * `updateSkill`/`deleteSkill` also answer the agent-facing Tool surface
+ * (`tools/skill-management.ts`), which catches the typed errors and translates
+ * them to an `{ error }` result instead of letting them bubble to an HTTP
+ * `onError`.
+ *
+ * "Not visible here" and "visible but locked" (a Shared Skill, a single source
+ * of truth edited only on the Organization surface — ADR-0007) are the
+ * cross-cutting errors of ADR-0010: at Workspace scope they throw via
+ * `requireWorkspaceMutable`, letting the routes bubble to `app.onError` and the
+ * Tool catch and translate. At Organization scope, "not visible here" throws
+ * `NotFoundError` via `requireOrgScoped`/`requireSharedDeletable` the same way;
+ * there is no "locked" case, since the Organization surface is where a Shared
+ * Skill is always editable.
+ */
+
+export type SkillRow = typeof skillTable.$inferSelect;
+
+/** The fields a create carries — every field but the id and its scope. */
+export type SkillCreateFields = Omit<
+  z.infer<typeof skillCreateSchema>,
+  "organizationId" | "workspaceId"
+>;
+
+/** The fields an update may carry — a partial edit of the same set. */
+export type SkillUpdateFields = z.infer<typeof skillUpdateSchema>;
+
+/**
+ * Which scope a write targets — the Workspace surface (ADR-0006 delegation
+ * applies, a Shared row is locked) or the Organization surface (admin-only,
+ * writes a Shared row directly). The one write model answers both surfaces by
+ * branching on this rather than existing twice. Mirrors `ProviderScope`.
+ */
+export type SkillScope =
+  | { kind: "workspace"; ctx: ScopeContext }
+  | { kind: "organization"; orgId: string };
+
+/** Appends `skillId` to `agentIds`' skill lists where it is not already set. */
+const assignToAgents = async (
+  workspaceId: string,
+  skillId: string,
+  agentIds: string[],
+): Promise<void> => {
+  if (agentIds.length === 0) return;
+  const skillIdJson = JSON.stringify([skillId]);
+  await db
+    .update(agentTable)
+    .set({
+      skillIds: sql`${agentTable.skillIds} || ${skillIdJson}::jsonb`,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(agentTable.workspaceId, workspaceId),
+        inArray(agentTable.id, agentIds),
+        sql`NOT ${agentTable.skillIds} @> ${skillIdJson}::jsonb`,
+      ),
+    );
+};
+
+/**
+ * Rewrites a Skill's agent set: removes the Skill from every Workspace agent
+ * not in the new list, then appends it to the ones that are. Runs only when an
+ * update carries `agentIds`; the field's undefined/null distinction is what
+ * separates "clear the set" from "leave it alone".
+ */
+const syncAgentAssignments = async (
+  workspaceId: string,
+  skillId: string,
+  agentIds: string[],
+): Promise<void> => {
+  const now = new Date();
+  const skillIdJson = JSON.stringify([skillId]);
+
+  // Remove skill from agents not in the new list.
+  const removeWhere = [
+    eq(agentTable.workspaceId, workspaceId),
+    sql`${agentTable.skillIds} @> ${skillIdJson}::jsonb`,
+  ];
+  if (agentIds.length > 0) {
+    removeWhere.push(notInArray(agentTable.id, agentIds));
+  }
+  await db
+    .update(agentTable)
+    .set({
+      skillIds: sql`(${agentTable.skillIds})::jsonb - ${skillId}::text`,
+      updatedAt: now,
+    })
+    .where(and(...removeWhere));
+
+  await assignToAgents(workspaceId, skillId, agentIds);
+};
+
+/**
+ * Creates a new Skill at the given scope. The scope comes from `scope`, never
+ * the body — a caller cannot mint a Shared Skill from the Workspace surface by
+ * naming an `organizationId` in the request (ADR-0006, ADR-0007). Agent
+ * associations are a Workspace concern; at Organization scope any `agentIds`
+ * are ignored, matching what the org surface used to do explicitly. A duplicate
+ * name surfaces as a Postgres unique violation, mapped to 409 by the central
+ * `onError` (ADR-0010).
+ */
+export async function createSkill(
+  scope: SkillScope,
+  fields: SkillCreateFields,
+): Promise<SkillRow> {
+  const { agentIds, ...data } = fields;
+
+  const [row] = await db
+    .insert(skillTable)
+    .values({
+      id: nanoid(),
+      ...data,
+      ...(scope.kind === "workspace"
+        ? { workspaceId: scope.ctx.workspaceId, organizationId: null }
+        : { organizationId: scope.orgId, workspaceId: null }),
+    })
+    .returning();
+
+  if (scope.kind === "workspace" && agentIds) {
+    await assignToAgents(scope.ctx.workspaceId, row.id, agentIds);
+  }
+  return row;
+}
+
+/**
+ * Updates a Skill at the given scope. Throws `NotFoundError` when the Skill is
+ * not visible at this scope, and (Workspace scope only) `LockedError` when it
+ * is a Shared Skill edited only on the Organization surface (ADR-0007). A
+ * duplicate name surfaces as a Postgres unique violation, mapped to 409 by the
+ * central `onError` (ADR-0010).
+ */
+export async function updateSkill(
+  scope: SkillScope,
+  skillId: string,
+  fields: SkillUpdateFields,
+): Promise<SkillRow> {
+  const { agentIds, ...data } = fields;
+
+  let where: SQL;
+  if (scope.kind === "workspace") {
+    // A Shared Skill is a single source of truth edited only on the
+    // Organization surface (ADR-0007); requireWorkspaceMutable throws
+    // NotFound (→404) when the Skill is not visible here, then Locked (→403)
+    // when it is org-scoped.
+    await requireWorkspaceMutable(db, "skill", skillId, scope.ctx);
+    where = workspaceScopedWhere("skill", skillId, scope.ctx.workspaceId);
+  } else {
+    // The existence check the Organization surface used to defer to an empty
+    // UPDATE result (#605): requireOrgScoped throws NotFound (→404) before the
+    // write ever runs.
+    await requireOrgScoped(db, "skill", skillId, scope.orgId);
+    where = orgScopedWhere("skill", skillId, scope.orgId);
+  }
+
+  const [row] = await db
+    .update(skillTable)
+    .set({ ...data, updatedAt: new Date() })
+    .where(where)
+    .returning();
+
+  // The pre-checks above prove the row exists, but a concurrent delete can still
+  // win the race between the check and the UPDATE; the Organization surface
+  // reports that as the 404 it always did, rather than an empty 200.
+  if (scope.kind === "organization" && !row) {
+    throw new NotFoundError("Skill not found");
+  }
+
+  if (scope.kind === "workspace" && agentIds !== undefined) {
+    await syncAgentAssignments(scope.ctx.workspaceId, skillId, agentIds);
+  }
+  return row;
+}
+
+/**
+ * Creates or overwrites the Workspace's own version of a Skill in one statement
+ * — the agent-facing Tool's write (it addresses Skills by name, no id). The
+ * conflict target is `(workspaceId, name)`, which is what keeps the write
+ * Workspace-private: reusing the name of an attached Shared Skill creates this
+ * Workspace's own version rather than editing the Organization's row. The scope
+ * comes from `ctx`, never the body.
+ */
+export async function upsertSkill(
+  ctx: ScopeContext,
+  fields: { name: string; description: string; body: string },
+): Promise<SkillRow> {
+  const now = new Date();
+  const [row] = await db
+    .insert(skillTable)
+    .values({
+      id: nanoid(),
+      workspaceId: ctx.workspaceId,
+      name: fields.name,
+      description: fields.description,
+      body: fields.body,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [skillTable.workspaceId, skillTable.name],
+      set: {
+        description: fields.description,
+        body: fields.body,
+        updatedAt: now,
+      },
+    })
+    .returning();
+  return row;
+}
+
+/**
+ * Deletes a Skill at the given scope. At Workspace scope, throws
+ * `NotFoundError`/`LockedError` (via `requireWorkspaceMutable`) under the same
+ * rule as {@link updateSkill}, and `ConflictError` while a Workspace agent
+ * still references the Skill. At Organization scope, throws `ConflictError`
+ * (via `requireSharedDeletable`) while an Attachment or Blueprint still
+ * references the Skill (ADR-0007/0008), and — because deleting a Shared Skill
+ * can orphan an Agent's `skillIds` reference to it — scrubs that reference in
+ * the same transaction as the delete.
+ */
+export async function deleteSkill(
+  scope: SkillScope,
+  skillId: string,
+): Promise<void> {
+  if (scope.kind === "workspace") {
+    await requireWorkspaceMutable(db, "skill", skillId, scope.ctx);
+
+    // A Skill that still names this Workspace's agents is still in use; refuse
+    // rather than leave dangling references.
+    const referencingAgents = await db
+      .select({ id: agentTable.id })
+      .from(agentTable)
+      .where(
+        and(
+          eq(agentTable.workspaceId, scope.ctx.workspaceId),
+          sql`${agentTable.skillIds} @> ${JSON.stringify([skillId])}::jsonb`,
+        ),
+      )
+      .limit(1);
+    if (referencingAgents.length > 0) {
+      throw new ConflictError(
+        "Cannot delete skill because it is referenced by one or more agents",
+      );
+    }
+
+    await db
+      .delete(skillTable)
+      .where(workspaceScopedWhere("skill", skillId, scope.ctx.workspaceId));
+    return;
+  }
+
+  // A Shared resource cannot be deleted while anything still points at it —
+  // an Attachment (ADR-0007) or a Blueprint (ADR-0008). Throws ConflictError
+  // → 409 via the central onError (ADR-0010).
+  await requireSharedDeletable(db, "skill", skillId);
+
+  // Delete the Skill and scrub its (now-dead) id from any Agent's skillIds in
+  // the same transaction, so deletion never leaves a dangling reference.
+  const result = await db.transaction(async (tx) => {
+    const rows = await tx
+      .delete(skillTable)
+      .where(orgScopedWhere("skill", skillId, scope.orgId))
+      .returning();
+    if (rows.length > 0) {
+      await scrubDeletedAgentReference(tx, "skillIds", skillId);
+    }
+    return rows;
+  });
+  if (result.length === 0) {
+    throw new NotFoundError("Skill not found");
+  }
+}

--- a/apps/backend/src/tools/skill-management.test.ts
+++ b/apps/backend/src/tools/skill-management.test.ts
@@ -153,8 +153,9 @@ describe("createSkillManagementTools", () => {
     });
 
     it("returns error when skill is referenced by agents", async () => {
-      mockDb.limit.mockResolvedValueOnce([{ id: "s1" }]);
-      mockDb.limit.mockResolvedValueOnce([{ id: "a1" }]);
+      mockDb.limit.mockResolvedValueOnce([{ id: "s1" }]); // name → workspace skill
+      mockDb.limit.mockResolvedValueOnce([{ id: "s1", workspaceId }]); // write model re-checks visibility
+      mockDb.limit.mockResolvedValueOnce([{ id: "a1" }]); // referencing agents
 
       const result = (await tools.deleteSkill.execute!(
         { name: "referenced-skill" },
@@ -182,12 +183,14 @@ describe("createSkillManagementTools", () => {
     });
 
     it("deletes skill when no agents reference it", async () => {
-      mockDb.limit.mockResolvedValueOnce([{ id: "s1" }]);
-      mockDb.limit.mockResolvedValueOnce([]);
+      mockDb.limit.mockResolvedValueOnce([{ id: "s1" }]); // name → workspace skill
+      mockDb.limit.mockResolvedValueOnce([{ id: "s1", workspaceId }]); // write model re-checks visibility
+      mockDb.limit.mockResolvedValueOnce([]); // referencing agents: none
 
       expect(
         await tools.deleteSkill.execute!({ name: "unused-skill" }, ctx),
       ).toEqual({ success: true });
+      expect(mockDb.delete).toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/tools/skill-management.ts
+++ b/apps/backend/src/tools/skill-management.ts
@@ -1,16 +1,18 @@
 import { tool, type Tool } from "ai";
 import { z } from "zod";
-import { and, eq, sql } from "drizzle-orm";
 import { skillBaseSchema } from "@platypus/schemas";
 import { db } from "../index.ts";
-import { skill as skillTable, agent as agentTable } from "../db/schema.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
 import {
   listScoped,
   resolveScopedByName,
   workspaceMutationLockedMessage,
-  workspaceScopedWhere,
 } from "../services/scoped-resource.ts";
+import {
+  deleteSkill as deleteSkillRow,
+  upsertSkill as upsertSkillRow,
+} from "../services/skill.ts";
+import { ConflictError, LockedError, NotFoundError } from "../errors.ts";
 import type { ScopeContext } from "../scope.ts";
 
 // Field constraints come from the shared schema so the agent-facing tool can
@@ -85,43 +87,21 @@ export function createSkillManagementTools(
       body: skillFields.body.describe("The Markdown content of the skill"),
     }),
     execute: async ({ name, description, body }) => {
-      // Writes only ever land on a workspace-scoped row: the conflict target is
-      // `(workspaceId, name)`, so upserting the name of an attached Shared Skill
-      // creates this Workspace's own version of it rather than editing the
-      // Organization's. `resolveScopedByName` then prefers that local row, which
-      // is what makes the override take effect.
-      const { nanoid } = await import("nanoid");
-      const now = new Date();
-
-      const record = await db
-        .insert(skillTable)
-        .values({
-          id: nanoid(),
-          workspaceId,
-          name,
-          description,
-          body,
-          createdAt: now,
-          updatedAt: now,
-        })
-        .onConflictDoUpdate({
-          target: [skillTable.workspaceId, skillTable.name],
-          set: {
-            description,
-            body,
-            updatedAt: now,
-          },
-        })
-        .returning();
+      // Writes only ever land on a workspace-scoped row: the conflict target
+      // inside `upsertSkill` is `(workspaceId, name)`, so upserting the name of
+      // an attached Shared Skill creates this Workspace's own version of it
+      // rather than editing the Organization's. `resolveScopedByName` then
+      // prefers that local row, which is what makes the override take effect.
+      const row = await upsertSkillRow(ctx, { name, description, body });
 
       const url = buildResourceUrl(
         frontendUrl,
         orgId,
         workspaceId,
-        `skills/${record[0].id}`,
+        `skills/${row.id}`,
       );
 
-      return { ...record[0], ...(url && { url }) };
+      return { ...row, ...(url && { url }) };
     },
   });
 
@@ -144,31 +124,23 @@ export function createSkillManagementTools(
         return { error: workspaceMutationLockedMessage("skill") };
       }
 
-      const skillId = existing.row.id;
-
-      const referencingAgents = await db
-        .select({ id: agentTable.id })
-        .from(agentTable)
-        .where(
-          and(
-            eq(agentTable.workspaceId, workspaceId),
-            sql`${agentTable.skillIds} @> ${JSON.stringify([skillId])}::jsonb`,
-          ),
-        )
-        .limit(1);
-
-      if (referencingAgents.length > 0) {
-        return {
-          error:
-            "Cannot delete skill because it is referenced by one or more agents",
-        };
+      // The write model re-establishes visibility (→404 here, when a race
+      // removed it), refuses a Skill this Workspace's agents still reference
+      // (→409), then deletes. Those types become the `{ error }` payload a tool
+      // reports instead of throwing into the run.
+      try {
+        await deleteSkillRow({ kind: "workspace", ctx }, existing.row.id);
+        return { success: true };
+      } catch (error) {
+        if (
+          error instanceof NotFoundError ||
+          error instanceof LockedError ||
+          error instanceof ConflictError
+        ) {
+          return { error: error.message };
+        }
+        throw error;
       }
-
-      await db
-        .delete(skillTable)
-        .where(workspaceScopedWhere("skill", skillId, workspaceId));
-
-      return { success: true };
     },
   });
 

--- a/apps/backend/src/tools/skill-management.ts
+++ b/apps/backend/src/tools/skill-management.ts
@@ -8,10 +8,7 @@ import {
   resolveScopedByName,
   workspaceMutationLockedMessage,
 } from "../services/scoped-resource.ts";
-import {
-  deleteSkill as deleteSkillRow,
-  upsertSkill as upsertSkillRow,
-} from "../services/skill.ts";
+import { deleteSkill, upsertSkill } from "../services/skill.ts";
 import { ConflictError, LockedError, NotFoundError } from "../errors.ts";
 import type { ScopeContext } from "../scope.ts";
 
@@ -34,7 +31,7 @@ export function createSkillManagementTools(
 ): Record<string, Tool> {
   const ctx: ScopeContext = { orgId, workspaceId };
 
-  const listSkills = tool({
+  const listSkillsTool = tool({
     description:
       "List the skills available in the current workspace, including shared skills attached to it. A skill with scope 'organization' is shared and cannot be edited or deleted here.",
     inputSchema: z.object({}),
@@ -51,7 +48,7 @@ export function createSkillManagementTools(
     },
   });
 
-  const getSkill = tool({
+  const getSkillTool = tool({
     description: "Get the full content of a skill by name.",
     inputSchema: z.object({
       name: z.string().describe("The name of the skill to retrieve"),
@@ -74,7 +71,7 @@ export function createSkillManagementTools(
     },
   });
 
-  const upsertSkill = tool({
+  const upsertSkillTool = tool({
     description:
       "Create a new skill or update an existing skill by name. If a skill with the given name already exists in this workspace, it will be updated. Using the name of a shared skill creates this workspace's own version of it — the organization's skill is left untouched.",
     inputSchema: z.object({
@@ -92,7 +89,7 @@ export function createSkillManagementTools(
       // an attached Shared Skill creates this Workspace's own version of it
       // rather than editing the Organization's. `resolveScopedByName` then
       // prefers that local row, which is what makes the override take effect.
-      const row = await upsertSkillRow(ctx, { name, description, body });
+      const row = await upsertSkill(ctx, { name, description, body });
 
       const url = buildResourceUrl(
         frontendUrl,
@@ -105,7 +102,7 @@ export function createSkillManagementTools(
     },
   });
 
-  const deleteSkill = tool({
+  const deleteSkillTool = tool({
     description:
       "Delete a skill by name. Will fail if the skill is referenced by one or more agents, or if it is a shared skill managed at the organization level.",
     inputSchema: z.object({
@@ -117,9 +114,13 @@ export function createSkillManagementTools(
       if (!existing) {
         return { error: "Skill not found" };
       }
+
       // Visible here, but a single source of truth deleted only on the
       // Organization surface (ADR-0007) — detaching it is the workspace-side
-      // action, and that is an Attachment concern, not a delete.
+      // action, and that is an Attachment concern, not a delete. The scope is
+      // already in hand, so refuse in `workspaceMutationLockedMessage`'s words
+      // rather than paying a second resolution to be told the same by the
+      // write model's `LockedError`.
       if (existing.scope === "organization") {
         return { error: workspaceMutationLockedMessage("skill") };
       }
@@ -129,7 +130,7 @@ export function createSkillManagementTools(
       // (→409), then deletes. Those types become the `{ error }` payload a tool
       // reports instead of throwing into the run.
       try {
-        await deleteSkillRow({ kind: "workspace", ctx }, existing.row.id);
+        await deleteSkill({ kind: "workspace", ctx }, existing.row.id);
         return { success: true };
       } catch (error) {
         if (
@@ -145,9 +146,9 @@ export function createSkillManagementTools(
   });
 
   return {
-    listSkills,
-    getSkill,
-    upsertSkill,
-    deleteSkill,
+    listSkills: listSkillsTool,
+    getSkill: getSkillTool,
+    upsertSkill: upsertSkillTool,
+    deleteSkill: deleteSkillTool,
   };
 }


### PR DESCRIPTION
## What

Stage 4 of #605 (closes #617): collapses the duplicated Skill column-set / agent-association SQL and the divergent attach/detach copies into two modules, with both route surfaces and the agent-facing tool surface as thin adapters.

## Skill write model

New `services/skill.ts` — `createSkill` / `updateSkill` / `upsertSkill` / `deleteSkill` taking a `SkillScope` (`workspace` | `organization`), the same shape as `services/agent.ts` and `services/provider-write.ts`.

- `routes/skill.ts` and `routes/org-skill.ts` are now adapters; the `name`/`description`/`body` column set and the `agentIds` association SQL exist once.
- The org surface gains the `requireOrgScoped` existence pre-check it previously skipped (#605) — a missing Shared Skill now 404s *before* the write (the old code discovered it only when the `UPDATE` matched nothing).
- `updateSkill` preserves the org 404 when a concurrent delete wins the race between the check and the update (no empty-200 regression).
- The agent-facing `tools/skill-management.ts` delegates `deleteSkill` and `upsertSkill` to the module, shrinking the tool to reads plus its error-translation.

## Attachment module

New `services/attachment.ts` owning the three ADR-0007 attach rules in one place:

- **resource-is-Shared** — only a Shared resource of the Organization may be attached (→ 404).
- **workspace-in-org** — the org surface's target workspace must belong to the Organization (→ 404).
- **already-attached** — the `(workspaceId, resourceType, resourceId)` unique constraint surfaces as a `ConflictError` (→ 409) instead of leaking the driver error.

`routes/attachment.ts` and `routes/org-attachment.ts` adapt over it. On both surfaces the unguarded path-param cast is gone, and every cross-cutting failure is an ADR-0010 typed error to the central `onError` — the inline `c.json({ error }, 404)` responses are removed.

## Mechanism-only

No user-facing behaviour change intended. The one deliberate status-code nuance: the org attach POST used to validate `resourceType` (400) before the workspace-in-org 404; the module now guards `resourceType` itself, and the 400-for-bad-type / 404-for-cross-org precedence is unchanged relative to each other.

## Verified

- New unit suites for both modules (`services/skill.test.ts`, `services/attachment.test.ts`), mirroring `provider-write.test.ts`.
- Updated route/tool mocks; added org-PUT 404 pre-check coverage.
- `pnpm typecheck`, `pnpm lint` clean; full suite green (2,089 backend / 497 frontend).