### PR TITLE
One web tool presentation: native search, Web-search backend, and page reads

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,6 +100,10 @@ A named bundle of Tools an Agent can be granted. Either contributed by a Plugin 
 One Agent's Tool sets, resolved for one Chat turn, together with the connections opened to serve them. Sessions nest: a Sub-Agent's session is opened on its first delegation and closes with the parent's, so a turn has exactly one thing to dispose however many tool sources it reached. A Tool set or Web-search backend that opens something with a lifetime registers its own close into that same one thing. A Tool set that cannot serve the turn — a factory that throws, an unreachable MCP — costs its own Tools and no more.
 _Avoid_: tool context (that is the scope handed to a Tool set factory), tool loader.
 
+**Web tool block**:
+The one presentation a reader sees for a native Provider search, a Web-search backend's `web_search` or `read_url`, and `@platypus/web-fetch`'s `fetchUrl` alike — a reader cannot tell which of them ran. Backed by a normalized result the backend computes once, server-side, discriminated by `kind: "search" | "page" | "find"` rather than by which tool produced it; the frontend renders only that shape and carries no vendor knowledge of its own. A tool the backend does not recognise as one of these — an MCP server's own `web_search`, a native search whose vendor payload it cannot read — keeps the generic Tool renderer, on the same "never guess a tool's identity from its payload" rule the block itself is built on.
+_Avoid_: web search card, search result block (both name only the search case; the block also covers a page read).
+
 **MCP**:
 A Model Context Protocol server registered at Workspace scope, or — as a Shared resource — at Organization scope. Resolves to a Tool set at Chat-turn time.
 

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -24,6 +24,7 @@ import { rewriteStorageUrls, deleteFiles } from "../storage/utils.ts";
 import { getOrigin } from "../utils/get-origin.ts";
 import { agentRunner } from "../runs/agent-runner.ts";
 import { ChatSink } from "../runs/sinks/chat-sink.ts";
+import { normalizeWebToolParts } from "../runs/web-tool-normalize.ts";
 import type { RunInput } from "../runs/types.ts";
 import { actorUserId } from "../scope.ts";
 import {
@@ -155,6 +156,14 @@ chat.get(
       chatResponse.messages = rewriteStorageUrls(
         chatResponse.messages as PlatypusUIMessage[],
         origin,
+      );
+      // A view over stored data, same as the URL rewrite above: the
+      // Transcript's appearance must not depend on which week it was sent
+      // (issue #525), and this is the read-path counterpart to the live
+      // stream's normalization in `runs/drive.ts` — no migration, no change
+      // to the stored part.
+      chatResponse.messages = normalizeWebToolParts(
+        chatResponse.messages as PlatypusUIMessage[],
       );
     }
 

--- a/apps/backend/src/runs/drive.ts
+++ b/apps/backend/src/runs/drive.ts
@@ -26,6 +26,7 @@ import {
 } from "./stream-error.ts";
 import { applyToolDurations } from "./tool-durations.ts";
 import type { RunStats, RunStatus } from "./types.ts";
+import { normalizeWebToolParts } from "./web-tool-normalize.ts";
 
 /**
  * The model call inside a registered run.
@@ -325,11 +326,14 @@ const runStreamedDrive = (
     onError: (error) => formatStreamError(error),
     onFinish: ({ messages: finalMessages }) => {
       finalHandedOver = true;
-      // The terminal finish, stamped with the locally-measured tool durations.
-      handoverMessages =
+      // The terminal finish, stamped with the locally-measured tool durations
+      // and the normalized web-tool view (issue #525) — same order both apply
+      // in the read path (`routes/chat.ts`), for one composed shape either way.
+      const withDurations =
         toolDurations && toolDurations.size > 0
           ? applyToolDurations(finalMessages, toolDurations)
           : finalMessages;
+      handoverMessages = normalizeWebToolParts(withDurations);
       onFinal?.(handoverMessages);
     },
   });
@@ -344,11 +348,15 @@ const runStreamedDrive = (
           failure ??= describeSdkError(error);
         },
       })) {
-        latest = message;
+        // Normalized live, not only on the folded final: a search must render
+        // identically while streaming and after a reload (issue #525), and the
+        // final's own normalization run happens separately, in `onFinish` above.
+        const normalized = normalizeWebToolParts([message])[0];
+        latest = normalized;
         // Drain past the handover but don't yield: a snapshot after the folded
         // final is no better than what it would overwrite (no durations).
         if (behavior.stopSnapshotsAfterFinal && finalHandedOver) continue;
-        yield message;
+        yield normalized;
       }
     } catch (error) {
       logger.error(

--- a/apps/backend/src/runs/web-tool-normalize.test.ts
+++ b/apps/backend/src/runs/web-tool-normalize.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect } from "vitest";
+import {
+  WEB_BACKEND_TOOL_MARKER,
+  WEB_TOOL_NORMALIZED_KEY,
+} from "@platypus/schemas";
+import {
+  normalizeWebToolPart,
+  normalizeWebToolParts,
+} from "./web-tool-normalize.ts";
+import type { PlatypusUIMessage } from "../types.ts";
+
+const assistant = (parts: unknown[]): PlatypusUIMessage =>
+  ({ id: "msg-1", role: "assistant", parts }) as PlatypusUIMessage;
+
+const part = (extra: Record<string, unknown>) => ({
+  type: "tool-web_search",
+  toolCallId: "call-1",
+  state: "output-available",
+  input: { query: "weather" },
+  output: {} as unknown,
+  ...extra,
+});
+
+const metadataOf = (message: PlatypusUIMessage, index: number) =>
+  (message.parts[index] as { toolMetadata?: Record<string, unknown> })
+    .toolMetadata;
+
+const normalizedOf = (message: PlatypusUIMessage, index: number) =>
+  metadataOf(message, index)?.[WEB_TOOL_NORMALIZED_KEY];
+
+describe("normalizeWebToolPart", () => {
+  describe("ownership", () => {
+    it("returns null for an MCP web_search with no marker and no providerExecuted", () => {
+      expect(
+        normalizeWebToolPart(
+          part({
+            output: { results: [{ url: "https://x.test", title: "X" }] },
+          }),
+        ),
+      ).toBeNull();
+    });
+
+    it("returns null for a native OpenRouter search, which never sets providerExecuted", () => {
+      expect(
+        normalizeWebToolPart(part({ providerExecuted: undefined, output: {} })),
+      ).toBeNull();
+    });
+
+    it("treats providerExecuted as decisive only for a known native tool name", () => {
+      expect(
+        normalizeWebToolPart({
+          ...part({ providerExecuted: true }),
+          type: "tool-someOtherTool",
+        }),
+      ).toBeNull();
+    });
+
+    it("prefers the core marker over providerExecuted when both are somehow set", () => {
+      const result = normalizeWebToolPart(
+        part({
+          providerExecuted: true,
+          toolMetadata: { [WEB_BACKEND_TOOL_MARKER]: true },
+          output: { query: "weather", results: [] },
+        }),
+      );
+      expect(result).toEqual({ kind: "search", query: "weather", results: [] });
+    });
+  });
+
+  describe("native Anthropic search", () => {
+    const anthropicPart = (output: unknown) =>
+      part({ providerExecuted: true, output });
+
+    it("reads only a count from the raw web_search_result array", () => {
+      const result = normalizeWebToolPart(
+        anthropicPart([
+          {
+            type: "web_search_result",
+            url: "https://a.test",
+            title: "A",
+            pageAge: "2024",
+            encryptedContent: "super-secret-blob",
+          },
+          {
+            type: "web_search_result",
+            url: "https://b.test",
+            title: "B",
+            encryptedContent: "another-secret-blob",
+          },
+        ]),
+      );
+      expect(result).toEqual({
+        kind: "search",
+        query: "weather",
+        resultCount: 2,
+      });
+      expect(JSON.stringify(result)).not.toContain("secret-blob");
+    });
+
+    it("counts zero results without error", () => {
+      expect(normalizeWebToolPart(anthropicPart([]))).toEqual({
+        kind: "search",
+        query: "weather",
+        resultCount: 0,
+      });
+    });
+  });
+
+  describe("native OpenAI hosted web tool", () => {
+    const openAiPart = (output: unknown, input: unknown = {}) =>
+      part({ providerExecuted: true, input, output });
+
+    it("reads a search action's query and, when present, a source count", () => {
+      const result = normalizeWebToolPart(
+        openAiPart({
+          action: { type: "search", query: "weather in paris" },
+          sources: [{ type: "url", url: "https://a.test" }],
+        }),
+      );
+      expect(result).toEqual({
+        kind: "search",
+        query: "weather in paris",
+        resultCount: 1,
+      });
+    });
+
+    it("falls back to the first of multiple queries", () => {
+      const result = normalizeWebToolPart(
+        openAiPart({ action: { type: "search", queries: ["a", "b"] } }),
+      );
+      expect(result).toEqual({
+        kind: "search",
+        query: "a",
+        resultCount: undefined,
+      });
+    });
+
+    it("omits the count when sources is absent, rather than reporting zero", () => {
+      const result = normalizeWebToolPart(
+        openAiPart({ action: { type: "search", query: "q" } }),
+      );
+      expect(result).toEqual({
+        kind: "search",
+        query: "q",
+        resultCount: undefined,
+      });
+      expect(
+        result && "resultCount" in result && result.resultCount,
+      ).toBeUndefined();
+    });
+
+    // camelCase, per @ai-sdk/openai@4.0.27's webSearchToolFactory output type —
+    // unlike the tool's own snake_case name and its sibling read_url.
+    it("normalizes an openPage action to kind page", () => {
+      const result = normalizeWebToolPart(
+        openAiPart({
+          action: { type: "openPage", url: "https://a.test/page" },
+        }),
+      );
+      expect(result).toEqual({ kind: "page", url: "https://a.test/page" });
+    });
+
+    it("normalizes a findInPage action to kind find", () => {
+      const result = normalizeWebToolPart(
+        openAiPart({
+          action: {
+            type: "findInPage",
+            url: "https://a.test/page",
+            pattern: "opening hours",
+          },
+        }),
+      );
+      expect(result).toEqual({
+        kind: "find",
+        url: "https://a.test/page",
+        pattern: "opening hours",
+      });
+    });
+
+    it("treats an unrecognised action.type as a search, the vendor's minimal case", () => {
+      const result = normalizeWebToolPart(
+        openAiPart({ action: { type: "something_new", query: "q" } }),
+      );
+      expect(result).toEqual({
+        kind: "search",
+        query: "q",
+        resultCount: undefined,
+      });
+    });
+  });
+
+  describe("unreadable native output", () => {
+    it("returns null for a shape it does not recognise (e.g. OpenRouter's unknown output)", () => {
+      expect(
+        normalizeWebToolPart(
+          part({ providerExecuted: true, output: { somethingElse: true } }),
+        ),
+      ).toBeNull();
+    });
+  });
+
+  describe("Web-search backend search (core marker)", () => {
+    const backendPart = (extra: Record<string, unknown>) =>
+      part({ toolMetadata: { [WEB_BACKEND_TOOL_MARKER]: true }, ...extra });
+
+    it("passes through query, results and answer unchanged", () => {
+      const result = normalizeWebToolPart(
+        backendPart({
+          output: {
+            query: "weather",
+            results: [{ title: "A", url: "https://a.test", snippet: "s" }],
+            answer: "It is sunny.",
+          },
+        }),
+      );
+      expect(result).toEqual({
+        kind: "search",
+        query: "weather",
+        results: [{ title: "A", url: "https://a.test", snippet: "s" }],
+        answer: "It is sunny.",
+      });
+    });
+
+    it("surfaces the backend's own { error } contract", () => {
+      const result = normalizeWebToolPart(
+        backendPart({ output: { error: "The web backend timed out." } }),
+      );
+      expect(result).toEqual({
+        kind: "search",
+        query: "weather",
+        error: "The web backend timed out.",
+      });
+    });
+  });
+
+  describe("Web-search backend read_url and web-fetch fetchUrl (core marker)", () => {
+    const pagePart = (toolName: string, extra: Record<string, unknown>) =>
+      part({
+        type: `tool-${toolName}`,
+        input: { url: "https://a.test" },
+        toolMetadata: { [WEB_BACKEND_TOOL_MARKER]: true },
+        ...extra,
+      });
+
+    it("normalizes read_url to kind page without echoing content", () => {
+      const result = normalizeWebToolPart(
+        pagePart("read_url", {
+          output: {
+            content: "a".repeat(500),
+            url: "https://a.test/resolved",
+            content_type: "text/html",
+            truncated: false,
+          },
+        }),
+      );
+      expect(result).toEqual({
+        kind: "page",
+        url: "https://a.test/resolved",
+        contentType: "text/html",
+        contentLength: 500,
+        truncated: false,
+      });
+    });
+
+    it("normalizes fetchUrl identically to read_url", () => {
+      const result = normalizeWebToolPart(
+        pagePart("fetchUrl", {
+          output: {
+            content: "hello",
+            url: "https://a.test",
+            content_type: "text/markdown",
+            truncated: true,
+          },
+        }),
+      );
+      expect(result).toEqual({
+        kind: "page",
+        url: "https://a.test",
+        contentType: "text/markdown",
+        contentLength: 5,
+        truncated: true,
+      });
+    });
+
+    it("surfaces a page tool's { error } contract with the requested url", () => {
+      const result = normalizeWebToolPart(
+        pagePart("read_url", {
+          output: { error: "Blocked by network policy." },
+        }),
+      );
+      expect(result).toEqual({
+        kind: "page",
+        url: "https://a.test",
+        error: "Blocked by network policy.",
+      });
+    });
+  });
+
+  describe("in-flight and rejected calls", () => {
+    it("reports a best-effort kind while a native search is still streaming", () => {
+      expect(
+        normalizeWebToolPart(
+          part({ providerExecuted: true, state: "input-streaming" }),
+        ),
+      ).toEqual({ kind: "search" });
+    });
+
+    it("reports kind page while a marked read_url is still streaming", () => {
+      expect(
+        normalizeWebToolPart(
+          part({
+            type: "tool-read_url",
+            toolMetadata: { [WEB_BACKEND_TOOL_MARKER]: true },
+            state: "input-available",
+          }),
+        ),
+      ).toEqual({ kind: "page" });
+    });
+
+    it("reads a native call's SDK-level errorText", () => {
+      expect(
+        normalizeWebToolPart(
+          part({
+            providerExecuted: true,
+            state: "output-error",
+            errorText: "The provider call failed.",
+          }),
+        ),
+      ).toEqual({ kind: "search", error: "The provider call failed." });
+    });
+  });
+});
+
+describe("normalizeWebToolParts", () => {
+  it("attaches the normalized result under WEB_TOOL_NORMALIZED_KEY, merging existing metadata", () => {
+    const messages = [
+      assistant([
+        part({
+          providerExecuted: true,
+          output: [
+            { url: "https://a.test", title: "A", encryptedContent: "x" },
+          ],
+          toolMetadata: { durationMs: 12 },
+        }),
+      ]),
+    ];
+
+    const patched = normalizeWebToolParts(messages);
+
+    expect(metadataOf(patched[0], 0)).toEqual({
+      durationMs: 12,
+      [WEB_TOOL_NORMALIZED_KEY]: {
+        kind: "search",
+        query: "weather",
+        resultCount: 1,
+      },
+    });
+  });
+
+  it("leaves an unrecognised web_search part, and its message, untouched", () => {
+    const messages = [
+      assistant([part({ output: { results: [] } })]),
+      assistant([{ type: "text", text: "hi" }]),
+    ];
+
+    const patched = normalizeWebToolParts(messages);
+
+    expect(patched[0]).toBe(messages[0]);
+    expect(patched[1]).toBe(messages[1]);
+    expect(normalizedOf(patched[0], 0)).toBeUndefined();
+  });
+
+  it("does not mutate the input messages", () => {
+    const rawPart = part({
+      toolMetadata: { [WEB_BACKEND_TOOL_MARKER]: true },
+      output: { query: "weather", results: [] },
+    });
+    const messages = [assistant([rawPart])];
+
+    normalizeWebToolParts(messages);
+
+    expect((rawPart as { toolMetadata?: unknown }).toolMetadata).toEqual({
+      [WEB_BACKEND_TOOL_MARKER]: true,
+    });
+  });
+});

--- a/apps/backend/src/runs/web-tool-normalize.ts
+++ b/apps/backend/src/runs/web-tool-normalize.ts
@@ -1,0 +1,242 @@
+import { isToolUIPart } from "ai";
+import {
+  WEB_BACKEND_TOOL_MARKER,
+  WEB_TOOL_KNOWN_NATIVE_SEARCH_NAMES,
+  WEB_TOOL_NORMALIZED_KEY,
+  type NormalizedWebToolResult,
+} from "@platypus/schemas";
+import type { PlatypusUIMessage } from "../types.ts";
+
+// Everything read here is `unknown` on purpose: a native payload is vendor
+// JSON the AI SDK hands through untouched, and a backend/plugin payload is
+// core's own shape but reached the same way `composeWebBackend` reaches a
+// plugin's — narrowed field by field, never trusted structurally.
+const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : {};
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+const isPageToolName = (toolName: string): boolean =>
+  toolName === "read_url" || toolName === "fetchUrl";
+
+/**
+ * Anthropic's `webSearch_20250305` output: `Array<web_search_result>`, each
+ * entry carrying `url`, `title`, `pageAge` and a large `encryptedContent`
+ * field core must never surface. Only the count is read — the array is never
+ * echoed, which is what stops `encryptedContent` reaching the Transcript.
+ */
+const normalizeAnthropicSearch = (
+  query: string | undefined,
+  results: readonly unknown[],
+): NormalizedWebToolResult => ({
+  kind: "search",
+  query,
+  resultCount: results.length,
+});
+
+/**
+ * OpenAI's hosted web tool: `{ action, sources? }`, one tool name covering a
+ * search, an opened page, and an in-page find. `action.type` is the only thing
+ * that says which occurred; a missing `action` (or an unrecognised `type`) is
+ * read as a search, the vendor's own minimal case.
+ *
+ * `action.type` is `"search" | "openPage" | "findInPage"` — camelCase, per
+ * `@ai-sdk/openai@4.0.27`'s `webSearchToolFactory` output type — unlike the
+ * tool's own snake_case name (`web_search`) and its sibling `read_url`.
+ *
+ * `sources` is an **optional** array of `{type:"url",url}` / `{type:"api",name}`
+ * entries — present only when the vendor chooses to report it, which is why a
+ * count is omitted rather than shown as zero when it is absent.
+ */
+const normalizeOpenAiOutput = (
+  output: Record<string, unknown>,
+): NormalizedWebToolResult => {
+  const action = asRecord(output.action);
+  const type = asString(action.type);
+
+  if (type === "openPage") {
+    return { kind: "page", url: asString(action.url) };
+  }
+  if (type === "findInPage") {
+    return {
+      kind: "find",
+      url: asString(action.url),
+      pattern: asString(action.pattern),
+    };
+  }
+
+  const queries = action.queries;
+  const query =
+    asString(action.query) ??
+    (Array.isArray(queries) ? asString(queries[0]) : undefined);
+  return {
+    kind: "search",
+    query,
+    resultCount: Array.isArray(output.sources)
+      ? output.sources.length
+      : undefined,
+  };
+};
+
+/**
+ * A native call's finished output, read per-vendor rather than by shape guess
+ * on *what tool it is* — ownership was already decided by `providerExecuted`
+ * before this runs (issue #525). This only decides how to read a confirmed
+ * native payload, which is unavoidably vendor-shaped: Anthropic returns an
+ * array, OpenAI an `{action,...}` object.
+ *
+ * A shape this doesn't recognise (OpenRouter's native `webSearch` declares no
+ * output type at all) returns `null` and falls to the generic renderer,
+ * unreadable exactly as it was before this issue.
+ */
+const normalizeNativeOutput = (
+  input: unknown,
+  output: unknown,
+): NormalizedWebToolResult | null => {
+  if (Array.isArray(output)) {
+    return normalizeAnthropicSearch(asString(asRecord(input).query), output);
+  }
+  const record = asRecord(output);
+  if ("action" in record || "sources" in record) {
+    return normalizeOpenAiOutput(record);
+  }
+  return null;
+};
+
+/**
+ * A core-built tool's finished output — a Web-search backend's `web_search` /
+ * `read_url` (ADR-0014), or the web-fetch Tool set's `fetchUrl`. All three
+ * already return core's own fixed shape, so this only relabels it, and an
+ * executor failure (`{ error }`, part of the tool's success contract, not an
+ * SDK rejection) is read the same way as a result.
+ */
+const normalizeBackendOutput = (
+  toolName: string,
+  input: unknown,
+  output: unknown,
+): NormalizedWebToolResult => {
+  const record = asRecord(output);
+  const isPageTool = isPageToolName(toolName);
+  const error = asString(record.error);
+  if (error !== undefined) {
+    return isPageTool
+      ? { kind: "page", url: asString(asRecord(input).url), error }
+      : { kind: "search", query: asString(asRecord(input).query), error };
+  }
+  if (isPageTool) {
+    return {
+      kind: "page",
+      url: asString(record.url),
+      contentType: asString(record.content_type),
+      contentLength:
+        typeof record.content === "string" ? record.content.length : undefined,
+      truncated:
+        typeof record.truncated === "boolean" ? record.truncated : undefined,
+    };
+  }
+  return {
+    kind: "search",
+    query: asString(record.query),
+    results: Array.isArray(record.results)
+      ? (record.results as Array<{
+          title: string;
+          url: string;
+          snippet?: string;
+        }>)
+      : undefined,
+    answer: asString(record.answer),
+  };
+};
+
+/**
+ * Decide, then read — the two questions issue #525 keeps separate.
+ *
+ * Ownership is decided first, exactly as `isPluginWebSearchPart` used to on
+ * the frontend, and by the same two positive signals: core's own marker, or a
+ * Provider's `providerExecuted` flag on a known native search tool name.
+ * Neither is inferred from the payload. Everything else — an MCP `web_search`,
+ * a native OpenRouter search, an unmarked backend result from before the
+ * marker shipped — returns `null` and keeps the generic renderer, which is
+ * where it belongs.
+ *
+ * Once ownership is settled, reading the payload is what is genuinely
+ * per-vendor: `normalizeNativeOutput` and `normalizeBackendOutput` never
+ * change *what* is rendered, only *how the shape is interpreted*.
+ */
+export const normalizeWebToolPart = (part: {
+  type: string;
+  state?: string;
+  input?: unknown;
+  output?: unknown;
+  errorText?: string;
+  toolMetadata?: Record<string, unknown>;
+  providerExecuted?: boolean;
+}): NormalizedWebToolResult | null => {
+  if (!part.type.startsWith("tool-")) return null;
+  const toolName = part.type.slice("tool-".length);
+
+  const isBackendOwned = part.toolMetadata?.[WEB_BACKEND_TOOL_MARKER] === true;
+  const isNativeSearch =
+    !isBackendOwned &&
+    part.providerExecuted === true &&
+    WEB_TOOL_KNOWN_NATIVE_SEARCH_NAMES.has(toolName);
+
+  if (!isBackendOwned && !isNativeSearch) return null;
+
+  const isPageTool = isPageToolName(toolName);
+
+  // An SDK-level tool error (`errorText`) rather than the `{ error }` success
+  // contract a core-built tool uses — a native call is the only kind that can
+  // reach this branch, since core's own tools never reject.
+  if (part.errorText) {
+    return isPageTool
+      ? { kind: "page", error: part.errorText }
+      : { kind: "search", error: part.errorText };
+  }
+
+  if (part.state !== "output-available") {
+    // In flight: nothing to read yet. `kind` is a best-effort placeholder so
+    // the card can show the right title as soon as it has one; OpenAI's
+    // search/page/find distinction cannot be known before the output arrives,
+    // the same way it never could be from the input alone.
+    return isPageTool ? { kind: "page" } : { kind: "search" };
+  }
+
+  return isBackendOwned
+    ? normalizeBackendOutput(toolName, part.input, part.output)
+    : normalizeNativeOutput(part.input, part.output);
+};
+
+const normalizeMessage = (message: PlatypusUIMessage): PlatypusUIMessage => {
+  let patched = false;
+  const parts = message.parts.map((part) => {
+    if (!isToolUIPart(part)) return part;
+    const normalized = normalizeWebToolPart(part);
+    if (!normalized) return part;
+    patched = true;
+    return {
+      ...part,
+      toolMetadata: {
+        ...part.toolMetadata,
+        [WEB_TOOL_NORMALIZED_KEY]: normalized,
+      },
+    };
+  });
+  return patched ? { ...message, parts } : message;
+};
+
+/**
+ * Attach the normalized web-tool view to every recognised part across a set of
+ * messages, without touching anything else. Called from both the live stream
+ * relay (`drive.ts`) and the saved-Transcript read path (`routes/chat.ts`),
+ * beside `rewriteStorageUrls` — a view computed at read/serve time, never
+ * written back to storage, so the vendor payload the part actually carries
+ * stays exactly what was stored (issue #525's retroactivity requirement: a
+ * Chat saved before this shipped renders on the block with no migration).
+ */
+export const normalizeWebToolParts = (
+  messages: PlatypusUIMessage[],
+): PlatypusUIMessage[] => messages.map(normalizeMessage);

--- a/apps/backend/src/tools/fetch.ts
+++ b/apps/backend/src/tools/fetch.ts
@@ -4,6 +4,7 @@ import { JSDOM } from "jsdom";
 import { Readability } from "@mozilla/readability";
 import TurndownService from "turndown";
 import robotsParser from "robots-parser";
+import { WEB_BACKEND_TOOL_MARKER } from "@platypus/schemas";
 import { logger } from "../logger.ts";
 import { checkEgress, EGRESS_BLOCKED_MESSAGE } from "../utils/egress-guard.ts";
 
@@ -52,6 +53,10 @@ export const createWebFetchTools = (ignoreRobotsTxt: boolean) => ({
   fetchUrl: tool({
     description:
       "Fetch content from a URL on the web. HTML is converted to Markdown to reduce token usage. Supports pagination for large pages.",
+    // Stamped so the Web tool block recognises this as a core-built page read
+    // (issue #525) — the same marker `composeWebBackend` stamps on `read_url`,
+    // reused rather than mirrored for `WEB_BACKEND_TOOL_MARKER`'s own reason.
+    metadata: { [WEB_BACKEND_TOOL_MARKER]: true },
     inputSchema: z.object({
       url: z.string().url().describe("URL to fetch"),
       max_length: z

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -68,6 +68,13 @@ Where the Provider uses a backend rather than the vendor's own search, turning
 **Search** on may also hand the model a page reader for that turn — see [what a
 backend grants](/concepts/providers#web-search).
 
+A search or a page read renders the same way whichever ran: a compact card
+naming the query or the page, a result count where one is knowable, and an
+error line where it failed — never a raw dump of what the vendor or backend
+actually returned. The **Web Fetch** Tool set's page reads render on the same
+card. A count isn't always shown; some Providers don't report one for their own
+search, and the card says nothing there rather than guessing.
+
 Occasionally a turn gets no search even though you asked for it: the Provider
 names a backend your Operator has since removed, or the backend fails to start.
 The reply is still written, without searching, and a line under it reads

--- a/apps/frontend/components/chat-message.test.tsx
+++ b/apps/frontend/components/chat-message.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { WEB_BACKEND_TOOL_MARKER, type Agent } from "@platypus/schemas";
+import {
+  WEB_TOOL_NORMALIZED_KEY,
+  type Agent,
+  type NormalizedWebToolResult,
+} from "@platypus/schemas";
 import type { PlatypusUIMessage } from "@platypus/backend/src/types";
 
 // Streamdown pulls in shiki and a worker-ish runtime that jsdom can't host;
@@ -125,18 +129,22 @@ describe("ChatMessage image parts", () => {
   });
 });
 
-// A Web-search backend's `web_search` is client-executed, so its citations arrive
-// as a tool result rather than as `source-url` parts. Without lifting them, the
-// same Chat toggle gives pills on Anthropic and nothing on vLLM (ADR-0014).
+// A Web-search backend's `web_search` result is normalized server-side into
+// `{ kind: "search", results, ... }` and stamped onto `toolMetadata` (issue
+// #525, `apps/backend/src/runs/web-tool-normalize.ts`) before the frontend
+// ever sees it — these tests build parts exactly as that normalizer leaves
+// them. Its results are client-executed, so its citations arrive as a tool
+// result rather than as `source-url` parts; without lifting them, the same
+// Chat toggle gives pills on Anthropic and nothing on vLLM (ADR-0014).
 describe("ChatMessage sources from a Web-search backend", () => {
-  // Core stamps this on the Tool it builds; the AI SDK carries it onto the part and
-  // into the stored message. It is what identifies a plugin call on a provider that
-  // does not report its own executions.
-  const marker = { [WEB_BACKEND_TOOL_MARKER]: true };
+  const normalizedMetadata = (result: NormalizedWebToolResult) => ({
+    [WEB_TOOL_NORMALIZED_KEY]: result,
+  });
 
   const searchMessage = (
-    output: unknown,
+    result: NormalizedWebToolResult,
     extraParts: unknown[] = [],
+    partOverrides: Record<string, unknown> = {},
   ): PlatypusUIMessage =>
     ({
       id: "m1",
@@ -146,9 +154,10 @@ describe("ChatMessage sources from a Web-search backend", () => {
           type: "tool-web_search",
           toolCallId: "c1",
           state: "output-available",
-          toolMetadata: marker,
           input: { query: "platypus habitat" },
-          output,
+          output: {},
+          toolMetadata: normalizedMetadata(result),
+          ...partOverrides,
         },
         ...extraParts,
       ],
@@ -168,7 +177,9 @@ describe("ChatMessage sources from a Web-search backend", () => {
     fireEvent.click(screen.getByRole("button", { name: /Web search/ }));
 
   it("renders a Sources pill per result, titled by the backend's title", () => {
-    renderMessage(searchMessage({ query: "platypus habitat", results }));
+    renderMessage(
+      searchMessage({ kind: "search", query: "platypus habitat", results }),
+    );
     openSources();
 
     expect(screen.getByRole("link", { name: "Platypus" })).toHaveAttribute(
@@ -183,6 +194,7 @@ describe("ChatMessage sources from a Web-search backend", () => {
   it("renders no pill for a result whose URL is not http(s)", () => {
     renderMessage(
       searchMessage({
+        kind: "search",
         query: "x",
         results: [
           { title: "Evil", url: "javascript:alert(1)" },
@@ -206,6 +218,7 @@ describe("ChatMessage sources from a Web-search backend", () => {
   it("counts only the results it will render", () => {
     renderMessage(
       searchMessage({
+        kind: "search",
         query: "x",
         results: [
           { title: "Evil", url: "javascript:alert(1)" },
@@ -222,6 +235,7 @@ describe("ChatMessage sources from a Web-search backend", () => {
   it("counts only the presentable results on the card", () => {
     renderMessage(
       searchMessage({
+        kind: "search",
         query: "x",
         results: [
           { title: "Evil", url: "javascript:alert(1)" },
@@ -240,6 +254,7 @@ describe("ChatMessage sources from a Web-search backend", () => {
   it("reports 0 results when no result was presentable", () => {
     renderMessage(
       searchMessage({
+        kind: "search",
         query: "x",
         results: [{ title: "Evil", url: "javascript:alert(1)" }],
       }),
@@ -253,6 +268,7 @@ describe("ChatMessage sources from a Web-search backend", () => {
   it("falls back to the URL when a result carries no usable title", () => {
     renderMessage(
       searchMessage({
+        kind: "search",
         query: "x",
         results: [{ title: "", url: "https://example.com/untitled" }],
       }),
@@ -266,13 +282,18 @@ describe("ChatMessage sources from a Web-search backend", () => {
 
   it("cites a page once when two searches in a turn both return it", () => {
     renderMessage(
-      searchMessage({ query: "a", results }, [
+      searchMessage({ kind: "search", query: "a", results }, [
         {
           type: "tool-web_search",
           toolCallId: "c2",
           state: "output-available",
           input: { query: "b" },
-          output: { query: "b", results: [results[0]] },
+          output: {},
+          toolMetadata: normalizedMetadata({
+            kind: "search",
+            query: "b",
+            results: [results[0]],
+          }),
         },
       ]),
     );
@@ -285,7 +306,7 @@ describe("ChatMessage sources from a Web-search backend", () => {
   // a history that mixes both reads as one list with one count.
   it("merges plugin results with native source-url parts", () => {
     renderMessage(
-      searchMessage({ query: "a", results: [results[0]] }, [
+      searchMessage({ kind: "search", query: "a", results: [results[0]] }, [
         {
           type: "source-url",
           sourceId: "s1",
@@ -306,7 +327,13 @@ describe("ChatMessage sources from a Web-search backend", () => {
   // The tool returns `{ error }` rather than rejecting, so a failed search
   // arrives as a successful part with nothing to cite.
   it("renders no Sources row when the search returned an error", () => {
-    renderMessage(searchMessage({ error: "Web search is unavailable." }));
+    renderMessage(
+      searchMessage({
+        kind: "search",
+        query: "x",
+        error: "Web search is unavailable.",
+      }),
+    );
 
     expect(screen.queryByText(/Used \d+ sources/)).toBeNull();
     openToolCard();
@@ -316,7 +343,9 @@ describe("ChatMessage sources from a Web-search backend", () => {
   // The generic tool renderer would repeat every result as a raw JSON body,
   // beneath pills that already list them — where native search shows pills alone.
   it("shows the query on a compact card instead of the raw result JSON", () => {
-    renderMessage(searchMessage({ query: "platypus habitat", results }));
+    renderMessage(
+      searchMessage({ kind: "search", query: "platypus habitat", results }),
+    );
 
     expect(
       screen.getByRole("button", { name: /Web search.*platypus habitat/ }),
@@ -333,7 +362,7 @@ describe("ChatMessage sources from a Web-search backend", () => {
   // `source-url` part has only the URL.
   it("cites a page once, by its title, when both rows name it", () => {
     renderMessage(
-      searchMessage({ query: "a", results: [results[0]] }, [
+      searchMessage({ kind: "search", query: "a", results: [results[0]] }, [
         {
           type: "source-url",
           sourceId: "s1",
@@ -352,75 +381,46 @@ describe("ChatMessage sources from a Web-search backend", () => {
   });
 
   // "0 results" is true of a search that has not answered yet, and reads as a
-  // search that found nothing. The marker is what identifies the call this early:
-  // there is no output to recognise yet.
+  // search that found nothing.
   it("says it is searching rather than reporting 0 results mid-call", () => {
-    renderMessage({
-      id: "m1",
-      role: "assistant",
-      parts: [
-        {
-          type: "tool-web_search",
-          toolCallId: "c1",
-          state: "input-available",
-          toolMetadata: marker,
-          input: { query: "platypus habitat" },
-        },
-      ],
-    } as unknown as PlatypusUIMessage);
+    renderMessage(
+      searchMessage({ kind: "search" }, [], { state: "input-available" }),
+    );
 
     openToolCard();
     expect(screen.getByText("Searching…")).toBeInTheDocument();
     expect(screen.queryByText(/0 results/)).toBeNull();
   });
 
-  // A denied call is not a running one. The header reports the state; the body must
-  // not claim a search is in flight.
+  // A denied call is not a running one. The header reports the state; the body
+  // must not claim a search is in flight.
   it("claims no search in flight for a call that was denied", () => {
-    renderMessage({
-      id: "m1",
-      role: "assistant",
-      parts: [
-        {
-          type: "tool-web_search",
-          toolCallId: "c1",
-          state: "output-denied",
-          toolMetadata: marker,
-          input: { query: "platypus habitat" },
-        },
-      ],
-    } as unknown as PlatypusUIMessage);
+    renderMessage(
+      searchMessage({ kind: "search" }, [], { state: "output-denied" }),
+    );
 
     openToolCard();
     expect(screen.queryByText("Searching…")).toBeNull();
     expect(screen.queryByText(/0 results/)).toBeNull();
   });
 
-  // The marker rides the first streaming chunk (`ai@7`, `tool-input-start`), so one
-  // of our own calls is identifiable before its input finishes arriving.
-  it("shows the card for a marked call still streaming its input", () => {
-    renderMessage({
-      id: "m1",
-      role: "assistant",
-      parts: [
-        {
-          type: "tool-web_search",
-          toolCallId: "c1",
-          state: "input-streaming",
-          toolMetadata: marker,
-          input: { query: "platypus habitat" },
-        },
-      ],
-    } as unknown as PlatypusUIMessage);
+  it("shows the card for a call still streaming its input", () => {
+    renderMessage(
+      searchMessage({ kind: "search" }, [], { state: "input-streaming" }),
+    );
 
     openToolCard();
     expect(screen.getByText("Searching…")).toBeInTheDocument();
     expect(screen.queryByText("Parameters")).toBeNull();
   });
 
-  // Messages stored before the marker shipped carry none. A finished call is still
-  // recognisable by the result shape core owns, so their pills do not vanish.
-  it("still lifts sources from a stored result that carries no marker", () => {
+  // Restoring the pre-normalization back-compat guess is explicitly out of
+  // scope (issue #525): a search stored before normalization existed carries
+  // no normalized `toolMetadata` and falls to the generic renderer, losing its
+  // card and its Sources pills. An accepted, narrow regression — nothing is
+  // lost from the Transcript, and the alternative is the guess this issue
+  // exists to delete.
+  it("falls to the generic renderer for a stored result with no normalized metadata", () => {
     renderMessage({
       id: "m1",
       role: "assistant",
@@ -435,15 +435,17 @@ describe("ChatMessage sources from a Web-search backend", () => {
       ],
     } as unknown as PlatypusUIMessage);
 
-    expect(screen.getByText("Used 1 sources")).toBeInTheDocument();
+    expect(screen.queryByText(/Used \d+ sources/)).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Web search/ }));
+    expect(screen.getByText("Parameters")).toBeInTheDocument();
   });
 });
 
-// Native provider search registers under the same `web_search` name as a plugin
-// backend's (`services/provider.ts` — OpenAI, OpenRouter, Anthropic), so the tool
-// name alone cannot tell them apart. `providerExecuted` can: a native part belongs
-// on the generic renderer, which shows the vendor payload the compact card cannot
-// read, and its citations come from `source-url` parts.
+// Native provider search is normalized server-side too (issue #525), reduced
+// to a bare count rather than the raw vendor payload. A shape the backend
+// cannot read (OpenRouter's unknown output, an MCP `web_search`) carries no
+// normalized metadata at all and stays on the generic renderer, which is the
+// only one that can show whatever it really is.
 describe("ChatMessage and provider-executed web_search", () => {
   const nativeSearchMessage = (extraParts: unknown[] = []): PlatypusUIMessage =>
     ({
@@ -456,24 +458,30 @@ describe("ChatMessage and provider-executed web_search", () => {
           state: "output-available",
           providerExecuted: true,
           input: { query: "platypus habitat" },
-          // Vendor-shaped: not core's `{ query, results }`.
+          // Vendor-shaped: not core's `{ query, results }` — the normalizer
+          // already reduced this to `resultCount` before the frontend saw it.
           output: [
             { type: "web_search_result", url: "https://vendor.example/a" },
           ],
+          toolMetadata: {
+            [WEB_TOOL_NORMALIZED_KEY]: {
+              kind: "search",
+              query: "platypus habitat",
+              resultCount: 1,
+            },
+          },
         },
         ...extraParts,
       ],
     }) as unknown as PlatypusUIMessage;
 
-  it("leaves a native search on the generic tool renderer", () => {
+  it("shows a bare count on the compact card, not the raw vendor payload", () => {
     renderMessage(nativeSearchMessage());
 
-    // Only the generic renderer shows the input/output blocks; the compact card
-    // has neither, and would claim "0 results" on this vendor-shaped output.
     fireEvent.click(screen.getByRole("button", { name: /Web search/ }));
-    expect(screen.getByText("Parameters")).toBeInTheDocument();
-    expect(screen.queryByText(/\d+ results?/)).toBeNull();
-    expect(screen.queryByText("Searching…")).toBeNull();
+    expect(screen.getByText("1 result")).toBeInTheDocument();
+    expect(screen.queryByText(/listed above as sources/)).toBeNull();
+    expect(screen.queryByText("Parameters")).toBeNull();
   });
 
   it("lifts no sources out of a native search result", () => {
@@ -555,12 +563,11 @@ describe("ChatMessage and provider-executed web_search", () => {
     expect(screen.getByText("Used 1 sources")).toBeInTheDocument();
   });
 
-  // `providerExecuted` is the provider package's to set, and
-  // `@openrouter/ai-sdk-provider` never sets it — so a native search there is a
-  // `tool-web_search` part with no flag, no marker, and no core-shaped output. It
-  // must not read as a plugin call: on the card it would sit at "Searching…" for a
-  // search that already ran.
-  it("leaves an unflagged, unmarked native search on the generic renderer", () => {
+  // A shape the backend cannot read at all (OpenRouter's unknown output, an
+  // MCP `web_search`) carries no normalized metadata — the backend never
+  // guesses a tool's identity from its payload, so this stays on the generic
+  // renderer exactly as an unrecognised tool always has.
+  it("leaves an unreadable native search on the generic renderer", () => {
     renderMessage({
       id: "m1",
       role: "assistant",
@@ -580,47 +587,27 @@ describe("ChatMessage and provider-executed web_search", () => {
     expect(screen.queryByText("Searching…")).toBeNull();
     expect(screen.queryByText(/Used \d+ sources/)).toBeNull();
   });
-
-  // The same part one chunk earlier. Core's marker is attached from the first
-  // streaming chunk, so an unmarked `input-streaming` part is native by
-  // elimination — treating the state itself as ours put a native OpenRouter search
-  // on the compact card mid-stream, which then swapped renderer at
-  // `input-available`.
-  it("leaves an unmarked, streaming native search on the generic renderer", () => {
-    renderMessage({
-      id: "m1",
-      role: "assistant",
-      parts: [
-        {
-          type: "tool-web_search",
-          toolCallId: "c1",
-          state: "input-streaming",
-          input: { query: "platypus habitat" },
-        },
-      ],
-    } as unknown as PlatypusUIMessage);
-
-    fireEvent.click(screen.getByRole("button", { name: /Web search/ }));
-    expect(screen.getByText("Parameters")).toBeInTheDocument();
-    expect(screen.queryByText("Searching…")).toBeNull();
-  });
 });
 
 // Issue #578: the dispatch used to be an if/else-if chain where a specialised
 // tool part had to be checked before the generic catch-all or it would land
 // there too, rendering its raw JSON body a second time alongside the
-// specialised card (and, for search, the Sources row). `isGenericToolPart` now
-// excludes every specialised tool part by construction, so this holds
-// regardless of where a renderer sits in the dispatch list.
+// specialised card (and, for search, the Sources row above the parts loop).
+// `isGenericToolPart` now excludes every specialised tool part by
+// construction, so this holds regardless of where a renderer sits in the
+// dispatch list.
 describe("ChatMessage generic tool renderer exclusion", () => {
-  it("never matches a plugin web-search part", () => {
+  it("never matches a web tool part carrying a normalized result", () => {
     expect(
       isGenericToolPart({
         type: "tool-web_search",
         toolCallId: "c1",
         state: "output-available",
         input: { query: "x" },
-        output: { query: "x", results: [] },
+        output: {},
+        toolMetadata: {
+          [WEB_TOOL_NORMALIZED_KEY]: { kind: "search", query: "x" },
+        },
       } as unknown as Parameters<typeof isGenericToolPart>[0]),
     ).toBe(false);
   });
@@ -661,10 +648,10 @@ describe("ChatMessage generic tool renderer exclusion", () => {
     ).toBe(true);
   });
 
-  // Native provider search is `tool-web_search` shaped but not a plugin
-  // call — it must stay on the generic renderer, which is the only one
-  // that can show its vendor-shaped payload.
-  it("matches a provider-executed web_search part", () => {
+  // Native provider search is `tool-web_search` shaped but carries no
+  // normalized metadata here — it must stay on the generic renderer, which is
+  // the only one that can show its vendor-shaped payload.
+  it("matches a web_search part with no normalized metadata", () => {
     expect(
       isGenericToolPart({
         type: "tool-web_search",

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -55,8 +55,8 @@ import { TurnNotice } from "./turn-notice";
 import { LoadSkillTool } from "./load-skill-tool";
 import { SubAgentTool } from "./sub-agent-tool";
 import {
-  WebSearchTool,
-  isPluginWebSearchPart,
+  WebToolCard,
+  isNormalizedWebToolPart,
   webSearchSources,
 } from "./web-search-tool";
 
@@ -93,8 +93,8 @@ const isLoadSkillPart = (part: MessagePart) => part.type === "tool-loadSkill";
 const isSubAgentToolPart = (part: MessagePart) =>
   isToolUIPart(part) && part.type.startsWith("tool-delegateTo");
 
-const isWebSearchToolPart = (part: MessagePart) =>
-  isToolUIPart(part) && isPluginWebSearchPart(part);
+const isWebToolPart = (part: MessagePart) =>
+  isToolUIPart(part) && isNormalizedWebToolPart(part);
 
 /**
  * Every tool-shaped part that has its own specialised renderer below. Kept as
@@ -108,7 +108,7 @@ const isWebSearchToolPart = (part: MessagePart) =>
  */
 const specializedToolMatchers: Array<(part: MessagePart) => boolean> = [
   isLoadSkillPart,
-  isWebSearchToolPart,
+  isWebToolPart,
   isSubAgentToolPart,
 ];
 
@@ -117,7 +117,7 @@ const specializedToolMatchers: Array<(part: MessagePart) => boolean> = [
  * `CustomUITools`), so they land here by elimination — anything tool-shaped
  * that no specialised renderer above has already claimed.
  *
- * Exported so a test can assert the exclusion directly: a plugin web-search
+ * Exported so a test can assert the exclusion directly: a Web tool block part
  * or Sub-Agent part must never also satisfy this, or its raw JSON body would
  * repeat what the specialised card (and, for search, the Sources row above
  * the parts loop) already shows.
@@ -359,9 +359,9 @@ export const ChatMessage = memo(function ChatMessage({
       ),
     },
     {
-      matches: isWebSearchToolPart,
+      matches: isWebToolPart,
       render: (part, i) => (
-        <WebSearchTool
+        <WebToolCard
           key={`${message.id}-${i}`}
           toolPart={part as ToolUIPart}
           messageMetadata={message.metadata}

--- a/apps/frontend/components/web-search-tool.test.tsx
+++ b/apps/frontend/components/web-search-tool.test.tsx
@@ -1,32 +1,55 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import type { ToolUIPart } from "ai";
+import {
+  WEB_TOOL_NORMALIZED_KEY,
+  type NormalizedWebToolResult,
+} from "@platypus/schemas";
 
-import { WebSearchTool } from "./web-search-tool";
+import { WebToolCard, webSearchSources } from "./web-search-tool";
 
-const searchCall = (toolMetadata?: Record<string, unknown>): ToolUIPart =>
+const searchCall = (
+  normalized: NormalizedWebToolResult,
+  extraMetadata?: Record<string, unknown>,
+): ToolUIPart =>
   ({
     type: "tool-web_search",
     toolCallId: "call-1",
     state: "output-available",
     input: { query: "platypus habitat" },
-    output: { query: "platypus habitat", results: [] },
-    toolMetadata,
+    output: {},
+    toolMetadata: {
+      ...extraMetadata,
+      [WEB_TOOL_NORMALIZED_KEY]: normalized,
+    },
   }) as unknown as ToolUIPart;
+
+const backendSearch: NormalizedWebToolResult = {
+  kind: "search",
+  query: "platypus habitat",
+  results: [],
+};
+
+/** The card's body is a closed `Collapsible` until clicked open. */
+const openCard = () => fireEvent.click(screen.getByRole("button"));
 
 // Issue #469. A plugin search is the tool most likely to take several seconds,
 // so the card that heads it is where the elapsed time is worth reading.
-describe("WebSearchTool duration", () => {
+describe("WebToolCard duration", () => {
   it("renders the duration recorded on the part", () => {
-    render(<WebSearchTool toolPart={searchCall({ durationMs: 4200 })} />);
+    render(
+      <WebToolCard
+        toolPart={searchCall(backendSearch, { durationMs: 4200 })}
+      />,
+    );
 
     expect(screen.getByText(/4\.2s/)).toBeInTheDocument();
   });
 
   it("renders the duration the message carries mid-turn", () => {
     render(
-      <WebSearchTool
-        toolPart={searchCall()}
+      <WebToolCard
+        toolPart={searchCall(backendSearch)}
         messageMetadata={{ toolDurations: { "call-1": 4200 } }}
       />,
     );
@@ -35,9 +58,122 @@ describe("WebSearchTool duration", () => {
   });
 
   it("renders no duration for a search recorded before timing existed", () => {
-    render(<WebSearchTool toolPart={searchCall()} />);
+    render(<WebToolCard toolPart={searchCall(backendSearch)} />);
 
     expect(screen.getByText("Web search")).toBeInTheDocument();
     expect(screen.queryByText(/^\d+(\.\d+)?(ms|s)$/)).toBeNull();
+  });
+});
+
+// Issue #525. The card must be uniform whichever search ran, and citations
+// must not widen to native results.
+describe("WebToolCard kinds", () => {
+  it("renders null when the part carries no normalized result", () => {
+    const { container } = render(
+      <WebToolCard
+        toolPart={
+          {
+            type: "tool-web_search",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: {},
+            output: {},
+          } as unknown as ToolUIPart
+        }
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a bare count for a native search, with no sources suffix", () => {
+    render(
+      <WebToolCard
+        toolPart={searchCall({
+          kind: "search",
+          query: "weather",
+          resultCount: 5,
+        })}
+      />,
+    );
+
+    openCard();
+    expect(screen.getByText("5 results")).toBeInTheDocument();
+    expect(screen.queryByText(/listed above as sources/)).toBeNull();
+  });
+
+  it("omits the count line entirely when a native search cannot report one", () => {
+    render(
+      <WebToolCard
+        toolPart={searchCall({ kind: "search", query: "weather" })}
+      />,
+    );
+
+    openCard();
+    expect(screen.queryByText(/result/)).toBeNull();
+  });
+
+  it("titles an opened page distinctly from a search", () => {
+    render(
+      <WebToolCard
+        toolPart={searchCall({ kind: "page", url: "https://a.test/page" })}
+      />,
+    );
+
+    expect(screen.getByText("Opened page")).toBeInTheDocument();
+  });
+
+  it("titles an in-page find distinctly from a search or a page", () => {
+    render(
+      <WebToolCard
+        toolPart={searchCall({
+          kind: "find",
+          url: "https://a.test/page",
+          pattern: "opening hours",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Searched page for text")).toBeInTheDocument();
+    openCard();
+    expect(
+      screen.getByText("Searched for “opening hours”"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the backend's own error", () => {
+    render(
+      <WebToolCard
+        toolPart={searchCall({
+          kind: "search",
+          query: "weather",
+          error: "The web backend timed out.",
+        })}
+      />,
+    );
+
+    openCard();
+    expect(screen.getByText("The web backend timed out.")).toBeInTheDocument();
+  });
+});
+
+describe("webSearchSources", () => {
+  it("lifts a Web-search backend's results", () => {
+    const sources = webSearchSources([
+      searchCall({
+        kind: "search",
+        query: "weather",
+        results: [{ title: "A", url: "https://a.test" }],
+      }),
+    ]);
+
+    expect(sources).toEqual([{ title: "A", url: "https://a.test" }]);
+  });
+
+  it("never lifts a native search's results, since it has none", () => {
+    const sources = webSearchSources([
+      searchCall({ kind: "search", query: "weather", resultCount: 5 }),
+    ]);
+
+    expect(sources).toEqual([]);
   });
 });

--- a/apps/frontend/components/web-search-tool.tsx
+++ b/apps/frontend/components/web-search-tool.tsx
@@ -1,137 +1,197 @@
 "use client";
 
 import type { ToolUIPart } from "ai";
-import { isPresentableUrl, WEB_BACKEND_TOOL_MARKER } from "@platypus/schemas";
+import {
+  isPresentableUrl,
+  WEB_TOOL_NORMALIZED_KEY,
+  type NormalizedWebToolResult,
+} from "@platypus/schemas";
 import { toolCallDurationMs } from "@/lib/tool-duration";
 import { Tool, ToolContent, ToolHeader } from "./ai-elements/tool";
 
 /**
  * One citation lifted out of a Web-search backend's `web_search` result.
  *
- * The shape mirrors the backend's `WebSearchToolResult` (core owns it — the
- * backend supplies only executors, ADR-0014), but it is narrowed at runtime here
- * rather than imported as a type: this is stored message content read back from
- * the database, and `url` becomes an `href`.
+ * Native provider search never contributes here — see `webSearchSources`.
  */
 export type WebSearchSource = { url: string; title: string };
 
-const asRecord = (value: unknown): Record<string, unknown> =>
-  typeof value === "object" && value !== null
-    ? (value as Record<string, unknown>)
-    : {};
-
 /**
- * Whether a message part is a **plugin** `web_search` call — the client-executed
- * kind a Web-search backend contributes (ADR-0014).
+ * The normalized web-tool view a message part carries, computed server-side
+ * (issue #525, `apps/backend/src/runs/web-tool-normalize.ts`) — `null` when
+ * the backend did not recognise this part as a web tool at all, in which case
+ * it renders on the generic tool renderer instead.
  *
- * The tool name alone does not identify one. Native provider search registers
- * under the same `web_search` key on OpenAI, OpenRouter and Anthropic
- * (`services/provider.ts`), so its parts are `tool-web_search` too — but they are
- * executed by the provider, carry a vendor-shaped output, and cite through
- * `source-url` parts. Getting this wrong either way is visible: a native search on
- * the compact card claims "0 results" for a search that returned ten, and a plugin
- * search on the generic renderer loses its Sources pills.
- *
- * Four checks, in order of how much each one actually knows:
- *
- * 1. `providerExecuted` is definitive where a provider sets it. Anthropic and
- *    OpenAI both set it from the first chunk, so a native call on either is
- *    excluded before anything else runs.
- * 2. `WEB_BACKEND_TOOL_MARKER` is the positive half, and the only check that does
- *    not depend on a vendor reporting itself — core stamps it on the Tool it
- *    builds, and the AI SDK carries it to the part. `@openrouter/ai-sdk-provider`
- *    never sets `providerExecuted`, so without this a native OpenRouter search
- *    would land on the card exactly as before.
- * 3. Core's own result shape, for a finished call carrying no marker: a message
- *    stored before the marker shipped. Native payloads are vendor-shaped (an array
- *    on Anthropic, a status object on OpenAI), so they do not match.
- * 4. An unfinished call cannot be decided on its output, and by here it has no
- *    marker either. The SDK attaches the marker on the first streaming chunk
- *    (`ai@7`, `tool-input-start`), so one of our own calls is already marked at
- *    `input-streaming` and matched by check 2 — the only parts reaching this point
- *    are the unmarked native ones, which belong on the generic renderer.
- *
- * Anything left over reads as native. That is the safe default: an unrecognised
- * `web_search` keeps the generic renderer, which shows whatever it really is.
+ * This is the ONLY thing the frontend reads to decide what a `web_search`,
+ * `google_search`, `read_url` or `fetchUrl` part looks like. It holds no
+ * vendor knowledge of its own: ownership (a Web-search backend's tool vs. a
+ * Provider's native search) and the per-vendor read of a native result are
+ * both decided once, on the backend, never re-derived here from the payload.
  */
-export const isPluginWebSearchPart = (part: {
-  type: string;
-  state?: string;
-  output?: unknown;
+export const normalizedWebTool = (part: {
   toolMetadata?: Record<string, unknown>;
-  providerExecuted?: boolean;
-}): boolean => {
-  if (part.type !== "tool-web_search") return false;
-  if (part.providerExecuted === true) return false;
-  if (part.toolMetadata?.[WEB_BACKEND_TOOL_MARKER] === true) return true;
-  if (part.state === "output-available") {
-    const output = asRecord(part.output);
-    return Array.isArray(output.results) || typeof output.error === "string";
-  }
-  return false;
-};
+}): NormalizedWebToolResult | null =>
+  (part.toolMetadata?.[WEB_TOOL_NORMALIZED_KEY] as
+    NormalizedWebToolResult | undefined) ?? null;
+
+/** Whether a message part is one the Web tool block should render. */
+export const isNormalizedWebToolPart = (part: {
+  toolMetadata?: Record<string, unknown>;
+}): boolean => normalizedWebTool(part) !== null;
 
 /**
- * The citations a plugin `web_search` result contributes to the Sources row.
+ * The citations a Web-search backend's `web_search` result contributes to the
+ * Sources row.
  *
- * Native provider search arrives as `source-url` message parts and needs none of
- * this. A Web-search backend's search is **client-executed** — the result comes
- * back as an ordinary tool part — so without lifting it, the same Chat toggle
- * gives citation pills on Anthropic and nothing on vLLM.
+ * Native provider search arrives as `source-url` message parts and needs none
+ * of this. A native search's normalized result never carries `results` —
+ * citation-lifting deliberately does not widen to it (issue #525): the
+ * Provider emits its own citation parts for the pages it actually used, while
+ * a native search's raw result list is every page it found, cited or not.
  *
- * Every URL is re-checked with `isPresentableUrl`, the same predicate the backend
- * drops unpresentable results with. Belt-and-braces on one rule, and this is the
- * copy that decides what becomes an `href`: a `javascript:` or `data:` URL in a
- * clickable pill is a live hole, and a backend is third-party code.
+ * Every URL is re-checked with `isPresentableUrl`, the same predicate the
+ * backend drops unpresentable results with. Belt-and-braces on one rule, and
+ * this is the copy that decides what becomes an `href`.
  *
- * Scheme only, deliberately: length is core's, which drops a result URL over
- * `MAX_URL_CHARS` and truncates a title to `MAX_TITLE_CHARS` before either is
- * stored, and an over-long pill is a layout complaint rather than a hole.
- *
- * Deduplicated by URL, first occurrence winning, so two searches in one turn that
- * both surface a page cite it once. Deduplication *against* the native
- * `source-url` row happens where both are rendered — see `chat-message.tsx`.
+ * Deduplicated by URL, first occurrence winning, so two searches in one turn
+ * that both surface a page cite it once.
  */
 export const webSearchSources = (
   parts:
-    | ReadonlyArray<{
-        type: string;
-        state?: string;
-        output?: unknown;
-        toolMetadata?: Record<string, unknown>;
-        providerExecuted?: boolean;
-      }>
+    | ReadonlyArray<{ type: string; toolMetadata?: Record<string, unknown> }>
     | undefined,
 ): WebSearchSource[] => {
   const sources: WebSearchSource[] = [];
   const seen = new Set<string>();
   for (const part of parts ?? []) {
-    if (!isPluginWebSearchPart(part)) continue;
-    const results = asRecord(part.output).results;
-    if (!Array.isArray(results)) continue;
-    for (const entry of results) {
-      const { url, title } = asRecord(entry);
-      if (!isPresentableUrl(url) || seen.has(url)) continue;
-      seen.add(url);
+    const result = normalizedWebTool(part);
+    if (!result || result.kind !== "search" || !result.results) continue;
+    for (const entry of result.results) {
+      if (!isPresentableUrl(entry.url) || seen.has(entry.url)) continue;
+      seen.add(entry.url);
       sources.push({
-        url,
-        title: typeof title === "string" && title !== "" ? title : url,
+        url: entry.url,
+        title: entry.title !== "" ? entry.title : entry.url,
       });
     }
   }
   return sources;
 };
 
+const titleFor = (kind: NormalizedWebToolResult["kind"]): string => {
+  switch (kind) {
+    case "search":
+      return "Web search";
+    case "page":
+      return "Opened page";
+    case "find":
+      return "Searched page for text";
+  }
+};
+
+const labelFor = (result: NormalizedWebToolResult): string | undefined => {
+  switch (result.kind) {
+    case "search":
+      return result.query;
+    case "page":
+    case "find":
+      return result.url;
+  }
+};
+
+const SearchBody = ({
+  result,
+  toolPart,
+}: {
+  result: Extract<NormalizedWebToolResult, { kind: "search" }>;
+  toolPart: ToolUIPart;
+}) => {
+  // A count only once there is an output to count — showing one for a search
+  // still in flight would otherwise read "0 results", and "Searching…" only
+  // for the two states where one genuinely is running. A denied call is
+  // neither: the header already reports that state, and claiming a search is
+  // running would be false.
+  if (
+    toolPart.state === "input-streaming" ||
+    toolPart.state === "input-available"
+  ) {
+    return <p className="text-muted-foreground text-xs">Searching…</p>;
+  }
+  if (toolPart.state !== "output-available") return null;
+
+  // A Web-search backend's own results, counted through the same helper the
+  // Sources row is built from, not off the raw array — the row lists only
+  // results that survive `isPresentableUrl`. Native search has no `results`
+  // at all: its count is the vendor's raw, unfiltered `resultCount`, and it
+  // never gains a "listed above as sources" suffix, since its results are not
+  // the pills.
+  const hasOwnResults = Array.isArray(result.results);
+  const shownCount = hasOwnResults
+    ? webSearchSources([toolPart]).length
+    : result.resultCount;
+
+  return (
+    <>
+      {result.answer && (
+        <p className="text-muted-foreground">{result.answer}</p>
+      )}
+      {shownCount !== undefined && (
+        <p className="text-muted-foreground text-xs">
+          {shownCount === 1 ? "1 result" : `${shownCount} results`}
+          {hasOwnResults && shownCount > 0 && " — listed above as sources"}
+        </p>
+      )}
+    </>
+  );
+};
+
+const PageBody = ({
+  result,
+}: {
+  result: Extract<NormalizedWebToolResult, { kind: "page" }>;
+}) => {
+  if (result.contentLength === undefined && !result.contentType) {
+    return <p className="text-muted-foreground text-xs">Opening…</p>;
+  }
+  return (
+    <p className="text-muted-foreground text-xs">
+      {[
+        result.contentLength !== undefined
+          ? `${result.contentLength.toLocaleString()} characters`
+          : null,
+        result.contentType || null,
+        result.truncated ? "truncated" : null,
+      ]
+        .filter(Boolean)
+        .join(" · ")}
+    </p>
+  );
+};
+
+const FindBody = ({
+  result,
+}: {
+  result: Extract<NormalizedWebToolResult, { kind: "find" }>;
+}) =>
+  result.pattern ? (
+    <p className="text-muted-foreground text-xs">
+      Searched for &ldquo;{result.pattern}&rdquo;
+    </p>
+  ) : (
+    <p className="text-muted-foreground text-xs">Searching page…</p>
+  );
+
 /**
- * The `web_search` tool card.
+ * The Web tool block: one card for a native provider search, a Web-search
+ * backend's search or page read, and the web-fetch Tool set's `fetchUrl`
+ * (issue #525) — a reader cannot tell which of them ran.
  *
- * Deliberately not the generic tool renderer: a client-executed search whose
- * results are already rendered as Sources pills would otherwise repeat all of them
- * as a raw JSON body, where native search shows pills alone. The card stays for
- * what the pills cannot say — that a search ran, what was searched for, and when
- * it failed.
+ * Deliberately not the generic tool renderer: a native search's citations
+ * already render as `source-url` pills, a plugin search's as Sources pills,
+ * and a page read has content that belongs in this card's summary, not
+ * dumped whole into the Transcript body.
  */
-export const WebSearchTool = ({
+export const WebToolCard = ({
   toolPart,
   messageMetadata,
   cleared,
@@ -148,32 +208,21 @@ export const WebSearchTool = ({
    *  of the next model call. */
   cleared?: boolean;
 }) => {
-  const query = asRecord(toolPart.input).query;
-  const output = asRecord(toolPart.output);
-  // The tool's contract is a returned `{ error }`, not a rejection, so a failed
-  // search arrives with `state: "output-available"` and no `errorText`.
-  const errorText =
-    toolPart.errorText ??
-    (typeof output.error === "string" ? output.error : null);
-  // Counted through the same helper the Sources row is built from, not off the raw
-  // array: the row lists only the results that survive `isPresentableUrl`, so a
-  // backend returning three results with two `javascript:` URLs would otherwise say
-  // "3 results — listed above as sources" above a single pill.
-  //
-  // This call's own results, deliberately: the count belongs to the card it sits in.
-  // Two searches in one turn that both surface a page therefore total one more than
-  // the row's pill count, which deduplicates across the whole message — the
-  // alternative is a card reporting a number that has nothing to do with the search
-  // it heads.
-  const shownCount = webSearchSources([toolPart]).length;
-  const answer = typeof output.answer === "string" ? output.answer : null;
+  const result = normalizedWebTool(toolPart);
+  if (!result) return null;
+
+  // The tool's contract is a returned `{ error }` for a core-built tool, not
+  // a rejection, so a failed backend call arrives with `state:
+  // "output-available"` and no `errorText` — the normalizer already folded
+  // both into `result.error`.
+  const errorText = toolPart.errorText ?? result.error ?? null;
 
   return (
     <Tool>
       <ToolHeader
-        title="Web search"
-        label={typeof query === "string" ? query : undefined}
-        type="tool-web_search"
+        title={titleFor(result.kind)}
+        label={labelFor(result)}
+        type={toolPart.type}
         state={errorText ? "output-error" : toolPart.state}
         durationMs={toolCallDurationMs(
           toolPart.toolMetadata,
@@ -186,25 +235,12 @@ export const WebSearchTool = ({
         <div className="space-y-2 p-4 text-sm">
           {errorText ? (
             <p className="text-destructive text-xs">{errorText}</p>
+          ) : result.kind === "search" ? (
+            <SearchBody result={result} toolPart={toolPart} />
+          ) : result.kind === "page" ? (
+            <PageBody result={result} />
           ) : (
-            <>
-              {answer && <p className="text-muted-foreground">{answer}</p>}
-              {/* A count only once there is an output to count — the same line
-              would otherwise read "0 results" for a search still in flight — and
-              "Searching…" only for the two states where one genuinely is. The
-              remaining states (a denied call, an `output-error` that arrived
-              without `errorText`) get neither: both are already reported by the
-              header, and claiming a search is running would be false. */}
-              {toolPart.state === "output-available" ? (
-                <p className="text-muted-foreground text-xs">
-                  {shownCount === 1 ? "1 result" : `${shownCount} results`}
-                  {shownCount > 0 && " — listed above as sources"}
-                </p>
-              ) : toolPart.state === "input-streaming" ||
-                toolPart.state === "input-available" ? (
-                <p className="text-muted-foreground text-xs">Searching…</p>
-              ) : null}
-            </>
+            <FindBody result={result} />
           )}
         </div>
       </ToolContent>

--- a/docs/adr/0014-web-search-backend-extension-point.md
+++ b/docs/adr/0014-web-search-backend-extension-point.md
@@ -156,3 +156,68 @@ does **not** widen the **Backend context** consequence above:
 Core passes its own `buildTurnTools` a `TurnToolsContext` that adds `providerId`
 and strips it again before the plugin-facing `createExecutors` call, so the
 published SDK contract is untouched.
+
+## Amendment — one Web tool block, normalized server-side (#525)
+
+The **Presenting results** decision above, and the **Citations** consequence's
+"the frontend reads it" — reasonable when core's own result shape was the only
+one the frontend had to read — no longer describes what ships. A native
+Provider's search rendered on the generic tool renderer, dumping a raw vendor
+payload (Anthropic's `web_search_result` array, `encryptedContent` included)
+into the Transcript, and the frontend's discriminator carried a **shape-guessing
+fallback**: a finished `tool-web_search` part with no marker and a `results`
+array or `error` string was read as a plugin call, on the theory that a message
+stored before the marker shipped needed some way back onto the card. That
+fallback was an ownership hole — nothing stopped an MCP server exposing its own
+`web_search` from being claimed the same way — and it is now **deleted
+outright**, not narrowed.
+
+**Uniform presentation, vendor-varying contents.** A native provider search, a
+Web-search backend's `web_search` / `read_url`, and `@platypus/web-fetch`'s
+`fetchUrl` now render on one block — the same title shape, the same place a
+query or a URL appears, the same place an error appears — discriminated by
+`kind: "search" | "page" | "find"` rather than by which tool produced the part.
+Strict indistinguishability was rejected as the goal: OpenAI's hosted tool may
+report no query and no result count at all, and suppressing what Anthropic
+legitimately has would be a worse Transcript, not a better one. "One shell,
+vendor-varying contents" is what shipped, not "no reader can tell which search
+ran."
+
+**The read moved to the backend, not the frontend.** `apps/backend/src/runs/web-tool-normalize.ts`
+holds one pure function, `normalizeWebToolPart`, called from both the live
+stream relay (`runs/drive.ts`) and the saved-Transcript read path
+(`routes/chat.ts`, beside `rewriteStorageUrls`) — a **view over stored data**,
+computed at read/serve time and never written back to storage, so a normalizer
+defect is a redeploy, not data loss, and a Chat saved before this shipped
+renders on the block with no migration run. This is a deliberate departure from
+this ADR's own "core owns the result shape, so the frontend reads it" — that
+principle held when core was reading its own normalized shape; here the
+backend is reading Anthropic's raw array and OpenAI's `{action, sources}`
+object, which is vendor knowledge the frontend must never carry, so the read
+could only move server-side once it became per-vendor.
+
+**Ownership is decided once, and never from the payload.** Two positive
+signals only: the existing `WEB_BACKEND_TOOL_MARKER` (now also stamped on
+`fetchUrl`, which is core-built in the same sense a Web-search backend's tools
+are, even though it is not one), or `providerExecuted === true` on a known
+native search tool name (`web_search`, `google_search`). Everything else —
+an MCP `web_search`, a native OpenRouter search (whose provider package never
+sets `providerExecuted`), an unmarked pre-#525 backend result — renders on the
+generic renderer. The **OpenRouter exception is permanent**: its hosted
+`webSearch` declares no output type at all, so even where ownership could be
+read some other way, the payload itself cannot be.
+
+**Citation-lifting did not widen.** `webSearchSources` still reads only a
+`results` array, and the normalizer only ever puts one on a Web-search
+backend's search — a native search's normalized result carries `resultCount`
+instead, deliberately absent `results`. The Provider emits its own citation
+parts (`source-url`) for the pages it actually used; lifting a native search's
+full, unfiltered result list into the same row as well would cite every page a
+search returned rather than the ones the reply drew from.
+
+**Deletion, not narrowing, of the guess.** `isPluginWebSearchPart`'s shape
+fallback is gone from the frontend, and there is no successor guess anywhere:
+a message stored before this issue's marker-and-normalize scheme existed now
+renders on the generic renderer, permanently. Accepted as a narrow regression
+— nothing is lost from the Transcript, since the raw part is unchanged, only
+its presentation reverts to what a truly unrecognised tool always got.

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -1416,8 +1416,83 @@ export const isPresentableUrl = (value: unknown): value is string => {
  *
  * Shared here rather than mirrored for `isPresentableUrl`'s reason: the frontend
  * reads what the backend writes, and two copies of the key drift.
+ *
+ * Also stamped on the web-fetch Tool set's `fetchUrl` (issue #525): that tool is
+ * not a Web-search backend, but it is core-built in exactly the same sense — a
+ * fixed, model-facing contract with no vendor behind it — and needs the same
+ * "core built this, don't guess" signal so its page reads join the Web tool
+ * block instead of dumping page content into the Transcript.
  */
 export const WEB_BACKEND_TOOL_MARKER = "platypusWebBackend";
+
+/**
+ * The `toolMetadata` key holding the outcome of backend-side web-tool
+ * normalization (issue #525): one shape for a native provider search, a
+ * Web-search backend's search or page read, and the web-fetch Tool set's
+ * `fetchUrl` — computed once, server-side (`normalizeWebToolPart` in
+ * `apps/backend/src/runs/web-tool-normalize.ts`), and read by the frontend
+ * with no vendor knowledge of its own.
+ *
+ * Absent means "not a recognised web tool" — the part renders on the generic
+ * tool renderer. Never inferred from the payload on the frontend; the backend
+ * is the only place that decides this.
+ */
+export const WEB_TOOL_NORMALIZED_KEY = "platypusNormalizedWebTool";
+
+/**
+ * A web tool's result, reduced to what every reader needs regardless of which
+ * search ran, which page-reader fetched it, or which vendor answered — the
+ * uniform presentation issue #525 asks for. Supersedes the frontend's old,
+ * search-only `WebSearchSource`-adjacent shape, which could not express a
+ * page read at all.
+ *
+ * `kind` follows what actually happened, not which tool was called: OpenAI's
+ * hosted web tool covers a search, an opened page, and an in-page find under
+ * one tool name, and only its output says which occurred.
+ *
+ * `results` is present only for a Web-search backend's search — the one case
+ * whose entries may still be lifted into the Sources row (ADR-0014). Native
+ * search deliberately omits it: the Provider emits its own citation parts for
+ * the pages it actually used, and lifting a native search's full result list
+ * as well would fill the row with pages the reply never cited. `resultCount`
+ * carries a native search's raw, unfiltered count instead — the entries the
+ * vendor returned, not the subset that could become a pill.
+ */
+export type NormalizedWebToolResult =
+  | {
+      kind: "search";
+      query?: string;
+      results?: Array<{ title: string; url: string; snippet?: string }>;
+      resultCount?: number;
+      answer?: string;
+      error?: string;
+    }
+  | {
+      kind: "page";
+      url?: string;
+      contentType?: string;
+      contentLength?: number;
+      truncated?: boolean;
+      error?: string;
+    }
+  | {
+      kind: "find";
+      url?: string;
+      pattern?: string;
+      error?: string;
+    };
+
+/**
+ * Tool names a Provider may execute natively for web search, keyed by the part
+ * type the AI SDK produces (`tool-<name>`). Read alongside `providerExecuted`,
+ * never alone: `google_search` is in this set purely because Google's native
+ * search registers under a name the old shape-guessing discriminator never
+ * saw, not because the name alone proves anything.
+ */
+export const WEB_TOOL_KNOWN_NATIVE_SEARCH_NAMES: ReadonlySet<string> = new Set([
+  "web_search",
+  "google_search",
+]);
 
 export const providerCreateSchema = providerBaseSchema.pick({
   organizationId: true,


### PR DESCRIPTION
## Summary
- Normalizes every web-tool result (native provider search, a Web-search backend's `web_search`/`read_url`, and the web-fetch Tool set's `fetchUrl`) into one server-side shape, discriminated by `kind: "search" | "page" | "find"`, computed once in `apps/backend/src/runs/web-tool-normalize.ts` and read by both the live stream relay and the saved-Transcript read path.
- Deletes the frontend's old shape-guessing discriminator (`isPluginWebSearchPart`'s fallback) — ownership is now decided only by the core marker or a confirmed `providerExecuted` native tool name, never inferred from payload shape. The frontend holds no vendor knowledge.
- Anthropic's raw `web_search_result` array (with `encryptedContent`) and OpenAI's `{action, sources}` payload are reduced to a query/count/page-url — no raw vendor payload reaches the Transcript.
- Citation-lifting into the Sources row does **not** widen to native results; a native search's normalized result never carries `results`, only a raw `resultCount`.
- `fetchUrl` now carries the same core marker as `read_url` so page reads render on the same block instead of dumping page content into the Transcript.
- Docs updated in the same PR: CONTEXT.md gains the "Web tool block" term, ADR-0014 is amended in its superseded-in-place style, and `building-with-platypus/chat.mdx` describes the unified presentation.
- Accepted, narrow regression (stated in the issue as out of scope to avoid): a Web-search backend search stored before the marker existed now falls to the generic renderer rather than being guessed back onto the card.

Closes #525.

## Test plan
- [x] `pnpm typecheck` (all packages)
- [x] `pnpm lint` (all packages)
- [x] `pnpm test` — 2141 backend + 511 frontend tests pass, including new coverage in `apps/backend/src/runs/web-tool-normalize.test.ts` and rewritten coverage in `apps/frontend/components/{web-search-tool,chat-message}.test.tsx`
- [x] Independent standards + spec-vs-issue review pass (caught and fixed one bug: OpenAI's `openPage`/`findInPage` action types are camelCase in `@ai-sdk/openai@4.0.27`, not snake_case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)