### PR TITLE
chore(backend): name the memory window and make pin reuse a type fact

### DIFF
--- a/apps/backend/src/routes/chat.test.ts
+++ b/apps/backend/src/routes/chat.test.ts
@@ -23,7 +23,7 @@ import { FileValidationError } from "../services/file-gate.ts";
 import {
   retrieveRecentSummaries,
   formatSummariesForSystemPrompt,
-  shouldRePinMemorySnapshot,
+  resolveMemoryPin,
   type MemorySummary,
 } from "../services/memory-retrieval.ts";
 
@@ -76,7 +76,7 @@ vi.mock("@ai-sdk/mcp", () => ({
 vi.mock("../services/memory-retrieval.ts", () => ({
   retrieveRecentSummaries: vi.fn().mockResolvedValue([]),
   formatSummariesForSystemPrompt: vi.fn().mockReturnValue(""),
-  shouldRePinMemorySnapshot: vi.fn().mockReturnValue(true),
+  resolveMemoryPin: vi.fn().mockReturnValue({ reuse: false }),
 }));
 
 describe("Chat Routes", () => {
@@ -390,7 +390,7 @@ describe("Chat Routes", () => {
       mockDb.limit.mockResolvedValueOnce([]); // ADR-0020 row lookup (no row → new chat)
       mockDb.returning.mockResolvedValueOnce([{ id: "chat-a" }]); // ChatSink.onStart
 
-      vi.mocked(shouldRePinMemorySnapshot).mockReturnValueOnce(true);
+      vi.mocked(resolveMemoryPin).mockReturnValueOnce({ reuse: false });
       vi.mocked(retrieveRecentSummaries).mockResolvedValueOnce([
         { id: "s1", summaryDate: "2026-04-29", summary: "Likes coffee." },
       ] as MemorySummary[]);
@@ -416,11 +416,11 @@ describe("Chat Routes", () => {
       };
       // The resolved block rides down through RunInput into prepareChatTurn.
       expect(inputArg.memorySnapshot).toBe("pinned-fresh");
-      // The two-day window is anchored to the re-take moment, not a clock read.
+      // The window is anchored to the re-take moment, not a clock read. Its
+      // span is not a call-site argument — the retrieval owns it.
       expect(retrieveRecentSummaries).toHaveBeenCalledWith(
         "user-1",
         "ws-1",
-        2,
         expect.any(Date),
       );
     });
@@ -442,7 +442,10 @@ describe("Chat Routes", () => {
       ]);
       mockDb.returning.mockResolvedValueOnce([{ id: "chat-b" }]); // ChatSink.onStart
 
-      vi.mocked(shouldRePinMemorySnapshot).mockReturnValueOnce(false);
+      vi.mocked(resolveMemoryPin).mockReturnValueOnce({
+        reuse: true,
+        block: "pinned-block",
+      });
 
       mockPrepareChatTurn.mockResolvedValueOnce(validTurn);
 

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -28,8 +28,8 @@ import type { RunInput } from "../runs/types.ts";
 import { actorUserId } from "../scope.ts";
 import {
   formatSummariesForSystemPrompt,
+  resolveMemoryPin,
   retrieveRecentSummaries,
-  shouldRePinMemorySnapshot,
 } from "../services/memory-retrieval.ts";
 
 /**
@@ -191,33 +191,28 @@ chat.post(
       .from(chatTable)
       .where(ownedWhere("chat", data.id, scope.workspaceId))
       .limit(1);
-    const existingSnapshot = existingChat[0]?.memorySnapshot ?? null;
-
     const now = new Date();
-    let memorySnapshot: string;
-    if (
-      shouldRePinMemorySnapshot({
-        existingSnapshot,
-        previousTurnAt: existingChat[0]?.lastTurnAt ?? null,
-        now,
-      })
-    ) {
-      // Re-take: a fresh Chat, a row written before this feature, or a Chat
-      // that has idled past the horizon (by which point the cached prefix is
-      // provably expired, so the re-take is free). The two-day retrieval window
-      // is anchored to `now`, not a render-time clock read.
-      const summaries = await retrieveRecentSummaries(
-        actorUserId(scope.principal),
-        scope.workspaceId,
-        2,
-        now,
-      );
-      memorySnapshot = formatSummariesForSystemPrompt(summaries);
-    } else {
-      // The Chat has not idled past the horizon — keep the existing pin so the
-      // prefix stays byte-identical across its turns.
-      memorySnapshot = existingSnapshot!;
-    }
+    const pin = resolveMemoryPin({
+      existingSnapshot: existingChat[0]?.memorySnapshot,
+      previousTurnAt: existingChat[0]?.lastTurnAt,
+      now,
+    });
+
+    // Reuse carries its own block, so there is no snapshot to assert about: the
+    // Chat has not idled past the horizon and the prefix stays byte-identical
+    // across its turns. Otherwise re-take — a fresh Chat, a row written before
+    // this feature, or a Chat that has idled past the horizon (by which point
+    // the cached prefix is provably expired, so the re-take is free). The
+    // retrieval window is anchored to `now`, not a render-time clock read.
+    const memorySnapshot = pin.reuse
+      ? pin.block
+      : formatSummariesForSystemPrompt(
+          await retrieveRecentSummaries(
+            actorUserId(scope.principal),
+            scope.workspaceId,
+            now,
+          ),
+        );
 
     const input: RunInput = {
       runId: data.id,

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -253,7 +253,7 @@ export type ChatTurnQueries = {
   ): Promise<{ global?: string; workspace?: string }>;
   /**
    * The recent daily memory summaries, anchored to `referenceDate` for the
-   * two-day window (ADR-0020) — the caller, never the renderer, bounds
+   * retrieval window (ADR-0020) — the caller, never the renderer, bounds
    * freshness.
    */
   getRecentMemories(
@@ -380,7 +380,7 @@ export const drizzleChatTurnQueries: ChatTurnQueries = {
   },
 
   async getRecentMemories(userId, workspaceId, referenceDate) {
-    return retrieveRecentSummaries(userId, workspaceId, 2, referenceDate);
+    return retrieveRecentSummaries(userId, workspaceId, referenceDate);
   },
 
   async getSandboxEnvKeys(workspaceId) {

--- a/apps/backend/src/services/memory-retrieval.test.ts
+++ b/apps/backend/src/services/memory-retrieval.test.ts
@@ -5,8 +5,9 @@ import {
   retrieveRecentSummaries,
   formatSummariesForSystemPrompt,
   summaryCutoffForReference,
-  shouldRePinMemorySnapshot,
+  resolveMemoryPin,
   MEMORY_SNAPSHOT_RE_PIN_HORIZON_MS,
+  MEMORY_SUMMARY_WINDOW_DAYS,
   type MemorySummary,
 } from "./memory-retrieval.ts";
 
@@ -36,26 +37,12 @@ describe("retrieveRecentSummaries", () => {
     const result = await retrieveRecentSummaries(
       "u1",
       "ws-1",
-      2,
       new Date("2026-05-03T12:00:00Z"),
     );
 
     expect(result).toBe(rows);
     expect(mockDb.select).toHaveBeenCalled();
     expect(mockDb.orderBy).toHaveBeenCalled();
-  });
-
-  it("uses a default cutoff of 2 days when not specified", async () => {
-    mockDb.orderBy.mockResolvedValueOnce([]);
-
-    await retrieveRecentSummaries(
-      "u1",
-      "ws-1",
-      2,
-      new Date("2026-05-03T12:00:00Z"),
-    );
-
-    expect(mockDb.where).toHaveBeenCalled();
   });
 });
 
@@ -73,29 +60,36 @@ describe("summaryCutoffForReference", () => {
     expect(summaryCutoffForReference(ref, 2)).toBe("2026-05-01");
     expect(summaryCutoffForReference(nextDay, 2)).toBe("2026-05-02");
   });
+
+  it("spans MEMORY_SUMMARY_WINDOW_DAYS back for the window the code actually ships", () => {
+    const ref = new Date("2026-05-03T12:00:00Z");
+    expect(summaryCutoffForReference(ref, MEMORY_SUMMARY_WINDOW_DAYS)).toBe(
+      "2026-05-01",
+    );
+  });
 });
 
-describe("shouldRePinMemorySnapshot", () => {
+describe("resolveMemoryPin", () => {
   const now = new Date("2026-05-03T12:00:00Z");
 
   it("re-pins when there is no existing snapshot (new Chat / pre-feature row)", () => {
     expect(
-      shouldRePinMemorySnapshot({
+      resolveMemoryPin({
         existingSnapshot: null,
         previousTurnAt: now,
         now,
       }),
-    ).toBe(true);
+    ).toEqual({ reuse: false });
   });
 
   it("re-pins when there is no recorded previous turn to measure idleness", () => {
     expect(
-      shouldRePinMemorySnapshot({
+      resolveMemoryPin({
         existingSnapshot: "block",
         previousTurnAt: null,
         now,
       }),
-    ).toBe(true);
+    ).toEqual({ reuse: false });
   });
 
   it("keeps the snapshot while the gap since the previous turn is within the horizon", () => {
@@ -103,23 +97,23 @@ describe("shouldRePinMemorySnapshot", () => {
       now.getTime() - MEMORY_SNAPSHOT_RE_PIN_HORIZON_MS + 1,
     );
     expect(
-      shouldRePinMemorySnapshot({
+      resolveMemoryPin({
         existingSnapshot: "block",
         previousTurnAt,
         now,
       }),
-    ).toBe(false);
+    ).toEqual({ reuse: true, block: "block" });
   });
 
   it("treats a pinned empty block as a valid pin, not an absent one", () => {
     const previousTurnAt = new Date(now.getTime() - 60 * 1000);
     expect(
-      shouldRePinMemorySnapshot({
+      resolveMemoryPin({
         existingSnapshot: "",
         previousTurnAt,
         now,
       }),
-    ).toBe(false);
+    ).toEqual({ reuse: true, block: "" });
   });
 
   it("keeps the snapshot at exactly the horizon boundary", () => {
@@ -127,12 +121,12 @@ describe("shouldRePinMemorySnapshot", () => {
       now.getTime() - MEMORY_SNAPSHOT_RE_PIN_HORIZON_MS,
     );
     expect(
-      shouldRePinMemorySnapshot({
+      resolveMemoryPin({
         existingSnapshot: "block",
         previousTurnAt,
         now,
       }),
-    ).toBe(false);
+    ).toEqual({ reuse: true, block: "block" });
   });
 
   it("re-pins once the idle gap exceeds the horizon — by which point the cached prefix is provably gone", () => {
@@ -140,24 +134,24 @@ describe("shouldRePinMemorySnapshot", () => {
       now.getTime() - MEMORY_SNAPSHOT_RE_PIN_HORIZON_MS - 1,
     );
     expect(
-      shouldRePinMemorySnapshot({
+      resolveMemoryPin({
         existingSnapshot: "block",
         previousTurnAt,
         now,
       }),
-    ).toBe(true);
+    ).toEqual({ reuse: false });
   });
 
   it("compares the idle gap, never the snapshot's own age", () => {
     // An eight-hour-old snapshot within an active Chat (short gaps) is kept.
     const previousTurnAt = new Date(now.getTime() - 60 * 1000);
     expect(
-      shouldRePinMemorySnapshot({
+      resolveMemoryPin({
         existingSnapshot: "block",
         previousTurnAt,
         now,
       }),
-    ).toBe(false);
+    ).toEqual({ reuse: true, block: "block" });
   });
 });
 

--- a/apps/backend/src/services/memory-retrieval.ts
+++ b/apps/backend/src/services/memory-retrieval.ts
@@ -5,6 +5,14 @@ import { memoryDailySummary as memoryDailySummaryTable } from "../db/schema.ts";
 export type MemorySummary = typeof memoryDailySummaryTable.$inferSelect;
 
 /**
+ * How many days of daily summaries the Memories fragment carries. A named
+ * concept rather than a literal at each call site: every caller wants the same
+ * window, and the one place it could differ — a caller passing its own `days` —
+ * would silently change what a Chat recalls.
+ */
+export const MEMORY_SUMMARY_WINDOW_DAYS = 2;
+
+/**
  * The `YYYY-MM-DD` cutoff a retrieval window starts at, anchored to
  * `referenceDate` and spanning `days` back. Extracted from the query so the
  * "window is an input, not a clock read" property (ADR-0020) is unit-testable:
@@ -12,7 +20,7 @@ export type MemorySummary = typeof memoryDailySummaryTable.$inferSelect;
  */
 export function summaryCutoffForReference(
   referenceDate: Date,
-  days: number = 2,
+  days: number,
 ): string {
   const cutoffDate = new Date(referenceDate);
   cutoffDate.setDate(cutoffDate.getDate() - days);
@@ -22,21 +30,25 @@ export function summaryCutoffForReference(
 /**
  * Retrieves the most recent daily summaries for a user in a workspace.
  *
- * The two-day retrieval window is anchored to the passed `referenceDate`, never
- * to a wall-clock read at render time (ADR-0020): a cutoff computed from the
- * clock made every Chat's prefix differ by the moment of composition and rolled
- * all of them over at midnight. The caller bounds its own freshness — the Chat
- * route passes the pin's re-take time, a headless run passes its resolution
- * time — and the renderer never reads the clock at all. `referenceDate` is
- * required so no caller silently inherits a hidden clock read.
+ * The window is {@link MEMORY_SUMMARY_WINDOW_DAYS} and is anchored to the passed
+ * `referenceDate`, never to a wall-clock read at render time (ADR-0020): a
+ * cutoff computed from the clock made every Chat's prefix differ by the moment
+ * of composition and rolled all of them over at midnight. The caller bounds its
+ * own freshness — the Chat route passes the pin's re-take time, a headless run
+ * passes its resolution time — and the renderer never reads the clock at all.
+ * `referenceDate` is required so no caller silently inherits a hidden clock
+ * read. The window itself is not a parameter: no caller varies it, and one that
+ * did would quietly change what a Chat recalls.
  */
 export async function retrieveRecentSummaries(
   userId: string,
   workspaceId: string,
-  days: number,
   referenceDate: Date,
 ): Promise<MemorySummary[]> {
-  const cutoffDateStr = summaryCutoffForReference(referenceDate, days);
+  const cutoffDateStr = summaryCutoffForReference(
+    referenceDate,
+    MEMORY_SUMMARY_WINDOW_DAYS,
+  );
 
   return db
     .select()
@@ -85,7 +97,17 @@ export function formatSummariesForSystemPrompt(
 export const MEMORY_SNAPSHOT_RE_PIN_HORIZON_MS = 60 * 60 * 1000;
 
 /**
- * Decides whether a Chat must re-take its pinned Memories block this turn.
+ * What a Chat turn does about its pinned Memories block. `reuse: true` carries
+ * the block to render, so a caller cannot reach for a snapshot the decision did
+ * not actually hand it: reuse and the reused text are one value, not a boolean
+ * plus a non-null assertion about a rule enforced in another module.
+ */
+export type MemoryPinDecision =
+  { reuse: false } | { reuse: true; block: string };
+
+/**
+ * Decides whether a Chat reuses its pinned Memories block this turn, and hands
+ * back the block when it does.
  *
  * Re-takes when there is no pin at all (`null`/`undefined` — a new Chat, or a
  * row written before this feature existed), when there is no recorded previous
@@ -98,15 +120,14 @@ export const MEMORY_SNAPSHOT_RE_PIN_HORIZON_MS = 60 * 60 * 1000;
  * memories still pins a stable (empty) prefix, so it must not re-retrieve every
  * turn. The absence signal is `null`/`undefined` only.
  */
-export function shouldRePinMemorySnapshot(args: {
+export function resolveMemoryPin(args: {
   existingSnapshot: string | null | undefined;
   previousTurnAt: Date | null | undefined;
   now: Date;
-}): boolean {
-  if (args.existingSnapshot == null) return true;
-  if (!args.previousTurnAt) return true;
-  return (
-    args.now.getTime() - args.previousTurnAt.getTime() >
-    MEMORY_SNAPSHOT_RE_PIN_HORIZON_MS
-  );
+}): MemoryPinDecision {
+  if (args.existingSnapshot == null) return { reuse: false };
+  if (!args.previousTurnAt) return { reuse: false };
+  const idleGapMs = args.now.getTime() - args.previousTurnAt.getTime();
+  if (idleGapMs > MEMORY_SNAPSHOT_RE_PIN_HORIZON_MS) return { reuse: false };
+  return { reuse: true, block: args.existingSnapshot };
 }


### PR DESCRIPTION
## What & why

Two review follow-ups from #658, both flagged during `/code-review` and deliberately left out of that PR. Neither changes behaviour.

## What changed

- **Name the retrieval window.** Both call sites spelled a bare `2`, while `summaryCutoffForReference` carried a `days = 2` default that no required-arg caller could reach. `MEMORY_SUMMARY_WINDOW_DAYS` names it once. `retrieveRecentSummaries` drops the parameter entirely rather than threading the constant through it: no caller varied the window, and one that did would quietly change what a Chat recalls.
- **Make pin reuse a type fact.** `shouldRePinMemorySnapshot` returned a boolean, which left the Chat route writing `memorySnapshot = existingSnapshot!` — sound only because of an invariant (`existingSnapshot == null` → re-pin) enforced in a different module and explained in a comment. It becomes `resolveMemoryPin`, returning a discriminated `MemoryPinDecision`:

  ```ts
  type MemoryPinDecision = { reuse: false } | { reuse: true; block: string }
  ```

  Reuse and the reused text are now one value, so the caller cannot reach for a snapshot the decision did not hand it. The `!` is gone.

## Tests

The pin-decision tests keep their coverage — no-pin, no-previous-turn, within-horizon, exact boundary, past-horizon, empty-string-is-a-pin, and idle-gap-not-snapshot-age — and now assert the returned block, not just a boolean.

One test was dropped: `"uses a default cutoff of 2 days when not specified"` passed `2` explicitly, so its name described a default it wasn't exercising, and its body duplicated the test above it. The window's span is now pinned against `MEMORY_SUMMARY_WINDOW_DAYS` in the `summaryCutoffForReference` block instead, which is the behaviour actually worth guarding.

## Verification

- `pnpm typecheck` — clean (all 7 packages)
- `pnpm lint` — clean
- `pnpm test` — backend 2115, frontend 504, schemas 142, docs 40, sdk 13, toolset 5, all pass
