### PR TITLE
chore(backend): give Promote one module instead of two copy-pasted route transactions

### DIFF
--- a/apps/backend/src/routes/agent.test.ts
+++ b/apps/backend/src/routes/agent.test.ts
@@ -643,38 +643,5 @@ describe("Agent Routes", () => {
       expect(mockDb.insert).toHaveBeenCalled();
       expect(mockDb.onConflictDoNothing).toHaveBeenCalled();
     });
-
-    it("returns 404 (no orphan attachment) on a lost promote race", async () => {
-      mockSession();
-      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
-      mockDb.limit.mockResolvedValueOnce([
-        { ownerId: "user-1", organizationId: "org-1" },
-      ]);
-      mockDb.limit.mockResolvedValueOnce([
-        {
-          id: "agent-1",
-          providerId: "p1",
-          workspaceId,
-          skillIds: [],
-          subAgentIds: [],
-          toolSetIds: [],
-        },
-      ]);
-
-      mockDb.where
-        .mockReturnValueOnce(mockDb) // requireOrgAccess
-        .mockReturnValueOnce(mockDb) // requireWorkspaceAccess
-        .mockReturnValueOnce(mockDb) // agent lookup
-        .mockResolvedValueOnce([
-          { id: "p1", name: "Shared Provider", organizationId: orgId },
-        ]); // provider validation → OK
-
-      // Transaction update matches no row (already re-scoped) → rollback
-      mockDb.returning.mockResolvedValueOnce([]);
-
-      const res = await app.request(promoteUrl, { method: "POST" });
-      expect(res.status).toBe(404);
-      expect(mockDb.onConflictDoNothing).not.toHaveBeenCalled();
-    });
   });
 });

--- a/apps/backend/src/routes/agent.ts
+++ b/apps/backend/src/routes/agent.ts
@@ -1,11 +1,7 @@
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
-import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import {
-  agent as agentTable,
-  attachment as attachmentTable,
-} from "../db/schema.ts";
+import { agent as agentTable } from "../db/schema.ts";
 import { agentCreateSchema, agentUpdateSchema } from "@platypus/schemas";
 import { requireAuth } from "../middleware/authentication.ts";
 import {
@@ -20,13 +16,13 @@ import {
   deleteAgent as deleteAgentRow,
 } from "../services/agent.ts";
 import { findNonSharedReferences } from "../services/agent-scope-validation.ts";
+import { promoteScoped } from "../services/promote.ts";
 import {
   listScoped,
   requireScoped,
   requireWorkspaceMutable,
   workspaceScopedWhere,
 } from "../services/scoped-resource.ts";
-import { NotFoundError } from "../errors.ts";
 import { storeAvatar, deleteAvatar } from "../services/avatar.ts";
 import { agentWithAvatarUrl } from "../utils/avatar-url.ts";
 import { getOrigin } from "../utils/get-origin.ts";
@@ -204,13 +200,12 @@ agent.delete(
 /**
  * Promote a workspace-scoped Agent to Organization scope (admin only — ADR-0007).
  *
- * Enforces the no-cascade rule: a Shared Agent may reference only other Shared
- * resources, so Promotion is blocked unless the Agent's Provider, every Skill,
- * every sub-Agent, and every MCP-backed tool set is already Organization-scoped.
- * When blocked, the offending references are returned as `blockers` so the UI
- * can present a fix-this checklist. On success the Agent re-scopes to the
- * Organization and its origin Workspace is auto-attached so it stays visible
- * and usable there; editing thereafter happens on the Organization surface.
+ * Runs the no-cascade rule (`findNonSharedReferences`) as the module's guard: a
+ * shared Agent may reference only other Shared resources, so Promotion is
+ * blocked unless the Agent's Provider, every Skill, every sub-agent, and every
+ * MCP-backed tool set is already Organization-scoped. When blocked, the
+ * offending references are returned as `blockers`. On success the Agent
+ * re-scopes to the Organization and its origin Workspace is auto-attached.
  */
 agent.post(
   "/:agentId/promote",
@@ -222,82 +217,27 @@ agent.post(
     const agentId = c.req.param("agentId");
     const baseUrl = getOrigin(c);
 
-    // Only a workspace-scoped Agent in this workspace can be promoted.
-    const [existing] = await db
-      .select()
-      .from(agentTable)
-      .where(workspaceScopedWhere("agent", agentId, workspaceId))
-      .limit(1);
-    if (!existing) {
-      throw new NotFoundError("Agent not found");
-    }
-
-    // No-cascade guard (ADR-0007): every travels-with reference must already be
-    // Organization-scoped, or Promotion is blocked with a fix-this checklist.
-    const blockers = await findNonSharedReferences(orgId, {
-      providerId: existing.providerId,
-      skillIds: existing.skillIds,
-      subAgentIds: existing.subAgentIds,
-      toolSetIds: existing.toolSetIds,
+    const outcome = await promoteScoped(db, {
+      type: "agent",
+      id: agentId,
+      orgId,
+      workspaceId,
+      guard: (existing) =>
+        findNonSharedReferences(orgId, {
+          providerId: existing.providerId,
+          skillIds: existing.skillIds,
+          subAgentIds: existing.subAgentIds,
+          toolSetIds: existing.toolSetIds,
+        }),
     });
-    if (blockers.length > 0) {
-      return c.json(
-        {
-          error:
-            "Promote blocked: this agent references workspace-private resources. Promote them first.",
-          blockers,
-        },
-        422,
-      );
+
+    if (!outcome.ok) {
+      return c.json({ error: outcome.message, blockers: outcome.blockers }, 422);
     }
-
-    // Sentinel for a lost TOCTOU race: the Agent was re-scoped or deleted between
-    // the lookup above and the in-transaction update. Throwing rolls back the
-    // auto-attach so we never leave a dangling Attachment.
-    const PROMOTE_RACE = "agent_no_longer_workspace_scoped";
-
-    try {
-      const promoted = await db.transaction(async (tx) => {
-        const [record] = await tx
-          .update(agentTable)
-          .set({
-            organizationId: orgId,
-            workspaceId: null,
-            updatedAt: new Date(),
-          })
-          .where(workspaceScopedWhere("agent", agentId, workspaceId))
-          .returning();
-
-        if (!record) {
-          throw new Error(PROMOTE_RACE);
-        }
-
-        // Auto-attach the origin Workspace so it keeps seeing the Agent.
-        await tx
-          .insert(attachmentTable)
-          .values({
-            id: nanoid(),
-            workspaceId,
-            resourceType: "agent",
-            resourceId: agentId,
-          })
-          .onConflictDoNothing();
-
-        return record;
-      });
-
-      return c.json(
-        { ...agentWithAvatarUrl(promoted, baseUrl), scope: "organization" },
-        200,
-      );
-    } catch (error) {
-      if (error instanceof Error && error.message === PROMOTE_RACE) {
-        throw new NotFoundError("Agent not found");
-      }
-      // A duplicate Shared-Agent name surfaces as a Postgres unique violation,
-      // mapped to 409 by the central onError (ADR-0010).
-      throw error;
-    }
+    return c.json(
+      { ...agentWithAvatarUrl(outcome.row, baseUrl), scope: "organization" },
+      200,
+    );
   },
 );
 

--- a/apps/backend/src/routes/skill.test.ts
+++ b/apps/backend/src/routes/skill.test.ts
@@ -295,24 +295,6 @@ describe("Skill Routes", () => {
       expect(mockDb.insert).toHaveBeenCalled();
       expect(mockDb.onConflictDoNothing).toHaveBeenCalled();
     });
-
-    it("returns 404 (no orphan attachment) when a concurrent promote already re-scoped the skill", async () => {
-      mockSession();
-      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]); // requireOrgAccess
-      mockDb.limit.mockResolvedValueOnce([
-        { ownerId: "user-1", organizationId: "org-1" },
-      ]); // requireWorkspaceAccess
-      mockDb.limit.mockResolvedValueOnce([
-        { id: "skill-1", workspaceId, name: "my-skill" },
-      ]); // skill lookup (pre-transaction)
-      // Transaction update matches no row (skill already re-scoped) → rollback
-      mockDb.returning.mockResolvedValueOnce([]);
-
-      const res = await app.request(promoteUrl, { method: "POST" });
-      expect(res.status).toBe(404);
-      // The auto-attach insert must never run when the update found nothing.
-      expect(mockDb.onConflictDoNothing).not.toHaveBeenCalled();
-    });
   });
 
   describe("DELETE /:skillId", () => {

--- a/apps/backend/src/routes/skill.ts
+++ b/apps/backend/src/routes/skill.ts
@@ -164,13 +164,6 @@ skill.post(
       workspaceId,
     });
 
-    if (!outcome.ok) {
-      // A leaf resource has no no-cascade guard, so this branch is unreachable;
-      // it exists only to satisfy the discriminated outcome. Return it the same
-      // way the guarded surfaces do.
-      return c.json({ error: outcome.message, blockers: outcome.blockers }, 422);
-    }
-
     return c.json({ ...outcome.row, scope: "organization" }, 200);
   },
 );

--- a/apps/backend/src/routes/skill.ts
+++ b/apps/backend/src/routes/skill.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { db } from "../index.ts";
-import { skill as skillTable, agent as agentTable } from "../db/schema.ts";
+import { agent as agentTable } from "../db/schema.ts";
 import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
 import { eq, and, sql } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
@@ -13,7 +13,6 @@ import {
 import {
   listScoped,
   requireScoped,
-  workspaceScopedWhere,
 } from "../services/scoped-resource.ts";
 import { createSkill, deleteSkill, updateSkill } from "../services/skill.ts";
 import { promoteScoped } from "../services/promote.ts";

--- a/apps/backend/src/routes/skill.ts
+++ b/apps/backend/src/routes/skill.ts
@@ -1,12 +1,7 @@
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
-import { nanoid } from "nanoid";
 import { db } from "../index.ts";
-import {
-  skill as skillTable,
-  agent as agentTable,
-  attachment as attachmentTable,
-} from "../db/schema.ts";
+import { skill as skillTable, agent as agentTable } from "../db/schema.ts";
 import { skillCreateSchema, skillUpdateSchema } from "@platypus/schemas";
 import { eq, and, sql } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
@@ -21,7 +16,7 @@ import {
   workspaceScopedWhere,
 } from "../services/scoped-resource.ts";
 import { createSkill, deleteSkill, updateSkill } from "../services/skill.ts";
-import { NotFoundError } from "../errors.ts";
+import { promoteScoped } from "../services/promote.ts";
 import type { Variables } from "../server.ts";
 
 const skill = new Hono<{ Variables: Variables }>();
@@ -148,10 +143,10 @@ skill.delete(
  * Re-scopes the Skill from this Workspace to the Organization, turning it into a
  * Shared resource, and auto-attaches the origin Workspace so the author keeps
  * using/editing it in place. A Skill is leaf text (it references no other
- * resource), so there is no "references must already be Shared" prerequisite —
- * Skills establish the Promote pattern that Agents build on. Workspace Agents
- * that already reference the Skill keep their references intact (the id is
- * unchanged) and resolve it at Chat-turn time via the Attachment.
+ * resource), so it passes no no-cascade guard — Skills establish the Promote
+ * pattern that Agents build on. Workspace Agents that already reference the
+ * Skill keep their references intact (the id is unchanged) and resolve it at
+ * Chat-turn time via the Attachment.
  */
 skill.post(
   "/:skillId/promote",
@@ -162,60 +157,21 @@ skill.post(
     const { orgId, workspaceId } = workspaceScopeOf(c);
     const skillId = c.req.param("skillId");
 
-    // Only a workspace-scoped Skill in this workspace can be promoted.
-    const [existing] = await db
-      .select()
-      .from(skillTable)
-      .where(workspaceScopedWhere("skill", skillId, workspaceId))
-      .limit(1);
-    if (!existing) {
-      throw new NotFoundError("Skill not found");
+    const outcome = await promoteScoped(db, {
+      type: "skill",
+      id: skillId,
+      orgId,
+      workspaceId,
+    });
+
+    if (!outcome.ok) {
+      // A leaf resource has no no-cascade guard, so this branch is unreachable;
+      // it exists only to satisfy the discriminated outcome. Return it the same
+      // way the guarded surfaces do.
+      return c.json({ error: outcome.message, blockers: outcome.blockers }, 422);
     }
 
-    // Sentinel for a lost TOCTOU race: the Skill was re-scoped or deleted
-    // between the lookup above and the in-transaction update. Throwing rolls
-    // back the auto-attach so we never leave a dangling Attachment.
-    const PROMOTE_RACE = "skill_no_longer_workspace_scoped";
-
-    try {
-      const promoted = await db.transaction(async (tx) => {
-        const [record] = await tx
-          .update(skillTable)
-          .set({
-            organizationId: orgId,
-            workspaceId: null,
-            updatedAt: new Date(),
-          })
-          .where(workspaceScopedWhere("skill", skillId, workspaceId))
-          .returning();
-
-        if (!record) {
-          throw new Error(PROMOTE_RACE);
-        }
-
-        // Auto-attach the origin Workspace so it keeps seeing the Skill.
-        await tx
-          .insert(attachmentTable)
-          .values({
-            id: nanoid(),
-            workspaceId,
-            resourceType: "skill",
-            resourceId: skillId,
-          })
-          .onConflictDoNothing();
-
-        return record;
-      });
-
-      return c.json({ ...promoted, scope: "organization" }, 200);
-    } catch (error) {
-      if (error instanceof Error && error.message === PROMOTE_RACE) {
-        throw new NotFoundError("Skill not found");
-      }
-      // A duplicate Shared-Skill name surfaces as a Postgres unique violation,
-      // mapped to 409 by the central onError (ADR-0010).
-      throw error;
-    }
+    return c.json({ ...outcome.row, scope: "organization" }, 200);
   },
 );
 

--- a/apps/backend/src/services/promote.test.ts
+++ b/apps/backend/src/services/promote.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { asDb, createMockDb, type MockDb } from "../test-utils.ts";
+import { promoteScoped } from "./promote.ts";
+import { NotFoundError } from "../errors.ts";
+
+describe("promoteScoped module", () => {
+  const mockDb: MockDb = createMockDb();
+
+  beforeEach(() => {
+    mockDb.where.mockReturnValue(mockDb);
+    mockDb.limit.mockReset();
+    mockDb.returning.mockReset();
+    mockDb.insert.mockReset();
+    mockDb.onConflictDoNothing.mockReset();
+    mockDb.transaction.mockReset();
+  });
+
+  it("throws NotFoundError when the resource is not workspace-scoped here", async () => {
+    mockDb.limit.mockResolvedValueOnce([]);
+
+    await expect(
+      promoteScoped(asDb(mockDb), {
+        type: "skill",
+        id: "s1",
+        orgId: "org-1",
+        workspaceId: "ws-1",
+      }),
+    ).rejects.toThrow(NotFoundError);
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  it("re-scopes the resource and auto-attaches the origin workspace", async () => {
+    mockDb.limit.mockResolvedValueOnce([{ id: "s1", workspaceId: "ws-1" }]);
+    mockDb.returning.mockResolvedValueOnce([
+      { id: "s1", organizationId: "org-1", workspaceId: null },
+    ]);
+
+    const outcome = await promoteScoped(asDb(mockDb), {
+      type: "skill",
+      id: "s1",
+      orgId: "org-1",
+      workspaceId: "ws-1",
+    });
+
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.row).toEqual({
+        id: "s1",
+        organizationId: "org-1",
+        workspaceId: null,
+      });
+    }
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(mockDb.onConflictDoNothing).toHaveBeenCalled();
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("turns a lost promote race into NotFoundError without attaching", async () => {
+    mockDb.limit.mockResolvedValueOnce([{ id: "s1", workspaceId: "ws-1" }]);
+    // The in-transaction re-scope matches no row (already re-scoped elsewhere),
+    // so the module must abort before it inserts the auto-attach.
+    mockDb.returning.mockResolvedValueOnce([]);
+
+    await expect(
+      promoteScoped(asDb(mockDb), {
+        type: "skill",
+        id: "s1",
+        orgId: "org-1",
+        workspaceId: "ws-1",
+      }),
+    ).rejects.toThrow(NotFoundError);
+
+    // The rollback invariant, asserted once through the module: no orphan
+    // Attachment is ever inserted when the re-scope loses the race.
+    expect(mockDb.onConflictDoNothing).not.toHaveBeenCalled();
+  });
+
+  it("runs a supplied guard and reports any blockers it returns", async () => {
+    mockDb.limit.mockResolvedValueOnce([
+      { id: "a1", providerId: "p1", skillIds: ["s1"], subAgentIds: [], toolSetIds: [] },
+    ]);
+
+    const outcome = await promoteScoped(asDb(mockDb), {
+      type: "agent",
+      id: "a1",
+      orgId: "org-1",
+      workspaceId: "ws-1",
+      guard: (_) => Promise.resolve([{ type: "skill", id: "s1", name: "ws-skill" }]),
+    });
+
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.blockers).toEqual([{ type: "skill", id: "s1", name: "ws-skill" }]);
+    }
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/services/promote.ts
+++ b/apps/backend/src/services/promote.ts
@@ -1,0 +1,133 @@
+import { nanoid } from "nanoid";
+import { attachment as attachmentTable } from "../db/schema.ts";
+import { db } from "../index.ts";
+import { NotFoundError } from "../errors.ts";
+import {
+  tableOf,
+  labelOf,
+  nounOf,
+  workspaceScopedWhere,
+  type RowOf,
+  type ScopedResourceType,
+} from "./scoped-resource.ts";
+
+/**
+ * Promote (CONTEXT.md): the Org-Admin action that re-scopes a Workspace-private
+ * Scoped resource to Organization scope, turning it into a **Shared resource**
+ * and auto-attaching its origin Workspace so it stays visible and usable there
+ * (ADR-0007). Editing thereafter happens on the Organization surface.
+ *
+ * One module owns the mechanism for any {@link ScopedResourceType}; the routes
+ * are thin adapters that authorize, run their per-resource precondition, and
+ * shape the response. The mechanism was previously copy-pasted inline in the
+ * Agent and Skill route handlers, byte-for-byte identical apart from the table
+ * and the noun, with copies #3 and #4 pending for MCP/Provider.
+ *
+ * The invariants that make Promote correct live here, once:
+ * - only a Workspace-scoped resource in the given Workspace can be promoted;
+ * - a lost TOCTOU race (the resource was re-scoped or deleted between the
+ *   pre-check lookup and the in-transaction re-scope) becomes `NotFoundError`
+ *   (→404) and rolls back the auto-attach so a dangling Attachment is never
+ *   left behind;
+ * - a unique-constraint violation (a duplicate Shared-resource name) surfaces
+ *   from the transaction untouched, to be mapped to 409 by the central
+ *   `app.onError` (ADR-0010).
+ *
+ * The Agent's no-cascade reference guard (`findNonSharedReferences`) is passed
+ * in as `guard`, not inlined, so a leaf resource like a Skill and future
+ * MCP/Provider surfaces adopt the same mechanism without copying the guard.
+ */
+export type Database = typeof db;
+
+/**
+ * A reference that blocks Promotion because it is not itself Organization-scoped
+ * (ADR-0007 no-cascade rule). `name` is so the UI can render a fix-this
+ * checklist. The guard decides the concrete shape; this module just carries it.
+ */
+export type PromoteBlocker = { type: string; id: string; name: string };
+
+/**
+ * A route-supplied rule that runs on the pre-check row before the transaction.
+ * An Agent passes the no-cascade reference check; a Skill — which references
+ * nothing — passes no guard.
+ */
+export type PromoteGuard<T extends ScopedResourceType> = (
+  resource: RowOf[T],
+) => Promise<PromoteBlocker[]>;
+
+/** How a promote attempt answers — promoted, or blocked pending fixes. */
+export type PromoteOutcome<T extends ScopedResourceType> =
+  | { ok: true; row: RowOf[T] }
+  | { ok: false; message: string; blockers: PromoteBlocker[] };
+
+export async function promoteScoped<T extends ScopedResourceType>(
+  database: Database,
+  args: {
+    type: T;
+    id: string;
+    orgId: string;
+    workspaceId: string;
+    guard?: PromoteGuard<T>;
+  },
+): Promise<PromoteOutcome<T>> {
+  const { type, id, orgId, workspaceId, guard } = args;
+  const table = tableOf(type);
+
+  // Only a Workspace-scoped resource in this Workspace can be promoted.
+  const [existing] = await database
+    .select()
+    .from(table)
+    .where(workspaceScopedWhere(type, id, workspaceId))
+    .limit(1);
+  if (!existing) {
+    throw new NotFoundError(`${labelOf(type)} not found`);
+  }
+
+  // A route-supplied guard rejects Promotion with a fix-this checklist when a
+  // travels-with reference is not itself Organization-scoped (ADR-0007).
+  if (guard) {
+    const blockers = await guard(existing as RowOf[T]);
+    if (blockers.length > 0) {
+      return {
+        ok: false,
+        message: `Promote blocked: this ${nounOf(type)} references workspace-private resources. Promote them first.`,
+        blockers,
+      };
+    }
+  }
+
+  // Re-scope and auto-attach atomically. Throwing `NotFoundError` for a lost
+  // race rolls back the whole transaction, so we never leave a dangling
+  // Attachment; the typed error reaches the central `app.onError` (ADR-0010).
+  let promoted: RowOf[T] | undefined;
+  await database.transaction(async (tx) => {
+    const [record] = await tx
+      .update(table)
+      .set({
+        organizationId: orgId,
+        workspaceId: null,
+        updatedAt: new Date(),
+      })
+      .where(workspaceScopedWhere(type, id, workspaceId))
+      .returning();
+
+    if (!record) {
+      throw new NotFoundError(`${labelOf(type)} not found`);
+    }
+
+    // Auto-attach the origin Workspace so it keeps seeing the resource.
+    await tx
+      .insert(attachmentTable)
+      .values({
+        id: nanoid(),
+        workspaceId,
+        resourceType: type,
+        resourceId: id,
+      })
+      .onConflictDoNothing();
+
+    promoted = record as RowOf[T];
+  });
+
+  return { ok: true, row: promoted! };
+}

--- a/apps/backend/src/services/promote.ts
+++ b/apps/backend/src/services/promote.ts
@@ -20,8 +20,9 @@ import {
  * One module owns the mechanism for any {@link ScopedResourceType}; the routes
  * are thin adapters that authorize, run their per-resource precondition, and
  * shape the response. The mechanism was previously copy-pasted inline in the
- * Agent and Skill route handlers, byte-for-byte identical apart from the table
- * and the noun, with copies #3 and #4 pending for MCP/Provider.
+ * Agent and Skill route handlers, identical apart from the table, the noun, and
+ * the Agent's inline no-cascade blocker check, with copies #3 and #4 pending
+ * for MCP/Provider.
  *
  * The invariants that make Promote correct live here, once:
  * - only a Workspace-scoped resource in the given Workspace can be promoted;
@@ -55,20 +56,30 @@ export type PromoteGuard<T extends ScopedResourceType> = (
   resource: RowOf[T],
 ) => Promise<PromoteBlocker[]>;
 
-/** How a promote attempt answers — promoted, or blocked pending fixes. */
+/** How a guard-backed promote attempt answers — promoted, or blocked pending fixes. */
 export type PromoteOutcome<T extends ScopedResourceType> =
   | { ok: true; row: RowOf[T] }
   | { ok: false; message: string; blockers: PromoteBlocker[] };
 
+export type PromoteArgs<T extends ScopedResourceType> = {
+  type: T;
+  id: string;
+  orgId: string;
+  workspaceId: string;
+};
+
+/** A guarded surface may be blocked; an unguarded leaf cannot, so it narrows. */
 export async function promoteScoped<T extends ScopedResourceType>(
   database: Database,
-  args: {
-    type: T;
-    id: string;
-    orgId: string;
-    workspaceId: string;
-    guard?: PromoteGuard<T>;
-  },
+  args: PromoteArgs<T> & { guard: PromoteGuard<T> },
+): Promise<PromoteOutcome<T>>;
+export async function promoteScoped<T extends ScopedResourceType>(
+  database: Database,
+  args: PromoteArgs<T> & { guard?: undefined },
+): Promise<{ ok: true; row: RowOf[T] }>;
+export async function promoteScoped<T extends ScopedResourceType>(
+  database: Database,
+  args: PromoteArgs<T> & { guard?: PromoteGuard<T> },
 ): Promise<PromoteOutcome<T>> {
   const { type, id, orgId, workspaceId, guard } = args;
   const table = tableOf(type);
@@ -99,8 +110,7 @@ export async function promoteScoped<T extends ScopedResourceType>(
   // Re-scope and auto-attach atomically. Throwing `NotFoundError` for a lost
   // race rolls back the whole transaction, so we never leave a dangling
   // Attachment; the typed error reaches the central `app.onError` (ADR-0010).
-  let promoted: RowOf[T] | undefined;
-  await database.transaction(async (tx) => {
+  return database.transaction(async (tx) => {
     const [record] = await tx
       .update(table)
       .set({
@@ -126,8 +136,6 @@ export async function promoteScoped<T extends ScopedResourceType>(
       })
       .onConflictDoNothing();
 
-    promoted = record as RowOf[T];
+    return { ok: true as const, row: record as RowOf[T] };
   });
-
-  return { ok: true, row: promoted! };
 }

--- a/apps/backend/src/services/scoped-resource.ts
+++ b/apps/backend/src/services/scoped-resource.ts
@@ -99,6 +99,18 @@ export const isScopedResourceType = (
 ): value is ScopedResourceType =>
   value !== undefined && SCOPED_RESOURCE_TYPES.has(value);
 
+/** The Drizzle table backing a Scoped-resource type, for the generic Writes. */
+export const tableOf = (type: ScopedResourceType): ScopedTable =>
+  REGISTRY[type].table;
+
+/** The human title of a Scoped-resource type ("Agent", "Skill", "MCP", "Provider"). */
+export const labelOf = (type: ScopedResourceType): string =>
+  REGISTRY[type].label;
+
+/** The noun for mid-sentence messages ("agent", "skill", "mcp", "provider"). */
+export const nounOf = (type: ScopedResourceType): string =>
+  REGISTRY[type].noun;
+
 type Database = typeof db;
 
 /**


### PR DESCRIPTION
## Summary

Closes #604. Promote — the Org-Admin action that re-scopes a Workspace-private Scoped resource to Organization scope and auto-attaches its origin Workspace (ADR-0007) — previously lived inline in two route handlers in `routes/agent.ts` and `routes/skill.ts`, near-identical apart from the table, the noun, and the Agent's inline no-cascade blocker check. Copies #3/#4 are pending for MCP/Provider.

## Change

New `apps/backend/src/services/promote.ts` owns the mechanism for any `ScopedResourceType`:

- workspace-scoped pre-check (`NotFoundError` → 404)
- the Agent's no-cascade reference guard passed in as `guard` (not inlined)
- the re-scope + auto-attach transaction, with the lost-race → `NotFoundError` (no orphan Attachment) invariant living once, inside the module (throwing the typed error rolls back the auto-attach; unique violations surface untouched to the central `onError`, ADR-0010)

Both routes are now one-call adapters: no sentinel, no transaction body, no `Error.message` parsing. `promoteScoped` is overloaded so a guard-less leaf (Skill) call returns only the success shape — no dead 422 branch in the Skill adapter.

Reuses the existing scoped-resource authority: `workspaceScopedWhere` plus three small registry accessors (`tableOf`/`labelOf`/`nounOf`) added to `services/scoped-resource.ts`. No hand-rolled `eq(workspaceId)` lookups.

## Tests

- New `services/promote.test.ts` asserts the lost-race → `NotFoundError` + no-orphan-Attachment invariant **once**, through the module interface
- Slimmed the per-route race stubs out of `routes/agent.test.ts` and `routes/skill.test.ts` (wiring/status tests retained)
- `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass (backend 130 files / 2078 tests)

Mechanism-only refactor — no behaviour change, no docs intersection.