### PR TITLE
fix(frontend): force Chat search off once the resolved selection can't search

### DIFF
--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -94,11 +94,11 @@ when:
 - nothing has resolved yet, because no Agent or model is selected.
 
 <Callout type="warning">
-  The toggle resets itself when you pick a different Provider or model directly
-  — the new endpoint may not support search, so it starts off. It does **not**
-  reset when you switch from one Agent to another, even though that changes
-  Provider too. So search you turned on for one Agent silently stays on for the
-  next one; turn it off yourself if you don't want it.
+  The toggle turns itself off the moment you switch to an Agent, Provider, or
+  model that can't search — the new endpoint may not support it, so it starts
+  off. Switching between two selections that both search leaves the toggle as
+  you set it, whether you're changing Agent or picking a Provider and model
+  directly; it never turns itself back on.
 </Callout>
 
 Search is a Provider setting, not a tool you grant. An Agent that should be able
@@ -253,7 +253,8 @@ switch to a model with a bigger window. Nothing happens automatically.
   **The meter appears; nothing enforces it.** Platypus does not trim, summarise,
   warn, or block a turn for approaching the window — reaching it fails at the
   vendor exactly as it did before, and the meter is the only thing that changed.
-  Treat a full meter as your cue to act, not as a guard rail that will catch you.
+  Treat a full meter as your cue to act, not as a guard rail that will catch
+  you.
 </Callout>
 
 **No meter at all** means one of two things, and both are normal: nobody has

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -39,8 +39,8 @@ import { type PlatypusUIMessage } from "@platypus/backend/src/types";
 import { joinUrl } from "@/lib/utils";
 import { writeAt, scopedPath } from "@/lib/api-write";
 import { useScopedSWR } from "@/hooks/use-scoped-swr";
-import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useChatSettings } from "@/hooks/use-chat-settings";
+import { useSearchToggle } from "@/hooks/use-search-toggle";
 import { useModelSelection } from "@/hooks/use-model-selection";
 import { resolveModel } from "@/lib/resolve-model";
 import { clearedToolCallIds } from "@/lib/tool-result-clearing";
@@ -86,7 +86,6 @@ export const Chat = ({
   const scope = useMemo(() => ({ orgId, workspaceId }), [orgId, workspaceId]);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [search, setSearch] = useState(false);
   const [inputValue, setInputValue] = useState("");
 
   // Fetch providers
@@ -212,6 +211,18 @@ export const Chat = ({
 
   // Extract values from hooks for easier access
   const { agentId, modelId, providerId } = selection;
+
+  // One entry point for "what model will this Chat turn use, and what can it
+  // do?" — replaces separately resolving the provider, the concrete model id,
+  // passthrough file types, context window and search capability by hand.
+  // `null` means nothing resolves yet: no selection made, or the selected
+  // Agent/Provider/model reference no longer exists.
+  const resolvedModel = resolveModel({
+    providers,
+    agents,
+    selection: { agentId, modelId, providerId },
+  });
+  const [search, setSearch] = useSearchToggle(resolvedModel);
   const {
     instructions,
     temperature,
@@ -342,9 +353,6 @@ export const Chat = ({
     }
   }, [initialAgentId, agentId, chatData, modelSetters]);
 
-  // Reset search when model or provider changes
-  useResetOnChange(`${modelId}:${providerId}`, () => setSearch(false));
-
   const handleCopyMessage = useCallback(
     async (content: string, messageId: string) => {
       try {
@@ -386,17 +394,6 @@ export const Chat = ({
   }
 
   const selectedAgent = agentId ? agents.find((a) => a.id === agentId) : null;
-
-  // One entry point for "what model will this Chat turn use, and what can it
-  // do?" — replaces separately resolving the provider, the concrete model id,
-  // passthrough file types, context window and search capability by hand.
-  // `null` means nothing resolves yet: no selection made, or the selected
-  // Agent/Provider/model reference no longer exists.
-  const resolvedModel = resolveModel({
-    providers,
-    agents,
-    selection: { agentId, modelId, providerId },
-  });
 
   // Context occupancy (ADR-0018): the capacity comes from the Org Admin's
   // declaration on the resolved model (`resolvedModel.contextWindow`), the

--- a/apps/frontend/hooks/use-search-toggle.test.tsx
+++ b/apps/frontend/hooks/use-search-toggle.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSearchToggle } from "./use-search-toggle";
+import type { ResolvedModel } from "@/lib/resolve-model";
+
+const searching: ResolvedModel = {
+  label: "Model",
+  concreteId: "model-1" as ResolvedModel["concreteId"],
+  contextWindow: undefined,
+  maxOutputTokens: undefined,
+  passthroughFileTypes: [],
+  canSearch: true,
+};
+
+const notSearching: ResolvedModel = { ...searching, canSearch: false };
+
+describe("useSearchToggle", () => {
+  it("starts off", () => {
+    const { result } = renderHook(() => useSearchToggle(searching));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("stays on switching between two selections that can both search", () => {
+    const { result, rerender } = renderHook(
+      ({ resolvedModel }: { resolvedModel: ResolvedModel | null }) =>
+        useSearchToggle(resolvedModel),
+      { initialProps: { resolvedModel: searching as ResolvedModel | null } },
+    );
+
+    act(() => result.current[1](true));
+    expect(result.current[0]).toBe(true);
+
+    // A different searchable selection (e.g. switching Agent) — search stays on.
+    rerender({
+      resolvedModel: {
+        ...searching,
+        concreteId: "model-2" as ResolvedModel["concreteId"],
+      },
+    });
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("forces off when switching to a selection that cannot search", () => {
+    const { result, rerender } = renderHook(
+      ({ resolvedModel }: { resolvedModel: ResolvedModel | null }) =>
+        useSearchToggle(resolvedModel),
+      { initialProps: { resolvedModel: searching as ResolvedModel | null } },
+    );
+
+    act(() => result.current[1](true));
+    expect(result.current[0]).toBe(true);
+
+    rerender({ resolvedModel: notSearching });
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("does not turn back on switching from a non-searching to a searching selection", () => {
+    const { result, rerender } = renderHook(
+      ({ resolvedModel }: { resolvedModel: ResolvedModel | null }) =>
+        useSearchToggle(resolvedModel),
+      { initialProps: { resolvedModel: notSearching as ResolvedModel | null } },
+    );
+
+    // Search was already forced/left off while on the non-searching selection.
+    expect(result.current[0]).toBe(false);
+
+    rerender({ resolvedModel: searching });
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("does nothing while the selection is unresolved, preserving the current setting", () => {
+    const { result, rerender } = renderHook(
+      ({ resolvedModel }: { resolvedModel: ResolvedModel | null }) =>
+        useSearchToggle(resolvedModel),
+      { initialProps: { resolvedModel: searching as ResolvedModel | null } },
+    );
+
+    act(() => result.current[1](true));
+    expect(result.current[0]).toBe(true);
+
+    // A brief loading/revalidation gap must not clobber the User's setting.
+    rerender({ resolvedModel: null });
+    expect(result.current[0]).toBe(true);
+
+    rerender({ resolvedModel: searching });
+    expect(result.current[0]).toBe(true);
+  });
+});

--- a/apps/frontend/hooks/use-search-toggle.ts
+++ b/apps/frontend/hooks/use-search-toggle.ts
@@ -1,0 +1,25 @@
+import { useState } from "react";
+import { useResetOnChange } from "./use-reset-on-change";
+import type { ResolvedModel } from "@/lib/resolve-model";
+
+/**
+ * The Chat search toggle, kept to one invariant (#624): search may not be on
+ * when the resolved selection cannot search. Keyed on `canSearch` itself —
+ * not on the Agent/Provider/model identity — so switching between two
+ * selections that can both search leaves the toggle exactly as the User set
+ * it. The invariant only ever forces the toggle off, never on, and does
+ * nothing while resolution is unknown (`resolvedModel === null`), so a brief
+ * loading/revalidation gap can't silently discard a chosen setting.
+ */
+export function useSearchToggle(resolvedModel: ResolvedModel | null) {
+  const [search, setSearch] = useState(false);
+
+  useResetOnChange(
+    resolvedModel === null ? null : resolvedModel.canSearch,
+    () => {
+      if (resolvedModel && !resolvedModel.canSearch) setSearch(false);
+    },
+  );
+
+  return [search, setSearch] as const;
+}


### PR DESCRIPTION
## Summary
- Replace the transition-based search reset (`useResetOnChange(${modelId}:${providerId}, ...)`) with an invariant, extracted into `useSearchToggle`: search may not be on when the resolved selection can't search.
- Every Agent produced the same `":"` reset key, so switching between Agents never reset the toggle — search stayed on (and kept being sent) across an Agent whose Provider can't search, or disappeared-but-stayed-on for a Provider with no search at all.
- The invariant unifies direct Provider/model selection and Agent selection onto one rule: force off whenever the resolved selection can't search, leave it as-is when switching between two searchable selections, never turn it back on, and do nothing while resolution is unresolved (`resolvedModel === null`) so a loading/revalidation gap can't clobber the user's setting.
- Updated the Chat docs callout to describe the unified behaviour.

Closes #624

## Test plan
- [x] `use-search-toggle.test.tsx` covers the issue's full truth table (stays on across two searching selections, forced off switching to a non-searching selection, stays off switching back to a searching one, unaffected by a transient unresolved state)
- [x] `pnpm typecheck`
- [x] `pnpm test` (2180 backend + 521 frontend + 40 docs, all passing)
- [x] `pnpm lint`