### PR TITLE
feat(backend,frontend): add a per-chat Max steps setting for Direct chats

### DIFF
--- a/apps/backend/drizzle/0052_minor_demogoblin.sql
+++ b/apps/backend/drizzle/0052_minor_demogoblin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "chat" ADD COLUMN "max_steps" integer;

--- a/apps/backend/drizzle/meta/0052_snapshot.json
+++ b/apps/backend/drizzle/meta/0052_snapshot.json
@@ -1,0 +1,4322 @@
+{
+  "id": "61b95b0b-c644-4416-8058-d61d32dfe339",
+  "prevId": "ec0f892e-6d3e-4bf1-9888-98a61cd4a9cd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_set_ids": {
+          "name": "tool_set_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "skill_ids": {
+          "name": "skill_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "sub_agent_ids": {
+          "name": "sub_agent_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "input_placeholder": {
+          "name": "input_placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_key": {
+          "name": "avatar_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_agent_workspace_id": {
+          "name": "idx_agent_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_organization_id": {
+          "name": "idx_agent_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_provider_id": {
+          "name": "idx_agent_provider_id",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_organization_id_organization_id_fk": {
+          "name": "agent_organization_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_workspace_id_workspace_id_fk": {
+          "name": "agent_workspace_id_workspace_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_provider_id_provider_id_fk": {
+          "name": "agent_provider_id_provider_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_agent_name_org": {
+          "name": "unique_agent_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attachment": {
+      "name": "attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_attachment_workspace": {
+          "name": "idx_attachment_workspace",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_attachment_resource": {
+          "name": "idx_attachment_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "attachment_workspace_id_workspace_id_fk": {
+          "name": "attachment_workspace_id_workspace_id_fk",
+          "tableFrom": "attachment",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_attachment": {
+          "name": "unique_attachment",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "resource_type",
+            "resource_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blueprint": {
+      "name": "blueprint",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_model_provider_id": {
+          "name": "task_model_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_provider_id": {
+          "name": "memory_extraction_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_embedding_provider_id": {
+          "name": "memory_embedding_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blueprint_organization_id": {
+          "name": "idx_blueprint_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blueprint_organization_id_organization_id_fk": {
+          "name": "blueprint_organization_id_organization_id_fk",
+          "tableFrom": "blueprint",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blueprint_task_model_provider_id_provider_id_fk": {
+          "name": "blueprint_task_model_provider_id_provider_id_fk",
+          "tableFrom": "blueprint",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "task_model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "blueprint_memory_extraction_provider_id_provider_id_fk": {
+          "name": "blueprint_memory_extraction_provider_id_provider_id_fk",
+          "tableFrom": "blueprint",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_extraction_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "blueprint_memory_embedding_provider_id_provider_id_fk": {
+          "name": "blueprint_memory_embedding_provider_id_provider_id_fk",
+          "tableFrom": "blueprint",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_embedding_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_blueprint_name_org": {
+          "name": "unique_blueprint_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blueprint_item": {
+      "name": "blueprint_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_blueprint_item_blueprint": {
+          "name": "idx_blueprint_item_blueprint",
+          "columns": [
+            {
+              "expression": "blueprint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_blueprint_item_resource": {
+          "name": "idx_blueprint_item_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blueprint_item_blueprint_id_blueprint_id_fk": {
+          "name": "blueprint_item_blueprint_id_blueprint_id_fk",
+          "tableFrom": "blueprint_item",
+          "tableTo": "blueprint",
+          "columnsFrom": [
+            "blueprint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_blueprint_item": {
+          "name": "unique_blueprint_item",
+          "nullsNotDistinct": false,
+          "columns": [
+            "blueprint_id",
+            "resource_type",
+            "resource_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat": {
+      "name": "chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'succeeded'"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_p": {
+          "name": "top_p",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "top_k": {
+          "name": "top_k",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "presence_penalty": {
+          "name": "presence_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency_penalty": {
+          "name": "frequency_penalty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_steps": {
+          "name": "max_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_memory_processed_at": {
+          "name": "last_memory_processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_status": {
+          "name": "memory_extraction_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_chat_workspace_id": {
+          "name": "idx_chat_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_tags": {
+          "name": "idx_chat_tags",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_chat_memory_processing": {
+          "name": "idx_chat_memory_processing",
+          "columns": [
+            {
+              "expression": "memory_extraction_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_memory_processed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_workspace_id_workspace_id_fk": {
+          "name": "chat_workspace_id_workspace_id_fk",
+          "tableFrom": "chat",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.context": {
+      "name": "context",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_context_user_id": {
+          "name": "idx_context_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_context_workspace_id": {
+          "name": "idx_context_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "context_user_id_user_id_fk": {
+          "name": "context_user_id_user_id_fk",
+          "tableFrom": "context",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "context_workspace_id_workspace_id_fk": {
+          "name": "context_workspace_id_workspace_id_fk",
+          "tableFrom": "context",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_context_user_workspace": {
+          "name": "unique_context_user_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workspace_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dashboard": {
+      "name": "dashboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desktop_layout": {
+          "name": "desktop_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "mobile_layout": {
+          "name": "mobile_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_dashboard_workspace_id": {
+          "name": "idx_dashboard_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_dashboard_workspace_name": {
+          "name": "uq_dashboard_workspace_name",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dashboard_workspace_id_workspace_id_fk": {
+          "name": "dashboard_workspace_id_workspace_id_fk",
+          "tableFrom": "dashboard",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "workspace_name": {
+          "name": "workspace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitation_email": {
+          "name": "idx_invitation_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitation_org_id": {
+          "name": "idx_invitation_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_invited_by_user_id_fk": {
+          "name": "invitation_invited_by_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_invitation_org_email": {
+          "name": "unique_invitation_org_email",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation_blueprint": {
+      "name": "invitation_blueprint",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blueprint_id": {
+          "name": "blueprint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invitation_blueprint_invitation": {
+          "name": "idx_invitation_blueprint_invitation",
+          "columns": [
+            {
+              "expression": "invitation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invitation_blueprint_blueprint": {
+          "name": "idx_invitation_blueprint_blueprint",
+          "columns": [
+            {
+              "expression": "blueprint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_blueprint_invitation_id_invitation_id_fk": {
+          "name": "invitation_blueprint_invitation_id_invitation_id_fk",
+          "tableFrom": "invitation_blueprint",
+          "tableTo": "invitation",
+          "columnsFrom": [
+            "invitation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_blueprint_blueprint_id_blueprint_id_fk": {
+          "name": "invitation_blueprint_blueprint_id_blueprint_id_fk",
+          "tableFrom": "invitation_blueprint",
+          "tableTo": "blueprint",
+          "columnsFrom": [
+            "blueprint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_invitation_blueprint": {
+          "name": "unique_invitation_blueprint",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invitation_id",
+            "blueprint_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_board": {
+      "name": "kanban_board",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_board_workspace_id": {
+          "name": "idx_kanban_board_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_board_workspace_id_workspace_id_fk": {
+          "name": "kanban_board_workspace_id_workspace_id_fk",
+          "tableFrom": "kanban_board",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_kanban_board_name_workspace": {
+          "name": "unique_kanban_board_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card": {
+      "name": "kanban_card",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "column_id": {
+          "name": "column_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_ids": {
+          "name": "label_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "assignees": {
+          "name": "assignees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_user_id": {
+          "name": "last_edited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_edited_by_agent_id": {
+          "name": "last_edited_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_column_id": {
+          "name": "idx_kanban_card_column_id",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_label_ids": {
+          "name": "idx_kanban_card_label_ids",
+          "columns": [
+            {
+              "expression": "label_ids",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_kanban_card_assignees": {
+          "name": "idx_kanban_card_assignees",
+          "columns": [
+            {
+              "expression": "assignees",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_kanban_card_due_date": {
+          "name": "idx_kanban_card_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_priority": {
+          "name": "idx_kanban_card_priority",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_kanban_card_column_position": {
+          "name": "idx_kanban_card_column_position",
+          "columns": [
+            {
+              "expression": "column_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_column_id_kanban_column_id_fk": {
+          "name": "kanban_card_column_id_kanban_column_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "kanban_column",
+          "columnsFrom": [
+            "column_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kanban_card_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_last_edited_by_user_id_user_id_fk": {
+          "name": "kanban_card_last_edited_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "user",
+          "columnsFrom": [
+            "last_edited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_last_edited_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_last_edited_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "last_edited_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_card_comment": {
+      "name": "kanban_card_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_agent_id": {
+          "name": "created_by_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_card_comment_card_id": {
+          "name": "idx_kanban_card_comment_card_id",
+          "columns": [
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_card_comment_card_id_kanban_card_id_fk": {
+          "name": "kanban_card_comment_card_id_kanban_card_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "kanban_card",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kanban_card_comment_created_by_user_id_user_id_fk": {
+          "name": "kanban_card_comment_created_by_user_id_user_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kanban_card_comment_created_by_agent_id_agent_id_fk": {
+          "name": "kanban_card_comment_created_by_agent_id_agent_id_fk",
+          "tableFrom": "kanban_card_comment",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "created_by_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.kanban_column": {
+      "name": "kanban_column",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_kanban_column_board_id": {
+          "name": "idx_kanban_column_board_id",
+          "columns": [
+            {
+              "expression": "board_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "kanban_column_board_id_kanban_board_id_fk": {
+          "name": "kanban_column_board_id_kanban_board_id_fk",
+          "tableFrom": "kanban_column",
+          "tableTo": "kanban_board",
+          "columnsFrom": [
+            "board_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp": {
+      "name": "mcp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bearer_token": {
+          "name": "bearer_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_access_token": {
+          "name": "oauth_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_refresh_token": {
+          "name": "oauth_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_expires_at": {
+          "name": "oauth_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_requested_scope": {
+          "name": "oauth_requested_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_secret": {
+          "name": "oauth_client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_mcp_workspace_id": {
+          "name": "idx_mcp_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_organization_id": {
+          "name": "idx_mcp_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_organization_id_organization_id_fk": {
+          "name": "mcp_organization_id_organization_id_fk",
+          "tableFrom": "mcp",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_workspace_id_workspace_id_fk": {
+          "name": "mcp_workspace_id_workspace_id_fk",
+          "tableFrom": "mcp",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_mcp_name_org": {
+          "name": "unique_mcp_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        },
+        "unique_mcp_name_workspace": {
+          "name": "unique_mcp_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mcp_oauth_state": {
+      "name": "mcp_oauth_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mcp_id": {
+          "name": "mcp_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_mcp_oauth_state_mcp_id": {
+          "name": "idx_mcp_oauth_state_mcp_id",
+          "columns": [
+            {
+              "expression": "mcp_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_oauth_state_mcp_id_mcp_id_fk": {
+          "name": "mcp_oauth_state_mcp_id_mcp_id_fk",
+          "tableFrom": "mcp_oauth_state",
+          "tableTo": "mcp",
+          "columnsFrom": [
+            "mcp_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memory_daily_summary": {
+      "name": "memory_daily_summary",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary_date": {
+          "name": "summary_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_daily_summary_user_workspace": {
+          "name": "idx_daily_summary_user_workspace",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_summary_date": {
+          "name": "idx_daily_summary_date",
+          "columns": [
+            {
+              "expression": "summary_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_daily_summary_user_id_user_id_fk": {
+          "name": "memory_daily_summary_user_id_user_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_daily_summary_workspace_id_workspace_id_fk": {
+          "name": "memory_daily_summary_workspace_id_workspace_id_fk",
+          "tableFrom": "memory_daily_summary",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_daily_summary_user_workspace_date": {
+          "name": "unique_daily_summary_user_workspace_date",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workspace_id",
+            "summary_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_workspace_id": {
+          "name": "idx_notification_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_agent_id": {
+          "name": "idx_notification_agent_id",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_created_at": {
+          "name": "idx_notification_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_workspace_id_workspace_id_fk": {
+          "name": "notification_workspace_id_workspace_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_agent_id_agent_id_fk": {
+          "name": "notification_agent_id_agent_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_read": {
+      "name": "notification_read",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_read_user_id": {
+          "name": "idx_notification_read_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_read_notification_id": {
+          "name": "idx_notification_read_notification_id",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_read_notification_id_notification_id_fk": {
+          "name": "notification_read_notification_id_notification_id_fk",
+          "tableFrom": "notification_read",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_read_user_id_user_id_fk": {
+          "name": "notification_read_user_id_user_id_fk",
+          "tableFrom": "notification_read",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_notification_read": {
+          "name": "unique_notification_read",
+          "nullsNotDistinct": false,
+          "columns": [
+            "notification_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_context": {
+          "name": "identity_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_member": {
+      "name": "organization_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_member_org_id": {
+          "name": "idx_org_member_org_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_member_user_id": {
+          "name": "idx_org_member_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_member_organization_id_organization_id_fk": {
+          "name": "organization_member_organization_id_organization_id_fk",
+          "tableFrom": "organization_member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_member_user_id_user_id_fk": {
+          "name": "organization_member_user_id_user_id_fk",
+          "tableFrom": "organization_member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider": {
+      "name": "provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraBody": {
+          "name": "extraBody",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_mode": {
+          "name": "api_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'responses'"
+        },
+        "native_search_enabled": {
+          "name": "native_search_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "web_backend": {
+          "name": "web_backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_source": {
+          "name": "search_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'native'"
+        },
+        "security_guardrails": {
+          "name": "security_guardrails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "modelIds": {
+          "name": "modelIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_model_id": {
+          "name": "task_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_extraction_model_id": {
+          "name": "memory_extraction_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding_model_id": {
+          "name": "embedding_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_workspace_id": {
+          "name": "idx_provider_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_provider_organization_id": {
+          "name": "idx_provider_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "provider_organization_id_organization_id_fk": {
+          "name": "provider_organization_id_organization_id_fk",
+          "tableFrom": "provider",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_provider_name_org": {
+          "name": "unique_provider_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        },
+        "unique_provider_name_workspace": {
+          "name": "unique_provider_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox": {
+      "name": "sandbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "admin_env": {
+          "name": "admin_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_env": {
+          "name": "user_env",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_sandbox_workspace_id": {
+          "name": "unique_sandbox_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sandbox_workspace_id_workspace_id_fk": {
+          "name": "sandbox_workspace_id_workspace_id_fk",
+          "tableFrom": "sandbox",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sandbox_teardown_failure": {
+      "name": "sandbox_teardown_failure",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backend": {
+          "name": "backend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempted_at": {
+          "name": "attempted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sandbox_teardown_failure_workspace_id": {
+          "name": "idx_sandbox_teardown_failure_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill": {
+      "name": "skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_skill_workspace_id": {
+          "name": "idx_skill_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_skill_organization_id": {
+          "name": "idx_skill_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_organization_id_organization_id_fk": {
+          "name": "skill_organization_id_organization_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_workspace_id_workspace_id_fk": {
+          "name": "skill_workspace_id_workspace_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_skill_name_workspace": {
+          "name": "unique_skill_name_workspace",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "name"
+          ]
+        },
+        "unique_skill_name_org": {
+          "name": "unique_skill_name_org",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger": {
+      "name": "trigger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instruction": {
+          "name": "instruction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_runs_to_keep": {
+          "name": "max_runs_to_keep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "search": {
+          "name": "search",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_workspace_id": {
+          "name": "idx_trigger_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_next_run_at": {
+          "name": "idx_trigger_next_run_at",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_type": {
+          "name": "idx_trigger_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_workspace_id_workspace_id_fk": {
+          "name": "trigger_workspace_id_workspace_id_fk",
+          "tableFrom": "trigger",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trigger_agent_id_agent_id_fk": {
+          "name": "trigger_agent_id_agent_id_fk",
+          "tableFrom": "trigger",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trigger_run": {
+      "name": "trigger_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_data": {
+          "name": "event_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_trigger_run_trigger_id": {
+          "name": "idx_trigger_run_trigger_id",
+          "columns": [
+            {
+              "expression": "trigger_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_trigger_run_started_at": {
+          "name": "idx_trigger_run_started_at",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trigger_run_trigger_id_trigger_id_fk": {
+          "name": "trigger_run_trigger_id_trigger_id_fk",
+          "tableFrom": "trigger_run",
+          "tableTo": "trigger",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook": {
+      "name": "webhook",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Webhook'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signing_secret": {
+          "name": "signing_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhook_workspace_id": {
+          "name": "idx_webhook_workspace_id",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_workspace_id_workspace_id_fk": {
+          "name": "webhook_workspace_id_workspace_id_fk",
+          "tableFrom": "webhook",
+          "tableTo": "workspace",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.widget": {
+      "name": "widget",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dashboard_id": {
+          "name": "dashboard_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_widget_dashboard_id": {
+          "name": "idx_widget_dashboard_id",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_widget_dashboard_title": {
+          "name": "uq_widget_dashboard_title",
+          "columns": [
+            {
+              "expression": "dashboard_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "widget_dashboard_id_dashboard_id_fk": {
+          "name": "widget_dashboard_id_dashboard_id_fk",
+          "tableFrom": "widget",
+          "tableTo": "dashboard",
+          "columnsFrom": [
+            "dashboard_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspace": {
+      "name": "workspace",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_model_provider_id": {
+          "name": "task_model_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_extraction_provider_id": {
+          "name": "memory_extraction_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_embedding_provider_id": {
+          "name": "memory_embedding_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_daily_summaries": {
+          "name": "max_daily_summaries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 90
+        },
+        "provider_self_management": {
+          "name": "provider_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mcp_self_management": {
+          "name": "mcp_self_management",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workspace_organization_id": {
+          "name": "idx_workspace_organization_id",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workspace_owner_id": {
+          "name": "idx_workspace_owner_id",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workspace_organization_id_organization_id_fk": {
+          "name": "workspace_organization_id_organization_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_owner_id_user_id_fk": {
+          "name": "workspace_owner_id_user_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workspace_task_model_provider_id_provider_id_fk": {
+          "name": "workspace_task_model_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "task_model_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_memory_extraction_provider_id_provider_id_fk": {
+          "name": "workspace_memory_extraction_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_extraction_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "workspace_memory_embedding_provider_id_provider_id_fk": {
+          "name": "workspace_memory_embedding_provider_id_provider_id_fk",
+          "tableFrom": "workspace",
+          "tableTo": "provider",
+          "columnsFrom": [
+            "memory_embedding_provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1786734053558,
       "tag": "0051_jazzy_kid_colt",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1787457700721,
+      "tag": "0052_minor_demogoblin",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -190,6 +190,10 @@ export const chat = pgTable(
     seed: t.real("seed"),
     presencePenalty: t.real("presence_penalty"),
     frequencyPenalty: t.real("frequency_penalty"),
+    // The per-chat Max steps setting for Direct (no-Agent) turns (#539),
+    // mirroring the Agent table's column. Nullable: null means "unset" and
+    // the turn falls back to DEFAULT_DIRECT_MAX_STEPS.
+    maxSteps: t.integer("max_steps"),
 
     // Memory processing tracking
     lastMemoryProcessedAt: t.timestamp("last_memory_processed_at"),

--- a/apps/backend/src/runs/agent-plan.test.ts
+++ b/apps/backend/src/runs/agent-plan.test.ts
@@ -102,8 +102,8 @@ describe("resolveGenerationPlan", () => {
     expect(plan.maxSteps).toBe(25);
   });
 
-  // A cleared setting serialises as null; null must mean "unset" here exactly
-  // as it does on the Agent branch (#263).
+  // A client may clear by sending an explicit null (the Agent form's way);
+  // null must mean "unset" here exactly as it does on the Agent branch (#263).
   it("resolves a direct selection's null step ceiling to the Direct default", async () => {
     const { plan } = await resolveGenerationPlan(
       { providerId: "p1", modelId: "gpt-4", maxSteps: null },

--- a/apps/backend/src/runs/agent-plan.test.ts
+++ b/apps/backend/src/runs/agent-plan.test.ts
@@ -90,6 +90,30 @@ describe("resolveGenerationPlan", () => {
     expect(modelReference).toBe("gpt-4");
   });
 
+  // Issue #539: the per-chat Max steps setting rides the turn request on the
+  // direct source and overrides the shared Direct ceiling when set.
+  it("forwards a direct selection's own step ceiling over the Direct default", async () => {
+    const { plan } = await resolveGenerationPlan(
+      { providerId: "p1", modelId: "gpt-4", maxSteps: 25 },
+      scope,
+      queriesWith([baseProvider]),
+    );
+
+    expect(plan.maxSteps).toBe(25);
+  });
+
+  // A cleared setting serialises as null; null must mean "unset" here exactly
+  // as it does on the Agent branch (#263).
+  it("resolves a direct selection's null step ceiling to the Direct default", async () => {
+    const { plan } = await resolveGenerationPlan(
+      { providerId: "p1", modelId: "gpt-4", maxSteps: null },
+      scope,
+      queriesWith([baseProvider]),
+    );
+
+    expect(plan.maxSteps).toBe(DEFAULT_DIRECT_MAX_STEPS);
+  });
+
   it("forwards a direct selection's own sampling overrides, treating unset as absent", async () => {
     const { plan } = await resolveGenerationPlan(
       { providerId: "p1", modelId: "gpt-4", temperature: 0.2, topP: undefined },

--- a/apps/backend/src/runs/agent-plan.ts
+++ b/apps/backend/src/runs/agent-plan.ts
@@ -41,7 +41,14 @@ export type GenerationAgentSource = {
  */
 export type GenerationSource =
   | { agent: GenerationAgentSource }
-  | ({ providerId: string; modelId: string } & SamplingSource);
+  // `maxSteps` is the per-chat Max steps setting riding the turn request
+  // (#539); null/absent means unset and falls back to the shared Direct
+  // ceiling, exactly as an Agent's null does to the Agent default.
+  | ({
+      providerId: string;
+      modelId: string;
+      maxSteps?: number | null;
+    } & SamplingSource);
 
 /**
  * Where a generation plan resolves — the half of a `WorkspaceScope` a
@@ -111,7 +118,7 @@ export const resolveGenerationPlan = async (
   const maxSteps =
     "agent" in source
       ? (source.agent.maxSteps ?? DEFAULT_AGENT_MAX_STEPS)
-      : DEFAULT_DIRECT_MAX_STEPS;
+      : (source.maxSteps ?? DEFAULT_DIRECT_MAX_STEPS);
   const samplingSource: SamplingSource =
     "agent" in source ? source.agent : source;
 

--- a/apps/backend/src/runs/sinks/chat-sink.test.ts
+++ b/apps/backend/src/runs/sinks/chat-sink.test.ts
@@ -49,6 +49,7 @@ const planAdhoc: ResolvedRunPlan = {
     seed: 42,
     presencePenalty: 0.1,
     frequencyPenalty: 0.2,
+    maxSteps: 25,
   },
 };
 
@@ -188,6 +189,7 @@ describe("ChatSink", () => {
       expect(finishSet.seed).toBeNull();
       expect(finishSet.presencePenalty).toBeNull();
       expect(finishSet.frequencyPenalty).toBeNull();
+      expect(finishSet.maxSteps).toBeNull();
     });
 
     // Issue #522's "the notice is present after a page reload" criterion. The
@@ -297,6 +299,32 @@ describe("ChatSink", () => {
       expect(finishSet.seed).toBe(42);
       expect(finishSet.presencePenalty).toBe(0.1);
       expect(finishSet.frequencyPenalty).toBe(0.2);
+      expect(finishSet.maxSteps).toBe(25);
+    });
+
+    // Issue #539's #263 guard: a Direct turn with no per-chat maxSteps must
+    // write the column null, not leave a previously-set value standing —
+    // clearing only persists because every turn rewrites all generation
+    // columns.
+    it("writes maxSteps null when the direct turn carries none", async () => {
+      mockDb.returning.mockResolvedValueOnce([{ id: "chat-4" }]); // onStart
+      mockDb.returning.mockResolvedValueOnce([{ id: "chat-4" }]); // onFinish
+
+      const sink = new ChatSink({ orgId: "org-1", workspaceId: "ws-1" });
+      await sink.onStart({ runId: "chat-4", messages: [] });
+      await sink.onResolved({
+        runId: "chat-4",
+        plan: { resolved: { ...planAdhoc.resolved, maxSteps: undefined } },
+      });
+      await sink.onFinish({
+        runId: "chat-4",
+        status: "succeeded",
+        messages: [],
+        stats: {},
+      });
+
+      const finishSet = mockDb.set.mock.calls[1][0] as Record<string, unknown>;
+      expect(finishSet.maxSteps).toBeNull();
     });
   });
 

--- a/apps/backend/src/runs/sinks/chat-sink.ts
+++ b/apps/backend/src/runs/sinks/chat-sink.ts
@@ -228,6 +228,7 @@ export class ChatSink implements RunSink {
       seed: resolved.seed ?? null,
       presencePenalty: resolved.presencePenalty ?? null,
       frequencyPenalty: resolved.frequencyPenalty ?? null,
+      maxSteps: resolved.maxSteps ?? null,
       updatedAt: new Date(),
     };
 

--- a/apps/backend/src/runs/types.ts
+++ b/apps/backend/src/runs/types.ts
@@ -28,6 +28,13 @@ export type ChatTurnRequest = {
   seed?: number;
   presencePenalty?: number;
   frequencyPenalty?: number;
+  /**
+   * The per-chat Max steps setting (#539). Read only on the Direct
+   * (no-Agent) branch, where it overrides `DEFAULT_DIRECT_MAX_STEPS`; an
+   * Agent-backed turn ignores it exactly as it ignores the sampling fields,
+   * because the Agent's own stored `maxSteps` governs. Null means cleared.
+   */
+  maxSteps?: number | null;
 };
 
 /**
@@ -109,6 +116,13 @@ export type ResolvedGeneration = {
   frequencyPenalty?: number;
   presencePenalty?: number;
   seed?: number;
+  /**
+   * The per-chat Max steps setting as REQUESTED, not as resolved (#539) —
+   * the plan always carries a concrete ceiling, so persisting it would turn
+   * "unset" into an explicit default on the row's first turn. Undefined
+   * leaves the column null, keeping "unset" and "explicitly set" distinct.
+   */
+  maxSteps?: number;
 };
 
 /**

--- a/apps/backend/src/runs/types.ts
+++ b/apps/backend/src/runs/types.ts
@@ -32,7 +32,9 @@ export type ChatTurnRequest = {
    * The per-chat Max steps setting (#539). Read only on the Direct
    * (no-Agent) branch, where it overrides `DEFAULT_DIRECT_MAX_STEPS`; an
    * Agent-backed turn ignores it exactly as it ignores the sampling fields,
-   * because the Agent's own stored `maxSteps` governs. Null means cleared.
+   * because the Agent's own stored `maxSteps` governs. Null and absent both
+   * mean cleared — the chat client clears by omission, and an explicit null
+   * is accepted so a client that clears the Agent form's way works too.
    */
   maxSteps?: number | null;
 };

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -566,7 +566,11 @@ describe("chat-execution", () => {
       const turn = await prepareChatTurn(
         {
           ...baseInput,
-          request: { providerId: baseProvider.id, modelId: "gpt-4", maxSteps: 25 },
+          request: {
+            providerId: baseProvider.id,
+            modelId: "gpt-4",
+            maxSteps: 25,
+          },
         },
         queries,
       );
@@ -575,10 +579,10 @@ describe("chat-execution", () => {
       expect(turn.resolved.maxSteps).toBe(25);
     });
 
-    // The #263 shape at this seam: a cleared setting serialises as null, and
-    // null must leave the row's copy unset rather than persisting the default
-    // over it — otherwise "unset" and "explicitly 10" become indistinguishable
-    // after one turn.
+    // The #263 shape at this seam: a null arriving from a client that clears
+    // by sending one must leave the row's copy unset rather than persisting
+    // the default over it — otherwise "unset" and "explicitly 10" become
+    // indistinguishable after one turn.
     it("treats a cleared per-chat maxSteps as unset on a Direct turn", async () => {
       const queries = createInMemoryChatTurnQueries({
         workspaces: [baseWorkspace],
@@ -588,7 +592,11 @@ describe("chat-execution", () => {
       const turn = await prepareChatTurn(
         {
           ...baseInput,
-          request: { providerId: baseProvider.id, modelId: "gpt-4", maxSteps: null },
+          request: {
+            providerId: baseProvider.id,
+            modelId: "gpt-4",
+            maxSteps: null,
+          },
         },
         queries,
       );

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -553,6 +553,71 @@ describe("chat-execution", () => {
       expect(turn.resolved.seed).toBe(99);
     });
 
+    // Issue #539: the per-chat Max steps setting rides the turn request and,
+    // on a Direct turn, becomes both the ceiling the model loop runs under
+    // and the value persisted back to the row — the same round-trip as seed
+    // above.
+    it("takes maxSteps from the request on a Direct turn", async () => {
+      const queries = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        providers: [baseProvider],
+      });
+
+      const turn = await prepareChatTurn(
+        {
+          ...baseInput,
+          request: { providerId: baseProvider.id, modelId: "gpt-4", maxSteps: 25 },
+        },
+        queries,
+      );
+
+      expect(turn.stream.maxSteps).toBe(25);
+      expect(turn.resolved.maxSteps).toBe(25);
+    });
+
+    // The #263 shape at this seam: a cleared setting serialises as null, and
+    // null must leave the row's copy unset rather than persisting the default
+    // over it — otherwise "unset" and "explicitly 10" become indistinguishable
+    // after one turn.
+    it("treats a cleared per-chat maxSteps as unset on a Direct turn", async () => {
+      const queries = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        providers: [baseProvider],
+      });
+
+      const turn = await prepareChatTurn(
+        {
+          ...baseInput,
+          request: { providerId: baseProvider.id, modelId: "gpt-4", maxSteps: null },
+        },
+        queries,
+      );
+
+      expect(turn.stream.maxSteps).toBe(DEFAULT_DIRECT_MAX_STEPS);
+      expect(turn.resolved.maxSteps).toBeUndefined();
+    });
+
+    // Mirrors the seed test above: an Agent's stored settings win on an
+    // Agent-backed Chat, and the row keeps no generation params of its own.
+    it("sends the Agent's own maxSteps, not the request's, on an Agent turn", async () => {
+      const queries = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        agents: [baseAgent],
+        providers: [baseProvider],
+      });
+
+      const turn = await prepareChatTurn(
+        {
+          ...baseInput,
+          request: { agentId: baseAgent.id, maxSteps: 25 },
+        },
+        queries,
+      );
+
+      expect(turn.stream.maxSteps).toBe(3);
+      expect(turn.resolved.maxSteps).toBeUndefined();
+    });
+
     // The output ceiling comes off the PROVIDER's model entry, not the Agent or
     // the request — it is a property of the (Provider, model) pair (issue #454).
     it("streams the model's declared maxOutputTokens", async () => {

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -691,6 +691,10 @@ export const prepareChatTurn = async (
       frequencyPenalty: agent ? undefined : context.plan.frequencyPenalty,
       presencePenalty: agent ? undefined : context.plan.presencePenalty,
       seed: agent ? undefined : context.plan.seed,
+      // The REQUESTED value, not the plan's resolved ceiling — see
+      // `ResolvedGeneration.maxSteps`. Normalised to undefined so a cleared
+      // null writes null to the column like every other unset field here.
+      maxSteps: agent ? undefined : (request.maxSteps ?? undefined),
     },
     searchUnavailable,
     // The session closes what it opened, delegates' nested sessions included —
@@ -789,6 +793,7 @@ const resolveChatContext = async (
       seed: data.seed,
       presencePenalty: data.presencePenalty,
       frequencyPenalty: data.frequencyPenalty,
+      maxSteps: data.maxSteps,
     };
   } else {
     throw new ValidationError(

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -385,17 +385,19 @@ it does for an Agent.
 
 **Max steps** caps how many steps a tool-using turn may run before it stops —
 the same ceiling an Agent's **Max steps** sets, tuned for this conversation. It
-takes a whole number from 1-50 steps; leave it empty and a default of 10
-applies. A research-shaped turn that keeps reading long pages through a
-Web-search backend is the usual reason to raise it.
+takes a whole number from 1-50 steps.
+
+Leave it empty and a default of 10 steps applies. A research-shaped turn that
+keeps reading long pages through a Web-search backend is the usual reason to
+raise it.
 
 <Callout type="warning">
   **With an Agent selected there is no settings button.** A Chat does not
   override an Agent's Instructions or sampling parameters for one conversation —
-  the Agent's own settings win, including its **Max steps**, and the info
-  button shows you what they are. If you want different behaviour, edit the
-  Agent, or copy it and edit the copy. Looking for the gear on an Agent-backed
-  Chat and concluding it's a bug is the usual confusion here.
+  the Agent's own settings win, including its **Max steps**, and the info button
+  shows you what they are. If you want different behaviour, edit the Agent, or
+  copy it and edit the copy. Looking for the gear on an Agent-backed Chat and
+  concluding it's a bug is the usual confusion here.
 </Callout>
 
 ## Sharing a Chat

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -212,9 +212,10 @@ The two markers name different limits. **Output limit** means the model ran out
 of room to write the reply it was writing; **step limit** means it ran out of
 steps before the work was done. For a Chat that uses an Agent, the number of
 steps is that Agent's **Max steps** — see
-[Tune generation](/building-with-platypus/agents#tune-generation). Asking for
-less in one message, so fewer tool calls are needed, is the other way to stay
-under it.
+[Tune generation](/building-with-platypus/agents#tune-generation). For a Chat
+that picks a Provider and model directly, it is **Max steps** in Chat Settings,
+described below. Asking for less in one message, so fewer tool calls are
+needed, is the other way to stay under it.
 
 ## How full the conversation is
 
@@ -374,21 +375,27 @@ Chat.
 When you have picked a Provider and model directly, a gear button — tooltip
 **Settings** — opens **Chat Settings**: an **Instructions** box, and under
 **Advanced settings** the sampling parameters — **Temperature**, **Seed**,
-**Top-p**, **Top-k**, **Presence Penalty** and **Frequency Penalty**. They are
-saved on this Chat and apply to every turn in it.
+**Top-p**, **Top-k**, **Presence Penalty** and **Frequency Penalty** — plus
+**Max steps**. They are saved on this Chat and apply to every turn in it.
 
 Think of it as the Agent form for a conversation you didn't build an Agent for.
 Platypus still composes the full system prompt around your Instructions, adding
 Workspace and user context, Memories and your Provider's guardrails, exactly as
 it does for an Agent.
 
+**Max steps** caps how many steps a tool-using turn may run before it stops —
+the same ceiling an Agent's **Max steps** sets, tuned for this conversation. It
+takes a whole number from 1-50 steps; leave it empty and a default of 10
+applies. A research-shaped turn that keeps reading long pages through a
+Web-search backend is the usual reason to raise it.
+
 <Callout type="warning">
   **With an Agent selected there is no settings button.** A Chat does not
   override an Agent's Instructions or sampling parameters for one conversation —
-  the Agent's own settings win, and the info button shows you what they are. If
-  you want different behaviour, edit the Agent, or copy it and edit the copy.
-  Looking for the gear on an Agent-backed Chat and concluding it's a bug is the
-  usual confusion here.
+  the Agent's own settings win, including its **Max steps**, and the info
+  button shows you what they are. If you want different behaviour, edit the
+  Agent, or copy it and edit the copy. Looking for the gear on an Agent-backed
+  Chat and concluding it's a bug is the usual confusion here.
 </Callout>
 
 ## Sharing a Chat

--- a/apps/docs/content/docs-contract.test.ts
+++ b/apps/docs/content/docs-contract.test.ts
@@ -35,6 +35,7 @@ import GithubSlugger from "github-slugger";
 import { describe, expect, it } from "vitest";
 import {
   agentSchema,
+  chatSchema,
   dashboardCreateSchema,
   DEFAULT_MAX_EXTRACTED_TEXT_CHARS,
   kanbanBoardSchema,
@@ -899,6 +900,12 @@ const LIMIT_CLAIMS: LimitClaim[] = [
     source: "packages/schemas/index.ts (modelConfigSchema.contextWindow)",
     expected: numberField(modelConfigSchema, "contextWindow"),
   },
+  {
+    doc: "building-with-platypus/chat.mdx",
+    anchor: "**Max steps** caps how many steps",
+    source: "packages/schemas/index.ts (chatSchema.maxSteps)",
+    expected: numberField(chatSchema, "maxSteps"),
+  },
 ];
 
 // A claim with no bound to compare is a test that always passes. Catch it here,
@@ -945,11 +952,11 @@ const normaliseNumbers = (text: string): string =>
     .replace(/(\d),(?=\d)/g, "$1");
 
 /**
- * The units a limit can be stated in. A character count and a token count are
- * both bounds a reader is rejected by, and neither page would thank us for
- * restating its number in the other's unit.
+ * The units a limit can be stated in. A character count, a token count, and a
+ * step count are all bounds a reader is rejected by, and none of these pages
+ * would thank us for restating its number in another's unit.
  */
-const LIMIT_UNIT = "(?:characters|tokens)";
+const LIMIT_UNIT = "(?:characters|tokens|steps)";
 
 const readClaimedLimits = (
   text: string,

--- a/apps/docs/content/docs-contract.test.ts
+++ b/apps/docs/content/docs-contract.test.ts
@@ -37,6 +37,7 @@ import {
   agentSchema,
   chatSchema,
   dashboardCreateSchema,
+  DEFAULT_DIRECT_MAX_STEPS,
   DEFAULT_MAX_EXTRACTED_TEXT_CHARS,
   kanbanBoardSchema,
   mcpSchema,
@@ -905,6 +906,14 @@ const LIMIT_CLAIMS: LimitClaim[] = [
     anchor: "**Max steps** caps how many steps",
     source: "packages/schemas/index.ts (chatSchema.maxSteps)",
     expected: numberField(chatSchema, "maxSteps"),
+  },
+  {
+    // Its own paragraph, not the bound's: a block states one limit, and the
+    // range above would be the number read from a shared one.
+    doc: "building-with-platypus/chat.mdx",
+    anchor: "Leave it empty and a default of",
+    source: "packages/schemas/index.ts (DEFAULT_DIRECT_MAX_STEPS)",
+    expected: { max: DEFAULT_DIRECT_MAX_STEPS },
   },
 ];
 

--- a/apps/frontend/components/chat-settings-dialog.test.tsx
+++ b/apps/frontend/components/chat-settings-dialog.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import { useState } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Dialog } from "./ui/dialog";
+import { ChatSettingsDialog } from "./chat-settings-dialog";
+
+const renderDialog = (
+  props: Partial<Parameters<typeof ChatSettingsDialog>[0]> = {},
+) => {
+  const onMaxStepsChange = vi.fn();
+  // A stateful parent: the dialog is a controlled component, so its derived
+  // validation state only moves when the value round-trips through state.
+  const Harness = () => {
+    const [maxSteps, setMaxSteps] = useState(props.maxSteps);
+    return (
+      <Dialog open>
+        <ChatSettingsDialog
+          instructions=""
+          onInstructionsChange={vi.fn()}
+          temperature={undefined}
+          onTemperatureChange={vi.fn()}
+          seed={undefined}
+          onSeedChange={vi.fn()}
+          topP={undefined}
+          onTopPChange={vi.fn()}
+          topK={undefined}
+          onTopKChange={vi.fn()}
+          presencePenalty={undefined}
+          onPresencePenaltyChange={vi.fn()}
+          frequencyPenalty={undefined}
+          onFrequencyPenaltyChange={vi.fn()}
+          maxSteps={maxSteps}
+          onMaxStepsChange={(v) => {
+            onMaxStepsChange(v);
+            setMaxSteps(v);
+          }}
+        />
+      </Dialog>
+    );
+  };
+  render(<Harness />);
+  // The step ceiling sits beside the sampling settings under the collapsed
+  // "Advanced settings" disclosure.
+  fireEvent.click(screen.getByText("Advanced settings"));
+  return onMaxStepsChange;
+};
+
+describe("ChatSettingsDialog", () => {
+  // Issue #539: the per-chat step ceiling lives beside the sampling settings,
+  // labelled like the Agent form's field.
+  it("renders a Max steps input", () => {
+    renderDialog({ maxSteps: 25 });
+
+    const input = screen.getByLabelText("Max steps");
+    expect(input).toHaveValue(25);
+  });
+
+  it("forwards typed values to onMaxStepsChange", () => {
+    const onMaxStepsChange = renderDialog();
+
+    fireEvent.change(screen.getByLabelText("Max steps"), {
+      target: { value: "30" },
+    });
+
+    expect(onMaxStepsChange).toHaveBeenCalledWith(30);
+  });
+
+  it("clears the setting when emptied", () => {
+    const onMaxStepsChange = renderDialog({ maxSteps: 25 });
+
+    fireEvent.change(screen.getByLabelText("Max steps"), {
+      target: { value: "" },
+    });
+
+    expect(onMaxStepsChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it.each(["0", "-2", "51"])(
+    "shows a visible validation error for %s",
+    (value) => {
+      renderDialog();
+
+      fireEvent.change(screen.getByLabelText("Max steps"), {
+        target: { value },
+      });
+
+      const input = screen.getByLabelText("Max steps");
+      expect(input).toHaveAttribute("aria-invalid", "true");
+      expect(
+        screen.getByText("Max steps must be a whole number between 1 and 50."),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it("clears the validation error once the value is corrected", () => {
+    renderDialog();
+
+    const input = screen.getByLabelText("Max steps");
+    fireEvent.change(input, { target: { value: "99" } });
+    expect(
+      screen.getByText("Max steps must be a whole number between 1 and 50."),
+    ).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "10" } });
+    expect(
+      screen.queryByText("Max steps must be a whole number between 1 and 50."),
+    ).not.toBeInTheDocument();
+    expect(input).not.toHaveAttribute("aria-invalid", "true");
+  });
+});

--- a/apps/frontend/components/chat-settings-dialog.tsx
+++ b/apps/frontend/components/chat-settings-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "./ui/collapsible";
 import { ChevronsUpDown } from "lucide-react";
 import { useState } from "react";
+import { CHAT_MAX_STEPS_MAX, CHAT_MAX_STEPS_MIN } from "@platypus/schemas";
 
 interface ChatSettingsDialogProps {
   instructions: string;
@@ -33,6 +34,8 @@ interface ChatSettingsDialogProps {
   onPresencePenaltyChange: (value: number | undefined) => void;
   frequencyPenalty: number | undefined;
   onFrequencyPenaltyChange: (value: number | undefined) => void;
+  maxSteps: number | undefined;
+  onMaxStepsChange: (value: number | undefined) => void;
   onClose?: () => void;
 }
 
@@ -51,9 +54,23 @@ export const ChatSettingsDialog = ({
   onPresencePenaltyChange,
   frequencyPenalty,
   onFrequencyPenaltyChange,
+  maxSteps,
+  onMaxStepsChange,
   onClose,
 }: ChatSettingsDialogProps) => {
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
+
+  // Derived from the value, not stored: a flag would reset when the dialog
+  // remounts while an out-of-range value stayed in state.
+  const maxStepsInvalid =
+    maxSteps !== undefined &&
+    (!Number.isInteger(maxSteps) ||
+      maxSteps < CHAT_MAX_STEPS_MIN ||
+      maxSteps > CHAT_MAX_STEPS_MAX);
+
+  const handleMaxStepsChange = (value: string) => {
+    onMaxStepsChange(value === "" ? undefined : parseInt(value));
+  };
 
   return (
     <DialogContent className="sm:max-w-[600px]" showCloseButton={false}>
@@ -192,6 +209,25 @@ export const ChatSettingsDialog = ({
                     )
                   }
                 />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="maxSteps">Max steps</Label>
+                <Input
+                  id="maxSteps"
+                  type="number"
+                  min={String(CHAT_MAX_STEPS_MIN)}
+                  max={String(CHAT_MAX_STEPS_MAX)}
+                  step="1"
+                  aria-invalid={maxStepsInvalid}
+                  value={maxSteps ?? ""}
+                  onChange={(e) => handleMaxStepsChange(e.target.value)}
+                />
+                {maxStepsInvalid && (
+                  <p className="text-destructive text-sm">
+                    Max steps must be a whole number between{" "}
+                    {CHAT_MAX_STEPS_MIN} and {CHAT_MAX_STEPS_MAX}.
+                  </p>
+                )}
               </div>
             </div>
           </CollapsibleContent>

--- a/apps/frontend/components/chat-settings-dialog.tsx
+++ b/apps/frontend/components/chat-settings-dialog.tsx
@@ -17,7 +17,18 @@ import {
 } from "./ui/collapsible";
 import { ChevronsUpDown } from "lucide-react";
 import { useState } from "react";
-import { CHAT_MAX_STEPS_MAX, CHAT_MAX_STEPS_MIN } from "@platypus/schemas";
+import {
+  CHAT_MAX_STEPS_MAX,
+  CHAT_MAX_STEPS_MIN,
+  isValidChatMaxSteps,
+} from "@platypus/schemas";
+
+/**
+ * Shown inline under the field and raised as a toast if a bad value somehow
+ * reaches send. One string so the two paths cannot describe the bound
+ * differently.
+ */
+export const CHAT_MAX_STEPS_ERROR = `Max steps must be a whole number between ${CHAT_MAX_STEPS_MIN} and ${CHAT_MAX_STEPS_MAX}.`;
 
 interface ChatSettingsDialogProps {
   instructions: string;
@@ -61,12 +72,9 @@ export const ChatSettingsDialog = ({
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
 
   // Derived from the value, not stored: a flag would reset when the dialog
-  // remounts while an out-of-range value stayed in state.
-  const maxStepsInvalid =
-    maxSteps !== undefined &&
-    (!Number.isInteger(maxSteps) ||
-      maxSteps < CHAT_MAX_STEPS_MIN ||
-      maxSteps > CHAT_MAX_STEPS_MAX);
+  // remounts while an out-of-range value stayed in state. Judged by the schema
+  // that will judge the request, not by a copy of its bounds.
+  const maxStepsInvalid = !isValidChatMaxSteps(maxSteps);
 
   const handleMaxStepsChange = (value: string) => {
     onMaxStepsChange(value === "" ? undefined : parseInt(value));
@@ -215,8 +223,8 @@ export const ChatSettingsDialog = ({
                 <Input
                   id="maxSteps"
                   type="number"
-                  min={String(CHAT_MAX_STEPS_MIN)}
-                  max={String(CHAT_MAX_STEPS_MAX)}
+                  min={CHAT_MAX_STEPS_MIN}
+                  max={CHAT_MAX_STEPS_MAX}
                   step="1"
                   aria-invalid={maxStepsInvalid}
                   value={maxSteps ?? ""}
@@ -224,8 +232,7 @@ export const ChatSettingsDialog = ({
                 />
                 {maxStepsInvalid && (
                   <p className="text-destructive text-sm">
-                    Max steps must be a whole number between{" "}
-                    {CHAT_MAX_STEPS_MIN} and {CHAT_MAX_STEPS_MAX}.
+                    {CHAT_MAX_STEPS_ERROR}
                   </p>
                 )}
               </div>

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -33,6 +33,7 @@ import {
   ToolSet,
   Skill,
   nextTurnOccupancy,
+  isValidChatMaxSteps,
 } from "@platypus/schemas";
 import { type PlatypusUIMessage } from "@platypus/backend/src/types";
 import { joinUrl } from "@/lib/utils";
@@ -54,7 +55,10 @@ import { useAuth } from "@/components/auth-provider";
 import { canSendChatMessages } from "@/lib/authorization";
 import { NoProvidersEmptyState } from "./no-providers-empty-state";
 import { AgentInfoDialog } from "./agent-info-dialog";
-import { ChatSettingsDialog } from "./chat-settings-dialog";
+import {
+  ChatSettingsDialog,
+  CHAT_MAX_STEPS_ERROR,
+} from "./chat-settings-dialog";
 import { ErrorDialog } from "./error-dialog";
 import {
   Tooltip,
@@ -474,6 +478,15 @@ export const Chat = ({
 
     if (!agentId && (!modelId || !providerId)) {
       toast.error("Please select a model or agent to start the chat");
+      return;
+    }
+
+    // The dialog already marks an out-of-range ceiling invalid, but nothing
+    // stopped it riding the turn — the user saw the inline error, sent anyway,
+    // and got a 400 back as a failed run instead of a correctable mistake
+    // (#539). Only Direct turns carry the value; an Agent turn ignores it.
+    if (!agentId && !isValidChatMaxSteps(maxSteps)) {
+      toast.error(CHAT_MAX_STEPS_ERROR);
       return;
     }
 

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -216,6 +216,7 @@ export const Chat = ({
     seed,
     presencePenalty,
     frequencyPenalty,
+    maxSteps,
   } = settings;
   const {
     isModelSelectorOpen,
@@ -249,6 +250,7 @@ export const Chat = ({
           seed,
           presencePenalty,
           frequencyPenalty,
+          maxSteps,
           search,
         };
 
@@ -264,6 +266,7 @@ export const Chat = ({
     seed,
     presencePenalty,
     frequencyPenalty,
+    maxSteps,
     search,
   ]);
 
@@ -657,6 +660,8 @@ export const Chat = ({
                           onPresencePenaltyChange={setters.setPresencePenalty}
                           frequencyPenalty={frequencyPenalty}
                           onFrequencyPenaltyChange={setters.setFrequencyPenalty}
+                          maxSteps={maxSteps}
+                          onMaxStepsChange={setters.setMaxSteps}
                           onClose={() => setIsSettingsDialogOpen(false)}
                         />
                       </Dialog>

--- a/apps/frontend/hooks/use-chat-settings.ts
+++ b/apps/frontend/hooks/use-chat-settings.ts
@@ -10,6 +10,7 @@ export interface ChatSettings {
   seed: number | undefined;
   presencePenalty: number | undefined;
   frequencyPenalty: number | undefined;
+  maxSteps: number | undefined;
 }
 
 export const useChatSettings = (
@@ -25,6 +26,7 @@ export const useChatSettings = (
   const [frequencyPenalty, setFrequencyPenalty] = useState<
     number | undefined
   >();
+  const [maxSteps, setMaxSteps] = useState<number | undefined>();
 
   // Initialize chat settings from existing chat data (only when no agent is
   // selected — an agent supplies its own settings). Re-syncs when either the
@@ -38,6 +40,7 @@ export const useChatSettings = (
       setSeed(chatData.seed ?? undefined);
       setPresencePenalty(chatData.presencePenalty ?? undefined);
       setFrequencyPenalty(chatData.frequencyPenalty ?? undefined);
+      setMaxSteps(chatData.maxSteps ?? undefined);
     }
   };
   useResetOnChange(chatData, initializeFromChat);
@@ -51,6 +54,7 @@ export const useChatSettings = (
     seed,
     presencePenalty,
     frequencyPenalty,
+    maxSteps,
   };
 
   const setters = {
@@ -61,6 +65,7 @@ export const useChatSettings = (
     setSeed,
     setPresencePenalty,
     setFrequencyPenalty,
+    setMaxSteps,
   };
 
   return { settings, setters, ...setters };

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -13,6 +13,7 @@ import {
   nextTurnOccupancy,
   attachmentCreateSchema,
   chatSubmitSchema,
+  isValidChatMaxSteps,
   sandboxEnvSchema,
   SANDBOX_ENV_MAX_ENTRIES,
   SANDBOX_ENV_MAX_VALUE_BYTES,
@@ -340,11 +341,15 @@ describe("Chat Submit Schema", () => {
     expect(result.success).toBe(true);
   });
 
-  // Issue #263 class of bug, guarded at the schema: a cleared field must reach
-  // the server as an explicit `null`, not a dropped key that silently keeps
-  // the column's previous value. null parses and means "unset".
+  // Issue #263 class of bug, guarded at the schema: a client that clears a
+  // field by sending an explicit `null` — rather than dropping the key, which
+  // silently keeps the column's previous value — is accepted here, and null
+  // means "unset".
   it("should accept a null maxSteps as cleared", () => {
-    const result = chatSubmitSchema.safeParse({ ...baseSubmit, maxSteps: null });
+    const result = chatSubmitSchema.safeParse({
+      ...baseSubmit,
+      maxSteps: null,
+    });
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.maxSteps).toBeNull();
@@ -362,6 +367,38 @@ describe("Chat Submit Schema", () => {
       expect(result.success).toBe(false);
     },
   );
+});
+
+describe("isValidChatMaxSteps", () => {
+  // The predicate the Chat settings input and the send guard both decide from,
+  // so an inline error and a 400 can never disagree about the bound.
+  it.each([1, 10, 50])("accepts %s", (value) => {
+    expect(isValidChatMaxSteps(value)).toBe(true);
+  });
+
+  it.each([0, -1, 2.5, 51])("rejects %s", (value) => {
+    expect(isValidChatMaxSteps(value)).toBe(false);
+  });
+
+  // Unset is not an error — it means fall back to the Direct default.
+  it.each([null, undefined])("treats %s as valid", (value) => {
+    expect(isValidChatMaxSteps(value)).toBe(true);
+  });
+
+  it("agrees with the request schema it is derived from", () => {
+    const base = {
+      id: "chat-1",
+      workspaceId: "ws-1",
+      messages: [],
+      providerId: "p1",
+      modelId: "gpt-4",
+    };
+    for (const value of [0, 1, 50, 51]) {
+      expect(isValidChatMaxSteps(value)).toBe(
+        chatSubmitSchema.safeParse({ ...base, maxSteps: value }).success,
+      );
+    }
+  });
 });
 
 describe("Provider Create Schema", () => {

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -12,6 +12,7 @@ import {
   attachmentSchema,
   nextTurnOccupancy,
   attachmentCreateSchema,
+  chatSubmitSchema,
   sandboxEnvSchema,
   SANDBOX_ENV_MAX_ENTRIES,
   SANDBOX_ENV_MAX_VALUE_BYTES,
@@ -323,6 +324,44 @@ describe("Agent Schema", () => {
     });
     expect(result.success).toBe(false);
   });
+});
+
+describe("Chat Submit Schema", () => {
+  const baseSubmit = {
+    id: "chat-1",
+    workspaceId: "ws-1",
+    messages: [],
+    providerId: "p1",
+    modelId: "gpt-4",
+  };
+
+  it("should accept a maxSteps override on the turn", () => {
+    const result = chatSubmitSchema.safeParse({ ...baseSubmit, maxSteps: 25 });
+    expect(result.success).toBe(true);
+  });
+
+  // Issue #263 class of bug, guarded at the schema: a cleared field must reach
+  // the server as an explicit `null`, not a dropped key that silently keeps
+  // the column's previous value. null parses and means "unset".
+  it("should accept a null maxSteps as cleared", () => {
+    const result = chatSubmitSchema.safeParse({ ...baseSubmit, maxSteps: null });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.maxSteps).toBeNull();
+    }
+  });
+
+  // A Direct turn has no no-progress detector, so this ceiling is its only
+  // backstop — bounded deliberately (unlike the Agent's unbounded field), and
+  // integer because it reaches `stepCountIs(n)`, where a fraction or a value
+  // below 1 can never equal a real step count.
+  it.each([0, -1, 2.5, 51])(
+    "should reject a chat maxSteps of %s",
+    (maxSteps) => {
+      const result = chatSubmitSchema.safeParse({ ...baseSubmit, maxSteps });
+      expect(result.success).toBe(false);
+    },
+  );
 });
 
 describe("Provider Create Schema", () => {

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -89,6 +89,15 @@ export const chatStatusSchema = z.enum([
 export type ChatStatus = z.infer<typeof chatStatusSchema>;
 
 /**
+ * Bounds on the per-chat Max steps setting (`chatSchema.maxSteps`). Exported
+ * because the documentation contract test pins the numbers the
+ * Operator-facing docs quote to these, and the Chat settings input enforces
+ * the same pair.
+ */
+export const CHAT_MAX_STEPS_MIN = 1;
+export const CHAT_MAX_STEPS_MAX = 50;
+
+/**
  * Placeholder title a chat is created with until it is titled. Load-bearing on
  * both sides: the backend only ever generates a title while the row still holds
  * this value (idempotent, first-wins), and the client only polls for a
@@ -117,6 +126,20 @@ export const chatSchema = z.object({
   seed: z.number().optional(),
   presencePenalty: z.number().optional(),
   frequencyPenalty: z.number().optional(),
+  // Per-chat step ceiling for Direct (no-Agent) turns (#539). Nullable like
+  // the Agent's sampling params rather than shaped like the Agent's own
+  // `maxSteps`: without null, a cleared value serialises as a dropped key and
+  // the column silently keeps its previous value (#263). Bounded above
+  // because a Direct turn never meets the no-progress detector — this ceiling
+  // is its only backstop — while the Agent form's field is deliberately left
+  // unbounded by its author.
+  maxSteps: z
+    .number()
+    .int()
+    .min(CHAT_MAX_STEPS_MIN)
+    .max(CHAT_MAX_STEPS_MAX)
+    .nullable()
+    .optional(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
@@ -135,6 +158,7 @@ export const chatSubmitSchema = chatSchema
     seed: true,
     presencePenalty: true,
     frequencyPenalty: true,
+    maxSteps: true,
   })
   .extend({
     agentId: z.string().optional(),
@@ -207,10 +231,12 @@ export const DEFAULT_AGENT_MAX_STEPS = 15;
  * Provider+model selection with no `agent` row to declare its own `maxSteps`.
  *
  * Deliberately BELOW `DEFAULT_AGENT_MAX_STEPS`: a Direct chat is a
- * conversation, not a configured workflow, it has no step-limit control in
- * the UI, and — unlike an unattended run — it is never guarded by the
- * no-progress detector. The ceiling itself is the only guard here, so do not
- * raise it to match the Agent default.
+ * conversation, not a configured workflow, and — unlike an unattended run — it
+ * is never guarded by the no-progress detector. The ceiling itself is the only
+ * guard here, so do not raise it to match the Agent default. It is the value
+ * the per-chat Max steps setting (#539) falls back to when left unset; do not
+ * derive that setting's maximum from this constant, whose job is to bound the
+ * conversation nobody has tuned.
  *
  * 10 rather than something smaller because the page-reader tool a Web-search
  * backend contributes is meant to be called repeatedly: it slices a long page

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -127,12 +127,15 @@ export const chatSchema = z.object({
   presencePenalty: z.number().optional(),
   frequencyPenalty: z.number().optional(),
   // Per-chat step ceiling for Direct (no-Agent) turns (#539). Nullable like
-  // the Agent's sampling params rather than shaped like the Agent's own
-  // `maxSteps`: without null, a cleared value serialises as a dropped key and
-  // the column silently keeps its previous value (#263). Bounded above
-  // because a Direct turn never meets the no-progress detector — this ceiling
-  // is its only backstop — while the Agent form's field is deliberately left
-  // unbounded by its author.
+  // its six sampling neighbours rather than shaped like the Agent's own
+  // `maxSteps`, so a client that clears a field by sending an explicit null
+  // — as the Agent form does — cannot hit #263, where a dropped key leaves
+  // the column's previous value standing. A chat turn happens to clear by
+  // omission instead and survives it only because every turn rewrites all
+  // generation columns; accepting null keeps the seam honest either way.
+  // Bounded above because a Direct turn never meets the no-progress detector
+  // — this ceiling is its only backstop — while the Agent form's field is
+  // deliberately left unbounded by its author.
   maxSteps: z
     .number()
     .int()
@@ -145,6 +148,18 @@ export const chatSchema = z.object({
 });
 
 export type Chat = z.infer<typeof chatSchema>;
+
+/**
+ * Whether a per-chat Max steps value is one the turn endpoint will accept.
+ *
+ * Shared so the Chat settings input, the send guard and the request validator
+ * all decide from `chatSchema.maxSteps` itself. Restating `int/min/max` in the
+ * UI is how the field's inline error and its 400 drift apart. "Unset" (null or
+ * undefined) is valid — it means fall back to the Direct default.
+ */
+export const isValidChatMaxSteps = (
+  value: number | null | undefined,
+): boolean => chatSchema.shape.maxSteps.safeParse(value).success;
 
 export const chatSubmitSchema = chatSchema
   .pick({


### PR DESCRIPTION
Closes #539.

## What

A Direct (no-Agent) Chat runs under a step ceiling it cannot change: every deployment shares one hardcoded `DEFAULT_DIRECT_MAX_STEPS`. Research-shaped turns — search → read → continuation → continuation → answer through a Web-search backend's page-reader — can legitimately need more than a default tuned for conversation. This adds a per-chat **Max steps** field to Chat Settings as a seventh per-chat setting following the six sampling settings' established pattern exactly.

## How it works

- **Schemas** (`@platypus/schemas`) — `chatSchema.maxSteps` is `.int().min(1).max(50).nullable().optional()`, deliberately *not* the Agent field's shape: without `.nullable()` a cleared value serialises as a dropped key and the column silently keeps its previous value (#263). The bounds are exported as `CHAT_MAX_STEPS_MIN`/`CHAT_MAX_STEPS_MAX` so the schema, the form input, and the docs contract pin share one source.
- **Backend** — the value rides the turn request like the six sampling settings and resolves as `<per-chat value> ?? DEFAULT_DIRECT_MAX_STEPS` on the direct branch of `resolveGenerationPlan`. The Agent branch is untouched; an Agent-backed turn ignores the stored chat value and the Agent's own `maxSteps` governs.
- **Persistence** — new nullable `chat.max_steps` integer column mirroring the Agent table's. `ResolvedGeneration.maxSteps` carries the **requested** value, not the plan's resolved ceiling, so an unset chat never gets the default written over its null — "unset" and "explicitly 10" stay distinguishable after reload. Clearing persists because every turn rewrites all generation columns (`resolved.maxSteps ?? null`).
- **Frontend** — numeric field labelled **Max steps** beside the sampling settings under Advanced settings; out-of-range values get an inline validation error derived from the current value (so it survives reopening the dialog with the bad value still in state).
- **Docs** — `building-with-platypus/chat.mdx` documents the setting in both the step-limit section and Per-Chat settings; the docs contract test now recognises step counts (`LIMIT_UNIT`) and pins the 1–50 claim to the schema field.

## Reviewer notes — two things flagged, not decided

1. **Helper text (the issue's open question).** Shipped without helper text to match every other field in this dialog. Proposed wording if reviewers want copy: *"How many steps a tool-using turn may run before it stops."*
2. **Prefill.** The dialog leaves the field empty rather than prefilling `DEFAULT_DIRECT_MAX_STEPS` the way the Agent form prefills `DEFAULT_AGENT_MAX_STEPS`. Prefilling would make "unset" unreachable after first render and break clear-back-to-default; empty + fallback satisfies "leaving it unset falls back to `DEFAULT_DIRECT_MAX_STEPS`" instead.

## Migration note

Migration `0052_minor_demogoblin.sql` is pure DDL (`ALTER TABLE "chat" ADD COLUMN "max_steps" integer;`). No data migration needed. My local dev database had pre-existing unrelated drift (a missing older unique constraint on `agent`), so rather than force a full `drizzle-kit push`, I applied this migration's SQL by hand there — production is unaffected and applies it via `scripts/migrate.ts` as usual.

## Acceptance criteria

- [x] Chat Settings shows **Max steps**, only where that dialog renders (no Agent selected)
- [x] Setting it changes the ceiling for subsequent Direct turns
- [x] Unset falls back to `DEFAULT_DIRECT_MAX_STEPS`
- [x] Clearing returns to the default and **persists** (#263 guard — tested at the schema, plan, execution and sink layers)
- [x] Value survives reload (row round-trips through `GET /chats/:id`)
- [x] Below 1 / above 50 rejected with a visible validation error (inline + zod backstop)
- [x] Agent selected ignores the stored chat value — tested mirroring "sends the Agent's own seed, not the request's"
- [x] Docs updated in this PR
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` pass

Out of scope per the issue: exposing Max steps on Agent chats, env-var configuration of the default, and surfacing an exhausted ceiling to the user.