### PR TITLE
chore: correct format drift and the stale core plugin table

### DIFF
--- a/.out-of-scope/capability-discovery-for-ad-hoc-chats.md
+++ b/.out-of-scope/capability-discovery-for-ad-hoc-chats.md
@@ -103,7 +103,7 @@ the #464 record did not know and which changes the case materially:
   therefore discards the prefix mid-turn, re-processing the whole conversation
   on every step that follows a disclosure.
 - Appending rather than removing does not rescue it. An appended definition is
-  inserted *before* the System prompt, not at the end of the request, so
+  inserted _before_ the System prompt, not at the end of the request, so
   everything behind the insertion point is discarded anyway. `toolOrder` keeps
   the stable core byte-identical and can do nothing about what follows it.
 - Delivering disclosed schemas in a tail channel after the messages — the one
@@ -140,7 +140,7 @@ here.
 
 #581 returned to the subscription with two of the three objections above
 answered. #467 has since landed, so a tool-name collision renames rather than
-overwrites; and #581 sequenced progressive disclosure *ahead* of the
+overwrites; and #581 sequenced progressive disclosure _ahead_ of the
 subscription so that "everything is eagerly loaded" would no longer follow. It
 also offered two smaller forms: a subscription covering only Skills and
 Sub-Agents, where no version of the collision argument applies, and — in place

--- a/apps/docs/content/self-hosting/configuration.mdx
+++ b/apps/docs/content/self-hosting/configuration.mdx
@@ -91,7 +91,7 @@ The deeper model — Providers, the role ladder, and the default admin — lives
 Platypus loads its extensions — starting with Tool sets — as **plugins**.
 Plugins come in two tiers:
 
-- **Always-on core** — `@platypus/tools-basic` (math, time) and
+- **Always-on core** — `@platypus/tools-basic` (math, time, identifiers) and
   `@platypus/tools-platform` (kanban, dashboards, triggers, memory,
   notifications, agent discovery/management, skill management). These load
   **unconditionally**; you neither list them nor can you disable them. They carry
@@ -108,7 +108,7 @@ repeat it.
 
 | Plugin                     | Tier      | Contributes                                                                                          |
 | -------------------------- | --------- | ---------------------------------------------------------------------------------------------------- |
-| `@platypus/tools-basic`    | Always-on | Pure-utility Tool sets — math conversions, time.                                                     |
+| `@platypus/tools-basic`    | Always-on | Pure-utility Tool sets — math conversions, time, identifiers.                                         |
 | `@platypus/tools-platform` | Always-on | The Platypus-domain Tool sets — kanban, dashboards, triggers, memory, notifications, agent discovery/management, skill management. |
 | `@platypus/web-fetch`      | Gate-able | The web-fetch Tool set. Its own plugin so **network egress** can be denied in isolation.             |
 | `@platypus/docker`         | Gate-able | The Docker Sandbox backend. Opt-in infra; also needs the `compose.sandbox.yaml` overlay.             |

--- a/apps/frontend/lib/chat-recovery.test.ts
+++ b/apps/frontend/lib/chat-recovery.test.ts
@@ -212,9 +212,9 @@ describe("composerTurnStatus", () => {
   // button — the same "a dropped connection reported as a failed turn" symptom
   // the modal fix removed, only moved onto the button.
   it("clears a recovered drop rather than leaving a failure on the button", () => {
-    expect(
-      composerTurnStatus(belief("succeeded", "error", true), "none"),
-    ).toBe("ready");
+    expect(composerTurnStatus(belief("succeeded", "error", true), "none")).toBe(
+      "ready",
+    );
   });
 
   // A turn that genuinely failed keeps its reading: the button should say so.
@@ -228,7 +228,9 @@ describe("composerTurnStatus", () => {
   });
 
   it("passes an ordinary turn through untouched", () => {
-    expect(composerTurnStatus(belief(undefined, "ready"), "none")).toBe("ready");
+    expect(composerTurnStatus(belief(undefined, "ready"), "none")).toBe(
+      "ready",
+    );
     expect(composerTurnStatus(belief("running", "streaming"), "none")).toBe(
       "streaming",
     );

--- a/apps/frontend/lib/utils.test.ts
+++ b/apps/frontend/lib/utils.test.ts
@@ -104,13 +104,13 @@ describe("optionalFetcher", () => {
   // as an error, or a broken deployment reads as an empty Chat.
   it("throws on every other failure", async () => {
     respondWith(500, { error: "boom" });
-    await expect(optionalFetcher("http://test/chat/chat-1")).rejects.toMatchObject(
-      { status: 500 },
-    );
+    await expect(
+      optionalFetcher("http://test/chat/chat-1"),
+    ).rejects.toMatchObject({ status: 500 });
 
     respondWith(403, { error: "nope" });
-    await expect(optionalFetcher("http://test/chat/chat-1")).rejects.toMatchObject(
-      { status: 403 },
-    );
+    await expect(
+      optionalFetcher("http://test/chat/chat-1"),
+    ).rejects.toMatchObject({ status: 403 });
   });
 });


### PR DESCRIPTION
Clears the two blockers the pre-release check found against the 2.11.0 range
(`v2.10.0..main`), so #675 can merge.

Both are `chore`s: neither changes behaviour, and neither should appear in the
2.11.0 changelog. The feature itself (the identifiers Tool set, #680) is
already listed there.

## Prettier formatting

`pnpm format` had drifted on `main` across two frontend test files and one
out-of-scope note — line wrapping, and `*emphasis*` where Prettier wants
`_emphasis_`. No assertions and no behaviour change.

No CI job runs the formatter, which is why lint, typecheck, test and build all
stayed green over it.

## The core plugin table

`@platypus/tools-basic` gained an `identifiers` Tool set in #680, but
`self-hosting/configuration.mdx` still described that plugin as contributing
only math and time — in both the tier list and the core plugin table.

That page says it owns the core plugin list and that other pages link here
rather than repeat it, so the omission was the whole of the record. An Operator
reads that table to decide what to permit, and it under-reported what the
always-on tier grants.

`CLAUDE.md` maps `apps/backend/src/plugins/**` to this page.
`building-with-platypus/tool-sets.mdx` did get its Identifiers row in #680, so
the builder-facing page was already correct — only the Operator-facing one was
stale. `docs-contract.test.ts` pins core plugin *names* rather than the Tool
sets each contributes, so nothing mechanical caught it.

`extending/index.mdx` is the other page in that mapping row; it lists plugin
names only, which did not change, so it needs no edit.

## Note on the .mdx formatting

`configuration.mdx` does not come out Prettier-clean, but `pnpm format` globs
`**/*.{ts,tsx,md}` — `.mdx` is outside it, and the file was already dirty by
that check before this change. Left as-is rather than pulling an unrelated
whole-file reformat into a release blocker fix.

## Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test` and `pnpm build` all pass. `pnpm
format` now leaves the tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)