### PR TITLE
feat(backend): surface MCP read-only hints for Tool-result clearing

### DIFF
--- a/apps/backend/src/runs/drive.ts
+++ b/apps/backend/src/runs/drive.ts
@@ -8,6 +8,7 @@ import {
 import { logger } from "../logger.ts";
 import type { PlatypusUIMessage } from "../types.ts";
 import { createMessageMetadata } from "./message-metadata.ts";
+import { isClearableToolName } from "./tool-result-clearing.ts";
 import {
   createNoProgressDetector,
   NoProgressError,
@@ -322,6 +323,11 @@ const runStreamedDrive = (
       stepCeiling: opts.plan.maxSteps,
       prepDurationMs,
       driveStartMs,
+      isClearableTool: (toolName) =>
+        isClearableToolName(
+          toolName,
+          (n) => opts.plan.readOnlyToolNames?.has(n) ?? false,
+        ),
     }),
     onError: (error) => formatStreamError(error),
     onFinish: ({ messages: finalMessages }) => {

--- a/apps/backend/src/runs/message-metadata.test.ts
+++ b/apps/backend/src/runs/message-metadata.test.ts
@@ -572,6 +572,83 @@ describe("Preparation and Model durations", () => {
   });
 });
 
+/**
+ * The turn's clearable Tool names, among the ones it actually called
+ * (ADR-0021, issue #626) — the fact the Chat UI's client-side clearing mirror
+ * reads instead of importing a name list of its own.
+ */
+describe("read-only Tool names over a real multi-step stream", () => {
+  it("reports a called tool the resolver says is clearable", async () => {
+    const result = streamText({
+      model: mockModel([
+        toolCallStep(usage(1_000, 30)),
+        answerStep(usage(4_200, 70)),
+      ]),
+      prompt: "Ping the service and tell me what it said.",
+      tools: { ping },
+      stopWhen: [stepCountIs(5)],
+    });
+
+    const message = await lastSnapshot(
+      result.toUIMessageStream({
+        messageMetadata: createMessageMetadata({
+          agentId: "agent-1",
+          isClearableTool: (name) => name === "ping",
+        }),
+      }),
+    );
+
+    expect(message?.metadata?.readOnlyToolNames).toEqual(["ping"]);
+  });
+
+  it("reports nothing when the resolver says no called tool is clearable", async () => {
+    const result = streamText({
+      model: mockModel([
+        toolCallStep(usage(1_000, 30)),
+        answerStep(usage(4_200, 70)),
+      ]),
+      prompt: "Ping the service and tell me what it said.",
+      tools: { ping },
+      stopWhen: [stepCountIs(5)],
+    });
+
+    const message = await lastSnapshot(
+      result.toUIMessageStream({
+        messageMetadata: createMessageMetadata({
+          agentId: "agent-1",
+          isClearableTool: () => false,
+        }),
+      }),
+    );
+
+    expect(message?.metadata).not.toHaveProperty("readOnlyToolNames");
+  });
+
+  it("reports nothing when no resolver is given at all", async () => {
+    const { message } = await runTurn();
+
+    expect(message?.metadata).not.toHaveProperty("readOnlyToolNames");
+  });
+
+  it("reports nothing for a turn that called no tools", async () => {
+    const result = streamText({
+      model: mockModel([answerStep(usage(1_000, 30))]),
+      prompt: "Just answer.",
+    });
+
+    const message = await lastSnapshot(
+      result.toUIMessageStream({
+        messageMetadata: createMessageMetadata({
+          agentId: "agent-1",
+          isClearableTool: () => true,
+        }),
+      }),
+    );
+
+    expect(message?.metadata).not.toHaveProperty("readOnlyToolNames");
+  });
+});
+
 describe("search availability over a real stream", () => {
   const answerOnly = () =>
     streamText({

--- a/apps/backend/src/runs/message-metadata.ts
+++ b/apps/backend/src/runs/message-metadata.ts
@@ -72,6 +72,15 @@ export type MessageMetadataFacts = {
   /** Injectable clock, so a test can assert an exact `modelDurationMs` rather
    *  than a real elapsed delay. Defaults to `Date.now`. */
   now?: () => number;
+  /**
+   * Whether a tool name is clearable this turn — the core allowlist plus
+   * whatever the Tool session resolved from MCP `readOnlyHint` declarations
+   * (ADR-0021, issue #626). Read on `tool-result`/`tool-error`, the same
+   * parts `toolDurations` is read on, since both need the call that just
+   * finished. Absent means no tool is ever reported, which is what a run with
+   * no resolved Tool session (a headless Trigger) already gets today.
+   */
+  isClearableTool?: (toolName: string) => boolean;
 };
 
 export const createMessageMetadata = ({
@@ -82,6 +91,7 @@ export const createMessageMetadata = ({
   prepDurationMs,
   driveStartMs,
   now = Date.now,
+  isClearableTool,
 }: MessageMetadataFacts = {}) => {
   // Whether any step of this turn has reported an input-token count. Only
   // read to erase a reading, never to synthesise one — see the `finish-step`
@@ -96,6 +106,10 @@ export const createMessageMetadata = ({
   // right beside it.
   let inputTokensSum = 0;
   let outputTokensSum = 0;
+  // The turn's clearable Tool names among the ones it has actually called so
+  // far — reported in full each time, like `tokenUsage`'s sum, since the
+  // merge replaces an array rather than concatenating it.
+  const calledClearableToolNames = new Set<string>();
 
   return ({
     part,
@@ -183,10 +197,16 @@ export const createMessageMetadata = ({
     // survives. A call absent from the map was executed by the Provider, never
     // locally, and so was never measured.
     if (part.type === "tool-result" || part.type === "tool-error") {
+      const meta: ChatMessageMetadata = {};
       const durationMs = toolDurations.get(part.toolCallId);
-      return durationMs === undefined
-        ? undefined
-        : { toolDurations: { [part.toolCallId]: Math.round(durationMs) } };
+      if (durationMs !== undefined) {
+        meta.toolDurations = { [part.toolCallId]: Math.round(durationMs) };
+      }
+      if (isClearableTool?.(part.toolName)) {
+        calledClearableToolNames.add(part.toolName);
+        meta.readOnlyToolNames = [...calledClearableToolNames];
+      }
+      return Object.keys(meta).length > 0 ? meta : undefined;
     }
     // The terminal finish only. A step inside a tool loop can end at the
     // ceiling and the run still recover and complete normally; flagging those

--- a/apps/backend/src/runs/run-plan.ts
+++ b/apps/backend/src/runs/run-plan.ts
@@ -5,7 +5,10 @@ import {
   type Tool,
 } from "ai";
 import type { NoProgressDetector } from "./no-progress.ts";
-import { applyToolResultClearing } from "./tool-result-clearing.ts";
+import {
+  applyToolResultClearing,
+  DEFAULT_CLEARING_POLICY,
+} from "./tool-result-clearing.ts";
 import { stepOccupancy } from "./run-stats.ts";
 
 /**
@@ -41,6 +44,16 @@ export type RunPlan = {
    * history, and for a Chat's very first turn.
    */
   initialOccupancy?: number;
+  /**
+   * Names this turn's Tool session resolved to an MCP-declared `readOnlyHint`
+   * (ADR-0021, issue #626) — keyed by the name a Tool enters the turn's tool
+   * map under, so it agrees with `ModelMessage` tool-result parts whether or
+   * not #467's namespacing has landed. The one input Tool-result clearing
+   * needs beyond the core allowlist it already knows; see
+   * `buildModelInvocation` below. Absent for a plan no Tool session resolved
+   * (a headless Trigger run), which clears only the core allowlist.
+   */
+  readOnlyToolNames?: ReadonlySet<string>;
 };
 
 /** The generation settings, minus any the plan never set. */
@@ -115,10 +128,12 @@ export const buildModelInvocation = (
       steps.length > 0
         ? stepOccupancy(steps[steps.length - 1]?.usage)
         : plan.initialOccupancy;
-    const cleared = applyToolResultClearing(messages, {
-      occupancy,
-      contextWindow: plan.contextWindow,
-    });
+    const cleared = applyToolResultClearing(
+      messages,
+      { occupancy, contextWindow: plan.contextWindow },
+      DEFAULT_CLEARING_POLICY,
+      (toolName) => plan.readOnlyToolNames?.has(toolName) ?? false,
+    );
     return cleared === messages ? {} : { messages: cleared };
   },
   ...declaredSettings(plan),

--- a/apps/backend/src/runs/sub-agent-lifecycle.test.ts
+++ b/apps/backend/src/runs/sub-agent-lifecycle.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { LanguageModelV3StreamPart } from "@ai-sdk/provider";
 import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
-import type { Tool } from "ai";
 import { z } from "zod";
 
 vi.mock("../logger.ts", () => ({
@@ -128,14 +127,17 @@ describe("a delegated run inside a parent run", () => {
       },
       loadTools: () =>
         Promise.resolve({
-          slowWork: {
-            inputSchema: z.object({}),
-            execute: async () => {
-              await sleep(SUB_AGENT_MS);
-              return "done";
+          tools: {
+            slowWork: {
+              inputSchema: z.object({}),
+              execute: async () => {
+                await sleep(SUB_AGENT_MS);
+                return "done";
+              },
             },
           },
-        } as unknown as Record<string, Tool>),
+          readOnlyToolNames: new Set(),
+        }),
       parentRun: { runId: "parent", scope: parentScope },
     });
 
@@ -195,7 +197,8 @@ describe("a delegated run inside a parent run", () => {
         ),
         maxSteps: DEFAULT_AGENT_MAX_STEPS,
       },
-      loadTools: () => Promise.resolve({}),
+      loadTools: () =>
+        Promise.resolve({ tools: {}, readOnlyToolNames: new Set() }),
       parentRun: { runId: "parent", scope: parentScope },
     });
 

--- a/apps/backend/src/runs/tool-result-clearing-coverage.test.ts
+++ b/apps/backend/src/runs/tool-result-clearing-coverage.test.ts
@@ -70,11 +70,13 @@ import { getToolSets, SANDBOX_TOOLSET_ID } from "../tools/index.ts";
  * materialized without one, so they are asserted by their known, grep-stable
  * literal names.
  *
- * Scope: core plugins only, matching the allowlist's own scope — MCP and
- * third-party plugin tools are deny-by-default and untouched by #524 pending
- * read-only hints (#626). Sub-Agent delegation is one fixed tool name,
- * `delegate`, assigned ad hoc in `chat-execution.ts` like `loadSkill` — the
- * `delegateTo*` names it replaced live on only in stored Chat history.
+ * Scope: core plugins only, matching the allowlist's own scope — an MCP or
+ * third-party plugin tool is deny-by-default here too, unless its MCP
+ * declared `readOnlyHint` (ADR-0021, issue #626), which this inventory does
+ * not exercise: that resolver lives on the Tool session, not in
+ * `isClearableToolName`'s own default. Sub-Agent delegation is one fixed tool
+ * name, `delegate`, assigned ad hoc in `chat-execution.ts` like `loadSkill` —
+ * the `delegateTo*` names it replaced live on only in stored Chat history.
  */
 
 const CORE_PLUGIN_NAMES = ["@platypus/web-fetch"];

--- a/apps/backend/src/runs/tool-result-clearing.test.ts
+++ b/apps/backend/src/runs/tool-result-clearing.test.ts
@@ -51,6 +51,26 @@ describe("isClearableToolName", () => {
       false,
     );
   });
+
+  // The MCP read-only hint (ADR-0021, issue #626): a caller-supplied resolver,
+  // never a concept this module holds itself.
+  describe("with an isReadOnlyTool resolver", () => {
+    it("allows a name the resolver reports read-only", () => {
+      expect(isClearableToolName("docs__search", () => true)).toBe(true);
+    });
+
+    it("denies a name the resolver reports not read-only", () => {
+      expect(isClearableToolName("docs__write", () => false)).toBe(false);
+    });
+
+    it("still allows the core allowlist even when the resolver denies everything", () => {
+      expect(isClearableToolName("web_search", () => false)).toBe(true);
+    });
+
+    it("denies everything outside the core allowlist with no resolver given", () => {
+      expect(isClearableToolName("docs__search")).toBe(false);
+    });
+  });
 });
 
 describe("clearStaleToolResults", () => {
@@ -116,6 +136,39 @@ describe("clearStaleToolResults", () => {
       toolResultMessage("read_url", "t2", "content"),
     ];
     expect(clearStaleToolResults(messages, POLICY)).toBe(messages);
+  });
+
+  it("clears an MCP tool's results when the resolver reports it read-only", () => {
+    const messages: ModelMessage[] = [
+      toolResultMessage("docs__search", "t1", "content"),
+      toolResultMessage("docs__search", "t2", "content"),
+      toolResultMessage("docs__search", "t3", "content"),
+    ];
+
+    const result = clearStaleToolResults(messages, POLICY, () => true);
+    const contents = result
+      .filter((m) => m.role === "tool")
+      .map((m) => (m as { content: unknown[] }).content[0]);
+    expect(contents).toEqual([
+      expect.objectContaining({
+        toolCallId: "t1",
+        output: { type: "text", value: CLEARED_TOOL_RESULT_MARKER },
+      }),
+      expect.objectContaining({ toolCallId: "t2" }),
+      expect.objectContaining({ toolCallId: "t3" }),
+    ]);
+  });
+
+  it("never clears an MCP tool's results when the resolver reports it not read-only", () => {
+    const messages: ModelMessage[] = [
+      toolResultMessage("docs__write", "w1", "wrote"),
+      toolResultMessage("docs__write", "w2", "wrote"),
+      toolResultMessage("docs__write", "w3", "wrote"),
+      toolResultMessage("docs__write", "w4", "wrote"),
+    ];
+
+    const result = clearStaleToolResults(messages, POLICY, () => false);
+    expect(result).toBe(messages);
   });
 
   it("counts recency across mixed clearable and non-clearable tool results", () => {
@@ -189,5 +242,21 @@ describe("applyToolResultClearing", () => {
       POLICY,
     );
     expect(result).toBe(messages);
+  });
+
+  it("passes isReadOnlyTool through to the underlying clearing pass", () => {
+    const mcpMessages: ModelMessage[] = [
+      toolResultMessage("docs__search", "t1", "content"),
+      toolResultMessage("docs__search", "t2", "content"),
+      toolResultMessage("docs__search", "t3", "content"),
+    ];
+
+    const result = applyToolResultClearing(
+      mcpMessages,
+      { occupancy: 95, contextWindow: 100 },
+      POLICY,
+      () => true,
+    );
+    expect(result).not.toBe(mcpMessages);
   });
 });

--- a/apps/backend/src/runs/tool-result-clearing.ts
+++ b/apps/backend/src/runs/tool-result-clearing.ts
@@ -22,8 +22,11 @@ import {
 
 /**
  * What a cleared result's content becomes. Deliberately says nothing about
- * re-running the tool: some tools have side effects, and Platypus cannot
- * currently tell which, so the marker only reports the absence.
+ * re-running the tool: a model told to call it again would spend steps
+ * re-fetching what it was just told to forget, and that holds regardless of
+ * whether the tool happens to be one core has affirmative reason to believe
+ * only reads (issue #626) — the marker's audience is the model, not an
+ * Operator deciding what is safe to clear.
  */
 export const CLEARED_TOOL_RESULT_MARKER =
   "[Tool result cleared: this content was removed from what was sent to the model to free up space in its context window. It is no longer available here.]";
@@ -40,25 +43,43 @@ export const DEFAULT_CLEARING_POLICY: ClearingPolicy = {
   keepRecent: TOOL_RESULT_CLEARING_KEEP_RECENT,
 };
 
-/** Whether a tool's results are on the clearable allowlist. Deny by default. */
-export const isClearableToolName = (toolName: string): boolean =>
-  CLEARABLE_TOOL_NAMES.has(toolName);
+/** Never treats a tool as read-only. The default for a caller with no MCP hints to consult. */
+const NEVER_READ_ONLY = (): boolean => false;
+
+/**
+ * Whether a tool's results are clearable: it is on the core allowlist, or
+ * `isReadOnlyTool` — the caller's answer for an MCP-declared `readOnlyHint`
+ * (ADR-0021, issue #626) — says so. Deny by default: an unclassified core name
+ * and an MCP tool with no (or no trustworthy) hint are both denied.
+ *
+ * This module stays a pure retention rule that knows nothing about MCP —
+ * `isReadOnlyTool` is the seam the Tool session's read-only sidecar is
+ * threaded through at, not a concept this module holds itself.
+ */
+export const isClearableToolName = (
+  toolName: string,
+  isReadOnlyTool: (toolName: string) => boolean = NEVER_READ_ONLY,
+): boolean => CLEARABLE_TOOL_NAMES.has(toolName) || isReadOnlyTool(toolName);
 
 /** The location of one tool-result part inside a `ModelMessage[]`. */
 type ResultLocation = { messageIndex: number; partIndex: number };
 
 /**
- * Every allowlisted tool-result part in `messages`, in transcript order —
- * which is recency order, since a Transcript only ever grows by appending.
+ * Every clearable tool-result part in `messages`, in transcript order — which
+ * is recency order, since a Transcript only ever grows by appending.
  */
 const clearableResultLocations = (
   messages: ModelMessage[],
+  isReadOnlyTool: (toolName: string) => boolean,
 ): ResultLocation[] => {
   const locations: ResultLocation[] = [];
   messages.forEach((message, messageIndex) => {
     if (message.role !== "tool") return;
     message.content.forEach((part, partIndex) => {
-      if (part.type === "tool-result" && isClearableToolName(part.toolName)) {
+      if (
+        part.type === "tool-result" &&
+        isClearableToolName(part.toolName, isReadOnlyTool)
+      ) {
         locations.push({ messageIndex, partIndex });
       }
     });
@@ -67,11 +88,16 @@ const clearableResultLocations = (
 };
 
 /**
- * Clears every allowlisted tool result EXCEPT the `keepRecent` most recent —
+ * Clears every clearable tool result EXCEPT the `keepRecent` most recent —
  * unconditionally, with no occupancy check. `applyToolResultClearing` below is
  * the gated entry point every caller outside this module should use; this is
  * exported separately so the "which results survive" rule can be tested on
  * its own from the threshold rule.
+ *
+ * `isReadOnlyTool` is the caller's per-turn answer for a name outside the core
+ * allowlist — an MCP's declared `readOnlyHint`, resolved by the Tool session
+ * (issue #626). Absent, every tool outside the core allowlist is denied,
+ * matching the deny-by-default posture this shipped with.
  *
  * Returns the same array reference when nothing changes, so a caller can tell
  * "untouched" from "rebuilt" without a deep comparison.
@@ -79,8 +105,9 @@ const clearableResultLocations = (
 export const clearStaleToolResults = (
   messages: ModelMessage[],
   policy: ClearingPolicy = DEFAULT_CLEARING_POLICY,
+  isReadOnlyTool: (toolName: string) => boolean = NEVER_READ_ONLY,
 ): ModelMessage[] => {
-  const locations = clearableResultLocations(messages);
+  const locations = clearableResultLocations(messages, isReadOnlyTool);
   const staleCount = Math.max(0, locations.length - policy.keepRecent);
   if (staleCount === 0) return messages;
 
@@ -126,9 +153,10 @@ export const applyToolResultClearing = (
   messages: ModelMessage[],
   reading: OccupancyReading,
   policy: ClearingPolicy = DEFAULT_CLEARING_POLICY,
+  isReadOnlyTool: (toolName: string) => boolean = NEVER_READ_ONLY,
 ): ModelMessage[] => {
   const { occupancy, contextWindow } = reading;
   if (occupancy === undefined || contextWindow === undefined) return messages;
   if (occupancy / contextWindow < policy.thresholdFraction) return messages;
-  return clearStaleToolResults(messages, policy);
+  return clearStaleToolResults(messages, policy, isReadOnlyTool);
 };

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -1848,7 +1848,10 @@ describe("chat-execution", () => {
 
     it("resolves an org-scoped (Shared) MCP at Chat-turn time", async () => {
       mockCreateMCPClient.mockResolvedValueOnce({
-        tools: vi.fn().mockResolvedValue({ mcpTool: { description: "x" } }),
+        listTools: vi.fn().mockResolvedValue({ tools: [{ name: "mcpTool" }] }),
+        toolsFromDefinitions: vi
+          .fn()
+          .mockReturnValue({ mcpTool: { description: "x" } }),
         close: vi.fn().mockResolvedValue(undefined),
       });
 
@@ -1876,6 +1879,37 @@ describe("chat-execution", () => {
       );
 
       expect(turn.stream.tools).toHaveProperty("test_mcp__mcpTool");
+      await turn.dispose();
+    });
+
+    // ADR-0021, issue #626: the Tool session's read-only sidecar rides the
+    // resolved plan, keyed the same way the tool map is.
+    it("carries an MCP tool's declared read-only hint onto the plan", async () => {
+      mockCreateMCPClient.mockResolvedValueOnce({
+        listTools: vi.fn().mockResolvedValue({
+          tools: [{ name: "readTool", annotations: { readOnlyHint: true } }],
+        }),
+        toolsFromDefinitions: vi
+          .fn()
+          .mockReturnValue({ readTool: { description: "reads only" } }),
+        close: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const queries = createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        agents: [agentWithMcp],
+        providers: [baseProvider],
+        mcps: [{ ...baseMcp, workspaceId: baseWorkspace.id }],
+      });
+
+      const turn = await prepareChatTurn(
+        { ...baseInput, request: { agentId: agentWithMcp.id } },
+        queries,
+      );
+
+      expect(turn.stream.readOnlyToolNames?.has("test_mcp__readTool")).toBe(
+        true,
+      );
       await turn.dispose();
     });
 

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -706,6 +706,11 @@ export const prepareChatTurn = async (
       tools: wrappedTools,
       system: systemPrompt,
       messages: inlinedMessages,
+      // Tool-result clearing's other input beyond the core allowlist
+      // (ADR-0021, issue #626): only the session's OWN MCP resolutions, never
+      // a delegate's — a Sub-Agent's plan carries its own nested session's
+      // hints (`createSubAgentDelegate`), resolved under its own rule.
+      readOnlyToolNames: session.readOnlyToolNames,
       ...(initialOccupancy !== undefined ? { initialOccupancy } : {}),
     },
     resolved: {
@@ -962,7 +967,10 @@ const loadSubAgents = async (
     async (subAgentId: string, toolSetIds: string[]) => {
       const parent = await session;
       const nested = await parent.nest({ id: subAgentId, toolSetIds });
-      return nested.tools;
+      return {
+        tools: nested.tools,
+        readOnlyToolNames: nested.readOnlyToolNames,
+      };
     },
     run,
     // Handed over rather than concatenated onto the result below: the tool

--- a/apps/backend/src/tools/sub-agent.test.ts
+++ b/apps/backend/src/tools/sub-agent.test.ts
@@ -9,6 +9,7 @@ import {
   createDelegateTools,
   createSubAgentDelegate,
   DELEGATE_TOOL_NAME,
+  type LoadedSubAgentTools,
   subAgentToolName,
   SUB_AGENT_STEP_LIMIT_NOTE,
   SUB_AGENT_TRUNCATION_NOTE,
@@ -107,11 +108,13 @@ const parentScope: WorkspaceScope = workspaceScope(
 
 /**
  * A delegate's tools as the lazy loader it now takes: they are opened on first
- * invocation, so the option is a thunk rather than a resolved map.
+ * invocation, so the option is a thunk rather than a resolved map. Carries no
+ * read-only hints — a test that needs one builds `LoadedSubAgentTools`
+ * directly.
  */
 const toolsOf =
-  (tools: Record<string, Tool>) => (): Promise<Record<string, Tool>> =>
-    Promise.resolve(tools);
+  (tools: Record<string, Tool>) => (): Promise<LoadedSubAgentTools> =>
+    Promise.resolve({ tools, readOnlyToolNames: new Set() });
 
 const baseOptions = {
   id: "agent-1",
@@ -132,7 +135,7 @@ type LegacyOptions = Partial<{
   description: string;
   instructions: string;
   model: ReturnType<typeof modelOf>;
-  loadTools: () => Promise<Record<string, Tool>>;
+  loadTools: () => Promise<LoadedSubAgentTools>;
   maxSteps: number;
   securityGuardrails: string | null;
   sampling: Partial<
@@ -980,7 +983,9 @@ describe("createSubAgentDelegate", () => {
   // (#321 one level down), which is why this wrapper no longer touches them.
   describe("sub-agent tools", () => {
     it("opens its tools on invocation, not when the delegate is built", async () => {
-      const loadTools = vi.fn().mockResolvedValue({});
+      const loadTools = vi
+        .fn()
+        .mockResolvedValue({ tools: {}, readOnlyToolNames: new Set() });
       const tool = delegateToolFor(buildOptions({ loadTools }));
       expect(loadTools).not.toHaveBeenCalled();
 
@@ -1169,7 +1174,9 @@ describe("createDelegateTools", () => {
     ];
 
     const resolvePlan = workingPlan();
-    const loadToolsFn = vi.fn().mockResolvedValue({});
+    const loadToolsFn = vi
+      .fn()
+      .mockResolvedValue({ tools: {}, readOnlyToolNames: new Set() });
 
     const result = await createDelegateTools(
       subAgents,
@@ -1214,7 +1221,7 @@ describe("createDelegateTools", () => {
     const { tools } = await createDelegateTools(
       [{ id: "sa-1", name: "Research" }],
       resolvePlan,
-      vi.fn().mockResolvedValue({}),
+      vi.fn().mockResolvedValue({ tools: {}, readOnlyToolNames: new Set() }),
     );
     await runTool(tools, "Research");
 
@@ -1239,7 +1246,7 @@ describe("createDelegateTools", () => {
     const result = await createDelegateTools(
       subAgents,
       resolvePlan,
-      vi.fn().mockResolvedValue({}),
+      vi.fn().mockResolvedValue({ tools: {}, readOnlyToolNames: new Set() }),
     );
 
     // Advertised: only the one that resolved.
@@ -1270,7 +1277,7 @@ describe("createDelegateTools", () => {
     const result = await createDelegateTools(
       subAgents,
       resolvePlan,
-      vi.fn().mockResolvedValue({}),
+      vi.fn().mockResolvedValue({ tools: {}, readOnlyToolNames: new Set() }),
     );
 
     expect(result.catalogue).toEqual([
@@ -1309,7 +1316,7 @@ describe("createDelegateTools", () => {
     const result = await createDelegateTools(
       [{ id: "sa-1", name: "Working" }],
       workingPlan(),
-      vi.fn().mockResolvedValue({}),
+      vi.fn().mockResolvedValue({ tools: {}, readOnlyToolNames: new Set() }),
       undefined,
       [{ id: "sub-gone", reason: "not available in this workspace" }],
     );
@@ -1333,7 +1340,7 @@ describe("createDelegateTools", () => {
     const { tools } = await createDelegateTools(
       [{ id: "sa-1", name: "Guarded", instructions: "You are guarded." }],
       resolvePlan,
-      vi.fn().mockResolvedValue({}),
+      vi.fn().mockResolvedValue({ tools: {}, readOnlyToolNames: new Set() }),
     );
     await runTool(tools, "Guarded");
 

--- a/apps/backend/src/tools/sub-agent.ts
+++ b/apps/backend/src/tools/sub-agent.ts
@@ -17,6 +17,16 @@ import type { PlatypusUIMessage } from "../types.ts";
 export const DELEGATE_TOOL_NAME = "delegate";
 
 /**
+ * What loading a delegate's tools resolves to: its Tools, plus which of them
+ * an MCP declared `readOnlyHint` on (ADR-0021, issue #626) — the nested Tool
+ * session's own sidecar, resolved by the same rule its parent's is.
+ */
+export type LoadedSubAgentTools = {
+  tools: Record<string, Tool>;
+  readOnlyToolNames: ReadonlySet<string>;
+};
+
+/**
  * The tool name a delegation was recorded under BEFORE the single `delegate`
  * dispatcher — "delegateTo<PascalCaseName>", e.g. "Research Agent" →
  * "delegateToResearchAgent".
@@ -196,7 +206,7 @@ interface SubAgentDelegateOptions {
    * the MCP servers its delegates would have used (the sub-agent's half of the
    * Tool session, see `tool-session.ts`).
    */
-  loadTools: () => Promise<Record<string, Tool>>;
+  loadTools: () => Promise<LoadedSubAgentTools>;
   /**
    * Everything THIS sub-agent's own (Provider, model) pair resolved to —
    * model, step ceiling, output ceiling, sampling — via `resolveGenerationPlan`,
@@ -362,7 +372,7 @@ export const createSubAgentDelegate = (
           // Inside the try: opening this delegate's own tools can fail the
           // same way its stream can, and it reaches the parent as a tool error
           // either way rather than an unattributed throw.
-          const tools = await loadTools();
+          const { tools, readOnlyToolNames } = await loadTools();
           const drive = driveDelegate({
             // A Sub-Agent invocation receives Instructions plus guardrails and
             // nothing else — no workspace context, no memories, no user
@@ -377,6 +387,11 @@ export const createSubAgentDelegate = (
               // arrive already normalized — the Tool session that loaded them
               // owns that (#321 one level down).
               tools: wrapToolsWithActivity(tools, run.onActivity),
+              // This delegate's OWN Tool session resolved these — never the
+              // parent's (ADR-0021, issue #626): a Sub-Agent's session
+              // resolves hints by the same rule its parent's does, but is a
+              // distinct session with its own MCP connections.
+              readOnlyToolNames,
             },
             prompt: task,
             run,
@@ -670,7 +685,7 @@ export const createDelegateTools = async <
   loadToolsFn: (
     subAgentId: string,
     toolSetIds: string[],
-  ) => Promise<Record<string, Tool>>,
+  ) => Promise<LoadedSubAgentTools>,
   parentRun?: ParentRunContext,
   alreadyUnavailable: SubAgentFailure[] = [],
 ): Promise<{
@@ -710,7 +725,7 @@ export const createDelegateTools = async <
 
       // The sub-agent's tools are opened on its first delegation, not here.
       // Memoized so a delegate called twice in one turn resolves them once.
-      let toolsPromise: Promise<Record<string, Tool>> | undefined;
+      let toolsPromise: Promise<LoadedSubAgentTools> | undefined;
       const loadTools = () =>
         (toolsPromise ??= loadToolsFn(subAgent.id, subAgent.toolSetIds || []));
 

--- a/apps/backend/src/tools/tool-session.test.ts
+++ b/apps/backend/src/tools/tool-session.test.ts
@@ -62,6 +62,34 @@ const grantedAgent = (...toolSetIds: string[]) => ({
 const toolNamed = (name: string): Tool =>
   ({ description: name }) as unknown as Tool;
 
+/**
+ * Queues one `createMCPClient` resolution behind the client's own two-step
+ * API (`listTools` + `toolsFromDefinitions`, #626) — mocked the way the real
+ * one behaves: `toolsFromDefinitions` ignores the definitions it's handed and
+ * returns the tools this helper already declared. `readOnlyHints` marks a
+ * subset of `tools`'s keys as MCP-declared read-only, for the tests that need
+ * one. Shared by every describe block below that opens an MCP connection.
+ */
+const connected = (
+  tools: Record<string, unknown>,
+  readOnlyHints: Record<string, unknown> = {},
+) => {
+  const close = vi.fn().mockResolvedValue(undefined);
+  mockCreateMCPClient.mockResolvedValueOnce({
+    listTools: vi.fn().mockResolvedValue({
+      tools: Object.keys(tools).map((name) => ({
+        name,
+        ...(name in readOnlyHints
+          ? { annotations: { readOnlyHint: readOnlyHints[name] } }
+          : {}),
+      })),
+    }),
+    toolsFromDefinitions: vi.fn().mockReturnValue(tools),
+    close,
+  });
+  return close;
+};
+
 /** Register a Tool set through the composed path a plugin's would take. */
 const register = (
   id: string,
@@ -187,15 +215,6 @@ describe("openToolSession", () => {
   });
 
   describe("the MCP branch", () => {
-    const connected = (tools: Record<string, unknown>) => {
-      const close = vi.fn().mockResolvedValue(undefined);
-      mockCreateMCPClient.mockResolvedValueOnce({
-        tools: vi.fn().mockResolvedValue(tools),
-        close,
-      });
-      return close;
-    };
-
     it("serves an MCP server's tools, namespaced under its slug, for an id no Tool set claims, and closes it on dispose", async () => {
       const close = connected({ mcpTool: toolNamed("mcpTool") });
 
@@ -262,7 +281,7 @@ describe("openToolSession", () => {
     it("closes a server that connects and then fails to list its tools", async () => {
       const close = vi.fn().mockResolvedValue(undefined);
       mockCreateMCPClient.mockResolvedValueOnce({
-        tools: vi.fn().mockRejectedValue(new Error("protocol error")),
+        listTools: vi.fn().mockRejectedValue(new Error("protocol error")),
         close,
       });
 
@@ -395,7 +414,8 @@ describe("openToolSession", () => {
     it("closes every connection even when one close throws", async () => {
       const failing = vi.fn().mockRejectedValue(new Error("socket gone"));
       mockCreateMCPClient.mockResolvedValueOnce({
-        tools: vi.fn().mockResolvedValue({ a: toolNamed("a") }),
+        listTools: vi.fn().mockResolvedValue({ tools: [{ name: "a" }] }),
+        toolsFromDefinitions: vi.fn().mockReturnValue({ a: toolNamed("a") }),
         close: failing,
       });
       const second = connected({ b: toolNamed("b") });
@@ -413,6 +433,72 @@ describe("openToolSession", () => {
       expect(failing).toHaveBeenCalled();
       expect(second).toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe("MCP read-only hints (issue #626)", () => {
+    it("carries a declared read-only hint through, keyed by the namespaced name", async () => {
+      connected({ readTool: toolNamed("readTool") }, { readTool: true });
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("mcp-1"),
+        queriesFor([mcpRow()]),
+      );
+
+      expect(session.readOnlyToolNames.has("test_mcp__readTool")).toBe(true);
+    });
+
+    it("treats a declared writes hint as not read-only", async () => {
+      connected({ writeTool: toolNamed("writeTool") }, { writeTool: false });
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("mcp-1"),
+        queriesFor([mcpRow()]),
+      );
+
+      expect(session.readOnlyToolNames.has("test_mcp__writeTool")).toBe(false);
+    });
+
+    it("treats an undeclared hint as not read-only", async () => {
+      connected({ plainTool: toolNamed("plainTool") });
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("mcp-1"),
+        queriesFor([mcpRow()]),
+      );
+
+      expect(session.readOnlyToolNames.has("test_mcp__plainTool")).toBe(false);
+    });
+
+    // Tri-state, never coerced (ADR-0021): only the boolean `true` counts.
+    it("treats a non-boolean hint as not read-only", async () => {
+      connected(
+        { sneaky: toolNamed("sneaky") },
+        { sneaky: "true" as unknown as boolean },
+      );
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("mcp-1"),
+        queriesFor([mcpRow()]),
+      );
+
+      expect(session.readOnlyToolNames.has("test_mcp__sneaky")).toBe(false);
+    });
+
+    it("carries no hint for a Tool set that is not an MCP", async () => {
+      register("set.readOnlyHints.plain", { plain: toolNamed("plain") });
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("set.readOnlyHints.plain"),
+        noMcps(),
+      );
+
+      expect(session.readOnlyToolNames.size).toBe(0);
     });
   });
 
@@ -562,7 +648,8 @@ describe("openToolSession", () => {
       vi.useFakeTimers();
       try {
         mockCreateMCPClient.mockResolvedValueOnce({
-          tools: vi.fn().mockResolvedValue({ a: toolNamed("a") }),
+          listTools: vi.fn().mockResolvedValue({ tools: [{ name: "a" }] }),
+          toolsFromDefinitions: vi.fn().mockReturnValue({ a: toolNamed("a") }),
           close: vi.fn(() => new Promise<void>(() => {})),
         });
 
@@ -619,15 +706,6 @@ describe("openToolSession", () => {
   });
 
   describe("nested sessions", () => {
-    const connected = (tools: Record<string, unknown>) => {
-      const close = vi.fn().mockResolvedValue(undefined);
-      mockCreateMCPClient.mockResolvedValueOnce({
-        tools: vi.fn().mockResolvedValue(tools),
-        close,
-      });
-      return close;
-    };
-
     it("keeps a delegate's tools to itself and closes them with the parent", async () => {
       register("set.parent", { parentTool: toolNamed("parentTool") });
       const parent = await openToolSession(
@@ -650,6 +728,30 @@ describe("openToolSession", () => {
       // One dispose, at the seam that opened everything.
       await parent.dispose();
       expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it("resolves a delegate's read-only hints independently of the parent's", async () => {
+      register("set.parent.readOnlyHints", {
+        parentTool: toolNamed("parentTool"),
+      });
+      const parent = await openToolSession(
+        scope,
+        grantedAgent("set.parent.readOnlyHints"),
+        queriesFor([mcpRow()]),
+      );
+      expect(parent.readOnlyToolNames.size).toBe(0);
+
+      connected(
+        { delegateTool: toolNamed("delegateTool") },
+        { delegateTool: true },
+      );
+      const child = await parent.nest({
+        id: "sub-agent-1",
+        toolSetIds: ["mcp-1"],
+      });
+
+      expect(child.readOnlyToolNames.has("test_mcp__delegateTool")).toBe(true);
+      expect(parent.readOnlyToolNames.size).toBe(0);
     });
 
     it("resolves the delegate's Tool sets under its own Agent id", async () => {

--- a/apps/backend/src/tools/tool-session.ts
+++ b/apps/backend/src/tools/tool-session.ts
@@ -101,6 +101,18 @@ export type ToolSession = {
   /** The Tools this session's Tool sets contributed, keyed by tool name. */
   tools: Record<string, Tool>;
   /**
+   * The names, among {@link tools}, whose MCP server declared `readOnlyHint`
+   * (ADR-0021, issue #626) — keyed the same way `tools` is, by the name the
+   * Tool enters this session under (post-namespacing, issue #467). Only the
+   * MCP branch ever adds to this: a registered Tool set has nowhere to
+   * declare the hint (out of scope for #626 — core Tool sets stay a literal
+   * allowlist).
+   *
+   * Resolved per session and never persisted — it lives exactly as long as
+   * `tools` does, and dies with this session the same way.
+   */
+  readOnlyToolNames: ReadonlySet<string>;
+  /**
    * Open a session for another Agent — a delegate — under this session's scope,
    * whose connections close with this one's. Lifetime nests so a delegate never
    * hands its clients back to a caller to remember.
@@ -144,6 +156,9 @@ export const openToolSession = async (
   // it can report the names it is about to take, and the reason this is a Map
   // rather than the tool map alone.
   const owners = new Map<string, ToolOwner>();
+  // Every name, among `tools`, whose MCP declared `readOnlyHint` (#626). Only
+  // ever added to from the MCP branch of `open` below.
+  const readOnlyToolNames = new Set<string>();
   const closers: Array<() => Promise<void>> = [];
   // Registered closers, by identity, and scoped to **this session** — so the
   // case it collapses is one turn reaching the same teardown twice, as two Tool
@@ -259,13 +274,30 @@ export const openToolSession = async (
       scope: mcp.organizationId ? "org" : "ws",
     });
 
-    let mcpTools: Record<string, Tool>;
+    // Split into the listing and the definitions-to-Tools conversion — still
+    // one round trip, not two — so the raw `readOnlyHint` annotation (#626)
+    // is in hand before it is discarded: `client.tools()` collapses both
+    // steps and keeps only what it needs to resolve a display title, and the
+    // hint is gone by the time it would return.
+    let definitions: Awaited<ReturnType<MCPClient["listTools"]>>;
     try {
-      mcpTools = await client.tools();
+      definitions = await client.listTools();
     } catch (error) {
       warnUnreachable(error);
       return;
     }
+    const mcpTools = client.toolsFromDefinitions(definitions);
+
+    // `true` only — the specification's own default for a missing hint, and
+    // the tri-state this reduces to a boolean at: a string `"false"`, a `1`,
+    // or any other non-boolean reads as undeclared exactly like an absent one
+    // (ADR-0021), never coerced.
+    const readOnlyHintByRawName = new Map<string, boolean>(
+      definitions.tools.map((def) => [
+        def.name,
+        def.annotations?.readOnlyHint === true,
+      ]),
+    );
 
     // Every MCP-sourced tool enters the turn under `<slug>__<toolName>`,
     // unconditionally rather than only on collision, so a name never depends
@@ -290,6 +322,13 @@ export const openToolSession = async (
         continue;
       }
       namespaced[namespacedName] = tool;
+      // Keyed by the namespaced name — the name Tool-result clearing and the
+      // rest of core will ever see this Tool under (#626) — so a Transcript
+      // predating #467's namespacing degrades safely: an unrecognised name
+      // reads as undeclared rather than being matched by accident.
+      if (readOnlyHintByRawName.get(rawName)) {
+        readOnlyToolNames.add(namespacedName);
+      }
     }
 
     const owner: ToolOwner = { toolSetId, plugin: null, mcpSlug: mcp.slug };
@@ -345,11 +384,11 @@ export const openToolSession = async (
     // having none simply leaves it without them.
     if (disposed) {
       await child.dispose();
-      return { ...child, tools: {} };
+      return { ...child, tools: {}, readOnlyToolNames: new Set() };
     }
     closers.push(child.dispose);
     return child;
   };
 
-  return { tools, nest, registerCloser, dispose };
+  return { tools, readOnlyToolNames, nest, registerCloser, dispose };
 };

--- a/apps/backend/src/types.ts
+++ b/apps/backend/src/types.ts
@@ -134,6 +134,21 @@ export type ChatMessageMetadata = {
    * cancelled turn is exactly when someone wants to know how long it ran.
    */
   modelDurationMs?: number;
+  /**
+   * The names of this turn's clearable Tools among the ones it actually
+   * called — the core allowlist and any MCP tool whose server declared
+   * `readOnlyHint` (ADR-0021, issue #626) — not the turn's whole resolved Tool
+   * set, which would put a large MCP server's whole catalogue on every
+   * message.
+   *
+   * The Chat UI's client-side clearing mirror unions this across every
+   * assistant message rather than importing a name list of its own: an MCP
+   * tool's clearability is only knowable by connecting, which only the server
+   * that resolved it has done. Absent for a turn that called no clearable
+   * tool — never an empty array, matching the rest of this type's optional
+   * fields.
+   */
+  readOnlyToolNames?: string[];
 };
 
 /**

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -268,10 +268,13 @@ model switches the meter with it, since the window belongs to the model.
 
 Where a **Context window** is declared, a long turn that reads a lot of pages
 or files gets one piece of automatic help: once the meter above would be
-running high, older results from a small set of read-only tools — web search,
-reading a URL, reading a file or listing a directory in a Sandbox — stop being
-sent to the model. Only the oldest ones go, and only enough to make room; the
-most recent stay.
+running high, older results from a small set of read-only tools stop being
+sent to the model. That set covers a handful of built-in reads — web search,
+reading a URL, reading a file or listing a directory in a Sandbox — plus any
+MCP tool whose server declares it read-only (see
+[MCP](/building-with-platypus/mcp)). An MCP server that declares nothing gets
+no benefit from this for that tool. Only the oldest results go, and only
+enough to make room; the most recent stay.
 
 Nothing is deleted. The full result is still in the message, still yours to
 read, and still there after a reload — this only changes what the model itself

--- a/apps/docs/content/building-with-platypus/mcp.mdx
+++ b/apps/docs/content/building-with-platypus/mcp.mdx
@@ -100,6 +100,19 @@ doesn't fit is excluded from the turn (and flagged by **Test Connection**)
 rather than being cut short; if you hit this, the fix is to give the MCP a
 shorter Name.
 
+### Read-only tools free up space automatically
+
+An MCP server can mark a tool as read-only — meaning it only looks things up
+and never changes anything. Platypus honours that declaration: once a long
+Chat turn is using a lot of its **Context window**, older results from a
+read-only tool stop being sent to the model to make room, the same way the
+built-in read tools already do (see
+[Freeing up space during a long tool-using turn](/building-with-platypus/chat#freeing-up-space-during-a-long-tool-using-turn)).
+
+This only ever affects a tool the server itself has declared read-only. A
+server that declares nothing gets no benefit from this for that tool — nothing
+is guessed on its behalf.
+
 ## Grant an MCP to an Agent
 
 Open the [Agent form](/building-with-platypus/agents) and find the **Tools** card.

--- a/apps/frontend/lib/tool-result-clearing.test.ts
+++ b/apps/frontend/lib/tool-result-clearing.test.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect } from "vitest";
-import type { UIMessage } from "ai";
+import type { PlatypusUIMessage } from "@platypus/backend/src/types";
 import { clearedToolCallIds } from "./tool-result-clearing";
 
-const toolResultMessage = (toolName: string, toolCallId: string): UIMessage =>
+/**
+ * A tool-result message, with `readOnlyToolNames` metadata reporting the tool
+ * clearable by default — the shape the backend now reports for the core
+ * allowlist and an MCP tool alike (ADR-0021, issue #626). Pass
+ * `clearable: false` for a tool no message ever reports.
+ */
+const toolResultMessage = (
+  toolName: string,
+  toolCallId: string,
+  { clearable = true }: { clearable?: boolean } = {},
+): PlatypusUIMessage =>
   ({
     id: `m-${toolCallId}`,
     role: "assistant",
@@ -15,7 +25,8 @@ const toolResultMessage = (toolName: string, toolCallId: string): UIMessage =>
         output: { ok: true },
       },
     ],
-  }) as unknown as UIMessage;
+    metadata: clearable ? { readOnlyToolNames: [toolName] } : undefined,
+  }) as unknown as PlatypusUIMessage;
 
 describe("clearedToolCallIds", () => {
   it("returns nothing when the Context window is unknown", () => {
@@ -54,15 +65,48 @@ describe("clearedToolCallIds", () => {
     expect(result).toEqual(new Set(["t0", "t1"]));
   });
 
-  it("never marks a non-allowlisted tool's result as cleared", () => {
+  it("never marks a tool's result as cleared when no message reports it clearable", () => {
     const messages = Array.from({ length: 6 }, (_, i) =>
-      toolResultMessage("fsWrite", `w${i}`),
+      toolResultMessage("fsWrite", `w${i}`, { clearable: false }),
     );
     const result = clearedToolCallIds(messages, {
       occupancy: 95,
       contextWindow: 100,
     });
     expect(result).toEqual(new Set());
+  });
+
+  // ADR-0021, issue #626: an MCP tool is clearable the same way a core one
+  // is — reported by name, not looked up against a name list this module no
+  // longer holds.
+  it("marks an MCP tool's result as cleared when its metadata reports it clearable", () => {
+    const messages = Array.from({ length: 6 }, (_, i) =>
+      toolResultMessage("docs_search__search", `t${i}`),
+    );
+    const result = clearedToolCallIds(messages, {
+      occupancy: 95,
+      contextWindow: 100,
+    });
+    expect(result).toEqual(new Set(["t0", "t1"]));
+  });
+
+  it("unions clearable names reported across different messages", () => {
+    // Only the LAST message's metadata reports `docs_search__search` as
+    // clearable; the earlier five carry no metadata of their own. The client
+    // holds no clearability policy of its own — it unions whatever the whole
+    // Transcript has reported by the time it reads it, so the earlier calls
+    // still count.
+    const messages: PlatypusUIMessage[] = Array.from({ length: 6 }, (_, i) => ({
+      ...toolResultMessage("docs_search__search", `t${i}`),
+      metadata: undefined,
+    }));
+    messages[5] = toolResultMessage("docs_search__search", "t5");
+
+    const result = clearedToolCallIds(messages, {
+      occupancy: 95,
+      contextWindow: 100,
+    });
+    expect(result).toEqual(new Set(["t0", "t1"]));
   });
 
   it("ignores a clearable tool call that hasn't produced its result yet", () => {
@@ -76,7 +120,8 @@ describe("clearedToolCallIds", () => {
           state: "input-available",
         },
       ],
-    } as unknown as UIMessage;
+      metadata: { readOnlyToolNames: ["read_url"] },
+    } as unknown as PlatypusUIMessage;
 
     const messages = [
       ...Array.from({ length: 6 }, (_, i) =>

--- a/apps/frontend/lib/tool-result-clearing.ts
+++ b/apps/frontend/lib/tool-result-clearing.ts
@@ -1,9 +1,9 @@
 import {
-  CLEARABLE_TOOL_NAMES,
   TOOL_RESULT_CLEARING_KEEP_RECENT,
   TOOL_RESULT_CLEARING_THRESHOLD,
 } from "@platypus/schemas";
-import { isToolUIPart, type UIMessage } from "ai";
+import { isToolUIPart } from "ai";
+import type { PlatypusUIMessage } from "@platypus/backend/src/types";
 
 /**
  * The client-side mirror of Tool-result clearing's "which results are stale"
@@ -11,11 +11,31 @@ import { isToolUIPart, type UIMessage } from "ai";
  * #524) — derived, never persisted, so it can never drift into a stored lie
  * about a message that a later turn changes the answer for.
  *
- * Shares its constants with the backend via `@platypus/schemas`, so this and
- * the actual clearing decision can't silently disagree on the threshold or how
- * many recent results survive; only the "what was sent" mechanics differ,
- * because this reads UI messages rather than `ModelMessage[]`.
+ * Shares its threshold and keep-recent constants with the backend via
+ * `@platypus/schemas`, so this and the actual clearing decision can't silently
+ * disagree on those; only the "what was sent" mechanics differ, because this
+ * reads UI messages rather than `ModelMessage[]`.
+ *
+ * Holds no clearability policy of its own (ADR-0021, issue #626): an MCP
+ * tool's clearability is only knowable by connecting to it, which only the
+ * backend has done, so the core allowlist has no client-side counterpart.
+ * Instead this unions `ChatMessageMetadata.readOnlyToolNames` across every
+ * assistant message in the Transcript — the turn's clearable Tool names among
+ * the ones it actually called.
  */
+
+/** Every clearable Tool name any assistant message in `messages` has reported. */
+const clearableToolNamesOf = (
+  messages: readonly PlatypusUIMessage[],
+): ReadonlySet<string> => {
+  const names = new Set<string>();
+  for (const message of messages) {
+    for (const name of message.metadata?.readOnlyToolNames ?? []) {
+      names.add(name);
+    }
+  }
+  return names;
+};
 
 type ToolLikePart = {
   type: string;
@@ -41,7 +61,7 @@ const toolNameOf = (part: ToolLikePart): string =>
 
 /**
  * The `toolCallId`s of tool results this session's Chat meter would report as
- * cleared: allowlisted, output-available, and NOT among the most recent
+ * cleared: clearable, output-available, and NOT among the most recent
  * `TOOL_RESULT_CLEARING_KEEP_RECENT` such results, given the Context occupancy
  * reading is at or above the shared threshold.
  *
@@ -49,7 +69,7 @@ const toolNameOf = (part: ToolLikePart): string =>
  * itself does nothing when occupancy or the Context window is unknown.
  */
 export const clearedToolCallIds = (
-  messages: readonly UIMessage[],
+  messages: readonly PlatypusUIMessage[],
   reading: { occupancy?: number; contextWindow?: number },
 ): ReadonlySet<string> => {
   const { occupancy, contextWindow } = reading;
@@ -60,12 +80,14 @@ export const clearedToolCallIds = (
     return new Set();
   }
 
+  const clearableToolNames = clearableToolNamesOf(messages);
+
   const clearableIds: string[] = [];
   for (const message of messages) {
     for (const part of message.parts ?? []) {
       if (!isToolLikePart(part)) continue;
       if (part.state !== "output-available") continue;
-      if (!CLEARABLE_TOOL_NAMES.has(toolNameOf(part))) continue;
+      if (!clearableToolNames.has(toolNameOf(part))) continue;
       clearableIds.push(part.toolCallId);
     }
   }

--- a/docs/adr/0021-a-read-only-hint-is-trusted-for-retention-never-for-authority.md
+++ b/docs/adr/0021-a-read-only-hint-is-trusted-for-retention-never-for-authority.md
@@ -1,17 +1,23 @@
 ---
-status: accepted-pending-implementation
+status: accepted
 implemented-by: "#626"
 ---
 
 # A tool's read-only hint is trusted for retention, never for authority
 
-> **In the code.** Nothing here is built yet. Today Platypus holds no notion of
-> whether a Tool reads or writes: **Tool-result clearing** consults
-> `CLEARABLE_TOOL_NAMES`, a fixed set of five core Tool names, and every MCP Tool
-> is denied by default. The MCP client's `annotations` never reach core, because
-> the Tool session resolves an MCP through the combined `tools()` call and the
-> definitions-to-Tools conversion inside it reads `annotations.title` and drops
-> the rest. To be built by [#626](https://github.com/willdady/platypus/issues/626).
+> **In the code.** The Tool session resolves an MCP in two steps —
+> `client.listTools()` then `client.toolsFromDefinitions()` — the same single
+> round trip as the combined `client.tools()` call it replaced, and keeps each
+> Tool's declared `readOnlyHint` in a sidecar (`ToolSession.readOnlyToolNames`)
+> keyed by the name the Tool enters the turn under. Tool-result clearing's
+> `isClearableToolName` takes that sidecar as a resolver alongside the core
+> `CLEARABLE_TOOL_NAMES` allowlist it already had, so an MCP tool with a
+> declared `readOnlyHint: true` is clearable and everything else — a declared
+> `false`, a non-boolean, or nothing declared at all — is not. The hint rides
+> a turn's assistant-message metadata (`readOnlyToolNames`, alongside Context
+> occupancy) so the Chat UI's clearing mirror can union it across the
+> Transcript instead of holding a name list of its own. See `apps/backend/src/tools/tool-session.ts`, `apps/backend/src/runs/tool-result-clearing.ts`,
+> and `apps/backend/src/runs/message-metadata.ts`.
 
 The MCP specification lets a server declare `readOnlyHint` on a Tool, meaning the
 Tool does not modify its environment. The specification is also unambiguous about

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -890,8 +890,13 @@ export const CONTEXT_WINDOW_MAX = 10_000_000;
  * Excludes anything that mutates state (`fsWrite`, `fsEdit`, `shellExec`),
  * sub-Agent delegation (its result is the point of the call, not disposable
  * page content), and `loadSkill` (its result is instructions the model is
- * meant to keep following, not data to discard). MCP and third-party plugin
- * tools are out of scope until read-only hints are surfaced (#626).
+ * meant to keep following, not data to discard).
+ *
+ * This is the core half of clearability, not the whole of it: an MCP tool
+ * whose server declares `readOnlyHint` is also clearable (ADR-0021, issue
+ * #626), resolved separately by the Tool session and combined with this set
+ * at the one place both are consulted — `isClearableToolName` in
+ * `apps/backend/src/runs/tool-result-clearing.ts`.
  */
 export const CLEARABLE_TOOL_NAMES: ReadonlySet<string> = new Set([
   "web_search",


### PR DESCRIPTION
## Summary
- The Tool session resolves an MCP through `listTools()` + `toolsFromDefinitions()` instead of the combined `tools()` call, keeping each tool's declared `readOnlyHint` in a per-session sidecar (`ToolSession.readOnlyToolNames`) keyed by the tool's namespaced name — one round trip, not two.
- Tool-result clearing composes that sidecar alongside its existing core allowlist, so an MCP tool whose server declares itself read-only is now clearable (ADR-0021). The module still holds no MCP concept of its own — the caller supplies the resolver.
- Assistant-message metadata now reports `readOnlyToolNames` (the clearable tools a turn actually called), so the Chat UI's client-side clearing mirror unions it across the Transcript instead of importing the core allowlist directly. A Sub-Agent delegate resolves and carries its own nested session's hints independently of its parent's.
- ADR-0021 flips from `accepted-pending-implementation` to `accepted`; `chat.mdx` and `mcp.mdx` are updated to describe MCP read-only tools.

Closes #626.

## Test plan
- [x] `pnpm typecheck` — all packages clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 2198 backend tests, 518 frontend tests, schemas and docs-contract suites all pass
- [x] New/updated coverage: `tool-session.test.ts` (MCP read-only hint resolution, tri-state, nested-session isolation), `tool-result-clearing.test.ts` (resolver threading), `message-metadata.test.ts` (reported read-only tool names), `chat-execution.test.ts` (plan carries the hint), `sub-agent.test.ts` / `sub-agent-lifecycle.test.ts` (delegate's own hints), frontend `tool-result-clearing.test.ts` (metadata-driven clearability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)