### PR TITLE
feat(backend): add identifiers Tool set for UUID and nanoid generation

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -52,6 +52,7 @@
     "ssh2": "^1.17.0",
     "turndown": "^7.2.4",
     "unpdf": "^1.8.0",
+    "uuid": "^14.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/apps/backend/src/plugins/tools-basic/index.test.ts
+++ b/apps/backend/src/plugins/tools-basic/index.test.ts
@@ -9,13 +9,13 @@ describe("@platypus/tools-basic plugin manifest", () => {
     expect(plugin.apiVersion).toBe(PLUGIN_API_VERSION);
   });
 
-  it("contributes the math-conversions and time tool sets with unprefixed ids", () => {
+  it("contributes the math-conversions, time and identifiers tool sets with unprefixed ids", () => {
     const ids = (plugin.contributes.toolSets ?? []).map((t) => t.id);
-    expect(ids).toEqual(["math-conversions", "time"]);
+    expect(ids).toEqual(["math-conversions", "time", "identifiers"]);
   });
 
   it("exposes the expected tools as static maps", () => {
-    const [math, time] = plugin.contributes.toolSets ?? [];
+    const [math, time, identifiers] = plugin.contributes.toolSets ?? [];
 
     expect(typeof math.tools).not.toBe("function");
     expect(Object.keys(math.tools as Record<string, unknown>)).toEqual([
@@ -29,6 +29,12 @@ describe("@platypus/tools-basic plugin manifest", () => {
     expect(Object.keys(time.tools as Record<string, unknown>)).toEqual([
       "getCurrentTime",
       "convertTimezone",
+    ]);
+
+    expect(typeof identifiers.tools).not.toBe("function");
+    expect(Object.keys(identifiers.tools as Record<string, unknown>)).toEqual([
+      "generateUuid",
+      "generateNanoId",
     ]);
   });
 });

--- a/apps/backend/src/plugins/tools-basic/index.ts
+++ b/apps/backend/src/plugins/tools-basic/index.ts
@@ -7,8 +7,10 @@ import {
   convertVolume,
 } from "../../tools/math.ts";
 import { getCurrentTime, convertTimezone } from "../../tools/time.ts";
+import { generateUuid, generateNanoId } from "../../tools/identifiers.ts";
 
-// First core plugin: pure utility Tool sets (math, time). Grouped by cohesion
+// First core plugin: pure utility Tool sets (math, time, identifiers). Grouped
+// by cohesion
 // per ADR-0013 (a capability gets its own plugin when an Operator would
 // plausibly want to deny it in isolation — utilities don't). Core ids stay
 // unprefixed, so every persisted `agent.toolSetIds` reference keeps working.
@@ -39,6 +41,16 @@ export const plugin: PlatypusPlugin = {
         tools: {
           getCurrentTime,
           convertTimezone,
+        },
+      },
+      {
+        id: "identifiers",
+        name: "Identifiers",
+        category: "Utilities",
+        description: "Generate unique UUIDs and short nanoids",
+        tools: {
+          generateUuid,
+          generateNanoId,
         },
       },
     ],

--- a/apps/backend/src/runs/tool-result-clearing-coverage.test.ts
+++ b/apps/backend/src/runs/tool-result-clearing-coverage.test.ts
@@ -159,6 +159,8 @@ const EXPECTED_CLEARABLE: Record<string, boolean> = {
   convertVolume: false,
   getCurrentTime: false,
   convertTimezone: false,
+  generateUuid: false,
+  generateNanoId: false,
 
   // Not clearable: Platypus-domain tools — mutating, or small/metadata-shaped
   // reads whose value is in staying visible, not in being large.

--- a/apps/backend/src/tools/identifiers.test.ts
+++ b/apps/backend/src/tools/identifiers.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import type { z } from "zod";
+import type { InferToolInput } from "ai";
+import { validate, version as uuidVersion } from "uuid";
+import { generateUuid, generateNanoId } from "./identifiers.ts";
+import { callTool } from "../test-utils.ts";
+
+type UuidInput = InferToolInput<typeof generateUuid>;
+type NanoIdInput = InferToolInput<typeof generateNanoId>;
+
+const uuidSchema = generateUuid.inputSchema as z.ZodType<UuidInput>;
+const nanoIdSchema = generateNanoId.inputSchema as z.ZodType<NanoIdInput>;
+
+/**
+ * `callTool` invokes `execute` directly, bypassing the AI SDK's schema-driven
+ * defaulting that happens before `execute` runs in production. These helpers
+ * resolve defaults through the schema first, so a test can omit an optional
+ * field the same way a model call omitting it would behave for real.
+ */
+const callUuidTool = (input: Partial<UuidInput>) =>
+  callTool(generateUuid, uuidSchema.parse(input));
+const callNanoIdTool = (input: Partial<NanoIdInput>) =>
+  callTool(generateNanoId, nanoIdSchema.parse(input));
+
+describe("generateUuid", () => {
+  it("with no arguments returns one hyphenated lowercase v4 UUID", async () => {
+    const result = await callUuidTool({});
+    expect(result.ids).toHaveLength(1);
+    const id = result.ids[0];
+    expect(validate(id)).toBe(true);
+    expect(uuidVersion(id)).toBe(4);
+    expect(id).toBe(id.toLowerCase());
+  });
+
+  it("with version v7 returns time-ordered v7 UUIDs", async () => {
+    const result = await callUuidTool({ version: "v7" });
+    const id = result.ids[0];
+    expect(validate(id)).toBe(true);
+    expect(uuidVersion(id)).toBe(7);
+
+    const second = await callUuidTool({ version: "v7" });
+    expect(id < second.ids[0]).toBe(true);
+  });
+
+  it("format no-hyphens returns a 32-character hex string with no hyphens", async () => {
+    const result = await callUuidTool({ format: "no-hyphens" });
+    expect(result.ids[0]).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("format standard returns 36 characters", async () => {
+    const result = await callUuidTool({ format: "standard" });
+    expect(result.ids[0]).toHaveLength(36);
+  });
+
+  it("rejects a version other than v4/v7", () => {
+    expect(uuidSchema.safeParse({ version: "v1" }).success).toBe(false);
+  });
+
+  it("rejects a format other than standard/no-hyphens", () => {
+    expect(uuidSchema.safeParse({ format: "uppercase" }).success).toBe(false);
+  });
+
+  it("count: 100 returns 100 distinct ids", async () => {
+    const result = await callUuidTool({ count: 100 });
+    expect(result.ids).toHaveLength(100);
+    expect(new Set(result.ids).size).toBe(100);
+  });
+
+  it("count: 0 is rejected as a validation error", () => {
+    expect(uuidSchema.safeParse({ count: 0 }).success).toBe(false);
+  });
+
+  it("count: 101 is rejected as a validation error, not clamped", () => {
+    expect(uuidSchema.safeParse({ count: 101 }).success).toBe(false);
+  });
+
+  it("returns an array for count: 1", async () => {
+    const result = await callUuidTool({ count: 1 });
+    expect(Array.isArray(result.ids)).toBe(true);
+  });
+});
+
+describe("generateNanoId", () => {
+  it("with no arguments returns one 21-character lowercase-alphanumeric id", async () => {
+    const result = await callNanoIdTool({});
+    expect(result.ids).toHaveLength(1);
+    expect(result.ids[0]).toMatch(/^[a-z0-9]{21}$/);
+  });
+
+  it("alphabet url-safe can return - or _", async () => {
+    const result = await callNanoIdTool({
+      alphabet: "url-safe",
+      count: 50,
+      size: 32,
+    });
+    const combined = result.ids.join("");
+    expect(/[-_]/.test(combined)).toBe(true);
+  });
+
+  it("alphabet alphanumeric returns only [A-Za-z0-9]", async () => {
+    const result = await callNanoIdTool({
+      alphabet: "alphanumeric",
+      count: 10,
+    });
+    for (const id of result.ids) {
+      expect(id).toMatch(/^[A-Za-z0-9]+$/);
+    }
+  });
+
+  it("alphabet lowercase-alphanumeric returns only [a-z0-9]", async () => {
+    const result = await callNanoIdTool({
+      alphabet: "lowercase-alphanumeric",
+      count: 10,
+    });
+    for (const id of result.ids) {
+      expect(id).toMatch(/^[a-z0-9]+$/);
+    }
+  });
+
+  it("size: 8 and size: 64 succeed", async () => {
+    const small = await callNanoIdTool({ size: 8 });
+    expect(small.ids[0]).toHaveLength(8);
+    const large = await callNanoIdTool({ size: 64 });
+    expect(large.ids[0]).toHaveLength(64);
+  });
+
+  it("size: 7 and size: 65 are rejected as validation errors", () => {
+    expect(nanoIdSchema.safeParse({ size: 7 }).success).toBe(false);
+    expect(nanoIdSchema.safeParse({ size: 65 }).success).toBe(false);
+  });
+
+  it("count: 100 returns 100 distinct ids", async () => {
+    const result = await callNanoIdTool({ count: 100 });
+    expect(result.ids).toHaveLength(100);
+    expect(new Set(result.ids).size).toBe(100);
+  });
+
+  it("count: 0 and count: 101 are rejected as validation errors, not clamped", () => {
+    expect(nanoIdSchema.safeParse({ count: 0 }).success).toBe(false);
+    expect(nanoIdSchema.safeParse({ count: 101 }).success).toBe(false);
+  });
+
+  it("returns an array for count: 1", async () => {
+    const result = await callNanoIdTool({ count: 1 });
+    expect(Array.isArray(result.ids)).toBe(true);
+  });
+});

--- a/apps/backend/src/tools/identifiers.ts
+++ b/apps/backend/src/tools/identifiers.ts
@@ -1,0 +1,94 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { v4 as uuidv4, v7 as uuidv7 } from "uuid";
+import { nanoid, customAlphabet } from "nanoid";
+
+const LOWERCASE_ALPHANUMERIC = "0123456789abcdefghijklmnopqrstuvwxyz";
+const ALPHANUMERIC =
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+export const generateUuid = tool({
+  description:
+    "Generate one or more RFC 9562 UUIDs. Use this for a standard 36-character " +
+    "(or 32-character, hyphen-free) interchange identifier — the default choice " +
+    "when nothing narrower is required. For a short id that fits a length or " +
+    "charset budget (e.g. a DNS label, an S3 or GCS bucket name), use " +
+    "generateNanoId instead.",
+  inputSchema: z.object({
+    version: z
+      .enum(["v4", "v7"])
+      .default("v4")
+      .describe(
+        "UUID version: v4 (random, default) or v7 (time-ordered, useful as database primary keys).",
+      ),
+    format: z
+      .enum(["standard", "no-hyphens"])
+      .default("standard")
+      .describe(
+        "Output format: standard hyphenated lowercase (default) or no-hyphens (32-character hex, no hyphens).",
+      ),
+    count: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .default(1)
+      .describe("How many UUIDs to generate (1-100, default 1)."),
+  }),
+  execute: ({ version, format, count }) => {
+    const generate = version === "v7" ? uuidv7 : uuidv4;
+    const ids = Array.from({ length: count }, () => {
+      const id = generate();
+      return format === "no-hyphens" ? id.replace(/-/g, "") : id;
+    });
+
+    return { ids, version, format, count };
+  },
+});
+
+// "url-safe" has no pool here: it maps to nanoid's own built-in alphabet, used
+// via the plain `nanoid()` call below rather than `customAlphabet`.
+const ALPHABETS = {
+  "lowercase-alphanumeric": LOWERCASE_ALPHANUMERIC,
+  alphanumeric: ALPHANUMERIC,
+  "url-safe": undefined,
+} as const;
+
+export const generateNanoId = tool({
+  description:
+    "Generate one or more short, unique nanoid identifiers. Use this when the " +
+    "target has a length or charset budget (e.g. a DNS label, an S3 or GCS " +
+    "bucket name, a k8s resource name) that a full UUID would not fit. For a " +
+    "standard 36-character interchange identifier, use generateUuid instead. " +
+    "The collision probability at a given size and alphabet is the caller's to " +
+    "reason about — this tool only enforces sane bounds, not a safety guarantee.",
+  inputSchema: z.object({
+    size: z
+      .number()
+      .int()
+      .min(8)
+      .max(64)
+      .default(21)
+      .describe("Length of each id in characters (8-64, default 21)."),
+    alphabet: z
+      .enum(["lowercase-alphanumeric", "alphanumeric", "url-safe"])
+      .default("lowercase-alphanumeric")
+      .describe(
+        "Character set to draw from: lowercase-alphanumeric [a-z0-9] (default, safe for DNS labels/S3/GCS), alphanumeric [A-Za-z0-9], or url-safe (nanoid's own 64-character alphabet, including - and _).",
+      ),
+    count: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .default(1)
+      .describe("How many ids to generate (1-100, default 1)."),
+  }),
+  execute: ({ size, alphabet, count }) => {
+    const pool = ALPHABETS[alphabet];
+    const generate = pool ? customAlphabet(pool, size) : () => nanoid(size);
+    const ids = Array.from({ length: count }, () => generate());
+
+    return { ids, size, alphabet, count };
+  },
+});

--- a/apps/docs/content/building-with-platypus/tool-sets.mdx
+++ b/apps/docs/content/building-with-platypus/tool-sets.mdx
@@ -21,6 +21,7 @@ has loaded. If something below isn't there, your Operator hasn't enabled it — 
 | ----------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
 | **Math Conversions**    | Math          | Convert temperature, distance, weight and volume between units.                                                     | Always                           |
 | **Time**                | Utilities     | Read the current time and convert between timezones.                                                                | Always                           |
+| **Identifiers**         | Utilities     | Generate unique ids — UUIDs, or short nanoids — for naming records and resources in external systems.               | Always                           |
 | **Kanban**              | Productivity  | Read a Board's full state, and create, move, copy, bulk-edit and delete cards and their comments.                   | Always                           |
 | **Dashboards**          | Productivity  | List Dashboards and their widgets, and write new data into a widget.                                                | Always                           |
 | **Triggers**            | Automation    | List and read Triggers, and **create, edit and delete** them — including scheduling new unattended runs.             | Always                           |

--- a/apps/frontend/components/ai-elements/tool.tsx
+++ b/apps/frontend/components/ai-elements/tool.tsx
@@ -27,6 +27,7 @@ import {
   FileIcon,
   FilePenIcon,
   FilePlusIcon,
+  FingerprintIcon,
   FolderIcon,
   GlobeIcon,
   KanbanSquareIcon,
@@ -104,6 +105,9 @@ const toolToToolSet: Record<string, string> = {
   // time
   getCurrentTime: "time",
   convertTimezone: "time",
+  // identifiers
+  generateUuid: "identifiers",
+  generateNanoId: "identifiers",
   // math-conversions
   convertTemperature: "math-conversions",
   convertDistance: "math-conversions",
@@ -157,6 +161,7 @@ const toolSetIcons: Record<string, LucideIcon> = {
   "skill-management": SparklesIcon,
   "agent-management": BotIcon,
   time: ClockIcon,
+  identifiers: FingerprintIcon,
   "math-conversions": ArrowRightLeftIcon,
   "web-fetch": GlobeIcon,
   notifications: BellIcon,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       unpdf:
         specifier: ^1.8.0
         version: 1.8.0
+      uuid:
+        specifier: ^14.0.1
+        version: 14.0.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -759,6 +762,9 @@ packages:
   '@aws-sdk/core@3.977.4':
     resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-env@3.972.65':
     resolution: {integrity: sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==}
@@ -4086,10 +4092,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -12823,7 +12831,7 @@ snapshots:
       eslint: 10.8.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@10.8.0(jiti@2.7.0)))(eslint@10.8.0(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.8.0(jiti@2.7.0)))(eslint@10.8.0(jiti@2.7.0)))(eslint@10.8.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.8.0(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.8.0(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@10.8.0(jiti@2.7.0))
@@ -12856,7 +12864,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.8.0(jiti@2.7.0)))(eslint@10.8.0(jiti@2.7.0)))(eslint@10.8.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -12870,7 +12878,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.8.0(jiti@2.7.0)))(eslint@10.8.0(jiti@2.7.0)))(eslint@10.8.0(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.8.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary

- Adds a `generateUuid` tool (v4/v7, standard/no-hyphens format, count 1-100) and a `generateNanoId` tool (size 8-64, three fixed alphabets, count 1-100) so an Agent gets real random ids instead of inventing them.
- Registers both under a new `identifiers` Tool set (category **Utilities**) in the always-on `@platypus/tools-basic` core plugin.
- Wires `FingerprintIcon` into the frontend tool-icon resolver for both tool names and the `identifiers` set.
- Adds the **Identifiers** row to the Tool sets catalogue doc, after **Time**.
- Adds `uuid` as a backend dependency (`nanoid` was already a direct dependency).

Closes #667, following the maintainer's Agent Brief on that issue (narrowed enums: no v1/v6, no uppercase/urn format, no free-text alphabet; Zod bounds reject out-of-range input rather than clamping; both tools always return an array and echo resolved options).

## Test plan

- [x] `pnpm test` — full suite passes (2199 backend tests, 516 frontend tests), including 19 new tests covering every acceptance criterion in the issue
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Standards + Spec code review (parallel sub-agents) — no hard violations, no missing/extra scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)