### PR TITLE
feat(frontend): add a copy-run-id control to the Trigger runs page

### DIFF
--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -169,6 +169,12 @@ when it ran and how long it took, the event type for Event triggers, per-run
 stats, and any error message. It's the place to confirm a schedule is actually
 firing and to debug a Trigger that's failing.
 
+Each run's identifier isn't shown on the row — it's an opaque value nobody
+reads at a glance. Instead every run offers a **Copy run id** control. Use it
+when a run fails and you need to find that run's log lines: backend logs are
+keyed by the run id, so copying it here and pasting it into your log query is
+how you cross-reference a failed run against what happened behind the scenes.
+
 Among the per-run stats, **in / out** are the run's total token counts across
 every step — what the run cost — while **context** is a different quantity: how
 much of the model's Context window the conversation filled on the run's final

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.test.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { act, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { Suspense } from "react";
 import type { TriggerRun, TriggerRunStats } from "@platypus/schemas";
 
@@ -23,6 +23,25 @@ vi.mock("@/components/auth-provider", () => ({
 vi.mock("@/components/back-button", () => ({
   BackButton: () => null,
 }));
+
+const { toastSuccessSpy, toastErrorSpy } = vi.hoisted(() => ({
+  toastSuccessSpy: vi.fn(),
+  toastErrorSpy: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+  toast: { success: toastSuccessSpy, error: toastErrorSpy },
+}));
+
+// Radix Tooltip content measures itself on focus, which jsdom has no
+// ResizeObserver for.
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
 
 import TriggerRunsPage from "./page";
 import {
@@ -158,5 +177,56 @@ describe("Trigger runs Context occupancy", () => {
 
     expect(screen.getByText(/1M context/)).toBeInTheDocument();
     expect(screen.getByText(/2\.5M in/)).toBeInTheDocument();
+  });
+});
+
+// Issue #665. Backend logs are keyed by runId, but the id is never rendered —
+// the clipboard is the only place an Operator can get it out of the UI.
+describe("Trigger runs copy-run-id control", () => {
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    writeText.mockReset().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    toastSuccessSpy.mockClear();
+    toastErrorSpy.mockClear();
+  });
+
+  it("never renders the run id as visible text", async () => {
+    await renderRuns([run(stats())]);
+
+    expect(screen.queryByText("run-1")).toBeNull();
+  });
+
+  it("exposes an accessible name and a matching tooltip", async () => {
+    await renderRuns([run(stats())]);
+
+    const button = screen.getByRole("button", { name: "Copy run id" });
+    expect(button).toBeInTheDocument();
+
+    fireEvent.focus(button);
+    expect(await screen.findAllByText("Copy run id")).not.toHaveLength(0);
+  });
+
+  it("copies the full run id and shows a success toast", async () => {
+    await renderRuns([run(stats())]);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy run id" }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith("run-1");
+    expect(toastSuccessSpy).toHaveBeenCalledWith("Copied to clipboard");
+  });
+
+  it("shows an error toast when the clipboard write rejects", async () => {
+    writeText.mockReset().mockRejectedValue(new Error("denied"));
+    await renderRuns([run(stats())]);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy run id" }));
+    });
+
+    expect(toastErrorSpy).toHaveBeenCalledWith("Failed to copy to clipboard");
   });
 });

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/runs/page.tsx
@@ -19,18 +19,21 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Loader2,
   Footprints,
   Wrench,
   MessageSquare,
   Gauge,
+  Copy,
 } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   RunCutShortNotice,
   RunStepLimitNotice,
 } from "@/components/run-cut-short-notice";
+import { toast } from "sonner";
 
 const TriggerRunsPage = ({
   params,
@@ -95,6 +98,15 @@ const TriggerRunsPage = ({
     return `${(ms / 60000).toFixed(1)}m`;
   };
 
+  const handleCopyRunId = async (runId: string) => {
+    try {
+      await navigator.clipboard.writeText(runId);
+      toast.success("Copied to clipboard");
+    } catch {
+      toast.error("Failed to copy to clipboard");
+    }
+  };
+
   return (
     <div className="flex justify-center pb-8">
       <div className="w-full px-4 md:px-0 xl:w-4/5 max-w-4xl">
@@ -108,13 +120,16 @@ const TriggerRunsPage = ({
             <div className="border rounded-lg divide-y">
               {Array.from({ length: 3 }).map((_, i) => (
                 <div key={i} className="p-4">
-                  <div className="flex items-center gap-4">
-                    <Skeleton className="h-5 w-16 rounded-full" />
-                    <div className="flex flex-col gap-1.5">
-                      <Skeleton className="h-4 w-40" />
-                      <Skeleton className="h-3 w-24" />
-                      <Skeleton className="h-3 w-32" />
+                  <div className="flex items-center gap-4 justify-between">
+                    <div className="flex items-center gap-4">
+                      <Skeleton className="h-5 w-16 rounded-full" />
+                      <div className="flex flex-col gap-1.5">
+                        <Skeleton className="h-4 w-40" />
+                        <Skeleton className="h-3 w-24" />
+                        <Skeleton className="h-3 w-32" />
+                      </div>
                     </div>
+                    <Skeleton className="h-8 w-8 rounded-md shrink-0" />
                   </div>
                 </div>
               ))}
@@ -140,105 +155,124 @@ const TriggerRunsPage = ({
                   const stats = run.stats as TriggerRunStats | null | undefined;
                   return (
                     <div key={run.id} className="p-4">
-                      <div className="flex items-center gap-4">
-                        {getStatusBadge(run.status)}
-                        <div>
-                          <p className="font-medium">
-                            {format(new Date(run.startedAt), "PPp")}
-                          </p>
-                          <p className="text-sm text-muted-foreground">
-                            {formatDistanceToNow(new Date(run.startedAt), {
-                              addSuffix: true,
-                            })}
-                          </p>
-                          {run.eventType && (
-                            <p className="text-sm text-muted-foreground">
-                              Event: {run.eventType}
+                      <div className="flex items-center gap-4 justify-between">
+                        <div className="flex items-center gap-4">
+                          {getStatusBadge(run.status)}
+                          <div>
+                            <p className="font-medium">
+                              {format(new Date(run.startedAt), "PPp")}
                             </p>
-                          )}
-                          {run.completedAt && (
                             <p className="text-sm text-muted-foreground">
-                              Duration: {getDuration(run)}
+                              {formatDistanceToNow(new Date(run.startedAt), {
+                                addSuffix: true,
+                              })}
                             </p>
-                          )}
-                          {stats && (
-                            <div className="flex gap-3 mt-1 text-xs text-muted-foreground">
-                              <span className="flex items-center gap-1">
-                                <Footprints className="h-3 w-3" />
-                                {stats.steps} step{stats.steps !== 1 ? "s" : ""}
-                              </span>
-                              {stats.toolCalls.length > 0 ? (
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <span className="flex items-center gap-1 cursor-default">
-                                      <Wrench className="h-3 w-3" />
-                                      {stats.toolCalls.reduce(
-                                        (sum, tc) => sum + tc.count,
-                                        0,
-                                      )}{" "}
-                                      tool call
-                                      {stats.toolCalls.reduce(
-                                        (sum, tc) => sum + tc.count,
-                                        0,
-                                      ) !== 1
-                                        ? "s"
-                                        : ""}
-                                    </span>
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    <ul className="text-left">
-                                      {stats.toolCalls.map((tc) => (
-                                        <li key={tc.name}>
-                                          {tc.name} &times;{tc.count}
-                                        </li>
-                                      ))}
-                                    </ul>
-                                  </TooltipContent>
-                                </Tooltip>
-                              ) : (
+                            {run.eventType && (
+                              <p className="text-sm text-muted-foreground">
+                                Event: {run.eventType}
+                              </p>
+                            )}
+                            {run.completedAt && (
+                              <p className="text-sm text-muted-foreground">
+                                Duration: {getDuration(run)}
+                              </p>
+                            )}
+                            {stats && (
+                              <div className="flex gap-3 mt-1 text-xs text-muted-foreground">
                                 <span className="flex items-center gap-1">
-                                  <Wrench className="h-3 w-3" />0 tool calls
+                                  <Footprints className="h-3 w-3" />
+                                  {stats.steps} step
+                                  {stats.steps !== 1 ? "s" : ""}
                                 </span>
-                              )}
-                              <span className="flex items-center gap-1">
-                                <MessageSquare className="h-3 w-3" />
-                                {formatTokens(stats.inputTokens)} in /{" "}
-                                {formatTokens(stats.outputTokens)} out
-                              </span>
-                              {/* How full the context got on the run's LAST
+                                {stats.toolCalls.length > 0 ? (
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <span className="flex items-center gap-1 cursor-default">
+                                        <Wrench className="h-3 w-3" />
+                                        {stats.toolCalls.reduce(
+                                          (sum, tc) => sum + tc.count,
+                                          0,
+                                        )}{" "}
+                                        tool call
+                                        {stats.toolCalls.reduce(
+                                          (sum, tc) => sum + tc.count,
+                                          0,
+                                        ) !== 1
+                                          ? "s"
+                                          : ""}
+                                      </span>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <ul className="text-left">
+                                        {stats.toolCalls.map((tc) => (
+                                          <li key={tc.name}>
+                                            {tc.name} &times;{tc.count}
+                                          </li>
+                                        ))}
+                                      </ul>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                ) : (
+                                  <span className="flex items-center gap-1">
+                                    <Wrench className="h-3 w-3" />0 tool calls
+                                  </span>
+                                )}
+                                <span className="flex items-center gap-1">
+                                  <MessageSquare className="h-3 w-3" />
+                                  {formatTokens(stats.inputTokens)} in /{" "}
+                                  {formatTokens(stats.outputTokens)} out
+                                </span>
+                                {/* How full the context got on the run's LAST
                                   step, which is a different quantity from the
                                   cross-step sums above (ADR-0018). Absent where
                                   the Provider reported no usage — occupancy is
                                   then unknown and nothing is estimated. */}
-                              {stats.contextOccupancy !== undefined && (
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <span className="flex items-center gap-1 cursor-default">
-                                      <Gauge className="h-3 w-3" />
-                                      {formatTokens(
-                                        stats.contextOccupancy,
-                                      )}{" "}
-                                      context
-                                    </span>
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    Tokens the conversation filled on the final
-                                    step
-                                  </TooltipContent>
-                                </Tooltip>
-                              )}
-                            </div>
-                          )}
-                          {stats?.truncatedByTokenLimit && (
-                            <RunCutShortNotice />
-                          )}
-                          {stats?.stoppedAtStepLimit && <RunStepLimitNotice />}
-                          {run.errorMessage && (
-                            <p className="text-sm text-destructive mt-1">
-                              {run.errorMessage}
-                            </p>
-                          )}
+                                {stats.contextOccupancy !== undefined && (
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <span className="flex items-center gap-1 cursor-default">
+                                        <Gauge className="h-3 w-3" />
+                                        {formatTokens(
+                                          stats.contextOccupancy,
+                                        )}{" "}
+                                        context
+                                      </span>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      Tokens the conversation filled on the
+                                      final step
+                                    </TooltipContent>
+                                  </Tooltip>
+                                )}
+                              </div>
+                            )}
+                            {stats?.truncatedByTokenLimit && (
+                              <RunCutShortNotice />
+                            )}
+                            {stats?.stoppedAtStepLimit && (
+                              <RunStepLimitNotice />
+                            )}
+                            {run.errorMessage && (
+                              <p className="text-sm text-destructive mt-1">
+                                {run.errorMessage}
+                              </p>
+                            )}
+                          </div>
                         </div>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              className="text-muted-foreground shrink-0"
+                              variant="ghost"
+                              size="icon"
+                              aria-label="Copy run id"
+                              onClick={() => handleCopyRunId(run.id)}
+                            >
+                              <Copy className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>Copy run id</TooltipContent>
+                        </Tooltip>
                       </div>
                     </div>
                   );


### PR DESCRIPTION
## Summary
- Adds an icon-only "Copy run id" control to each row on the Trigger runs page, writing the run's full id to the clipboard so it can be cross-referenced against backend logs (which key every log line by `runId`).
- The id itself is never rendered — the control is the only place it surfaces, per the issue's explicit requirement.
- Accessible name (`aria-label="Copy run id"`) plus a matching tooltip shown on hover and keyboard focus; success/error toasts on the clipboard write.
- Documents the control in `apps/docs/content/building-with-platypus/triggers.mdx` under "Review run history".

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (all packages, including new tests: no visible run id, accessible name + tooltip, success-toast copy, error-toast on rejected clipboard write)
- [x] `apps/docs` docs-contract test still passes

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)