### PR TITLE
chore: record the #581 triage outcomes in the out-of-scope knowledge base

### DIFF
--- a/.out-of-scope/capability-discovery-for-ad-hoc-chats.md
+++ b/.out-of-scope/capability-discovery-for-ad-hoc-chats.md
@@ -80,17 +80,55 @@ carries an ordered set of Blueprints applied on accept (ADR-0009, and #549 for
 the redemption path). A Workspace provisioned with one Agent presents no
 selection problem at all.
 
-## What remains open
+## What remains open, and what it now costs
 
 The token cost underneath this request is real, and one direction for attacking
-it generically survives: **per-step `activeTools` gating** — declare the full
-tool set as today, render a name + description index into the system prompt
-exactly as Skills already do, and narrow per step to the meta-tools plus
-whatever the model has asked for. That is the "dynamic tool discovery" recorded
-when #179 was closed, and it adds no new data-model concept.
+it generically survives in principle: **per-step `activeTools` gating** —
+declare the full tool set as today, render a name + description index into the
+System prompt exactly as Skills already do, and narrow per step to the
+meta-tools plus whatever the model has asked for. That is the "dynamic tool
+discovery" recorded when #179 was closed, and it adds no new data-model
+concept.
 
-It is gated on measuring what opening MCP tool sessions actually costs. #557
-carries that measurement and the design constraints that go with it.
+#581 re-raised it as its step 4. Triaging #581 established what it costs, which
+the #464 record did not know and which changes the case materially:
+
+- `activeTools` narrows at the **wire level**, not merely in the TypeScript
+  result type. `filterActiveTools` (`ai@7.0.48`, `dist/index.js:3062`) rebuilds
+  the tools object with `Object.fromEntries(...filter(...))`, and that filtered
+  result is what `prepareTools` sends to the Provider. So the saving is real —
+  and so is the invalidation.
+- Tool definitions render at position 0, ahead of the System prompt and ahead
+  of the entire transcript (ADR-0020). A set that changes **between steps**
+  therefore discards the prefix mid-turn, re-processing the whole conversation
+  on every step that follows a disclosure.
+- Appending rather than removing does not rescue it. An appended definition is
+  inserted *before* the System prompt, not at the end of the request, so
+  everything behind the insertion point is discarded anyway. `toolOrder` keeps
+  the stable core byte-identical and can do nothing about what follows it.
+- Delivering disclosed schemas in a tail channel after the messages — the one
+  position where appending would be safe — is the option ADR-0020 has already
+  rejected: the `{role: "system"}` form throws on Google and Bedrock and is
+  model-gated on Anthropic, and tail content is never cached in any case.
+- Today the tools block is stable **within** a turn (`run-plan.ts` passes
+  `tools` once at the top-level call, and `prepareStep` overrides only
+  `messages`) and **across** turns. Every disclosure scheme spends one or both.
+  Narrowing once per turn from the User's message is stable within a turn but
+  changes on every turn; per-step disclosure changes within the turn as well.
+  There is no cache-improving variant — only degrees of cost.
+
+The consequence for the case, as opposed to the mechanism: under a warm prefix
+the schemas are re-read at roughly a tenth of price, so the headline "55k
+tokens of definitions" is a first-turn cost rather than a per-turn one, and
+deferral trades a cached cost for an uncached one. What survives untouched is
+the **selection-quality** argument — a model's ability to pick the right tool
+degrades past roughly 30-50 of them, and no amount of caching improves that.
+Anything built here should be argued on selection quality and sized against the
+cache cost above, never proposed as a straightforward token saving.
+
+Not gated on #557, contrary to what was recorded when #464 closed. #557
+measures connection latency, which no form of progressive disclosure changes.
+The two are independent and can proceed in either order.
 
 Also proposed here and **not** taken: caching each MCP's tool listing,
 invalidated when the MCP row is edited. A server redeploy edits no row, so it
@@ -98,10 +136,36 @@ reintroduces the same staleness this request complains about. The underlying
 want — stop re-listing every turn — is live, and belongs to #557 rather than
 here.
 
+## The #581 re-raise, and why the subscription still does not land
+
+#581 returned to the subscription with two of the three objections above
+answered. #467 has since landed, so a tool-name collision renames rather than
+overwrites; and #581 sequenced progressive disclosure *ahead* of the
+subscription so that "everything is eagerly loaded" would no longer follow. It
+also offered two smaller forms: a subscription covering only Skills and
+Sub-Agents, where no version of the collision argument applies, and — in place
+of any subscription — a prompt on the Skill and MCP create forms asking which
+Agents should receive the new resource, plus an "unattached" badge in the
+Workspace list.
+
+All three were declined, on the ground beneath the objections rather than on
+the objections themselves. The motivating problem is a Workspace holding 15+
+Agents whose lists go stale by hand, and the evidence that this is a general
+shape rather than one reporter's Workspace is not there. The Workspace boundary
+answer above remains the first response to a crowded roster. A mitigation for a
+problem not established as general does not earn a new concept, a new form
+field or a new badge — and if the creation-time prompt is worth building, it is
+worth its own issue argued on plain usability grounds by whoever feels the
+friction.
+
 ## Prior requests
 
 - #464 — "Direction wanted: capability discovery for ad-hoc chats, instead of
   hand-maintained Orchestrator Agents"
+- #581 — "Direction wanted: separate \"which model runs\" from \"what it can
+  reach\", and make a large catalogue affordable" (steps 4 and 5 of six; see
+  also [`per-chat-model-override.md`](./per-chat-model-override.md) for its
+  step 6)
 
 Related but distinct: [`mcp-profiles.md`](./mcp-profiles.md) rejects _static,
 hand-curated_ tool subsetting as a data-model concept. This file rejects the

--- a/.out-of-scope/per-chat-model-override.md
+++ b/.out-of-scope/per-chat-model-override.md
@@ -1,0 +1,83 @@
+# Per-Chat Model Override on a Selected Agent
+
+Platypus does **not** let a Chat choose which model runs when that Chat has an
+Agent selected. Selecting an Agent resolves the Provider, the model, the
+Instructions, the generation parameters and the step ceiling from the Agent row
+and from nowhere else. There is no "use this Agent, but on a stronger model"
+control, and the Chat's own generation columns stay inert for as long as an
+Agent is selected.
+
+This rejects the **override**, not the observation underneath it. Wanting the
+same capabilities on a cheaper or stronger model is a reasonable thing to want;
+the answer in Platypus is a second Agent, and that is the intended shape.
+
+## Why it is out of scope
+
+### The rule it breaks is load-bearing, not descriptive
+
+`CONTEXT.md` defines an Agent as "a configurable preset that pins a Provider,
+model, Instructions, generation parameters, Tools, Skills, and Sub-Agents.
+Selecting an Agent on a Chat turn replaces direct Provider/model selection."
+
+The word doing the work is **replaces**. An Agent is not a set of defaults that
+a Chat may amend; it is the whole of what a turn resolves against. That is a
+deliberate decision rather than an accident of the current implementation, and
+it is what makes an Agent legible: a person reading an Agent row knows what a
+turn using it will do, without also having to read the Chat.
+
+The proposal for an override argues that model choice is a "quality tier"
+rather than a capability, so moving it does not disturb "an Agent grants
+capability, and a bare model is bare". That is true as far as it goes, and it
+is not the objection. The objection is that an Agent stops fully determining a
+turn — and once that is conceded for one field, the boundary between the fields
+a Chat may amend and the fields it may not becomes a judgement call defended
+case by case, rather than one rule anybody can state.
+
+### The enforcement is already wholesale, across seven fields
+
+This is not a rule that exists only in prose. The Chat row already carries
+`instructions`, `temperature`, `topP`, `topK`, `seed`, `presencePenalty` and
+`frequencyPenalty`, and every one of them is ignored the moment an Agent is
+selected — a single line decides it:
+
+```ts
+// apps/backend/src/runs/agent-plan.ts
+const samplingSource: SamplingSource =
+  "agent" in source ? source.agent : source;
+```
+
+The same fork resolves `providerId`, `modelId` and `maxSteps`, and the per-chat
+step ceiling added in #539 is deliberately scoped to Direct turns for the same
+reason. The Chat schema then makes the two paths mutually exclusive by
+validation — a Chat carries `agentId`, **or** it carries `providerId` and
+`modelId`, never both.
+
+So an override for the model alone would not be an extension of an existing
+pattern. It would be the first exception to a rule currently enforced without
+exception, and it would leave the six sampling columns beside it inert for no
+reason a User could infer. The larger version — let the Chat's columns override
+the Agent's generally — is a much bigger change to what an Agent means, and
+sweeps in `instructions`, which is far closer to capability than model choice
+is.
+
+### The problem it was offered to solve is not established
+
+The case for the override is that welding the model to the Agent is what makes
+Agent rosters grow: to run the same capabilities on a different tier you must
+clone the Agent, so a Workspace accumulates variations of itself. The mechanism
+is real — there is genuinely no other way to do it — but the claim that this is
+what produces a crowded roster in practice rests on a single reporter's
+Workspace. A crowded roster is answered first by the Workspace boundary, as
+recorded in
+[`capability-discovery-for-ad-hoc-chats.md`](./capability-discovery-for-ad-hoc-chats.md).
+
+If the clone-per-tier pattern turns up repeatedly, across Workspaces that are
+not one person's, this is worth reopening — the mechanism is not in dispute,
+only how much of the observed growth it explains.
+
+## Prior requests
+
+- #581 — "Direction wanted: separate \"which model runs\" from \"what it can
+  reach\", and make a large catalogue affordable" (step 6 of six; steps 4 and 5
+  are recorded in
+  [`capability-discovery-for-ad-hoc-chats.md`](./capability-discovery-for-ad-hoc-chats.md))


### PR DESCRIPTION
Triage of #581, which proposed a six-step arc. Steps 1-3 had already shipped as
#463, #467 and #556. Steps 5 and 6 are refused and recorded here. Step 4
survives as a live thread on #635 and the new #682.

No code changes — this is the institutional-memory half of closing #581.

## `capability-discovery-for-ad-hoc-chats.md` (modified)

The Workspace subscription was rejected once already, at #464. #581 re-raised
it having answered two of the three objections on record: #467 has since landed
so a tool-name collision renames rather than overwrites, and #581 sequenced
progressive disclosure ahead of the subscription so "everything is eagerly
loaded" no longer follows.

It is declined on the ground beneath those objections instead — that
hand-maintained lists going stale is not established as a general problem
rather than a large-Workspace one. The narrowed Skills-and-Sub-Agents variant
and the creation-time attachment prompt are recorded as declined with it, with
a note that the prompt is worth its own issue on usability grounds if anyone
feels the friction.

"What remains open" is rewritten to carry what triage established about the
surviving direction, none of which the #464 record knew:

- `activeTools` narrows at the **wire level** — `filterActiveTools`
  (`ai@7.0.48`, `dist/index.js:3062`) rebuilds the tools object and the
  filtered result is what reaches the Provider.
- Tool definitions render at position 0, ahead of the System prompt and the
  transcript, so a set that changes between steps discards the prefix mid-turn.
- Appending rather than removing does not help: an appended definition is
  inserted *before* the System prompt, so everything behind it is discarded
  anyway. The tail-channel escape is the one ADR-0020 already rejected.
- Today's arrangement is stable within a turn *and* across turns, so every
  disclosure scheme spends one or both. There is no cache-improving variant.
- Consequently the token case is much weaker than the uncached figures suggest,
  since a warm prefix re-reads schemas at roughly a tenth of price. The
  selection-quality case is untouched and is what a future attempt should be
  argued on.

Also drops the #557 gate recorded when #464 closed. #557 measures connection
latency, which progressive disclosure does not change; the two are independent.

## `per-chat-model-override.md` (new)

Step 6 — letting a Chat choose the model while a selected Agent still grants
capability.

The `CONTEXT.md` rule that selecting an Agent replaces direct Provider/model
selection is load-bearing rather than descriptive. It is already enforced
without exception across ten fields: `providerId`, `modelId`, `maxSteps` and
the seven sampling columns a Chat row carries and which go inert the moment an
Agent is selected. A model-only override would be the first exception to it,
and would leave its six neighbours inert for no reason a User could infer.

Records that the mechanism behind the request is real — there is genuinely no
way to run one Agent's capabilities on another model without cloning it — and
that what was not accepted is the causal claim that this is what makes rosters
grow, which rests on a single Workspace. Reopenable if the pattern turns up
more widely.

## Docs

None. `.out-of-scope/` is the triage knowledge base, not user-facing
documentation, and nothing in the CLAUDE.md docs table is touched by this diff.

Closes nothing — #581 is already closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)