### PR TITLE
fix(backend,frontend): recover a chat stream that drops mid-run

### DIFF
--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 
 /**
  * As much of a stream part as the metadata extractor reads. The SDK hands it
@@ -109,13 +109,14 @@ vi.mock("../logger.ts", () => ({
 }));
 
 import { AgentRunner } from "./agent-runner.ts";
+import { ConflictError, mapError } from "../errors.ts";
 import { logger } from "../logger.ts";
 import { runRegistry, TimeoutError } from "./run-registry.ts";
 import type { ResolvedRunPlan, RunInput, RunSink, RunStats } from "./types.ts";
 import type { WorkspaceScope } from "../scope.ts";
 
 type LifecycleEvent =
-  | { name: "onStart"; runId: string }
+  | { name: "onStart"; runId: string; messages?: unknown[] }
   | { name: "onResolved"; runId: string; plan: ResolvedRunPlan }
   | { name: "onProgress"; runId: string }
   | {
@@ -130,8 +131,12 @@ type LifecycleEvent =
 class RecordingSink implements RunSink {
   events: LifecycleEvent[] = [];
 
-  onStart(ctx: { runId: string }): Promise<void> {
-    this.events.push({ name: "onStart", runId: ctx.runId });
+  onStart(ctx: { runId: string; messages?: unknown[] }): Promise<void> {
+    this.events.push({
+      name: "onStart",
+      runId: ctx.runId,
+      messages: ctx.messages,
+    });
     return Promise.resolve();
   }
   onResolved(ctx: { runId: string; plan: ResolvedRunPlan }): Promise<void> {
@@ -782,6 +787,117 @@ describe("AgentRunner.stream — failure paths", () => {
     expect(finish.status).toBe("failed");
     expect(finish.error).toBe("Workspace missing");
     // Stream was never invoked
+    expect(mockStreamText).not.toHaveBeenCalled();
+  });
+});
+
+// Issue #648. A Chat run's id IS the chat id, so a duplicate submission into a
+// Chat with a live turn arrives with a runId the registry already holds. The
+// ORDER is the whole point: the claim has to come before the sink's start hook,
+// because that hook overwrites the row's messages with the second request's
+// history. Claim second and the duplicate destroys the live run's persisted
+// state on its way to failing.
+describe("AgentRunner — duplicate submission for a live run", () => {
+  let runner: AgentRunner;
+  beforeEach(() => {
+    runner = new AgentRunner();
+    vi.clearAllMocks();
+    resetStreamHarness();
+  });
+
+  // These runs are deliberately left in flight, so the registry entries and the
+  // unconsumed `once` mock values have to be cleared by hand — `clearAllMocks`
+  // resets recorded calls but not a queued `mockResolvedValueOnce`.
+  afterEach(() => {
+    runRegistry.unregister("chat-live");
+    runRegistry.unregister("chat-start-throws");
+    mockPrepareChatTurn.mockReset();
+    mockStreamText.mockReset();
+  });
+
+  const liveRun = async (sink: RecordingSink) => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    streamHarness.queue = new streamHarness.AsyncQueue();
+    primeStreamText();
+    await runner.stream({
+      scope,
+      input: {
+        ...baseInput,
+        runId: "chat-live",
+        messages: [{ id: "u1", role: "user", parts: [] }] as never,
+      },
+      sink,
+      options: { origin: "http://test" },
+    });
+  };
+
+  it("rejects the duplicate with a ConflictError (409) and writes nothing", async () => {
+    const sink = new RecordingSink();
+    await liveRun(sink);
+
+    // The second submission carries its own history — what would have replaced
+    // the live run's messages.
+    await expect(
+      runner.stream({
+        scope,
+        input: {
+          ...baseInput,
+          runId: "chat-live",
+          messages: [
+            { id: "u1", role: "user", parts: [] },
+            { id: "a1", role: "assistant", parts: [] },
+            { id: "u2", role: "user", parts: [] },
+          ] as never,
+        },
+        sink,
+        options: { origin: "http://test" },
+      }),
+    ).rejects.toThrow(ConflictError);
+
+    expect(mapError(new ConflictError("x"))?.status).toBe(409);
+    // One start hook, carrying the live run's own history — byte-for-byte what
+    // it was registered with.
+    const starts = sink.events.filter((e) => e.name === "onStart");
+    expect(starts).toHaveLength(1);
+    expect(starts[0]).toMatchObject({ messages: [{ id: "u1" }] });
+    expect(mockValidateTurnAttachments).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the live run running rather than terminating it", async () => {
+    const sink = new RecordingSink();
+    await liveRun(sink);
+
+    await expect(
+      runner.stream({
+        scope,
+        input: { ...baseInput, runId: "chat-live" },
+        sink,
+        options: { origin: "http://test" },
+      }),
+    ).rejects.toThrow(ConflictError);
+
+    expect(sink.names()).not.toContain("onFinish");
+    expect(runRegistry.has("chat-live")).toBe(true);
+  });
+
+  // The claim being first means a hook that throws would otherwise hold the id
+  // forever — and since the id is the chat id, that locks the Chat out of every
+  // later turn, not just this one.
+  it("releases the claim when the start hook throws", async () => {
+    mockPrepareChatTurn.mockResolvedValueOnce(fakeTurn());
+    const sink = new RecordingSink();
+    sink.onStart = () => Promise.reject(new Error("row write failed"));
+
+    await expect(
+      runner.stream({
+        scope,
+        input: { ...baseInput, runId: "chat-start-throws" },
+        sink,
+        options: { origin: "http://test" },
+      }),
+    ).rejects.toThrow("row write failed");
+
+    expect(runRegistry.has("chat-start-throws")).toBe(false);
     expect(mockStreamText).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -16,6 +16,7 @@ import type { PlatypusUIMessage } from "../types.ts";
 import { runRegistry, type RunTimeouts } from "./run-registry.ts";
 import { startRun } from "./run-lifecycle.ts";
 import { driveChat, driveOnce } from "./drive.ts";
+import { withStreamKeepalive } from "./stream-keepalive.ts";
 import type {
   ResolvedRunPlan,
   RunId,
@@ -163,16 +164,17 @@ export class AgentRunner {
       workspaceId: scope.workspaceId,
     });
 
-    await sink.onStart({
-      runId: input.runId,
-      messages: input.messages,
-      memorySnapshot: input.memorySnapshot,
-    });
-
     const state: RunState = {
       messages: input.messages,
     };
 
+    // Claim the run BEFORE the sink writes anything (issue #648). A second
+    // submission for a Chat that already has a live run reaches here with the
+    // same runId — a Chat run's id is the chat id — and `startRun` rejects it
+    // with a `ConflictError` the central handler answers 409 (ADR-0010). Run
+    // the other way round and the duplicate's start hook overwrites the live
+    // run's persisted messages with its own history first, then fails: the
+    // client gets an error AND the run it interrupted loses its state.
     const run = startRun({
       runId: input.runId,
       timeouts: params.timeouts,
@@ -203,6 +205,22 @@ export class AgentRunner {
           );
       },
     });
+
+    // Registered now, so a start hook that throws releases the claim rather
+    // than leaving the runId held by a run that never began — which, with the
+    // claim taken first, would lock the Chat out of every later turn.
+    try {
+      await sink.onStart({
+        runId: input.runId,
+        messages: input.messages,
+        memorySnapshot: input.memorySnapshot,
+      });
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.error({ error, runId: input.runId }, "Run sink onStart failed");
+      await run.finish("failed", err);
+      throw err;
+    }
 
     try {
       state.turn = await this.prepare(
@@ -320,7 +338,13 @@ export class AgentRunner {
       logger.error({ err, runId: input.runId }, "Chat drive background error"),
     );
 
-    return createUIMessageStreamResponse({ stream: drive.response });
+    // Wrapped past the tee, so the heartbeat reaches the client and not the
+    // server-side drain above (issue #648). The no-buffering header a reverse
+    // proxy needs is already on the response the SDK builds; `stream-keepalive`
+    // carries it through, and its test pins that it is still there.
+    return withStreamKeepalive(
+      createUIMessageStreamResponse({ stream: drive.response }),
+    );
   }
 
   /**

--- a/apps/backend/src/runs/run-registry.test.ts
+++ b/apps/backend/src/runs/run-registry.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_PER_RUN_TIMEOUT_MS,
   describeTimeout,
 } from "./run-registry.ts";
+import { ConflictError, mapError } from "../errors.ts";
 
 describe("RunRegistry", () => {
   let registry: RunRegistry;
@@ -29,6 +30,39 @@ describe("RunRegistry", () => {
 
   it("cancel(unknown) returns false and does not throw", () => {
     expect(registry.cancel("nope")).toBe(false);
+  });
+
+  // Issue #648. A Chat run's id IS the chat id, so a second submission into a
+  // Chat with a live turn lands here — and the claim is now the first thing a
+  // run does, ahead of any persistence, so this rejection is what protects the
+  // live run's state. Typed as a `ConflictError` because ADR-0010's central
+  // handler answers 409 for one; a plain `Error` became a 500.
+  it("rejects a duplicate runId with a ConflictError the handler maps to 409", () => {
+    registry.register("dup-1");
+
+    expect(() => registry.register("dup-1")).toThrow(ConflictError);
+    expect(mapError(new ConflictError("x"))?.status).toBe(409);
+  });
+
+  it("frees the id for a later run once the first unregisters", () => {
+    registry.register("dup-2");
+    registry.unregister("dup-2");
+
+    expect(() => registry.register("dup-2")).not.toThrow();
+  });
+
+  // The rejection must not disturb the run that holds the id: its signal and
+  // its timers belong to the first claim.
+  it("leaves the holding run untouched when a duplicate is rejected", () => {
+    const handle = registry.register("dup-3", {
+      perStepTimeoutMs: 1000,
+      perRunTimeoutMs: 1_000_000,
+    });
+
+    expect(() => registry.register("dup-3")).toThrow(ConflictError);
+
+    expect(handle.signal.aborted).toBe(false);
+    expect(registry.cancel("dup-3")).toBe(true);
   });
 
   it("cancel is idempotent", () => {
@@ -204,11 +238,6 @@ describe("RunRegistry", () => {
     vi.advanceTimersByTime(2000);
 
     expect(onTimeout).not.toHaveBeenCalled();
-  });
-
-  it("registering the same runId twice throws", () => {
-    registry.register("dup");
-    expect(() => registry.register("dup")).toThrow(/already registered/);
   });
 
   it("default timeouts are exported and reasonable", () => {

--- a/apps/backend/src/runs/run-registry.ts
+++ b/apps/backend/src/runs/run-registry.ts
@@ -1,3 +1,4 @@
+import { ConflictError } from "../errors.ts";
 import type { RunId } from "./types.ts";
 
 /**
@@ -127,10 +128,21 @@ type Entry = {
 export class RunRegistry {
   private readonly entries = new Map<RunId, Entry>();
 
+  /**
+   * Claims `runId` and returns its handle.
+   *
+   * A runId that is already claimed is a second run for something that already
+   * has one — a Chat whose turn has not finished, since a Chat run's id IS the
+   * chat id. Typed as a `ConflictError` so the central error handler answers
+   * 409 (ADR-0010) instead of an unhandled throw becoming a 500, and so the
+   * claim can be made the first thing a run does: registering before anything
+   * is persisted is what stops a duplicate submission overwriting the live
+   * run's messages on its way to failing (issue #648).
+   */
   register(runId: RunId, options: RegisterOptions = {}): RunHandle {
     const existing = this.entries.get(runId);
     if (existing) {
-      throw new Error(`RunRegistry: run '${runId}' already registered`);
+      throw new ConflictError(`A run is already in progress for '${runId}'`);
     }
 
     const controller = new AbortController();

--- a/apps/backend/src/runs/stream-keepalive.test.ts
+++ b/apps/backend/src/runs/stream-keepalive.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { createUIMessageStreamResponse } from "ai";
+import {
+  SSE_HEARTBEAT_FRAME,
+  withHeartbeatFrames,
+  withStreamKeepalive,
+} from "./stream-keepalive.ts";
+
+const HEARTBEAT_MS = 50;
+
+/** Reads a byte stream to the end and returns it as one decoded string. */
+const readAll = async (stream: ReadableStream<Uint8Array>): Promise<string> => {
+  const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  return out + decoder.decode();
+};
+
+/** A byte stream the test pushes to and ends by hand. */
+const controllable = () => {
+  const encoder = new TextEncoder();
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start: (c) => {
+      controller = c;
+    },
+  });
+  return {
+    stream,
+    write: (text: string) => controller.enqueue(encoder.encode(text)),
+    end: () => controller.close(),
+  };
+};
+
+const heartbeats = (text: string) => text.split(SSE_HEARTBEAT_FRAME).length - 1;
+
+describe("withHeartbeatFrames", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("puts bytes on the wire while the source says nothing", async () => {
+    const source = controllable();
+    const kept = withHeartbeatFrames(source.stream, HEARTBEAT_MS);
+    const collected = readAll(kept);
+
+    // Nothing from the model for several heartbeat intervals — the case a
+    // proxy's idle timeout would otherwise kill.
+    await new Promise((r) => setTimeout(r, HEARTBEAT_MS * 3.5));
+    source.end();
+
+    expect(heartbeats(await collected)).toBeGreaterThanOrEqual(3);
+  });
+
+  it("passes the source's own frames through untouched", async () => {
+    const source = controllable();
+    const kept = withHeartbeatFrames(source.stream, 10_000);
+    const collected = readAll(kept);
+
+    source.write('data: {"type":"text-delta","delta":"hi"}\n\n');
+    source.write('data: {"type":"finish"}\n\n');
+    source.end();
+
+    const text = await collected;
+    expect(text).toBe(
+      'data: {"type":"text-delta","delta":"hi"}\n\n' +
+        'data: {"type":"finish"}\n\n',
+    );
+    expect(heartbeats(text)).toBe(0);
+  });
+
+  // A heartbeat frame inside another frame would corrupt the event the client
+  // is parsing, so they may only ever land on a frame boundary.
+  it("never splits a source frame", async () => {
+    const source = controllable();
+    const kept = withHeartbeatFrames(source.stream, HEARTBEAT_MS);
+    const collected = readAll(kept);
+
+    for (let i = 0; i < 4; i++) {
+      source.write(`data: {"seq":${i}}\n\n`);
+      await new Promise((r) => setTimeout(r, HEARTBEAT_MS + 5));
+    }
+    source.end();
+
+    const text = await collected;
+    expect(heartbeats(text)).toBeGreaterThanOrEqual(3);
+    for (const frame of text.split("\n\n").filter(Boolean)) {
+      expect(
+        frame === ": heartbeat" || /^data: \{"seq":\d\}$/.test(frame),
+      ).toBe(true);
+    }
+  });
+
+  // Wrapping must not turn the run into a buffer on a slow client's behalf. A
+  // wrapper that pumped the source from `start` would drain all 100 chunks into
+  // memory after a single read.
+  it("reads from the source only as the consumer asks for more", async () => {
+    const encoder = new TextEncoder();
+    let produced = 0;
+    const source = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        produced += 1;
+        if (produced > 100) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(encoder.encode(`data: {"n":${produced}}\n\n`));
+      },
+    });
+
+    const reader = withHeartbeatFrames(source, 10_000).getReader();
+    await reader.read();
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(produced).toBeLessThan(10);
+    await reader.cancel();
+  });
+
+  // The interval outlives the request otherwise: a client that navigates away
+  // cancels the response body, and a timer still enqueueing into it leaks for
+  // the life of the process.
+  it("stops beating when the consumer cancels", async () => {
+    vi.useFakeTimers();
+    const source = controllable();
+    const kept = withHeartbeatFrames(source.stream, HEARTBEAT_MS);
+    const reader = kept.getReader();
+
+    await reader.cancel("client gone");
+    vi.advanceTimersByTime(HEARTBEAT_MS * 10);
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("stops beating once the source ends", async () => {
+    const source = controllable();
+    const kept = withHeartbeatFrames(source.stream, HEARTBEAT_MS);
+    const collected = readAll(kept);
+    source.end();
+    await collected;
+
+    vi.useFakeTimers();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("surfaces a source failure to the consumer", async () => {
+    const failing = new ReadableStream<Uint8Array>({
+      start: (c) => c.error(new Error("upstream died")),
+    });
+
+    await expect(
+      readAll(withHeartbeatFrames(failing, HEARTBEAT_MS)),
+    ).rejects.toThrow("upstream died");
+  });
+});
+
+describe("withStreamKeepalive", () => {
+  /** The response shape the runner hands over, built the way the SDK builds it. */
+  const streamedRunResponse = () =>
+    createUIMessageStreamResponse({
+      stream: new ReadableStream({
+        start: (c) => c.close(),
+      }),
+    });
+
+  // The other half of surviving an intermediary: a proxy that buffers a
+  // streamed response holds every heartbeat back until the run ends, which
+  // defeats the point of sending them.
+  it("keeps the no-buffering header a reverse proxy reads", () => {
+    const kept = withStreamKeepalive(streamedRunResponse(), HEARTBEAT_MS);
+
+    expect(kept.headers.get("x-accel-buffering")).toBe("no");
+  });
+
+  it("keeps the event-stream content type and status", () => {
+    const kept = withStreamKeepalive(streamedRunResponse(), HEARTBEAT_MS);
+
+    expect(kept.status).toBe(200);
+    expect(kept.headers.get("content-type")).toBe("text/event-stream");
+  });
+
+  it("returns a bodyless response unchanged rather than rebuilding it", () => {
+    const original = new Response(null, { status: 204 });
+
+    expect(withStreamKeepalive(original, HEARTBEAT_MS)).toBe(original);
+  });
+
+  it("beats on a real streamed run response that has gone quiet", async () => {
+    let close!: () => void;
+    const response = createUIMessageStreamResponse({
+      stream: new ReadableStream({
+        start: (c) => {
+          close = () => c.close();
+        },
+      }),
+    });
+
+    const kept = withStreamKeepalive(response, HEARTBEAT_MS);
+    const collected = readAll(kept.body!);
+    await new Promise((r) => setTimeout(r, HEARTBEAT_MS * 2.5));
+    close();
+
+    expect(heartbeats(await collected)).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/backend/src/runs/stream-keepalive.ts
+++ b/apps/backend/src/runs/stream-keepalive.ts
@@ -1,0 +1,107 @@
+/**
+ * Keepalive for a streamed run's HTTP response.
+ *
+ * A Chat turn can go a long time with nothing to say: one slow MCP call or one
+ * sandbox shell exec produces no model output at all, and the per-step bound
+ * that would notice a genuine stall is measured in minutes. An intermediary
+ * with a 60-second idle timeout — nginx, a corporate proxy — wins that race and
+ * tears down a run that was perfectly healthy. Periodic bytes are what stop it,
+ * and they are also the only thing a client could build a dead-socket watchdog
+ * on: with no traffic at all, a socket that dies silently produces no event.
+ *
+ * The bytes are SSE comments, injected into the encoded response body rather
+ * than the run's chunk stream. Two reasons that boundary matters:
+ *
+ * - A comment is inert by construction. The UI message protocol has no "no-op
+ *   chunk", and anything that IS a chunk would reach the message the client is
+ *   folding. `eventsource-parser` drops a comment line unless a consumer asks
+ *   for one, which nothing here does.
+ * - The run stream is teed — a client branch and a server-side drain that keeps
+ *   the persisted messages current. Injecting after the response is built puts
+ *   the heartbeat past the tee, so the drain cannot observe it.
+ */
+
+/** How often a silent stream puts bytes on the wire. */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 15_000;
+
+/**
+ * One SSE comment frame. A line opening with `:` carries no event, so a
+ * conforming parser reads it and moves on.
+ */
+export const SSE_HEARTBEAT_FRAME = ": heartbeat\n\n";
+
+/**
+ * Copies `source` through, adding a heartbeat frame every `intervalMs`.
+ *
+ * Frames are enqueued between whole source chunks — the encoder upstream emits
+ * one complete `data:` frame per chunk, and a timer callback cannot interleave
+ * with an enqueue — so a heartbeat can never land inside another frame.
+ *
+ * The source is read from `pull` rather than pumped from `start`, so
+ * backpressure survives the wrapping: a slow client still slows the reads
+ * instead of having the whole run's bytes buffered on its behalf. The heartbeat
+ * is the one thing that does not wait to be asked for, which is the point of it.
+ */
+export const withHeartbeatFrames = (
+  source: ReadableStream<Uint8Array>,
+  intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
+): ReadableStream<Uint8Array> => {
+  const encoder = new TextEncoder();
+  const reader = source.getReader();
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const stopBeating = () => {
+    if (timer !== undefined) clearInterval(timer);
+    timer = undefined;
+  };
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      timer = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(SSE_HEARTBEAT_FRAME));
+        } catch {
+          // The consumer closed the stream between the tick being scheduled
+          // and it running. Nothing left to keep alive.
+          stopBeating();
+        }
+      }, intervalMs);
+    },
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          stopBeating();
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        stopBeating();
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      stopBeating();
+      return reader.cancel(reason);
+    },
+  });
+};
+
+/**
+ * The same response, with its body kept alive while the run is silent.
+ *
+ * Returned unchanged when there is no body to keep alive, so a caller wraps
+ * unconditionally rather than testing first.
+ */
+export const withStreamKeepalive = (
+  response: Response,
+  intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS,
+): Response => {
+  if (!response.body) return response;
+  return new Response(withHeartbeatFrames(response.body, intervalMs), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+};

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chat
-description: The screen you use every day — attaching files, web search, voice input, editing messages, organising a long history, and what happens when you close the tab mid-run.
+description: The screen you use every day — attaching files, web search, voice input, editing messages, organising a long history, and what happens when you lose the connection mid-run.
 ---
 
 import { Callout } from "nextra/components";
@@ -316,10 +316,12 @@ The actions are hidden while the last reply is still streaming.
 
 <Callout type="warning">
   **Delete removes the message from the view, and the next thing you send makes
-  that permanent.** Nothing is written when you click it, so reloading before
-  you send anything brings the message back. Send a message afterwards and the
-  shortened conversation is what gets stored — the deletion you thought was
-  cosmetic is now the history. Reload first if you want it back.
+  that permanent.** Nothing is written when you click it, so anything that
+  re-reads the Chat brings the message back — reloading, and also switching away
+  from the tab and returning. Send a message afterwards and the shortened
+  conversation is what gets stored — the deletion you thought was cosmetic is now
+  the history. If you are pruning a long Chat, send in the same sitting rather
+  than leaving it and coming back.
 </Callout>
 
 ## Organising a long history
@@ -359,7 +361,7 @@ then your **Agents**, **Boards** and **Triggers** by name. Selecting an Agent
 opens a new Chat already set to it. **Docs** opens this documentation site in a
 new tab.
 
-## Closing the tab mid-run
+## Losing the connection mid-run
 
 A Chat turn runs on the server, not in your browser. Closing the tab, losing your
 connection, or navigating away does not stop it. The Agent keeps working, and its
@@ -369,10 +371,30 @@ Come back to the Chat and it picks up where things got to: while the run is stil
 going, the page polls and the finished parts of the reply appear. The sidebar
 shows a spinner beside any Chat with a run in progress.
 
-While a run you didn't start in this tab is still going, the input is disabled
-and reads **Run in progress…**, and the send button becomes a stop button. That
-is deliberate — it stops a second tab kicking off a concurrent run on the same
-Chat.
+You don't have to close the tab for this to happen. Switching to another app on a
+phone, or backgrounding the tab for long enough, is usually all it takes — the
+browser tears down the connection carrying the reply. When it does, a line
+appears above the input reading **Connection interrupted. The reply is still
+being written and will keep filling in here.** Leave it be: the reply carries on
+arriving in the same Chat, a few seconds behind, and finishes on its own. There
+is nothing to press and no need to reload.
+
+While a run is still going and this tab isn't the one receiving it — a second tab
+on the same Chat, a tab that arrived mid-run, or one whose connection dropped —
+the input is disabled and reads **Run in progress…**, and the send button becomes
+a stop button. That is deliberate: it stops a second, concurrent run on a Chat
+that already has one. If a second one does get as far as being sent — two tabs
+racing, say — it is refused rather than accepted, and the running turn is left
+untouched.
+
+<Callout type="warning">
+  **A lost connection is not a failed turn, and the difference is visible.** The
+  interrupted line above means the run is fine and the reply is on its way. A
+  **Chat Error** dialog means something actually failed — the turn errored, or
+  the request was refused before it started — and that one is worth reading.
+  Reloading the page on the interrupted line does no harm, but it also buys you
+  nothing.
+</Callout>
 
 <Callout type="info">
   Pressing stop **cancels the run on the server**, not only your connection to

--- a/apps/frontend/components/chat-reconnecting-notice.test.tsx
+++ b/apps/frontend/components/chat-reconnecting-notice.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  CHAT_RECONNECTING_MESSAGE,
+  ChatReconnectingNotice,
+} from "./chat-reconnecting-notice";
+
+describe("ChatReconnectingNotice", () => {
+  // A dropped connection to a healthy run gets a line in the page, not the
+  // modal a failed turn gets (issue #648). The wording is quoted in the Chat
+  // documentation, so it is pinned here.
+  it("says the reply is still being written", () => {
+    render(<ChatReconnectingNotice />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      CHAT_RECONNECTING_MESSAGE,
+    );
+  });
+
+  it("is announced politely rather than interrupting", () => {
+    render(<ChatReconnectingNotice />);
+
+    expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/apps/frontend/components/chat-reconnecting-notice.tsx
+++ b/apps/frontend/components/chat-reconnecting-notice.tsx
@@ -1,0 +1,25 @@
+import { RefreshCw } from "lucide-react";
+
+/** The sentence a reader sees; also what the documentation quotes. */
+export const CHAT_RECONNECTING_MESSAGE =
+  "Connection interrupted. The reply is still being written and will keep filling in here.";
+
+/**
+ * The line shown while a Chat has lost its stream to a run that is still going.
+ *
+ * A dropped connection is not a failed turn — the run outlives the request and
+ * the answer keeps arriving from the poll — so it gets a line in the flow of the
+ * page rather than the modal a real failure gets (issue #648). Announced
+ * politely so a screen reader picks it up without interrupting the reply being
+ * read.
+ */
+export const ChatReconnectingNotice = () => (
+  <div
+    role="status"
+    aria-live="polite"
+    className="mb-2 flex items-center gap-2 rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground"
+  >
+    <RefreshCw className="size-4 shrink-0 animate-spin" aria-hidden="true" />
+    <span>{CHAT_RECONNECTING_MESSAGE}</span>
+  </div>
+);

--- a/apps/frontend/components/chat.test.tsx
+++ b/apps/frontend/components/chat.test.tsx
@@ -1,0 +1,478 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render } from "@testing-library/react";
+import type { ChatStatus } from "ai";
+import type { PlatypusUIMessage } from "@platypus/backend/src/types";
+
+/**
+ * The wiring between `Chat` and `lib/chat-recovery` (issue #648).
+ *
+ * The recovery decisions are pure functions with their own tests; what those
+ * cannot see is whether the component actually feeds them the right inputs. The
+ * original bug was exactly a wiring bug — the poll interval was derived from the
+ * fetched row's status and nothing else — so a test that only exercises the
+ * predicates would have passed against the broken code.
+ *
+ * So this file asserts the seams: what the Chat detail read is configured with,
+ * what reaches the interval predicate, how a fetched snapshot is applied, and
+ * which of the two error surfaces a given state selects. The presentational tree
+ * is stubbed down to the props under test — this is not a rendering test.
+ */
+
+type SwrCall = {
+  key: string;
+  fetcher: unknown;
+  config: Record<string, unknown> | undefined;
+};
+
+const { harness } = vi.hoisted(() => ({
+  harness: {
+    swrCalls: [] as SwrCall[],
+    /** Response bodies by key suffix. */
+    data: new Map<string, unknown>(),
+    /** Built once per key so the identity a hydrate effect keys off is stable. */
+    responses: new Map<string, unknown>(),
+    turn: {
+      status: "ready" as ChatStatus,
+      error: undefined as Error | undefined,
+      messages: [] as PlatypusUIMessage[],
+    },
+    setMessages: vi.fn(),
+    sendMessage: vi.fn(),
+    chatMutate: vi.fn(),
+  },
+}));
+
+vi.mock("swr", () => ({
+  __esModule: true,
+  default: (
+    key: string | null,
+    fetcher: unknown,
+    config: Record<string, unknown> | undefined,
+  ) => {
+    if (!key) return { data: undefined, isLoading: false, mutate: vi.fn() };
+    harness.swrCalls.push({ key, fetcher, config });
+    let response = harness.responses.get(key);
+    if (!response) {
+      const match = [...harness.data.entries()].find(([suffix]) =>
+        key.endsWith(suffix),
+      );
+      response = {
+        data: match ? match[1] : undefined,
+        isLoading: false,
+        mutate: key.includes("/chat/") ? harness.chatMutate : vi.fn(),
+      };
+      harness.responses.set(key, response);
+    }
+    return response;
+  },
+  useSWRConfig: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@ai-sdk/react", () => ({
+  useChat: () => ({
+    messages: harness.turn.messages,
+    setMessages: harness.setMessages,
+    sendMessage: harness.sendMessage,
+    status: harness.turn.status,
+    error: harness.turn.error,
+    regenerate: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+vi.mock("@/app/client-context", () => ({ useBackendUrl: () => "http://test" }));
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({ user: { id: "u1" }, ownsWorkspace: true }),
+}));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), info: vi.fn() } }));
+
+// The presentational tree, stubbed to the props under test. `PromptInputTextarea`
+// and `PromptInputSubmit` keep theirs, because the composer guard is one of the
+// behaviours being pinned.
+vi.mock("@/components/ai-elements/conversation", () => ({
+  Conversation: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ConversationContent: ({ children }: { children?: React.ReactNode }) => (
+    <div data-conversation>{children}</div>
+  ),
+  ConversationScrollButton: () => null,
+}));
+
+vi.mock("@/components/ai-elements/prompt-input", () => ({
+  PromptInput: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PromptInputBody: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PromptInputFooter: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PromptInputTools: () => null,
+  PromptInputAttachments: () => null,
+  PromptInputAttachment: () => null,
+  PromptInputActionMenu: () => null,
+  PromptInputActionMenuTrigger: () => null,
+  PromptInputActionMenuContent: () => null,
+  PromptInputActionAddAttachments: () => null,
+  PromptInputButton: () => null,
+  PromptInputSpeechButton: () => null,
+  PromptInputTextarea: ({
+    placeholder,
+    disabled,
+    status,
+  }: {
+    placeholder?: string;
+    disabled?: boolean;
+    status?: string;
+  }) => (
+    <textarea
+      readOnly
+      placeholder={placeholder}
+      disabled={disabled}
+      data-status={status}
+    />
+  ),
+  PromptInputSubmit: ({ status }: { status?: string }) => (
+    <button type="submit" data-testid="submit" data-status={status} />
+  ),
+}));
+
+vi.mock("./chat-message", () => ({ ChatMessage: () => null }));
+vi.mock("./context-meter", () => ({ ContextMeter: () => null }));
+vi.mock("./file-compatibility-warning", () => ({
+  FileCompatibilityWarning: () => null,
+}));
+vi.mock("./no-providers-empty-state", () => ({
+  NoProvidersEmptyState: () => null,
+}));
+vi.mock("./model-selector-dialog", () => ({ ModelSelectorDialog: () => null }));
+vi.mock("./agent-info-dialog", () => ({ AgentInfoDialog: () => null }));
+vi.mock("./chat-settings-dialog", () => ({
+  ChatSettingsDialog: () => null,
+  CHAT_MAX_STEPS_ERROR: "bad max steps",
+}));
+vi.mock("./error-dialog", () => ({
+  ErrorDialog: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div role="dialog">Chat Error</div> : null,
+}));
+
+import { Chat } from "./chat";
+import { optionalFetcher } from "@/lib/utils";
+import { CHAT_POLL_INTERVAL_MS } from "@/lib/chat-recovery";
+
+const CHAT_ID = "chat-1";
+const CHAT_KEY = `http://test/organizations/org1/workspaces/ws1/chat/${CHAT_ID}`;
+
+const provider = {
+  id: "p1",
+  name: "OpenRouter",
+  modelIds: [{ id: "m1", passthroughFileTypes: [] }],
+};
+
+const message = (id: string, text: string): PlatypusUIMessage =>
+  ({
+    id,
+    role: id.startsWith("u") ? "user" : "assistant",
+    parts: [{ type: "text", text }],
+  }) as PlatypusUIMessage;
+
+/** The config the Chat detail read was last built with. */
+const chatReadConfig = () => {
+  const call = harness.swrCalls.filter((c) => c.key === CHAT_KEY).at(-1);
+  if (!call) throw new Error("the Chat detail read was never made");
+  return call;
+};
+
+/** What the interval predicate answers for a given fetched row. */
+const pollFor = (row: { status: string } | null) => {
+  const refreshInterval = chatReadConfig().config?.refreshInterval as (
+    data: unknown,
+  ) => number;
+  return refreshInterval(row);
+};
+
+const renderChat = () =>
+  render(<Chat orgId="org1" workspaceId="ws1" chatId={CHAT_ID} />);
+
+/**
+ * Renders, then walks the local turn through a status sequence the way the chat
+ * hook would. The sequence matters: whether a turn ever reached `streaming` is
+ * what tells a dropped connection from a request the server refused, so a test
+ * that jumped straight to `error` would be describing a different failure.
+ */
+const renderThrough = (...statuses: ChatStatus[]) => {
+  const view = renderChat();
+  for (const status of statuses) {
+    harness.turn.status = status;
+    if (status === "error") harness.turn.error = new Error("Failed to fetch");
+    view.rerender(<Chat orgId="org1" workspaceId="ws1" chatId={CHAT_ID} />);
+  }
+  return view;
+};
+
+/** A turn that was streaming when the browser tore the connection down. */
+const DROPPED: ChatStatus[] = ["submitted", "streaming", "error"];
+
+/** A turn the server refused before any of it arrived. */
+const REFUSED: ChatStatus[] = ["submitted", "error"];
+
+beforeEach(() => {
+  harness.swrCalls = [];
+  harness.data = new Map<string, unknown>([
+    ["/providers", { results: [provider] }],
+  ]);
+  harness.responses = new Map();
+  harness.turn = { status: "ready", error: undefined, messages: [] };
+  harness.setMessages.mockReset();
+  harness.sendMessage.mockReset();
+  harness.chatMutate.mockReset();
+  harness.chatMutate.mockResolvedValue(undefined);
+});
+
+describe("Chat detail read", () => {
+  // A brand-new Chat is read before its row exists. `fetcher` throwing on that
+  // 404 is what put an error in the cache, and SWR does not revalidate on an
+  // interval while one is there.
+  it("reads through the fetcher that treats a missing row as absence", () => {
+    renderChat();
+
+    expect(chatReadConfig().fetcher).toBe(optionalFetcher);
+  });
+
+  // Every other read keeps the throwing contract; the concession is per-key.
+  it("leaves the other reads on the shared fetcher", () => {
+    renderChat();
+
+    const others = harness.swrCalls.filter((c) => c.key !== CHAT_KEY);
+    expect(others.length).toBeGreaterThan(0);
+    for (const call of others) {
+      expect(call.fetcher).not.toBe(optionalFetcher);
+    }
+  });
+
+  // The trap the original code fell into: focus and reconnect revalidation were
+  // switched off, which removed the only two triggers left once the interval
+  // was inert. They are the "user came back" and "network returned" signals.
+  it("leaves focus and reconnect revalidation on", () => {
+    renderChat();
+
+    const { config } = chatReadConfig();
+    expect(config?.revalidateOnFocus).toBeUndefined();
+    expect(config?.revalidateOnReconnect).toBeUndefined();
+  });
+});
+
+// The wiring the pure-function tests cannot see. Gating the interval on the
+// fetched status ALONE is the bootstrap deadlock: on an existing Chat that
+// status is the previous turn's `succeeded` until something refetches it, and
+// the only thing that would was the poll.
+describe("polling a live run", () => {
+  it("polls a turn this tab just submitted, though the row reads succeeded", () => {
+    harness.turn.status = "submitted";
+    renderChat();
+
+    expect(pollFor({ status: "succeeded" })).toBe(CHAT_POLL_INTERVAL_MS);
+  });
+
+  it("polls while this tab is streaming", () => {
+    harness.turn.status = "streaming";
+    renderChat();
+
+    expect(pollFor({ status: "succeeded" })).toBe(CHAT_POLL_INTERVAL_MS);
+  });
+
+  // A brand-new Chat has no row to read a status off at all.
+  it("polls a turn on a Chat with no row yet", () => {
+    harness.turn.status = "submitted";
+    renderChat();
+
+    expect(pollFor(null)).toBe(CHAT_POLL_INTERVAL_MS);
+  });
+
+  it("polls a run this tab did not start", () => {
+    renderChat();
+
+    expect(pollFor({ status: "running" })).toBe(CHAT_POLL_INTERVAL_MS);
+  });
+
+  // The recovery itself. A dropped stream leaves the turn at `error` while the
+  // run carries on, and this is the reading that gets the answer moving again.
+  it("keeps polling after a stream drops while the run is still going", () => {
+    harness.data.set(`/chat/${CHAT_ID}`, { status: "running", messages: [] });
+    renderThrough(...DROPPED);
+
+    expect(pollFor({ status: "running" })).toBe(CHAT_POLL_INTERVAL_MS);
+  });
+
+  // Nothing streamed, so the server never took a run: polling for an outcome
+  // that will never come would spin for the life of the page.
+  it("does not poll a turn the server refused", () => {
+    renderThrough(...REFUSED);
+
+    expect(pollFor(null)).toBe(0);
+  });
+
+  it("does not poll an idle Chat", () => {
+    renderChat();
+
+    expect(pollFor({ status: "succeeded" })).toBe(0);
+  });
+});
+
+// Monotonic hydration, at the seam: the effect reads the fetched row and hands
+// `setMessages` an updater rather than a list, so what lands is decided against
+// whatever is on screen at that moment.
+describe("applying a fetched snapshot", () => {
+  const applied = (held: PlatypusUIMessage[]) => {
+    const update = harness.setMessages.mock.calls.at(-1)?.[0] as (
+      held: PlatypusUIMessage[],
+    ) => PlatypusUIMessage[];
+    expect(typeof update).toBe("function");
+    return update(held);
+  };
+
+  it("hydrates an empty transcript from the row", () => {
+    const snapshot = [message("u1", "q"), message("a1", "an answer")];
+    harness.data.set(`/chat/${CHAT_ID}`, {
+      status: "succeeded",
+      messages: snapshot,
+    });
+    renderChat();
+
+    expect(applied([])).toBe(snapshot);
+  });
+
+  // The row is written on a flush interval, so a snapshot fetched mid-run lags
+  // the stream. Applying it would make the answer visibly shorten.
+  it("refuses a snapshot behind what is on screen", () => {
+    harness.data.set(`/chat/${CHAT_ID}`, {
+      status: "running",
+      messages: [message("u1", "q"), message("a1", "the first third")],
+    });
+    renderThrough(...DROPPED);
+
+    const held = [
+      message("u1", "q"),
+      message("a1", "the first third and then some more of it"),
+    ];
+    expect(applied(held)).toBe(held);
+  });
+
+  it("applies a snapshot that has moved on", () => {
+    const snapshot = [
+      message("u1", "q"),
+      message("a1", "the first third and then the rest of the answer"),
+    ];
+    harness.data.set(`/chat/${CHAT_ID}`, {
+      status: "running",
+      messages: snapshot,
+    });
+    renderThrough(...DROPPED);
+
+    expect(applied([message("u1", "q"), message("a1", "the first")])).toBe(
+      snapshot,
+    );
+  });
+
+  // A live stream is left alone entirely — the guard that predates this change.
+  it("does not touch the transcript while this tab is streaming", () => {
+    harness.turn.status = "streaming";
+    harness.data.set(`/chat/${CHAT_ID}`, {
+      status: "running",
+      messages: [message("u1", "q")],
+    });
+    renderChat();
+
+    expect(harness.setMessages).not.toHaveBeenCalled();
+  });
+});
+
+// Which surface an error selects. The reported symptom was a modal telling the
+// user their turn had failed while the run was healthy and still going.
+describe("routing a chat error", () => {
+  const RECOVERING = /Connection interrupted/;
+
+  it("shows an inline line and no modal when the run is still going", () => {
+    harness.data.set(`/chat/${CHAT_ID}`, { status: "running", messages: [] });
+    const { container, queryByRole } = renderThrough(...DROPPED);
+
+    expect(container.textContent).toMatch(RECOVERING);
+    expect(queryByRole("dialog")).toBeNull();
+  });
+
+  // The run finished while the connection was gone, so there is nothing to
+  // report and nothing to wait for — the snapshot already holds the answer.
+  it("says nothing once the run has finished behind the drop", () => {
+    harness.data.set(`/chat/${CHAT_ID}`, { status: "succeeded", messages: [] });
+    const { container, queryByRole } = renderThrough(...DROPPED);
+
+    expect(container.textContent).not.toMatch(RECOVERING);
+    expect(queryByRole("dialog")).toBeNull();
+  });
+
+  it("opens the modal for a run that reached a terminal failed status", () => {
+    harness.data.set(`/chat/${CHAT_ID}`, { status: "failed", messages: [] });
+    const { container, getByRole } = renderThrough(...DROPPED);
+
+    expect(getByRole("dialog")).toBeInTheDocument();
+    expect(container.textContent).not.toMatch(RECOVERING);
+  });
+
+  // Nothing streamed, so the server never took a run: a rejected attachment, a
+  // refused submission. The user has to be told.
+  it("opens the modal for a request that never established", () => {
+    harness.data.set(`/chat/${CHAT_ID}`, { status: "succeeded", messages: [] });
+    const { container, getByRole } = renderThrough(...REFUSED);
+
+    expect(getByRole("dialog")).toBeInTheDocument();
+    expect(container.textContent).not.toMatch(RECOVERING);
+  });
+
+  it("says nothing at all while a turn is healthy", () => {
+    harness.data.set(`/chat/${CHAT_ID}`, { status: "running", messages: [] });
+    const { container, queryByRole } = renderChat();
+
+    expect(container.textContent).not.toMatch(RECOVERING);
+    expect(queryByRole("dialog")).toBeNull();
+  });
+});
+
+// The composer guard. The old predicate required the local status to be `ready`,
+// which is the one reading a dropped stream never has.
+describe("holding the composer", () => {
+  it("holds it after a stream drops mid-run", () => {
+    harness.data.set(`/chat/${CHAT_ID}`, { status: "running", messages: [] });
+    const { getByPlaceholderText, getByTestId } = renderThrough(...DROPPED);
+
+    expect(getByPlaceholderText("Run in progress…")).toBeDisabled();
+    expect(getByTestId("submit")).toHaveAttribute("data-status", "streaming");
+  });
+
+  it("holds it for a tab that arrived mid-run", () => {
+    harness.data.set(`/chat/${CHAT_ID}`, { status: "running", messages: [] });
+    const { getByPlaceholderText } = renderChat();
+
+    expect(getByPlaceholderText("Run in progress…")).toBeDisabled();
+  });
+
+  // Once the run is over the composer comes back, and the submit button must
+  // not keep a failure icon on it — the local status is still `error`.
+  it("releases it once the run is over, with no failure on the button", () => {
+    harness.data.set(`/chat/${CHAT_ID}`, { status: "succeeded", messages: [] });
+    const { getByPlaceholderText, getByTestId } = renderThrough(...DROPPED);
+
+    expect(
+      getByPlaceholderText("What would you like to know?"),
+    ).not.toBeDisabled();
+    expect(getByTestId("submit")).toHaveAttribute("data-status", "ready");
+  });
+
+  it("keeps the error reading for a turn that actually failed", () => {
+    harness.data.set(`/chat/${CHAT_ID}`, { status: "failed", messages: [] });
+    const { getByTestId } = renderThrough(...DROPPED);
+
+    expect(getByTestId("submit")).toHaveAttribute("data-status", "error");
+  });
+});

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -41,6 +41,7 @@ import { writeAt, scopedPath } from "@/lib/api-write";
 import {
   chatPollIntervalMs,
   classifyChatError,
+  composerTurnStatus,
   isRunHeldElsewhere,
   snapshotIsAtLeastAsComplete,
   snapshotMessages,
@@ -503,7 +504,7 @@ export const Chat = ({
   // `isRunHeldElsewhere` covers a dropped stream too, whose status is `error`
   // rather than `ready` — the reading the old predicate missed (issue #648).
   const runHeldElsewhere = isRunHeldElsewhere(runBelief);
-  const effectiveStatus = runHeldElsewhere ? "streaming" : status;
+  const effectiveStatus = composerTurnStatus(runBelief, errorTreatment);
 
   // A dropped connection to a run that is still going: an inline line, and the
   // answer keeps arriving from the poll. The modal is for a turn that failed.

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -36,9 +36,18 @@ import {
   isValidChatMaxSteps,
 } from "@platypus/schemas";
 import { type PlatypusUIMessage } from "@platypus/backend/src/types";
-import { joinUrl } from "@/lib/utils";
+import { joinUrl, optionalFetcher } from "@/lib/utils";
 import { writeAt, scopedPath } from "@/lib/api-write";
+import {
+  chatPollIntervalMs,
+  classifyChatError,
+  isRunHeldElsewhere,
+  snapshotIsAtLeastAsComplete,
+  snapshotMessages,
+} from "@/lib/chat-recovery";
 import { useScopedSWR } from "@/hooks/use-scoped-swr";
+import { useTurnEstablished } from "@/hooks/use-turn-established";
+import { useRevalidateOnRestore } from "@/hooks/use-revalidate-on-restore";
 import { useChatSettings } from "@/hooks/use-chat-settings";
 import { useSearchToggle } from "@/hooks/use-search-toggle";
 import { useModelSelection } from "@/hooks/use-model-selection";
@@ -66,6 +75,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ChatMessage } from "./chat-message";
+import { ChatReconnectingNotice } from "./chat-reconnecting-notice";
 import { ModelSelectorDialog } from "./model-selector-dialog";
 import { toast } from "sonner";
 
@@ -134,20 +144,6 @@ export const Chat = ({
     [skillsData?.results],
   );
 
-  // Fetch existing chat data. Poll while the server reports the run is
-  // still in progress so users who reconnect mid-run see partial messages
-  // land without manually reloading. Stop polling once the run reaches a
-  // terminal status.
-  const { data: chatData, isLoading: isChatLoading } = useScopedSWR<ChatType>(
-    `chat/${chatId}`,
-    scope,
-    {
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-      refreshInterval: (data) => (data?.status === "running" ? 3000 : 0),
-    },
-  );
-
   const {
     messages,
     setMessages,
@@ -194,20 +190,78 @@ export const Chat = ({
     }),
   });
 
+  // Whether this turn's stream had started arriving before it broke — what tells
+  // a dropped connection from a request the server refused (issue #648).
+  const turnEstablished = useTurnEstablished(status);
+
+  // Fetch existing chat data, and re-read it while there is reason to believe a
+  // run is live so a client that lost its stream sees the partial answer keep
+  // filling in. `chatPollIntervalMs` owns that decision, and reads THIS tab's
+  // turn status as well as the fetched one: gated on the fetched status alone
+  // the poll could never start, because on an existing Chat that status is the
+  // previous turn's `succeeded` until something refetches it — and the only
+  // thing that would was the poll (issue #648).
+  //
+  // Focus and reconnect revalidation are deliberately left on (SWR's defaults).
+  // They are the "the user came back" and "the network returned" signals, and a
+  // frozen mobile tab's timers do not run at all while it is away, so they are
+  // the only thing that can wake a poll promptly. Safe to leave on because
+  // hydration is monotonic — see the hydrate effect below.
+  //
+  // `optionalFetcher` because a brand-new Chat is read before its row exists
+  // (the run creates it): a thrown 404 would sit in the cache as an error, and
+  // SWR does not revalidate on an interval while one is there.
+  const {
+    data: chatData,
+    isLoading: isChatLoading,
+    mutate: mutateChat,
+  } = useScopedSWR<ChatType | null>(`chat/${chatId}`, scope, {
+    fetcher: optionalFetcher,
+    refreshInterval: (data) =>
+      chatPollIntervalMs({
+        runStatus: data?.status,
+        turnStatus: status,
+        turnEstablished,
+      }),
+  });
+
+  // Re-read the row from the authority. Nothing here awaits it and a failure is
+  // not worth reporting: the poll gate reads this tab's own turn status too, so
+  // recovery never depends on one refresh landing.
+  const refreshChat = useCallback(() => {
+    void mutateChat().catch(() => {});
+  }, [mutateChat]);
+
+  // A restored page's poll was frozen the whole time it was away, and a bfcache
+  // restore is neither a focus nor a reconnect.
+  useRevalidateOnRestore(refreshChat);
+
+  // One reading of "is a run in flight?", shared by the composer guard and the
+  // error classification below, so the two cannot disagree.
+  const runBelief = {
+    runStatus: chatData?.status,
+    turnStatus: status,
+    turnEstablished,
+  };
+  const errorTreatment = classifyChatError({ error, ...runBelief });
+
   // Custom hooks for state management (must be called before any conditional returns)
   const {
     selection,
     handleModelChange,
     setters: modelSetters,
   } = useModelSelection(
-    chatData,
+    chatData ?? undefined,
     providers,
     agents,
     isChatLoading,
     workspaceId,
   );
-  const { settings, setters } = useChatSettings(chatData, selection.agentId);
-  const chatUI = useChatUI(error);
+  const { settings, setters } = useChatSettings(
+    chatData ?? undefined,
+    selection.agentId,
+  );
+  const chatUI = useChatUI(error, errorTreatment);
 
   // Extract values from hooks for easier access
   const { agentId, modelId, providerId } = selection;
@@ -319,15 +373,25 @@ export const Chat = ({
     statusRef.current = status;
   }, [status]);
 
+  // Hydration is monotonic: a fetched snapshot lands only where it is at least
+  // as far along as what is on screen (issue #648). The chat row is written on a
+  // flush interval, so a snapshot fetched mid-run lags the stream by up to one
+  // flush — applying it unconditionally is what would make the answer visibly
+  // shorten and then grow back. The comparison is made against the live message
+  // list through the updater rather than a dependency, so the effect still runs
+  // only when `chatData` changes and not on every streamed chunk.
   useEffect(() => {
+    const snapshot = snapshotMessages(chatData);
     if (
-      chatData?.messages &&
-      chatData.messages.length > 0 &&
-      statusRef.current !== "streaming" &&
-      statusRef.current !== "submitted"
+      !snapshot ||
+      statusRef.current === "streaming" ||
+      statusRef.current === "submitted"
     ) {
-      setMessages(chatData.messages);
+      return;
     }
+    setMessages((held) =>
+      snapshotIsAtLeastAsComplete(snapshot, held) ? snapshot : held,
+    );
   }, [chatData, setMessages]);
 
   // Poll for a backend-generated title while the chat is still "Untitled".
@@ -436,9 +500,14 @@ export const Chat = ({
   // so a tab that reconnects mid-run (or an unrelated tab opened on the
   // same chat) can't kick off a second concurrent run. The submit button
   // becomes a stop button and Enter is blocked by PromptInputTextarea.
-  const isReconnectedToRunningRun =
-    chatData?.status === "running" && status === "ready";
-  const effectiveStatus = isReconnectedToRunningRun ? "streaming" : status;
+  // `isRunHeldElsewhere` covers a dropped stream too, whose status is `error`
+  // rather than `ready` — the reading the old predicate missed (issue #648).
+  const runHeldElsewhere = isRunHeldElsewhere(runBelief);
+  const effectiveStatus = runHeldElsewhere ? "streaming" : status;
+
+  // A dropped connection to a run that is still going: an inline line, and the
+  // answer keeps arriving from the poll. The modal is for a turn that failed.
+  const isRecoveringRun = errorTreatment === "recovering";
 
   const handleSubmit = async (message: PromptInputMessage) => {
     // Stop the stream if currently streaming or submitted
@@ -496,6 +565,12 @@ export const Chat = ({
       },
       { body },
     );
+
+    // Tell the chat read a run has started rather than leaving it to infer one.
+    // The run's start hook writes `status: "running"`, and until this read
+    // learns that, nothing here can tell a live run from last turn's finished
+    // one (issue #648).
+    refreshChat();
   };
 
   return (
@@ -538,6 +613,7 @@ export const Chat = ({
       <div className="grid shrink-0 gap-4 p-4">
         <div className="flex justify-center min-w-0">
           <div className="w-full xl:w-4/5 max-w-4xl min-w-0">
+            {isRecoveringRun && <ChatReconnectingNotice />}
             {canSendMessages ? (
               <PromptInput
                 onSubmit={(message) => {
@@ -562,14 +638,14 @@ export const Chat = ({
                     onChange={(e) => setInputValue(e.target.value)}
                     className={messages.length === 0 ? "min-h-24" : undefined}
                     placeholder={
-                      isReconnectedToRunningRun
+                      runHeldElsewhere
                         ? "Run in progress…"
                         : selectedAgent?.inputPlaceholder ||
                           "What would you like to know?"
                     }
                     autoFocus
                     status={effectiveStatus}
-                    disabled={isReconnectedToRunningRun}
+                    disabled={runHeldElsewhere}
                   />
                 </PromptInputBody>
                 <PromptInputFooter className="flex-wrap">

--- a/apps/frontend/hooks/use-chat-ui.test.tsx
+++ b/apps/frontend/hooks/use-chat-ui.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { ChatErrorTreatment } from "@/lib/chat-recovery";
+import { useChatUI } from "./use-chat-ui";
+
+describe("useChatUI error dialog", () => {
+  const withError = (error: Error | undefined, treatment: ChatErrorTreatment) =>
+    renderHook(
+      (props: { error: Error | undefined; treatment: ChatErrorTreatment }) =>
+        useChatUI(props.error, props.treatment),
+      { initialProps: { error, treatment } },
+    );
+
+  it("stays closed while nothing has gone wrong", () => {
+    expect(withError(undefined, "none").result.current.showErrorDialog).toBe(
+      false,
+    );
+  });
+
+  it("opens on a run that failed", () => {
+    const { result } = withError(new Error("boom"), "failure");
+    expect(result.current.showErrorDialog).toBe(true);
+  });
+
+  // The reported symptom: backgrounding the tab tore down the stream and the
+  // user was shown a modal saying the turn had failed, while the run was
+  // healthy and went on to finish.
+  it("stays closed for a dropped connection to a live run", () => {
+    const { result } = withError(new Error("Failed to fetch"), "recovering");
+    expect(result.current.showErrorDialog).toBe(false);
+  });
+
+  it("stays closed for a stream that ended after its run finished", () => {
+    const { result } = withError(new Error("Failed to fetch"), "none");
+    expect(result.current.showErrorDialog).toBe(false);
+  });
+
+  // The dialog is keyed on the error so it can be dismissed while the error
+  // persists; a later error still reopens it.
+  it("reopens for a second, different failure", () => {
+    const { result, rerender } = withError(new Error("first"), "failure");
+    result.current.setShowErrorDialog(false);
+    rerender({ error: new Error("second"), treatment: "failure" });
+
+    expect(result.current.showErrorDialog).toBe(true);
+  });
+});

--- a/apps/frontend/hooks/use-chat-ui.ts
+++ b/apps/frontend/hooks/use-chat-ui.ts
@@ -1,7 +1,17 @@
 import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
+import type { ChatErrorTreatment } from "@/lib/chat-recovery";
 
-export const useChatUI = (error: Error | undefined) => {
+export const useChatUI = (
+  error: Error | undefined,
+  /**
+   * How this error should be surfaced, from `classifyChatError`. Only a
+   * `failure` opens the modal: a dropped connection to a run that is still
+   * going gets an inline line instead, because the turn has not failed and the
+   * answer keeps filling in on its own (issue #648).
+   */
+  errorTreatment: ChatErrorTreatment,
+) => {
   const [isModelSelectorOpen, setIsModelSelectorOpen] = useState(false);
   const [isSettingsDialogOpen, setIsSettingsDialogOpen] = useState(false);
   const [isAgentInfoDialogOpen, setIsAgentInfoDialogOpen] = useState(false);
@@ -13,7 +23,7 @@ export const useChatUI = (error: Error | undefined) => {
   // Show error dialog when a new error arrives from useChat. Keyed on the error
   // so the user can still dismiss the dialog while the error persists.
   useResetOnChange(error, () => {
-    if (error) {
+    if (error && errorTreatment === "failure") {
       setShowErrorDialog(true);
     }
   });

--- a/apps/frontend/hooks/use-revalidate-on-restore.test.tsx
+++ b/apps/frontend/hooks/use-revalidate-on-restore.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  RESTORE_THROTTLE_MS,
+  useRevalidateOnRestore,
+} from "./use-revalidate-on-restore";
+
+/** A `pageshow` as the browser fires it; jsdom has no PageTransitionEvent. */
+const pageshow = (persisted: boolean) => {
+  const event = new Event("pageshow");
+  Object.defineProperty(event, "persisted", { value: persisted });
+  window.dispatchEvent(event);
+};
+
+describe("useRevalidateOnRestore", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // The gap SWR's own focus and reconnect revalidation leaves: a restored page
+  // was frozen, so its poll has not been polling and what is on screen is as
+  // old as the moment it was put away.
+  it("revalidates when the page is restored from the back/forward cache", () => {
+    const revalidate = vi.fn();
+    renderHook(() => useRevalidateOnRestore(revalidate));
+
+    pageshow(true);
+
+    expect(revalidate).toHaveBeenCalledTimes(1);
+  });
+
+  // An ordinary navigation fires `pageshow` too, and that page already
+  // revalidates on mount — acting on it would double every page load.
+  it("ignores an ordinary page load", () => {
+    const revalidate = vi.fn();
+    renderHook(() => useRevalidateOnRestore(revalidate));
+
+    pageshow(false);
+
+    expect(revalidate).not.toHaveBeenCalled();
+  });
+
+  // Some browsers fire a restore alongside their own focus event, which SWR
+  // revalidates on separately. Coming back must cost one request, not several.
+  it("collapses a burst of restores into a single revalidation", () => {
+    const revalidate = vi.fn();
+    renderHook(() => useRevalidateOnRestore(revalidate));
+
+    pageshow(true);
+    pageshow(true);
+    pageshow(true);
+
+    expect(revalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("revalidates again on a later return", () => {
+    vi.useFakeTimers();
+    const revalidate = vi.fn();
+    renderHook(() => useRevalidateOnRestore(revalidate));
+
+    pageshow(true);
+    vi.advanceTimersByTime(RESTORE_THROTTLE_MS + 1);
+    pageshow(true);
+
+    expect(revalidate).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls the latest revalidate rather than the one it mounted with", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(
+      ({ fn }: { fn: () => void }) => useRevalidateOnRestore(fn),
+      { initialProps: { fn: first } },
+    );
+
+    rerender({ fn: second });
+    pageshow(true);
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops listening once unmounted", () => {
+    const revalidate = vi.fn();
+    const { unmount } = renderHook(() => useRevalidateOnRestore(revalidate));
+
+    unmount();
+    pageshow(true);
+
+    expect(revalidate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/hooks/use-revalidate-on-restore.ts
+++ b/apps/frontend/hooks/use-revalidate-on-restore.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Shortest gap between two revalidations this hook will trigger. Long enough
+ * that a browser firing a restore alongside its own focus event — which SWR
+ * revalidates on separately — collapses into one request.
+ */
+export const RESTORE_THROTTLE_MS = 3_000;
+
+/**
+ * Revalidates a read when the page comes back from the back/forward cache.
+ *
+ * SWR revalidates on focus and on reconnect, which covers `visibilitychange`,
+ * `focus` and `online`. A bfcache restore is none of those, and it is the case
+ * that most needs it: a frozen page's timers do not run at all while it is
+ * away, so a correctly-armed poll has not been polling and the row on screen is
+ * as old as the moment the page was put away.
+ *
+ * Only an actual restore is acted on. An ordinary navigation fires `pageshow`
+ * too, with `persisted` false, and that page already revalidates on mount.
+ */
+export const useRevalidateOnRestore = (revalidate: () => void) => {
+  const revalidateRef = useRef(revalidate);
+  useEffect(() => {
+    revalidateRef.current = revalidate;
+  }, [revalidate]);
+
+  useEffect(() => {
+    let lastAt = 0;
+    const onPageShow = (event: Event) => {
+      if (!(event as PageTransitionEvent).persisted) return;
+      const now = Date.now();
+      if (now - lastAt < RESTORE_THROTTLE_MS) return;
+      lastAt = now;
+      revalidateRef.current();
+    };
+    window.addEventListener("pageshow", onPageShow);
+    return () => window.removeEventListener("pageshow", onPageShow);
+  }, []);
+};

--- a/apps/frontend/hooks/use-scoped-swr.test.tsx
+++ b/apps/frontend/hooks/use-scoped-swr.test.tsx
@@ -11,15 +11,18 @@ vi.mock("@/components/auth-provider", () => ({
 }));
 
 let capturedKey: unknown;
+let capturedFetcher: unknown;
 vi.mock("swr", () => ({
   __esModule: true,
-  default: (key: unknown) => {
+  default: (key: unknown, fn: unknown) => {
     capturedKey = key;
+    capturedFetcher = fn;
     return { data: undefined, isLoading: false };
   },
 }));
 
 import { useScopedSWR } from "./use-scoped-swr";
+import { fetcher, optionalFetcher } from "@/lib/utils";
 
 describe("useScopedSWR", () => {
   afterEach(() => {
@@ -51,5 +54,21 @@ describe("useScopedSWR", () => {
       useScopedSWR("providers", { orgId: "org1", workspaceId: "ws1" }),
     );
     expect(capturedKey).toBeNull();
+  });
+
+  it("reads through the shared fetcher by default", () => {
+    renderHook(() => useScopedSWR("providers", { orgId: "org1" }));
+    expect(capturedFetcher).toBe(fetcher);
+  });
+
+  // Issue #648: the Chat detail read needs 404-as-absence, and only that read.
+  it("lets one read swap its reader without changing the default", () => {
+    renderHook(() =>
+      useScopedSWR("chat/c1", { orgId: "org1" }, { fetcher: optionalFetcher }),
+    );
+    expect(capturedFetcher).toBe(optionalFetcher);
+
+    renderHook(() => useScopedSWR("agents", { orgId: "org1" }));
+    expect(capturedFetcher).toBe(fetcher);
   });
 });

--- a/apps/frontend/hooks/use-scoped-swr.ts
+++ b/apps/frontend/hooks/use-scoped-swr.ts
@@ -12,6 +12,10 @@ import { scopedUrl, type Scope } from "@/lib/api-write";
  * `scope: null` (rather than a boolean `enabled`) lets a caller withhold the
  * fetch for the same reason it can't yet name a scope — e.g. a dialog that
  * hasn't opened, or an id that hasn't resolved.
+ *
+ * `config.fetcher` swaps the reader for one read — `optionalFetcher` for a row
+ * that may not exist yet (issue #648). Absent one, every read keeps `fetcher`'s
+ * contract, where any non-OK response is an error.
  */
 export function useScopedSWR<T>(
   entity: string,
@@ -22,5 +26,5 @@ export function useScopedSWR<T>(
   const backendUrl = useBackendUrl();
   const key =
     backendUrl && user && scope ? scopedUrl(backendUrl, entity, scope) : null;
-  return useSWR<T>(key, fetcher, config);
+  return useSWR<T>(key, config?.fetcher ?? fetcher, config);
 }

--- a/apps/frontend/hooks/use-turn-established.test.tsx
+++ b/apps/frontend/hooks/use-turn-established.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { ChatStatus } from "ai";
+import { useTurnEstablished } from "./use-turn-established";
+
+describe("useTurnEstablished", () => {
+  const walk = (statuses: ChatStatus[]) => {
+    const { result, rerender } = renderHook(
+      ({ status }: { status: ChatStatus }) => useTurnEstablished(status),
+      { initialProps: { status: statuses[0] } },
+    );
+    for (const status of statuses.slice(1)) rerender({ status });
+    return result;
+  };
+
+  it("starts out with nothing established", () => {
+    expect(walk(["ready"]).current).toBe(false);
+  });
+
+  // A request the server refused — a rejected attachment, a duplicate
+  // submission answered 409, a network that was never there. Nothing streamed,
+  // so there is no run to recover and the user has to be told.
+  it("reads a turn that failed before streaming as never established", () => {
+    expect(walk(["ready", "submitted", "error"]).current).toBe(false);
+  });
+
+  // The reported case: the stream was arriving and the browser tore the
+  // connection down. The run behind it is healthy.
+  it("reads a turn that streamed and then broke as established", () => {
+    expect(walk(["ready", "submitted", "streaming", "error"]).current).toBe(
+      true,
+    );
+  });
+
+  it("is answered on the render the status changes, not the one after", () => {
+    const { result, rerender } = renderHook(
+      ({ status }: { status: ChatStatus }) => useTurnEstablished(status),
+      { initialProps: { status: "submitted" as ChatStatus } },
+    );
+
+    rerender({ status: "streaming" });
+    expect(result.current).toBe(true);
+  });
+
+  // A second turn in the same Chat must be judged on its own stream, not the
+  // previous turn's.
+  it("forgets an earlier turn's stream when a new one is submitted", () => {
+    expect(
+      walk(["submitted", "streaming", "ready", "submitted", "error"]).current,
+    ).toBe(false);
+  });
+
+  it("keeps the answer while a broken turn sits there", () => {
+    expect(walk(["submitted", "streaming", "error", "error"]).current).toBe(
+      true,
+    );
+  });
+});

--- a/apps/frontend/hooks/use-turn-established.ts
+++ b/apps/frontend/hooks/use-turn-established.ts
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import type { ChatStatus } from "ai";
+import { useResetOnChange } from "@/hooks/use-reset-on-change";
+
+/**
+ * Whether the current Chat turn's stream ever started arriving.
+ *
+ * The one thing that tells a dropped connection from a request the server never
+ * took: a turn that got bytes passed through `streaming` on its way to `error`,
+ * and one that was refused went from `submitted` straight to `error`. Without
+ * it, a rejected attachment and a backgrounded tab look identical from the
+ * client — both are just an error on the chat hook (issue #648).
+ *
+ * Reset at each submit, so the answer is about the turn in hand rather than an
+ * earlier one. Kept in state adjusted during render rather than a ref written
+ * in an effect: the classification is read on the very render the error appears,
+ * and a ref would still be holding the previous render's value by then.
+ */
+export const useTurnEstablished = (status: ChatStatus): boolean => {
+  const [established, setEstablished] = useState(false);
+
+  useResetOnChange(status, () => {
+    if (status === "submitted") setEstablished(false);
+    else if (status === "streaming") setEstablished(true);
+  });
+
+  return established;
+};

--- a/apps/frontend/lib/chat-recovery.test.ts
+++ b/apps/frontend/lib/chat-recovery.test.ts
@@ -6,6 +6,7 @@ import {
   CHAT_POLL_INTERVAL_MS,
   chatPollIntervalMs,
   classifyChatError,
+  composerTurnStatus,
   isRunHeldElsewhere,
   snapshotIsAtLeastAsComplete,
   snapshotMessages,
@@ -191,6 +192,49 @@ describe("classifyChatError", () => {
         classifyChatError({ error, ...belief(runStatus, "error", false) }),
       ).toBe("failure");
     }
+  });
+});
+
+describe("composerTurnStatus", () => {
+  // A run this tab is not receiving reads as streaming, so the submit button is
+  // a stop button and Enter is blocked.
+  it("presents a run held elsewhere as streaming", () => {
+    expect(composerTurnStatus(belief("running", "ready"), "none")).toBe(
+      "streaming",
+    );
+    expect(
+      composerTurnStatus(belief("running", "error", true), "recovering"),
+    ).toBe("streaming");
+  });
+
+  // The defect this exists for: once recovery finishes the turn is still sitting
+  // at `error`, and passing that through puts a failure icon on the submit
+  // button — the same "a dropped connection reported as a failed turn" symptom
+  // the modal fix removed, only moved onto the button.
+  it("clears a recovered drop rather than leaving a failure on the button", () => {
+    expect(
+      composerTurnStatus(belief("succeeded", "error", true), "none"),
+    ).toBe("ready");
+  });
+
+  // A turn that genuinely failed keeps its reading: the button should say so.
+  it("keeps the error reading for a turn that actually failed", () => {
+    expect(composerTurnStatus(belief("failed", "error", true), "failure")).toBe(
+      "error",
+    );
+    expect(
+      composerTurnStatus(belief(undefined, "error", false), "failure"),
+    ).toBe("error");
+  });
+
+  it("passes an ordinary turn through untouched", () => {
+    expect(composerTurnStatus(belief(undefined, "ready"), "none")).toBe("ready");
+    expect(composerTurnStatus(belief("running", "streaming"), "none")).toBe(
+      "streaming",
+    );
+    expect(composerTurnStatus(belief("running", "submitted"), "none")).toBe(
+      "submitted",
+    );
   });
 });
 

--- a/apps/frontend/lib/chat-recovery.test.ts
+++ b/apps/frontend/lib/chat-recovery.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from "vitest";
+import type { ChatStatus as RunStatus } from "@platypus/schemas";
+import type { ChatStatus as TurnStatus } from "ai";
+import type { PlatypusUIMessage } from "@platypus/backend/src/types";
+import {
+  CHAT_POLL_INTERVAL_MS,
+  chatPollIntervalMs,
+  classifyChatError,
+  isRunHeldElsewhere,
+  snapshotIsAtLeastAsComplete,
+  snapshotMessages,
+  transcriptExtent,
+} from "./chat-recovery";
+
+const user = (text: string): PlatypusUIMessage =>
+  ({
+    id: `u-${text}`,
+    role: "user",
+    parts: [{ type: "text", text }],
+  }) as PlatypusUIMessage;
+
+const assistant = (text: string, extraParts = 0): PlatypusUIMessage =>
+  ({
+    id: "a-1",
+    role: "assistant",
+    parts: [
+      { type: "text", text },
+      ...Array.from({ length: extraParts }, (_, i) => ({
+        type: "tool-getCard",
+        toolCallId: `call-${i}`,
+        state: "output-available",
+        input: {},
+        output: {},
+      })),
+    ],
+  }) as PlatypusUIMessage;
+
+/** The three readings the recovery decisions are made from. */
+const belief = (
+  runStatus: RunStatus | undefined,
+  turnStatus: TurnStatus,
+  turnEstablished = false,
+) => ({ runStatus, turnStatus, turnEstablished });
+
+describe("chatPollIntervalMs", () => {
+  // The reported bug in one assertion. An existing Chat's row still reads
+  // `succeeded` from the previous turn at the moment the next one is sent, and
+  // gating on that alone is a deadlock: only the poll would refresh it.
+  it("polls a turn just submitted into a Chat whose row still reads succeeded", () => {
+    expect(chatPollIntervalMs(belief("succeeded", "submitted"))).toBe(
+      CHAT_POLL_INTERVAL_MS,
+    );
+  });
+
+  it("polls while this tab is streaming", () => {
+    expect(chatPollIntervalMs(belief("succeeded", "streaming"))).toBe(
+      CHAT_POLL_INTERVAL_MS,
+    );
+  });
+
+  // A brand-new Chat is read before its row exists, so there is no status at
+  // all to gate on.
+  it("polls a turn on a Chat that has no row yet", () => {
+    expect(chatPollIntervalMs(belief(undefined, "submitted"))).toBe(
+      CHAT_POLL_INTERVAL_MS,
+    );
+  });
+
+  // The recovery itself: a dropped stream leaves the turn at `error` while the
+  // run carries on, and this is what gets the partial answer moving again.
+  it("keeps polling after a stream drops while the run is still going", () => {
+    expect(chatPollIntervalMs(belief("running", "error", true))).toBe(
+      CHAT_POLL_INTERVAL_MS,
+    );
+  });
+
+  // A brand-new Chat whose row was still absent when the drop happened: there
+  // is no status to lean on, only the fact that bytes had been arriving.
+  it("keeps polling after a drop on a Chat with no row yet", () => {
+    expect(chatPollIntervalMs(belief(undefined, "error", true))).toBe(
+      CHAT_POLL_INTERVAL_MS,
+    );
+  });
+
+  it("polls a run this tab did not start", () => {
+    expect(chatPollIntervalMs(belief("running", "ready"))).toBe(
+      CHAT_POLL_INTERVAL_MS,
+    );
+  });
+
+  it("stops once the server reports an outcome for a dropped turn", () => {
+    for (const runStatus of ["succeeded", "failed", "cancelled"] as const) {
+      expect(chatPollIntervalMs(belief(runStatus, "error", true))).toBe(0);
+    }
+  });
+
+  // Nothing streamed, so no run was ever taken — a rejected attachment or a
+  // refused submission. Polling for an outcome that will never come would spin
+  // forever.
+  it("does not poll a turn the server refused", () => {
+    expect(chatPollIntervalMs(belief(undefined, "error", false))).toBe(0);
+  });
+
+  it("does not poll an idle Chat", () => {
+    expect(chatPollIntervalMs(belief("succeeded", "ready"))).toBe(0);
+    expect(chatPollIntervalMs(belief(undefined, "ready"))).toBe(0);
+  });
+});
+
+describe("isRunHeldElsewhere", () => {
+  // The case the old guard missed: it required the local status to be `ready`,
+  // and a dropped stream leaves it at `error`, so the composer came back and a
+  // second concurrent run could be fired into a Chat that already had one.
+  it("holds the composer after a stream drops mid-run", () => {
+    expect(isRunHeldElsewhere(belief("running", "error", true))).toBe(true);
+  });
+
+  it("holds the composer after a drop on a Chat with no row yet", () => {
+    expect(isRunHeldElsewhere(belief(undefined, "error", true))).toBe(true);
+  });
+
+  it("holds the composer for a tab that arrived mid-run", () => {
+    expect(isRunHeldElsewhere(belief("running", "ready"))).toBe(true);
+  });
+
+  // This tab IS the one streaming, so the ordinary streaming controls apply
+  // rather than the reconnected-to-someone-else's-run ones.
+  it("leaves a turn this tab is streaming alone", () => {
+    expect(isRunHeldElsewhere(belief("running", "streaming"))).toBe(false);
+    expect(isRunHeldElsewhere(belief("running", "submitted"))).toBe(false);
+  });
+
+  // A turn that genuinely failed must leave the composer usable, or there is no
+  // way to retry.
+  it("releases the composer when no run is live", () => {
+    expect(isRunHeldElsewhere(belief("failed", "error", true))).toBe(false);
+    expect(isRunHeldElsewhere(belief(undefined, "ready"))).toBe(false);
+  });
+
+  // The trap the previous case would walk into if `turnEstablished` were
+  // ignored: a brand-new Chat whose first submission was refused has no row and
+  // an `error` status, and the composer would be locked with no way out.
+  it("releases the composer after a refused submission on a new Chat", () => {
+    expect(isRunHeldElsewhere(belief(undefined, "error", false))).toBe(false);
+  });
+});
+
+describe("classifyChatError", () => {
+  const error = new Error("Failed to fetch");
+
+  it("says nothing when there is no error", () => {
+    expect(
+      classifyChatError({
+        error: undefined,
+        ...belief("running", "streaming"),
+      }),
+    ).toBe("none");
+  });
+
+  // The reported symptom: a backgrounded tab's socket teardown was reported as
+  // a failed turn, while the run was healthy and completed normally.
+  it("treats a drop from a live run as recovering, not a failure", () => {
+    expect(
+      classifyChatError({ error, ...belief("running", "error", true) }),
+    ).toBe("recovering");
+  });
+
+  it("treats a drop on a Chat with no row yet as recovering", () => {
+    expect(
+      classifyChatError({ error, ...belief(undefined, "error", true) }),
+    ).toBe("recovering");
+  });
+
+  it("says nothing when the run finished while the connection was gone", () => {
+    expect(
+      classifyChatError({ error, ...belief("succeeded", "error", true) }),
+    ).toBe("none");
+  });
+
+  it("reports a run that reached a terminal failed status", () => {
+    expect(
+      classifyChatError({ error, ...belief("failed", "error", true) }),
+    ).toBe("failure");
+  });
+
+  // Nothing streamed, so there is no run to recover: a rejected attachment, a
+  // duplicate submission answered 409, a network that was never there.
+  it("reports a request that never established, whatever the row says", () => {
+    for (const runStatus of ["running", "succeeded", undefined] as const) {
+      expect(
+        classifyChatError({ error, ...belief(runStatus, "error", false) }),
+      ).toBe("failure");
+    }
+  });
+});
+
+describe("transcriptExtent", () => {
+  it("counts messages, parts and text", () => {
+    expect(transcriptExtent([user("hello"), assistant("hi there", 2)])).toEqual(
+      {
+        messages: 2,
+        parts: 4,
+        textLength: 13,
+      },
+    );
+  });
+
+  it("reads an absent transcript as nothing at all", () => {
+    expect(transcriptExtent(undefined)).toEqual({
+      messages: 0,
+      parts: 0,
+      textLength: 0,
+    });
+  });
+});
+
+describe("snapshotIsAtLeastAsComplete", () => {
+  // The lagging-snapshot case directly: the row is flushed on an interval, so
+  // mid-run it holds less text than the stream has already shown. Applying it
+  // would make the answer visibly shorten.
+  it("refuses a snapshot that is behind the text on screen", () => {
+    const held = [user("q"), assistant("the first two thirds of an answer")];
+    const snapshot = [user("q"), assistant("the first third")];
+
+    expect(snapshotIsAtLeastAsComplete(snapshot, held)).toBe(false);
+  });
+
+  it("refuses a snapshot missing a part the client already has", () => {
+    const held = [user("q"), assistant("same text", 2)];
+    const snapshot = [user("q"), assistant("same text", 1)];
+
+    expect(snapshotIsAtLeastAsComplete(snapshot, held)).toBe(false);
+  });
+
+  it("applies a snapshot that has moved on", () => {
+    const held = [user("q"), assistant("the first third")];
+    const snapshot = [user("q"), assistant("the first third and the rest")];
+
+    expect(snapshotIsAtLeastAsComplete(snapshot, held)).toBe(true);
+  });
+
+  it("applies a snapshot carrying a whole extra message", () => {
+    const held = [user("q")];
+    const snapshot = [user("q"), assistant("an answer")];
+
+    expect(snapshotIsAtLeastAsComplete(snapshot, held)).toBe(true);
+  });
+
+  // Initial hydration is the same comparison: nothing held, so anything wins.
+  it("applies the first snapshot onto an empty transcript", () => {
+    expect(snapshotIsAtLeastAsComplete([user("q"), assistant("a")], [])).toBe(
+      true,
+    );
+  });
+
+  // The row is the canonical form of the transcript — rewritten attachment
+  // URLs, normalized tool parts — so an otherwise-identical snapshot has to be
+  // allowed through rather than leaving the page on its own version until a
+  // reload.
+  it("applies a snapshot equal to what is held", () => {
+    const held = [user("q"), assistant("an answer", 1)];
+
+    expect(snapshotIsAtLeastAsComplete([...held], held)).toBe(true);
+  });
+
+  // A shorter transcript is a different conversation (an edit dropped the tail),
+  // not a later state of this one, and the client's own view is the newer.
+  it("refuses a snapshot with fewer messages", () => {
+    const held = [user("q"), assistant("an answer"), user("follow up")];
+    const snapshot = [user("q"), assistant("an answer")];
+
+    expect(snapshotIsAtLeastAsComplete(snapshot, held)).toBe(false);
+  });
+});
+
+describe("snapshotMessages", () => {
+  it("reads the messages off a fetched row", () => {
+    const messages = [user("q")];
+    expect(snapshotMessages({ messages } as never)).toBe(messages);
+  });
+
+  // A brand-new Chat's row does not exist yet, and the read resolves to null
+  // rather than throwing.
+  it("reads an absent row as no snapshot", () => {
+    expect(snapshotMessages(null)).toBeUndefined();
+    expect(snapshotMessages(undefined)).toBeUndefined();
+    expect(snapshotMessages({ messages: [] } as never)).toBeUndefined();
+  });
+});

--- a/apps/frontend/lib/chat-recovery.ts
+++ b/apps/frontend/lib/chat-recovery.ts
@@ -1,0 +1,189 @@
+import type { Chat, ChatStatus as RunStatus } from "@platypus/schemas";
+import type { ChatStatus as TurnStatus } from "ai";
+import type { PlatypusUIMessage } from "@platypus/backend/src/types";
+
+/**
+ * Recovering a Chat turn whose stream was cut (issue #648).
+ *
+ * A turn outlives the request that started it. Background the tab and the
+ * browser tears down the connection carrying the stream, but the run keeps
+ * going server-side and the chat row keeps taking the partial answer. So
+ * recovery is a matter of asking the server again — and the three decisions
+ * that involves live here, as pure functions, so each is testable without a
+ * Chat component around it:
+ *
+ * - **Whether a run may be underway.** {@link runMayBeLive}, which the poll and
+ *   the composer guard are both derived from. The trap is deriving it from the
+ *   fetched status alone: on an existing Chat that status is last turn's
+ *   `succeeded` until something refetches it, so a poll gated on it can never
+ *   start — it only polls once the fetched row says a run is live, and only the
+ *   poll would put that there. On a brand-new Chat there is no status at all,
+ *   because the row does not exist until the run creates it.
+ * - **What to say about the drop.** {@link classifyChatError}. A dropped
+ *   connection to a healthy run is not a failed turn and must not be reported
+ *   as one.
+ * - **Whether a snapshot may land.** {@link snapshotIsAtLeastAsComplete}. The
+ *   row lags the stream by up to one flush interval, so an unguarded snapshot
+ *   rewinds visible text.
+ */
+
+/** How often a Chat with a live run re-reads its row. */
+export const CHAT_POLL_INTERVAL_MS = 3_000;
+
+/** A status the server reports for a run that has ended, however it ended. */
+const isRunOver = (status: RunStatus | undefined): boolean =>
+  status === "succeeded" || status === "failed" || status === "cancelled";
+
+/** Everything the client knows about whether a turn is in flight. */
+export type RunBelief = {
+  /** The status on the fetched Chat row; absent before the row exists. */
+  runStatus: RunStatus | undefined;
+  /** This tab's own view of the turn, from the chat hook. */
+  turnStatus: TurnStatus;
+  /** Whether this turn's stream had started arriving before it broke. */
+  turnEstablished: boolean;
+};
+
+/**
+ * Whether a run for this Chat may still be underway.
+ *
+ * Three readings, because no one of them is enough:
+ *
+ * - The fetched row says `running`. Covers a tab that arrived mid-run and a
+ *   second tab open on the same Chat — neither has a local turn to go on.
+ * - This tab has a turn in flight. Covers the reason the poll never used to
+ *   start: nothing has refetched the row since the previous turn finished, so
+ *   its status still reads `succeeded` while a run is in fact underway.
+ * - This tab's turn ended at `error` having streamed. That is a dropped
+ *   connection to a run that is still going, and treating it as settled is what
+ *   left the answer frozen forever. Having streamed is the qualifier: a request
+ *   the server refused reaches `error` too, and there is no run behind it.
+ *
+ * A dropped turn stops counting once the row reports an outcome. That reading is
+ * this turn's rather than the previous one's because the row is refetched when
+ * the turn is submitted.
+ */
+export const runMayBeLive = ({
+  runStatus,
+  turnStatus,
+  turnEstablished,
+}: RunBelief): boolean => {
+  if (runStatus === "running") return true;
+  if (turnStatus === "submitted" || turnStatus === "streaming") return true;
+  return turnStatus === "error" && turnEstablished && !isRunOver(runStatus);
+};
+
+/** How long until the Chat row should be read again, or `0` for "don't". */
+export const chatPollIntervalMs = (belief: RunBelief): number =>
+  runMayBeLive(belief) ? CHAT_POLL_INTERVAL_MS : 0;
+
+/**
+ * Whether a run may be underway that this tab is not streaming.
+ *
+ * What the composer is disabled on. The old guard required the local status to
+ * be `ready`, which is why it missed a dropped stream — that status is `error`.
+ * Submitting a second turn into a Chat that already has one is refused by the
+ * server with a 409, so this is a courtesy rather than the protection; it exists
+ * to stop the user asking for something they can't have.
+ */
+export const isRunHeldElsewhere = (belief: RunBelief): boolean =>
+  runMayBeLive(belief) &&
+  belief.turnStatus !== "streaming" &&
+  belief.turnStatus !== "submitted";
+
+/** How a Chat error should be surfaced. */
+export type ChatErrorTreatment = "none" | "recovering" | "failure";
+
+/**
+ * Tells a dropped connection from a failed turn.
+ *
+ * The signal is whether the turn's stream ever started arriving. A request the
+ * server refused — a rejected attachment, a duplicate submission, a network
+ * that was never there — goes from `submitted` straight to `error` with nothing
+ * received, and the user needs to be told. A turn that got bytes and then lost
+ * them passed through `streaming` on its way, and the run behind it is fine:
+ *
+ * - `failure` — the modal. The run reached a terminal `failed` status, or the
+ *   request never established in the first place.
+ * - `recovering` — an inline line, never a modal. The run is still going and
+ *   the partial answer keeps filling in from the poll.
+ * - `none` — say nothing. The stream ended, but the run went on to finish, so
+ *   the next snapshot is the whole answer.
+ */
+export const classifyChatError = ({
+  error,
+  ...belief
+}: RunBelief & { error: Error | undefined }): ChatErrorTreatment => {
+  if (!error) return "none";
+  if (!belief.turnEstablished) return "failure";
+  if (belief.runStatus === "failed") return "failure";
+  return runMayBeLive(belief) ? "recovering" : "none";
+};
+
+/**
+ * How far a transcript has got: the message count, the part count, and the
+ * length of the text those parts carry.
+ *
+ * Three numbers rather than one because a turn grows in all three directions —
+ * a new message, a new tool part, more text in the part being written — and any
+ * one of them alone reads a step forward as no change.
+ */
+export type TranscriptExtent = {
+  messages: number;
+  parts: number;
+  textLength: number;
+};
+
+export const transcriptExtent = (
+  messages: readonly PlatypusUIMessage[] | undefined,
+): TranscriptExtent => {
+  const extent: TranscriptExtent = { messages: 0, parts: 0, textLength: 0 };
+  if (!messages) return extent;
+  extent.messages = messages.length;
+  for (const message of messages) {
+    const parts = message.parts ?? [];
+    extent.parts += parts.length;
+    for (const part of parts) {
+      // Text and reasoning both carry a `text`; every other part shape carries
+      // none, and is counted by `parts` alone.
+      const text: unknown = (part as { text?: unknown }).text;
+      if (typeof text === "string") extent.textLength += text.length;
+    }
+  }
+  return extent;
+};
+
+/**
+ * Whether a fetched snapshot may replace the messages on screen.
+ *
+ * The chat row is written on a flush interval, so a snapshot fetched mid-run is
+ * behind the stream by up to one flush. Applying it unconditionally is what
+ * makes text disappear and reappear. Monotonicity is the guard: a snapshot
+ * lands only where it is at least as far along as what is already held, which
+ * makes it safe to hydrate on any signal — a poll, a focus, a restored page —
+ * without checking first whether a stream is live.
+ *
+ * An equal snapshot does land. That is deliberate: the row is the canonical form
+ * of the transcript — attachment URLs rewritten, normalized tool parts — and
+ * refusing an equal one would keep the page on its own version of the same
+ * content until a reload.
+ */
+export const snapshotIsAtLeastAsComplete = (
+  snapshot: readonly PlatypusUIMessage[] | undefined,
+  held: readonly PlatypusUIMessage[] | undefined,
+): boolean => {
+  const next = transcriptExtent(snapshot);
+  const current = transcriptExtent(held);
+  if (next.messages !== current.messages) {
+    return next.messages > current.messages;
+  }
+  return next.parts >= current.parts && next.textLength >= current.textLength;
+};
+
+/** The messages on a fetched Chat row, or `undefined` where it carries none. */
+export const snapshotMessages = (
+  chat: Chat | null | undefined,
+): PlatypusUIMessage[] | undefined => {
+  const messages = chat?.messages as PlatypusUIMessage[] | undefined;
+  return messages && messages.length > 0 ? messages : undefined;
+};

--- a/apps/frontend/lib/chat-recovery.ts
+++ b/apps/frontend/lib/chat-recovery.ts
@@ -121,6 +121,28 @@ export const classifyChatError = ({
 };
 
 /**
+ * The status the composer should present, which is not always the turn's own.
+ *
+ * Two corrections to the raw reading:
+ *
+ * - A run this tab is not streaming reads as `streaming`, so the submit button
+ *   is a stop button and Enter is blocked.
+ * - A turn left at `error` by a drop that has since been recovered from reads as
+ *   `ready`. The answer arrived, nothing failed, and the composer is usable —
+ *   but the raw `error` leaves a failure icon on the submit button, which is the
+ *   same "a dropped connection reported as a failed turn" defect the modal fix
+ *   removed, only moved onto the button.
+ */
+export const composerTurnStatus = (
+  belief: RunBelief,
+  treatment: ChatErrorTreatment,
+): TurnStatus => {
+  if (isRunHeldElsewhere(belief)) return "streaming";
+  if (belief.turnStatus === "error" && treatment !== "failure") return "ready";
+  return belief.turnStatus;
+};
+
+/**
  * How far a transcript has got: the message count, the part count, and the
  * length of the text those parts carry.
  *

--- a/apps/frontend/lib/utils.test.ts
+++ b/apps/frontend/lib/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { joinUrl } from "./utils";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { fetcher, joinUrl, optionalFetcher } from "./utils";
 
 describe("joinUrl", () => {
   it("should join base URL and path", () => {
@@ -22,5 +22,95 @@ describe("joinUrl", () => {
 
   it("should return path when base is empty", () => {
     expect(joinUrl("", "/api/test")).toBe("/api/test");
+  });
+});
+
+describe("fetcher", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const respondWith = (status: number, body: unknown = {}) => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  };
+
+  it("returns the parsed body on success", async () => {
+    respondWith(200, { id: "chat-1" });
+    await expect(fetcher("http://test/chat/chat-1")).resolves.toEqual({
+      id: "chat-1",
+    });
+  });
+
+  it("sends credentials so the session cookie rides along", async () => {
+    const fetchMock = respondWith(200);
+    await fetcher("http://test/chat/chat-1");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://test/chat/chat-1",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  it("throws on a missing row, carrying the status and the body", async () => {
+    respondWith(404, { error: "Chat not found" });
+    await expect(fetcher("http://test/chat/gone")).rejects.toMatchObject({
+      status: 404,
+      info: { error: "Chat not found" },
+    });
+  });
+});
+
+// Issue #648: SWR stops interval revalidation while the cached entry holds an
+// error, and the only thing that would clear it is a fetch the interval will no
+// longer perform. A brand-new Chat is read before its row exists, so a throwing
+// 404 there disables the poll that is meant to recover the run.
+describe("optionalFetcher", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const respondWith = (status: number, body: unknown = {}) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(status === 204 ? null : JSON.stringify(body), {
+          status,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+  };
+
+  it("reads a missing row as absence rather than failure", async () => {
+    respondWith(404, { error: "Chat not found" });
+    await expect(optionalFetcher("http://test/chat/new")).resolves.toBeNull();
+  });
+
+  it("still returns the row once it exists", async () => {
+    respondWith(200, { id: "chat-1", status: "running" });
+    await expect(optionalFetcher("http://test/chat/chat-1")).resolves.toEqual({
+      id: "chat-1",
+      status: "running",
+    });
+  });
+
+  // Absence is the only concession. A real failure must still reach the cache
+  // as an error, or a broken deployment reads as an empty Chat.
+  it("throws on every other failure", async () => {
+    respondWith(500, { error: "boom" });
+    await expect(optionalFetcher("http://test/chat/chat-1")).rejects.toMatchObject(
+      { status: 500 },
+    );
+
+    respondWith(403, { error: "nope" });
+    await expect(optionalFetcher("http://test/chat/chat-1")).rejects.toMatchObject(
+      { status: 403 },
+    );
   });
 });

--- a/apps/frontend/lib/utils.ts
+++ b/apps/frontend/lib/utils.ts
@@ -18,18 +18,43 @@ export function joinUrl(base: string, path: string): string {
   return `${normalizedBase}${normalizedPath}`;
 }
 
+/** The error a failed read throws, carrying the status and the response body. */
+const fetchError = async (res: Response) => {
+  const error: Error & { info?: unknown; status?: number } = new Error(
+    "An error occurred while fetching the data.",
+  );
+  // Attach extra info to the error object.
+  error.info = await res.json().catch(() => ({}));
+  error.status = res.status;
+  return error;
+};
+
 export const fetcher = async (input: RequestInfo | URL, init?: RequestInit) => {
   const res = await fetch(input, { ...init, credentials: "include" });
-  if (!res.ok) {
-    const error: Error & { info?: unknown; status?: number } = new Error(
-      "An error occurred while fetching the data.",
-    );
-    // Attach extra info to the error object.
-    const info = await res.json().catch(() => ({}));
-    error.info = info;
-    error.status = res.status;
-    throw error;
-  }
+  if (!res.ok) throw await fetchError(res);
+  return res.json();
+};
+
+/**
+ * A read whose subject may legitimately not exist yet: 404 resolves to `null`
+ * rather than throwing.
+ *
+ * SWR gates interval revalidation on the cached entry being error-free, so a
+ * read that throws on a missing row poisons its own polling — the only thing
+ * that would clear the error is a fetch the interval will no longer perform. A
+ * brand-new Chat is read before its row exists, since the run creates it, which
+ * is exactly that case (issue #648).
+ *
+ * A per-read concession, not a change to `fetcher`'s contract: everywhere else
+ * a 404 is a failure and still surfaces as one.
+ */
+export const optionalFetcher = async (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => {
+  const res = await fetch(input, { ...init, credentials: "include" });
+  if (res.status === 404) return null;
+  if (!res.ok) throw await fetchError(res);
   return res.json();
 };
 


### PR DESCRIPTION
Closes #648.

## The problem

Background the tab mid-reply — switching apps on a phone is enough — and the browser tears down the connection carrying the stream. The **Chat turn** is unaffected: the **Drive** continues server-side, writes the **Transcript** to the Chat row every 5 seconds, and runs to a terminal status. But the client showed a modal saying the turn had failed, and then never recovered. Dismissing it left a frozen half-answer that never updated, however long you waited. Only a page reload surfaced the finished reply.

The client had a recovery poll. It could never start.

Its interval came from one value — the status on the last-read Chat row. On a Chat with an earlier completed turn that status is `succeeded`, and the row is only re-read when the poll runs, and the poll only runs when the status is `running`. Each condition needed the other first.

A brand-new Chat failed a second way. The **Drive** creates the row, so the first read 404s; the shared fetcher threw, and SWR does not revalidate on an interval while an error sits in the cache.

Two further faults compounded it. Any error opened the modal, so a closed connection was reported as a failed turn. And the composer guard tested for the local status `ready` — the one reading a dropped stream never has, since it is `error` — so the composer stayed open and a second turn could be submitted into a Chat that already had one. Server-side that was the worst ordering available: the runner awaited the sink's start hook, which overwrites the row's messages with the second request's history, and only then registered the run, where the registry threw. The duplicate destroyed the live turn's **Transcript** and then returned a 500.

## The fix

`apps/frontend/lib/chat-recovery.ts` gathers the decisions into one place, as pure functions over three readings — the fetched row's status, this tab's own turn status, and whether this turn's reply had started to arrive:

| Function | Decides |
| --- | --- |
| `runMayBeLive` | whether a turn may be in flight; the poll and the composer guard both derive from it, so they cannot disagree |
| `classifyChatError` | inline line, modal, or nothing — a lost connection is not a failed turn |
| `snapshotIsAtLeastAsComplete` | whether a fetched snapshot may replace what is on screen |
| `composerTurnStatus` | what the composer shows, which is not always the turn's own status |

Around them: `optionalFetcher` reads a missing row as absence rather than failure (per-key, every other read keeps the throwing contract); `useTurnEstablished` supplies the did-it-stream signal; `useRevalidateOnRestore` covers a back/forward-cache restore, which neither focus nor reconnect fires on.

Hydration is now monotonic — a snapshot lands only when it is at least as far along as the reply on screen. That is what made it safe to re-enable focus and reconnect revalidation, which the original code had switched off. A hidden tab does not fetch at all (`refreshWhenHidden` is false by design), and a frozen phone tab runs no timers, so the focus read is the thing that makes recovery prompt on the platform where this was reported.

Server-side, the run is claimed **before** the sink writes anything, and `RunRegistry.register` throws a `ConflictError` — 409 through the central handler (ADR-0010). A start hook that throws releases the claim, so one bad write cannot lock a Chat out of every later turn. A keepalive SSE comment goes out every 15 seconds on the client branch of the teed stream, past the tee so the server-side drain never observes it, so a proxy with a 60-second idle timeout stops killing turns that are merely quiet during a long tool call.

## Scope

Recovery becomes correct, prompt and stable. It does **not** become token-seamless: the reply arrives in blocks a few seconds behind, not token by token. The ordered run event log, token-level replay, the resume endpoint and multi-node cancellation are #686 and are deliberately absent here. No table was added, `RunRegistry`'s process model is untouched, the flush cadence and poll interval keep their existing values, and there is no new global SWR configuration.

## Verification

Driven against a running stack with Playwright, on both an existing Chat (one with a prior completed turn — the reported repro) and a brand-new one whose row does not exist at the first read. Cutting the connection mid-reply in each case: no modal, the interrupted line shown, the composer held at **Run in progress…**, and the reply filling in to completion with no reload (544 → 6552 characters; 411 → 6251). Reads every 3 seconds, stopping when the row reports a terminal status.

A duplicate submission during a live run returned **409** with the row's messages byte-for-byte identical before and after. A burst of five focus events produced one read; three bfcache restores produced one. An idle Chat produced none. One keepalive frame was observed on the wire with the stream still parsing cleanly.

`pnpm typecheck`, `pnpm lint` and `pnpm test` all pass.

## Reviewer notes

**One documented behaviour changed as a side effect.** Re-enabling focus revalidation means an unsent local **Delete** is now undone by switching away from the tab and back, not only by reloading. The Chat page's callout has been updated to say so rather than carve out an exception. Push back if you would rather idle Chats were left alone — it is a small addition to the hydration condition.

**Test shape.** `chat.test.tsx` is new and covers the wiring rather than the predicates, because the original bug was a wiring fault that predicate tests would have passed against. It is mutation-checked: reverting each part of the fix in turn fails it — the poll gate back on the fetched status alone (3 tests), the shared fetcher (1), the revalidation triggers switched off (1), non-monotonic hydration (1), every error to the modal (2), a stale `error` left on the composer (1), and the original `status === "ready"` guard (1).

**One gap.** Nothing asserts that the server-side drain never sees a heartbeat frame. That holds by construction — the frames are injected into the encoded response body, past the tee — but I could not test it without standing up a real Drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)