### PR TITLE
chore(docs): fix drift found in administering and reference audits

### DIFF
--- a/apps/docs/content/administering/shared-resources.mdx
+++ b/apps/docs/content/administering/shared-resources.mdx
@@ -104,8 +104,11 @@ default Context.
 ### Apply it
 
 From the Blueprints list, open a Blueprint's menu and choose **Apply to
-workspace**. Applying is additive — it attaches what's missing and leaves the rest
-alone, so running it twice is safe.
+workspace**. The Shared resources it attaches are additive — it attaches
+whatever's missing and leaves existing attachments alone. The task and memory
+Provider defaults and the default Context are not: applying always overwrites
+those on the target Workspace, even if the Owner has since set their own.
+Reapply only when you intend to reset those too.
 
 ### Or apply it automatically
 

--- a/apps/docs/content/administering/workspaces.mdx
+++ b/apps/docs/content/administering/workspaces.mdx
@@ -102,9 +102,10 @@ say.
 
 ## Deleting a Workspace
 
-**Delete** asks you to type `Delete workspace` to confirm, and takes everything in
-it: Chats, Agents, Skills, Boards, Dashboards, its Sandbox. It is not recoverable
-from inside the product — only from a database backup.
+**Delete** asks you to type `Delete workspace` to confirm, and takes everything
+scoped to the Workspace — Chats, Agents, Skills, MCP servers, Triggers,
+Webhooks, memory, Boards, Dashboards, its Sandbox. It is not recoverable from
+inside the product — only from a database backup.
 
 ## Where to next
 

--- a/apps/docs/content/reference/backend-configuration.mdx
+++ b/apps/docs/content/reference/backend-configuration.mdx
@@ -30,12 +30,13 @@ For a guided walkthrough of configuring a deployment, see
 | `NODE_OPTIONS`    | Node runtime flags. Ships set to silence the experimental-feature warning.                                                                                                                                                                 | `--disable-warning=ExperimentalWarning`                  | No       |
 
 <Callout type="warning">
-  `TIMEZONE` is read in exactly one place: the `getCurrentTime` and
-  `convertTimezone` tools. It does **not** set the zone a Trigger's cron
-  schedule is evaluated in — each Trigger carries its own **Timezone** field,
-  set in the Trigger form and defaulting to the browser's zone — and it does not
-  affect log timestamps. Setting `TIMEZONE` and expecting a 9am Trigger to fire
-  at 9am local is the trap; set the zone on the Trigger.
+  `TIMEZONE` is read in exactly one place: the `getCurrentTime` tool.
+  `convertTimezone` takes explicit `fromTimezone`/`toTimezone` parameters and
+  never reads this variable. `TIMEZONE` also does **not** set the zone a
+  Trigger's cron schedule is evaluated in — each Trigger carries its own
+  **Timezone** field, set in the Trigger form and defaulting to the browser's
+  zone — and it does not affect log timestamps. Setting `TIMEZONE` and expecting
+  a 9am Trigger to fire at 9am local is the trap; set the zone on the Trigger.
 </Callout>
 
 ## Plugins
@@ -55,11 +56,19 @@ The manifest side is in
 
 ## Authentication
 
-| Variable                 | Purpose                                                                                                                  | Default                                                    | Required |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- | -------- |
-| `BETTER_AUTH_SECRET`     | Secret used to sign session tokens (better-auth). Must be a secure random string, 32+ characters. Treat like a password. | `your-secret-key-min-32-chars` _(placeholder — change it)_ | **Yes**  |
-| `BETTER_AUTH_URL`        | Public base URL of the backend, used by better-auth.                                                                     | `http://localhost:4001`                                    | **Yes**  |
-| `INVITATION_EXPIRY_DAYS` | Days a Workspace/Org invitation remains valid.                                                                           | `7`                                                        | No       |
+| Variable                 | Purpose                                                                                                                                                                                                                 | Default                                                    | Required |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | -------- |
+| `BETTER_AUTH_SECRET`     | Secret used to sign session tokens (better-auth). Must be a secure random string, 32+ characters. Treat like a password.                                                                                                | `your-secret-key-min-32-chars` _(placeholder — change it)_ | **Yes**  |
+| `BETTER_AUTH_URL`        | Public base URL of the backend, used by better-auth. Falls back to `http://localhost:4001`, which only works for local dev — a real deployment must set this explicitly or auth redirects and callbacks break silently. | `http://localhost:4001`                                    | No       |
+| `INVITATION_EXPIRY_DAYS` | Days a Workspace/Org invitation remains valid.                                                                                                                                                                          | `7`                                                        | No       |
+
+<Callout type="warning">
+  `BETTER_AUTH_SECRET`'s 32+ character requirement is enforced only when
+  `NODE_ENV=production` — the published Docker image sets this, but running from
+  source without it gets no hard failure at all: an unset or weak secret
+  silently falls back to a well-known default and only logs a warning. Don't
+  rely on the runtime to catch a missing secret outside the published image.
+</Callout>
 
 ## Default admin
 
@@ -113,10 +122,10 @@ tool call never trips it; only a provider that stops responding does. Raise the
 wall-clock timeout if your Agents run long multi-step turns that people wait
 through.
 
-| Variable                   | Purpose                                                                                                 | Default                | Required |
-| -------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------- | -------- |
+| Variable                   | Purpose                                                                                                  | Default                | Required |
+| -------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------- | -------- |
 | `CHAT_PER_STEP_TIMEOUT_MS` | Idle timeout for a Chat turn; the run is stopped after this long with no streamed output from the model. | `120000` (2 minutes)   | No       |
-| `CHAT_PER_RUN_TIMEOUT_MS`  | Wall-clock timeout for an entire Chat turn.                                                             | `1800000` (30 minutes) | No       |
+| `CHAT_PER_RUN_TIMEOUT_MS`  | Wall-clock timeout for an entire Chat turn.                                                              | `1800000` (30 minutes) | No       |
 
 When either bound stops a turn, the reason is shown in the chat rather than the
 answer simply ending.


### PR DESCRIPTION
## Summary
- Fixes docs drift found while auditing `apps/docs/content/administering/` and `apps/docs/content/reference/` (see `/docs-audit`).
- `shared-resources.mdx`: Blueprint "Apply to workspace" is additive for attachments only — reapplying overwrites the target Workspace's task/memory Provider defaults and Context, contradicting the doc's "running it twice is safe" claim.
- `workspaces.mdx`: the "Delete workspace" entity list omitted MCP servers, Triggers, Webhooks, and memory, all of which actually cascade-delete.
- `backend-configuration.mdx`: the `TIMEZONE` callout wrongly credited `convertTimezone` with reading the env var (only `getCurrentTime` does); `BETTER_AUTH_URL`'s Required flag didn't match its code-level fallback; `BETTER_AUTH_SECRET`'s 32+ character requirement is only enforced when `NODE_ENV=production`, which wasn't documented.

Also filed #661 separately for a real product bug found during the same audit (workspace-scoped Providers are orphaned rather than deleted on workspace delete) — not part of this PR.

## Test plan
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @platypus/docs test` (docs-contract.test.ts, 40/40)