### PR TITLE
fix(backend): give Trigger CRUD one write model instead of two drifted copies

### DIFF
--- a/apps/backend/src/routes/trigger.test.ts
+++ b/apps/backend/src/routes/trigger.test.ts
@@ -140,23 +140,35 @@ describe("Trigger Routes", () => {
       expect(body.nextRunAt).toBe(nextRun.toISOString());
     });
 
-    it("rejects invalid cron expressions with 400", async () => {
+    it("creates an event trigger with a full filters shape (columnId, changedFields) and returns 201", async () => {
       stubAuthLookups();
-      mockDb.limit.mockResolvedValueOnce([{ id: "agent-1", workspaceId }]);
-      mockValidateCronExpression.mockReturnValueOnce(null);
+      mockDb.limit.mockResolvedValueOnce([{ id: "agent-1", workspaceId }]); // agent verify
+      const eventBody = {
+        ...createBody,
+        type: "event",
+        config: {
+          events: ["card.created", "card.updated"],
+          filters: {
+            boardId: "board-1",
+            columnId: "col-1",
+            changedFields: ["title"],
+          },
+        },
+      };
+      mockDb.returning.mockResolvedValueOnce([
+        { ...eventTrigger, id: "trig-new", config: eventBody.config },
+      ]);
 
       const res = await app.request(baseUrl, {
         method: "POST",
-        body: JSON.stringify({
-          ...createBody,
-          config: { cronExpression: "not-a-cron", timezone: "UTC" },
-        }),
+        body: JSON.stringify(eventBody),
         headers: { "Content-Type": "application/json" },
       });
-      expect(res.status).toBe(400);
-      expect(await res.json()).toEqual({
-        error: "Invalid cron expression or timezone",
-      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { config: unknown };
+      expect(body.config).toEqual(eventBody.config);
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.config).toEqual(eventBody.config);
     });
 
     it("accepts a Shared agent attached to this workspace", async () => {
@@ -197,22 +209,6 @@ describe("Trigger Routes", () => {
         error: "Agent not found in this workspace",
       });
     });
-
-    it("rejects an event trigger with no events", async () => {
-      stubAuthLookups();
-      mockDb.limit.mockResolvedValueOnce([{ id: "agent-1", workspaceId }]);
-
-      const res = await app.request(baseUrl, {
-        method: "POST",
-        body: JSON.stringify({
-          ...createBody,
-          type: "event",
-          config: { events: [] },
-        }),
-        headers: { "Content-Type": "application/json" },
-      });
-      expect(res.status).toBe(400);
-    });
   });
 
   describe("PUT /:triggerId", () => {
@@ -240,10 +236,6 @@ describe("Trigger Routes", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as { name: string };
       expect(body.name).toBe("Updated");
-      expect(mockValidateCronExpression).toHaveBeenCalledWith(
-        "0 10 * * *",
-        "UTC",
-      );
     });
 
     it("returns 404 when the trigger doesn't exist in this workspace", async () => {
@@ -260,7 +252,6 @@ describe("Trigger Routes", () => {
 
     it("rejects an agent change when the new agent is not in the workspace", async () => {
       stubAuthLookups();
-      mockDb.limit.mockResolvedValueOnce([cronTrigger]); // existing
       mockDb.limit.mockResolvedValueOnce([]); // new agent not found
 
       const res = await app.request(`${baseUrl}/trig-1`, {
@@ -272,6 +263,33 @@ describe("Trigger Routes", () => {
       expect(await res.json()).toEqual({
         error: "Agent not found in this workspace",
       });
+    });
+
+    it("round-trips a columnId/changedFields filter through a config update", async () => {
+      stubAuthLookups();
+      mockDb.limit.mockResolvedValueOnce([eventTrigger]); // existing
+      const newConfig = {
+        events: ["card.updated"],
+        filters: {
+          boardId: "board-1",
+          columnId: "col-2",
+          changedFields: ["priority"],
+        },
+      };
+      mockDb.returning.mockResolvedValueOnce([
+        { ...eventTrigger, config: newConfig },
+      ]);
+
+      const res = await app.request(`${baseUrl}/trig-2`, {
+        method: "PUT",
+        body: JSON.stringify({ config: newConfig }),
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { config: unknown };
+      expect(body.config).toEqual(newConfig);
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.config).toEqual(newConfig);
     });
 
     it("clears nextRunAt when switching to event type", async () => {

--- a/apps/backend/src/routes/trigger.ts
+++ b/apps/backend/src/routes/trigger.ts
@@ -1,7 +1,6 @@
 import { Hono } from "hono";
 import { sValidator } from "@hono/standard-validator";
 import { z } from "zod";
-import { nanoid } from "nanoid";
 import { desc, eq } from "drizzle-orm";
 import { db } from "../index.ts";
 import {
@@ -20,13 +19,12 @@ import { resolveScoped } from "../services/scoped-resource.ts";
 import {
   requireOwned,
   listOwned,
-  updateOwned,
   deleteOwned,
 } from "../services/workspace-resource.ts";
+import { createTrigger, updateTrigger } from "../services/trigger.ts";
 import { NotFoundError } from "../errors.ts";
 import type { Variables } from "../server.ts";
 import { logger } from "../logger.ts";
-import { validateCronExpression } from "../utils/cron.ts";
 
 const trigger = new Hono<{ Variables: Variables }>();
 
@@ -86,48 +84,13 @@ trigger.post(
       return c.json({ error: "Agent not found in this workspace" }, 400);
     }
 
-    let nextRunAt: Date | null = null;
-    const config = data.config as Record<string, unknown>;
-
-    if (data.type === "cron") {
-      const cronExpression = config.cronExpression as string;
-      const timezone = (config.timezone as string) || "UTC";
-      nextRunAt = validateCronExpression(cronExpression, timezone);
-
-      if (!nextRunAt) {
-        return c.json({ error: "Invalid cron expression or timezone" }, 400);
-      }
-    } else if (data.type === "event") {
-      const events = config.events as unknown[];
-      if (!events || !Array.isArray(events) || events.length === 0) {
-        return c.json(
-          { message: "Event triggers must have at least one event" },
-          400,
-        );
-      }
-    }
-
-    const id = nanoid();
-    const now = new Date();
-
-    const record = await db
-      .insert(triggerTable)
-      .values({
-        id,
-        ...data,
-        workspaceId,
-        nextRunAt,
-        config: data.config,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning();
+    const record = await createTrigger(scope, data);
 
     logger.info(
-      `Created trigger '${id}' in workspace '${workspaceId}'${nextRunAt ? ` - next run at ${nextRunAt.toISOString()}` : ""}`,
+      `Created trigger '${record.id}' in workspace '${workspaceId}'${record.nextRunAt ? ` - next run at ${record.nextRunAt.toISOString()}` : ""}`,
     );
 
-    return c.json(record[0], 201);
+    return c.json(record, 201);
   },
 );
 
@@ -142,15 +105,12 @@ trigger.put(
   async (c) => {
     const triggerId = c.req.param("triggerId");
     const scope = workspaceScopeOf(c);
-    const { workspaceId } = scope;
     const data = c.req.valid("json");
 
-    // Verify trigger exists in workspace
-    const existing = await requireOwned(db, "trigger", triggerId, workspaceId);
-
-    // If agentId is being changed, verify new agent exists
-    if (data.agentId && data.agentId !== existing.agentId) {
-      // See the create route: workspace-scoped, or Shared and attached here.
+    // A new agentId must be usable here: workspace-scoped, or a Shared one
+    // attached to this Workspace (ADR-0007) — see the create route.
+    // `updateTrigger` itself 404s if the trigger doesn't exist.
+    if (data.agentId) {
       const agentRecord = await resolveScoped(db, "agent", data.agentId, scope);
 
       if (!agentRecord) {
@@ -158,52 +118,7 @@ trigger.put(
       }
     }
 
-    const updateData: Record<string, unknown> = {
-      ...data,
-      updatedAt: new Date(),
-    };
-
-    // Determine the effective type (updated or existing)
-    const effectiveType = data.type ?? existing.type;
-
-    if (effectiveType === "event") {
-      // Event triggers don't have nextRunAt
-      if (data.config) {
-        const config = data.config as Record<string, unknown>;
-        const events = config.events as unknown[];
-        if (!events || !Array.isArray(events) || events.length === 0) {
-          return c.json(
-            { error: "Event triggers must have at least one event" },
-            400,
-          );
-        }
-      }
-      updateData.nextRunAt = null;
-    } else if (effectiveType === "cron") {
-      // Recompute nextRunAt if cron config changes
-      const config = (data.config ?? existing.config) as Record<
-        string,
-        unknown
-      >;
-      const cronExpression = config.cronExpression as string;
-      const timezone = (config.timezone as string) || "UTC";
-
-      if (data.config || data.type) {
-        const nextRunAt = validateCronExpression(cronExpression, timezone);
-        if (!nextRunAt) {
-          return c.json({ error: "Invalid cron expression or timezone" }, 400);
-        }
-        updateData.nextRunAt = nextRunAt;
-      }
-    }
-
-    const record = await updateOwned(
-      db,
-      "trigger",
-      triggerId,
-      workspaceId,
-      updateData,
-    );
+    const record = await updateTrigger(scope, triggerId, data);
 
     logger.info(`Updated trigger '${triggerId}'`);
 

--- a/apps/backend/src/services/trigger.test.ts
+++ b/apps/backend/src/services/trigger.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockDb, resetMockDb } from "../test-utils.ts";
+
+vi.mock("../utils/cron.ts", () => ({
+  validateCronExpression: vi.fn((expr: string) => {
+    if (expr === "invalid") return null;
+    return new Date("2026-01-01T10:00:00Z");
+  }),
+}));
+
+vi.mock("nanoid", () => ({
+  nanoid: vi.fn(() => "trig-new"),
+}));
+
+import {
+  createTrigger,
+  updateTrigger,
+  type TriggerCreateFields,
+  type TriggerUpdateFields,
+} from "./trigger.ts";
+import { NotFoundError, ValidationError } from "../errors.ts";
+
+const ctx = { orgId: "org-1", workspaceId: "ws-1" };
+
+const cronFields = (): TriggerCreateFields => ({
+  agentId: "agent-1",
+  type: "cron",
+  name: "Daily",
+  instruction: "Do something",
+  enabled: true,
+  maxRunsToKeep: 10,
+  search: false,
+  config: { cronExpression: "0 9 * * *", timezone: "UTC", isOneOff: false },
+});
+
+const eventFields = (): TriggerCreateFields => ({
+  agentId: "agent-1",
+  type: "event",
+  name: "On Card",
+  instruction: "Handle card",
+  enabled: true,
+  maxRunsToKeep: 10,
+  search: false,
+  config: { events: ["card.created"] },
+});
+
+describe("trigger module", () => {
+  beforeEach(() => {
+    resetMockDb();
+    vi.clearAllMocks();
+    mockDb.where.mockReturnValue(mockDb);
+  });
+
+  describe("createTrigger", () => {
+    it("computes nextRunAt and inserts a cron trigger", async () => {
+      const inserted = { id: "trig-new", type: "cron" };
+      mockDb.returning.mockResolvedValueOnce([inserted]);
+
+      const row = await createTrigger(ctx, cronFields());
+
+      expect(row).toEqual(inserted);
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.workspaceId).toBe("ws-1");
+      expect(values.nextRunAt).toEqual(new Date("2026-01-01T10:00:00Z"));
+    });
+
+    it("throws ValidationError for an invalid cron expression", async () => {
+      await expect(
+        createTrigger(ctx, {
+          ...cronFields(),
+          config: {
+            cronExpression: "invalid",
+            timezone: "UTC",
+            isOneOff: false,
+          },
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("throws ValidationError when cronExpression is missing", async () => {
+      await expect(
+        createTrigger(ctx, {
+          ...cronFields(),
+          config: {} as never,
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("inserts an event trigger with a full filters shape (columnId, changedFields)", async () => {
+      const inserted = { id: "trig-new", type: "event" };
+      mockDb.returning.mockResolvedValueOnce([inserted]);
+
+      await createTrigger(ctx, {
+        ...eventFields(),
+        config: {
+          events: ["card.created", "card.updated"],
+          filters: {
+            boardId: "board-1",
+            columnId: "col-1",
+            changedFields: ["title", "body"],
+          },
+        },
+      });
+
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.config).toEqual({
+        events: ["card.created", "card.updated"],
+        filters: {
+          boardId: "board-1",
+          columnId: "col-1",
+          changedFields: ["title", "body"],
+        },
+      });
+      expect(values.nextRunAt).toBeNull();
+    });
+
+    it("throws ValidationError for an empty events array", async () => {
+      await expect(
+        createTrigger(ctx, { ...eventFields(), config: { events: [] } }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("throws ValidationError for an event name outside the real enum", async () => {
+      await expect(
+        createTrigger(ctx, {
+          ...eventFields(),
+          config: { events: ["card.commented"] as never },
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("throws ValidationError for a filters object with an unknown-shaped field", async () => {
+      await expect(
+        createTrigger(ctx, {
+          ...eventFields(),
+          config: {
+            events: ["card.created"],
+            filters: { changedFields: "not-an-array" as never },
+          },
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("throws ValidationError for an unrecognized trigger type", async () => {
+      await expect(
+        createTrigger(ctx, {
+          ...cronFields(),
+          type: "invalid" as never,
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe("updateTrigger", () => {
+    it("throws NotFoundError when the trigger doesn't exist in this workspace", async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      await expect(
+        updateTrigger(ctx, "trig-missing", { name: "x" }),
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it("recomputes nextRunAt when a cron trigger's config changes", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "cron",
+          config: { cronExpression: "0 9 * * *", timezone: "UTC" },
+        },
+      ]);
+      const updated = { id: "trig-1", name: "Updated" };
+      mockDb.returning.mockResolvedValueOnce([updated]);
+
+      const row = await updateTrigger(ctx, "trig-1", {
+        name: "Updated",
+        config: {
+          cronExpression: "0 10 * * *",
+          timezone: "UTC",
+          isOneOff: false,
+        },
+      });
+
+      expect(row).toEqual(updated);
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.nextRunAt).toEqual(new Date("2026-01-01T10:00:00Z"));
+    });
+
+    it("leaves nextRunAt untouched when a cron trigger's config/type are not part of the update", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "cron",
+          config: { cronExpression: "0 9 * * *", timezone: "UTC" },
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "trig-1", enabled: false },
+      ]);
+
+      await updateTrigger(ctx, "trig-1", { enabled: false });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg).not.toHaveProperty("nextRunAt");
+    });
+
+    it("throws ValidationError for an invalid cron expression on update", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "cron",
+          config: { cronExpression: "0 9 * * *", timezone: "UTC" },
+        },
+      ]);
+
+      await expect(
+        updateTrigger(ctx, "trig-1", {
+          config: {
+            cronExpression: "invalid",
+            timezone: "UTC",
+            isOneOff: false,
+          },
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("clears nextRunAt when switching to event type", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "cron",
+          config: { cronExpression: "0 9 * * *", timezone: "UTC" },
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([{ id: "trig-1", type: "event" }]);
+
+      await updateTrigger(ctx, "trig-1", {
+        type: "event",
+        config: { events: ["card.created"] },
+      });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.nextRunAt).toBeNull();
+    });
+
+    it("throws ValidationError for an empty events array on update", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "trig-1", type: "event", config: { events: ["card.created"] } },
+      ]);
+
+      await expect(
+        updateTrigger(ctx, "trig-1", { config: { events: [] } }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("throws ValidationError for an event name outside the real enum on update", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "trig-1", type: "event", config: { events: ["card.created"] } },
+      ]);
+
+      await expect(
+        updateTrigger(ctx, "trig-1", {
+          config: { events: ["card.commented"] as never },
+        }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("round-trips a columnId/changedFields filter through a full-replace config update", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "event",
+          config: { events: ["card.created"], filters: { boardId: "board-1" } },
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([{ id: "trig-1" }]);
+
+      const newConfig: TriggerUpdateFields["config"] = {
+        events: ["card.updated"],
+        filters: {
+          boardId: "board-1",
+          columnId: "col-2",
+          changedFields: ["priority"],
+        },
+      };
+
+      await updateTrigger(ctx, "trig-1", { config: newConfig });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.config).toEqual(newConfig);
+    });
+
+    it("replaces config wholesale rather than merging — omitting filters on update drops the old ones", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "event",
+          config: {
+            events: ["card.created"],
+            filters: { boardId: "board-1", columnId: "col-1" },
+          },
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([{ id: "trig-1" }]);
+
+      await updateTrigger(ctx, "trig-1", {
+        config: { events: ["card.created", "card.updated"] },
+      });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.config).toEqual({
+        events: ["card.created", "card.updated"],
+      });
+    });
+
+    it("leaves config untouched when not supplied", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "event",
+          config: { events: ["card.created"] },
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([{ id: "trig-1" }]);
+
+      await updateTrigger(ctx, "trig-1", { enabled: false });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg).not.toHaveProperty("config");
+    });
+  });
+});

--- a/apps/backend/src/services/trigger.ts
+++ b/apps/backend/src/services/trigger.ts
@@ -1,0 +1,226 @@
+import { nanoid } from "nanoid";
+import {
+  cronTriggerConfigSchema,
+  eventTriggerConfigSchema,
+  type CronTriggerConfig,
+  type EventTriggerConfig,
+  type TriggerType,
+} from "@platypus/schemas";
+import { db } from "../index.ts";
+import { trigger as triggerTable } from "../db/schema.ts";
+import type { ScopeContext } from "../scope.ts";
+import { NotFoundError, ValidationError } from "../errors.ts";
+import { validateCronExpression } from "../utils/cron.ts";
+import { requireOwned, updateOwned } from "./workspace-resource.ts";
+
+/**
+ * The Trigger write model: the one place `type`/`config` validation and
+ * `nextRunAt` computation happen, behind an interface both surfaces call.
+ * `routes/trigger.ts` (the UI's HTTP route) and `tools/trigger.ts` (the
+ * Agent-facing Tool set) used to each hand-roll this — the Tool's copy
+ * imported nothing from `@platypus/schemas`, so it drifted narrower on
+ * `filters` and looser on `events` than the real schema allows (#690).
+ * Composing the real field-level schemas here (`cronTriggerConfigSchema`,
+ * `eventTriggerConfigSchema`) is what actually prevents that drift.
+ *
+ * Trigger is Workspace-only (the `trigger` table has no `organizationId`
+ * column) — no scope union like `services/provider-write.ts`'s. There is no
+ * `deleteTrigger`: delete has no domain-specific rule to consolidate, so both
+ * callers keep their existing generic delete path.
+ *
+ * `config` update semantics are full-replace only: supplying `config` on an
+ * update replaces it wholesale rather than merging. A caller that wants to
+ * preserve part of the existing config reads it first and supplies the
+ * complete merged object itself — this is what closes the shallow-merge bug
+ * where the Tool's update silently wiped a User-set `columnId`/`changedFields`.
+ *
+ * Failures are the typed errors of ADR-0010 — `routes/trigger.ts` lets them
+ * propagate to the central `onError` mapper; `tools/trigger.ts` catches them
+ * and translates to its `{success:false, error}` tool-result shape, since a
+ * Tool result isn't an HTTP response.
+ */
+
+export type TriggerRow = typeof triggerTable.$inferSelect;
+
+type TriggerBaseFields = {
+  agentId: string;
+  type: TriggerType;
+  name: string;
+  description?: string | null;
+  instruction: string;
+  enabled: boolean;
+  maxRunsToKeep: number;
+  search: boolean;
+  config: CronTriggerConfig | EventTriggerConfig;
+};
+
+/**
+ * The fields a create carries. Defaults (`enabled`, `maxRunsToKeep`, `search`)
+ * are the caller's responsibility to resolve first — the HTTP route gets them
+ * from `triggerCreateSchema`'s own Zod defaults, the Tool applies its own
+ * (intentionally different) defaults — this module only validates and writes.
+ */
+export type TriggerCreateFields = TriggerBaseFields;
+
+/** The fields an update carries — only the ones actually supplied. */
+export type TriggerUpdateFields = Partial<TriggerBaseFields>;
+
+/**
+ * Validates a cron config and returns it normalized (Zod defaults applied —
+ * e.g. `timezone` filled in as `"UTC"`) alongside its next run time. Returning
+ * the parsed, not the raw, config is what guarantees a concrete `timezone`
+ * ends up in the stored row regardless of whether the caller supplied one.
+ */
+const parseCronConfig = (
+  config: unknown,
+): { config: CronTriggerConfig; nextRunAt: Date } => {
+  const parsed = cronTriggerConfigSchema.safeParse(config);
+  if (!parsed.success) {
+    throw new ValidationError(
+      "Cron triggers require a non-empty config.cronExpression and a valid config.timezone.",
+    );
+  }
+  const nextRunAt = validateCronExpression(
+    parsed.data.cronExpression,
+    parsed.data.timezone,
+  );
+  if (!nextRunAt) {
+    throw new ValidationError(
+      "Invalid cron expression or timezone. Example: '0 9 * * *' for daily at 9 AM.",
+    );
+  }
+  return { config: parsed.data, nextRunAt };
+};
+
+/**
+ * Validates an event config — a non-empty `events` array of real
+ * `webhookEventSchema` values, and (if present) `filters` matching the real
+ * `eventTriggerFiltersSchema` (`boardId`/`columnId`/`changedFields`) — and
+ * returns it normalized, or throws.
+ */
+const parseEventConfig = (config: unknown): EventTriggerConfig => {
+  const parsed = eventTriggerConfigSchema.safeParse(config);
+  if (!parsed.success) {
+    throw new ValidationError(
+      "Event triggers require config.events: a non-empty array of valid event names, and, if present, a valid config.filters object.",
+    );
+  }
+  return parsed.data;
+};
+
+/**
+ * Creates a new Trigger in this Workspace. Branches on `type`: cron
+ * expressions are parsed via `validateCronExpression` to compute `nextRunAt`;
+ * event configs are validated against the real schema. Throws
+ * `ValidationError` on an invalid cron expression/timezone, an invalid or
+ * empty `events` array, or invalid `filters`.
+ */
+export async function createTrigger(
+  ctx: ScopeContext,
+  fields: TriggerCreateFields,
+): Promise<TriggerRow> {
+  let nextRunAt: Date | null = null;
+  let config: CronTriggerConfig | EventTriggerConfig;
+  if (fields.type === "cron") {
+    const parsed = parseCronConfig(fields.config);
+    config = parsed.config;
+    nextRunAt = parsed.nextRunAt;
+  } else if (fields.type === "event") {
+    config = parseEventConfig(fields.config);
+  } else {
+    throw new ValidationError(
+      "Invalid trigger type. Must be 'cron' or 'event'.",
+    );
+  }
+
+  const [row] = await db
+    .insert(triggerTable)
+    .values({
+      id: nanoid(),
+      workspaceId: ctx.workspaceId,
+      agentId: fields.agentId,
+      type: fields.type,
+      name: fields.name,
+      description: fields.description ?? null,
+      instruction: fields.instruction,
+      enabled: fields.enabled,
+      maxRunsToKeep: fields.maxRunsToKeep,
+      search: fields.search,
+      config,
+      nextRunAt,
+    })
+    .returning();
+  return row;
+}
+
+/**
+ * Updates a Trigger in this Workspace. Throws `NotFoundError` when it does
+ * not exist here. `config`, if supplied, replaces the stored value wholesale
+ * and is (re)validated against the effective type; `nextRunAt` is recomputed
+ * for a cron trigger whose `config`/`type` changed, and cleared for an event
+ * trigger.
+ */
+export async function updateTrigger(
+  ctx: ScopeContext,
+  triggerId: string,
+  fields: TriggerUpdateFields,
+): Promise<TriggerRow> {
+  const existing = await requireOwned(
+    db,
+    "trigger",
+    triggerId,
+    ctx.workspaceId,
+  );
+  const effectiveType = fields.type ?? (existing.type as TriggerType);
+
+  const updateData: Partial<TriggerRow> = {
+    updatedAt: new Date(),
+  };
+  if (fields.agentId !== undefined) updateData.agentId = fields.agentId;
+  if (fields.name !== undefined) updateData.name = fields.name;
+  if (fields.description !== undefined)
+    updateData.description = fields.description;
+  if (fields.instruction !== undefined)
+    updateData.instruction = fields.instruction;
+  if (fields.enabled !== undefined) updateData.enabled = fields.enabled;
+  if (fields.maxRunsToKeep !== undefined)
+    updateData.maxRunsToKeep = fields.maxRunsToKeep;
+  if (fields.search !== undefined) updateData.search = fields.search;
+  if (fields.type !== undefined) updateData.type = fields.type;
+
+  // `config`, when supplied, is set below alongside validation — normalized
+  // (Zod defaults applied), not the raw input.
+  if (effectiveType === "event") {
+    // Event triggers don't have nextRunAt; only (re)validate when config
+    // actually changed on this update.
+    if (fields.config !== undefined) {
+      updateData.config = parseEventConfig(fields.config);
+    }
+    updateData.nextRunAt = null;
+  } else if (effectiveType === "cron") {
+    if (fields.config !== undefined || fields.type !== undefined) {
+      const effectiveConfigInput = fields.config ?? existing.config;
+      const parsed = parseCronConfig(effectiveConfigInput);
+      updateData.nextRunAt = parsed.nextRunAt;
+      if (fields.config !== undefined) {
+        updateData.config = parsed.config;
+      }
+    }
+  } else {
+    throw new ValidationError(
+      "Invalid trigger type. Must be 'cron' or 'event'.",
+    );
+  }
+
+  const row = await updateOwned(
+    db,
+    "trigger",
+    triggerId,
+    ctx.workspaceId,
+    updateData,
+  );
+  if (!row) {
+    throw new NotFoundError("Trigger not found");
+  }
+  return row;
+}

--- a/apps/backend/src/tools/trigger.test.ts
+++ b/apps/backend/src/tools/trigger.test.ts
@@ -152,25 +152,6 @@ describe("createTriggerTools", () => {
       expect(result.url).toContain("triggers/");
     });
 
-    it("returns error for invalid cron expression", async () => {
-      mockDb.limit.mockResolvedValue([{ id: "a1", workspaceId }]);
-
-      const result = (await tools.upsertTrigger.execute!(
-        {
-          label: "Bad",
-          name: "Bad",
-          agentId: "a1",
-          instruction: "Run",
-          type: "cron",
-          config: { cronExpression: "invalid" },
-        },
-        ctx,
-      )) as TriggerResult;
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("Invalid cron");
-    });
-
     it("creates an event trigger", async () => {
       const trigger = {
         id: "t2",
@@ -196,23 +177,34 @@ describe("createTriggerTools", () => {
       expect(result.success).toBe(true);
     });
 
-    it("returns error for event trigger without events", async () => {
+    it("creates an event trigger with a full filters shape (columnId, changedFields)", async () => {
+      const config = {
+        events: ["card.created", "card.updated"],
+        filters: {
+          boardId: "board-1",
+          columnId: "col-1",
+          changedFields: ["title"],
+        },
+      };
+      const trigger = { id: "t2", name: "On Card", type: "event", config };
       mockDb.limit.mockResolvedValue([{ id: "a1", workspaceId }]);
+      mockDb.returning.mockResolvedValue([trigger]);
 
       const result = (await tools.upsertTrigger.execute!(
         {
-          label: "Bad Event",
-          name: "Bad Event",
+          label: "On Card",
+          name: "On Card",
           agentId: "a1",
-          instruction: "Handle",
+          instruction: "Handle card",
           type: "event",
-          config: { events: [] },
+          config,
         },
         ctx,
       )) as TriggerResult;
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("events");
+      expect(result.success).toBe(true);
+      const values = mockDb.values.mock.calls[0][0] as Record<string, unknown>;
+      expect(values.config).toEqual(config);
     });
 
     it("returns error when agent not found", async () => {
@@ -287,6 +279,37 @@ describe("createTriggerTools", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("Trigger not found");
+    });
+
+    it("round-trips a columnId/changedFields filter through a config update", async () => {
+      mockDb.limit.mockResolvedValue([
+        {
+          id: "t1",
+          agentId: "a1",
+          type: "event",
+          config: { events: ["card.created"] },
+        },
+      ]);
+      const newConfig = {
+        events: ["card.updated"],
+        filters: {
+          boardId: "board-1",
+          columnId: "col-2",
+          changedFields: ["priority"],
+        },
+      };
+      mockDb.returning.mockResolvedValue([
+        { id: "t1", name: "On Card", config: newConfig },
+      ]);
+
+      const result = (await tools.upsertTrigger.execute!(
+        { triggerId: "t1", label: "On Card", config: newConfig },
+        ctx,
+      )) as TriggerResult;
+
+      expect(result.success).toBe(true);
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.config).toEqual(newConfig);
     });
   });
 

--- a/apps/backend/src/tools/trigger.ts
+++ b/apps/backend/src/tools/trigger.ts
@@ -1,12 +1,19 @@
 import { tool, type Tool } from "ai";
 import { z } from "zod";
-import { nanoid } from "nanoid";
 import { and, desc, eq } from "drizzle-orm";
+import {
+  cronTriggerConfigSchema,
+  eventTriggerFiltersSchema,
+  webhookEventSchema,
+  type CronTriggerConfig,
+  type EventTriggerConfig,
+} from "@platypus/schemas";
 import { db } from "../index.ts";
 import { trigger as triggerTable } from "../db/schema.ts";
-import { validateCronExpression } from "../utils/cron.ts";
 import { buildResourceUrl } from "../utils/resource-url.ts";
 import { listScoped, resolveScoped } from "../services/scoped-resource.ts";
+import { createTrigger, updateTrigger } from "../services/trigger.ts";
+import { NotFoundError, ValidationError } from "../errors.ts";
 import type { ScopeContext } from "../scope.ts";
 
 export function createTriggerTools(
@@ -149,8 +156,7 @@ export function createTriggerTools(
         ),
       config: z
         .object({
-          cronExpression: z
-            .string()
+          cronExpression: cronTriggerConfigSchema.shape.cronExpression
             .optional()
             .describe(
               "Cron expression for cron triggers (e.g., '0 9 * * *' for daily at 9 AM UTC)",
@@ -162,21 +168,15 @@ export function createTriggerTools(
               "IANA timezone for cron triggers (e.g., 'America/New_York'). Defaults to 'UTC'.",
             ),
           events: z
-            .array(z.string())
+            .array(webhookEventSchema)
             .optional()
             .describe(
-              "Array of event names for event triggers (e.g., ['card.created', 'card.updated'])",
+              `Array of event names for event triggers. Allowed values: ${webhookEventSchema.options.join(", ")}`,
             ),
-          filters: z
-            .object({
-              boardId: z
-                .string()
-                .optional()
-                .describe("Filter card events to a specific board"),
-            })
+          filters: eventTriggerFiltersSchema
             .optional()
             .describe(
-              "Optional filters to narrow which events trigger this agent",
+              "Optional filters to narrow which events trigger this agent: boardId, columnId, and/or changedFields (changedFields only applies to card.updated).",
             ),
         })
         .optional()
@@ -206,32 +206,15 @@ export function createTriggerTools(
     }),
     execute: async (params) => {
       const { triggerId, label: _label, ...fields } = params;
+      const config = fields.config as
+        (CronTriggerConfig | EventTriggerConfig) | undefined;
 
       // Update existing trigger
       if (triggerId) {
-        const existing = await db
-          .select()
-          .from(triggerTable)
-          .where(
-            and(
-              eq(triggerTable.id, triggerId),
-              eq(triggerTable.workspaceId, workspaceId),
-            ),
-          )
-          .limit(1);
-
-        if (existing.length === 0) {
-          return {
-            success: false,
-            error:
-              "Trigger not found in this workspace. Use list-triggers to find valid IDs.",
-          };
-        }
-
-        const currentTrigger = existing[0];
-
-        // If agentId is being changed, verify the new agent is usable here
-        if (fields.agentId && fields.agentId !== currentTrigger.agentId) {
+        // A new agentId must be usable here: workspace-scoped, or a Shared
+        // one attached to this Workspace (ADR-0007) — see the create branch
+        // below. `updateTrigger` itself errors if the trigger doesn't exist.
+        if (fields.agentId) {
           const agentRecord = await resolveScoped(
             db,
             "agent",
@@ -248,101 +231,44 @@ export function createTriggerTools(
           }
         }
 
-        const effectiveType = fields.type ?? currentTrigger.type;
-        const effectiveConfig = fields.config
-          ? {
-              ...(currentTrigger.config as Record<string, unknown>),
-              ...fields.config,
-            }
-          : (currentTrigger.config as Record<string, unknown>);
+        try {
+          const record = await updateTrigger(ctx, triggerId, {
+            agentId: fields.agentId,
+            type: fields.type,
+            name: fields.name,
+            description: fields.description,
+            instruction: fields.instruction,
+            enabled: fields.enabled,
+            maxRunsToKeep: fields.maxRunsToKeep,
+            search: fields.search,
+            config,
+          });
 
-        // Validate config based on type
-        if (effectiveType === "cron") {
-          const cronExpression = effectiveConfig.cronExpression as
-            string | undefined;
-          if (!cronExpression) {
-            return {
-              success: false,
-              error: "Cron triggers require config.cronExpression.",
-            };
-          }
-          const timezone = (effectiveConfig.timezone as string) ?? "UTC";
-          const nextRunAt = validateCronExpression(cronExpression, timezone);
-          if (!nextRunAt) {
-            return {
-              success: false,
-              error:
-                "Invalid cron expression or timezone. Example: '0 9 * * *' for daily at 9 AM.",
-            };
-          }
-        } else if (effectiveType === "event") {
-          const events = effectiveConfig.events as string[] | undefined;
-          if (!events || events.length === 0) {
-            return {
-              success: false,
-              error:
-                "Event triggers require config.events array with at least one event.",
-            };
-          }
-        } else {
+          const url = buildResourceUrl(
+            frontendUrl,
+            orgId,
+            workspaceId,
+            `triggers/${triggerId}`,
+          );
+
           return {
-            success: false,
-            error: "Invalid trigger type. Must be 'cron' or 'event'.",
+            success: true,
+            trigger: record,
+            ...(url && { url }),
           };
+        } catch (error) {
+          if (
+            error instanceof ValidationError ||
+            error instanceof NotFoundError
+          ) {
+            return { success: false, error: error.message };
+          }
+          throw error;
         }
-
-        // Build update payload from provided fields
-        const updateData: Record<string, unknown> = {
-          updatedAt: new Date(),
-        };
-        if (fields.name !== undefined) updateData.name = fields.name;
-        if (fields.agentId !== undefined) updateData.agentId = fields.agentId;
-        if (fields.instruction !== undefined)
-          updateData.instruction = fields.instruction;
-        if (fields.description !== undefined)
-          updateData.description = fields.description;
-        if (fields.enabled !== undefined) updateData.enabled = fields.enabled;
-        if (fields.maxRunsToKeep !== undefined)
-          updateData.maxRunsToKeep = fields.maxRunsToKeep;
-        if (fields.search !== undefined) updateData.search = fields.search;
-        if (fields.type !== undefined) updateData.type = fields.type;
-        if (fields.config !== undefined) updateData.config = effectiveConfig;
-
-        // Set nextRunAt based on type
-        if (effectiveType === "cron") {
-          const cronExpression = effectiveConfig.cronExpression as string;
-          const timezone = (effectiveConfig.timezone as string) ?? "UTC";
-          if (fields.config?.cronExpression || fields.config?.timezone)
-            updateData.nextRunAt = validateCronExpression(
-              cronExpression,
-              timezone,
-            );
-        } else {
-          updateData.nextRunAt = null;
-        }
-
-        const record = await db
-          .update(triggerTable)
-          .set(updateData)
-          .where(eq(triggerTable.id, triggerId))
-          .returning();
-
-        const url = buildResourceUrl(
-          frontendUrl,
-          orgId,
-          workspaceId,
-          `triggers/${triggerId}`,
-        );
-
-        return {
-          success: true,
-          trigger: record[0],
-          ...(url && { url }),
-        };
       }
 
       // Create new trigger — validate required fields
-      const { name, agentId, instruction, type, config } = fields;
+      const { name, agentId, instruction, type } = fields;
 
       if (!name || !agentId || !instruction || !type || !config) {
         return {
@@ -362,115 +288,37 @@ export function createTriggerTools(
         };
       }
 
-      const enabled = fields.enabled ?? true;
-      const maxRunsToKeep = fields.maxRunsToKeep ?? 10;
-      const search = fields.search ?? false;
-      const id = nanoid();
-      const now = new Date();
-
-      if (type === "cron") {
-        const cronExpression = config.cronExpression;
-        if (!cronExpression) {
-          return {
-            success: false,
-            error: "Cron triggers require config.cronExpression.",
-          };
-        }
-
-        const timezone = config.timezone ?? "UTC";
-        const nextRunAt = validateCronExpression(cronExpression, timezone);
-        if (!nextRunAt) {
-          return {
-            success: false,
-            error:
-              "Invalid cron expression or timezone. Example: '0 9 * * *' for daily at 9 AM.",
-          };
-        }
-
-        const record = await db
-          .insert(triggerTable)
-          .values({
-            id,
-            workspaceId,
-            agentId,
-            type,
-            name,
-            description: fields.description,
-            instruction,
-            enabled,
-            maxRunsToKeep,
-            search,
-            config: { cronExpression, timezone },
-            nextRunAt,
-            createdAt: now,
-            updatedAt: now,
-          })
-          .returning();
+      try {
+        const record = await createTrigger(ctx, {
+          agentId,
+          type,
+          name,
+          description: fields.description,
+          instruction,
+          enabled: fields.enabled ?? true,
+          maxRunsToKeep: fields.maxRunsToKeep ?? 10,
+          search: fields.search ?? false,
+          config,
+        });
 
         const url = buildResourceUrl(
           frontendUrl,
           orgId,
           workspaceId,
-          `triggers/${id}`,
+          `triggers/${record.id}`,
         );
 
         return {
           success: true,
-          trigger: record[0],
+          trigger: record,
           ...(url && { url }),
         };
-      }
-
-      if (type === "event") {
-        const events = config.events;
-        if (!events || events.length === 0) {
-          return {
-            success: false,
-            error:
-              "Event triggers require config.events array with at least one event.",
-          };
+      } catch (error) {
+        if (error instanceof ValidationError) {
+          return { success: false, error: error.message };
         }
-
-        const eventConfig: Record<string, unknown> = { events };
-        if (config.filters) eventConfig.filters = config.filters;
-
-        const record = await db
-          .insert(triggerTable)
-          .values({
-            id,
-            workspaceId,
-            agentId,
-            type,
-            name,
-            description: fields.description,
-            instruction,
-            enabled,
-            maxRunsToKeep,
-            search,
-            config: eventConfig,
-            createdAt: now,
-            updatedAt: now,
-          })
-          .returning();
-
-        const url = buildResourceUrl(
-          frontendUrl,
-          orgId,
-          workspaceId,
-          `triggers/${id}`,
-        );
-
-        return {
-          success: true,
-          trigger: record[0],
-          ...(url && { url }),
-        };
+        throw error;
       }
-
-      return {
-        success: false,
-        error: "Invalid trigger type. Must be 'cron' or 'event'.",
-      };
     },
   });
 


### PR DESCRIPTION
## Summary

`tools/trigger.ts` (the Agent-facing Tool set) hand-rolled its own Zod validation with zero import from `@platypus/schemas`, drifting from `routes/trigger.ts` (the UI's HTTP route, already schema-validated) in two directions at once:

- **Narrower `filters`** — an Agent could only set `boardId`, never `columnId`/`changedFields`, even though the real schema and `event-dispatch.ts`'s filter-matching support all three.
- **Looser `events`** — accepted any string, not just the real 8-member enum, so an Agent could write an invalid event name that silently produces a Trigger that looks configured but can never fire.
- **Shallow-merge on update** — the Tool's update logic replaced `filters` wholesale on any config touch, so an Agent's unrelated update could silently wipe a `columnId`/`changedFields` filter a User set through the UI.

New `apps/backend/src/services/trigger.ts` is the single Trigger write model: `createTrigger`/`updateTrigger` validate `type`/`config` by composing the real schemas (`cronTriggerConfigSchema`, `eventTriggerConfigSchema`, `webhookEventSchema`, `eventTriggerFiltersSchema`), throw typed errors (ADR-0010), and treat `config` updates as full-replace only (no merge — a caller that wants to preserve part of the existing config reads it first). Both `routes/trigger.ts` and `tools/trigger.ts` are now thin adapters over it.

- **1** — `services/trigger.ts`: `createTrigger`/`updateTrigger`, Workspace-only (no scope union), no `deleteTrigger` (delete stays each caller's existing generic path).
- **2** — `tools/trigger.ts`'s input schema now composes the real field-level schemas directly instead of a hand-rolled shape.
- **3** — Both routes are thin adapters: the HTTP route lets typed errors propagate to the central `onError`; the Tool catches and translates to its `{success:false, error}` shape.
- **5** — New `services/trigger.test.ts` is the authoritative suite for cron/event/filter validation; `routes/trigger.test.ts`/`tools/trigger.test.ts` trimmed of redundant hand-rolled cases, both gained `columnId`/`changedFields` round-trip coverage.

No data migration — every persisted `filters` value is a valid, narrower instance of the real schema.

Closes #690

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format` (prettier --check on changed files) — clean
- [x] `pnpm test` — full backend suite, 139 files / 2251 tests passing
- [x] Two-axis `/code-review` (Standards + Spec sub-agents) — Spec fully compliant, no scope creep; Standards judgement-call notes addressed (imprecise cron error message fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)