### PR TITLE
fix(backend): name the real user a Trigger run acts on behalf of

### DIFF
--- a/apps/backend/src/services/trigger-execution.test.ts
+++ b/apps/backend/src/services/trigger-execution.test.ts
@@ -70,14 +70,14 @@ const baseTrigger = {
   updatedAt: new Date(),
 };
 
-const mockWorkspace = {
-  id: "ws-1",
+/**
+ * The row the run scope is built from — not a Workspace row: the lookup
+ * projects the Workspace's org and owner joined to the owner's name.
+ */
+const mockScopeRow = {
   organizationId: "org-1",
   ownerId: "user-1",
-  name: "Test Workspace",
-  context: null,
-  createdAt: new Date(),
-  updatedAt: new Date(),
+  ownerName: "Ada Lovelace",
 };
 
 describe("trigger-execution", () => {
@@ -89,7 +89,7 @@ describe("trigger-execution", () => {
 
   describe("executeTrigger", () => {
     it("returns a runId and delegates execution to agentRunner.generate", async () => {
-      mockDb.limit.mockResolvedValueOnce([mockWorkspace]);
+      mockDb.limit.mockResolvedValueOnce([mockScopeRow]);
       mockGenerate.mockResolvedValueOnce({ text: "ok", stats: {} });
 
       const runId = await executeTrigger(baseTrigger);
@@ -105,6 +105,7 @@ describe("trigger-execution", () => {
         throw new Error("expected a trigger principal");
       expect(principal.triggerId).toBe("trigger-1");
       expect(principal.onBehalfOfUserId).toBe("user-1");
+      expect(principal.name).toBe("Ada Lovelace");
       expect(args.input.runId).toBe("test-id");
       expect(args.input.request.agentId).toBe("agent-1");
       expect(args.input.messages).toHaveLength(1);
@@ -115,7 +116,7 @@ describe("trigger-execution", () => {
     });
 
     it("prepends event context to the instruction for event triggers", async () => {
-      mockDb.limit.mockResolvedValueOnce([mockWorkspace]);
+      mockDb.limit.mockResolvedValueOnce([mockScopeRow]);
       mockGenerate.mockResolvedValueOnce({ text: "ok", stats: {} });
 
       await executeTrigger(baseTrigger, {
@@ -130,8 +131,31 @@ describe("trigger-execution", () => {
       expect(text).toContain("Do something");
     });
 
+    it("names the owner looked up for this workspace, on an event trigger too", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { ...mockScopeRow, ownerName: "Grace Hopper" },
+      ]);
+      mockGenerate.mockResolvedValueOnce({ text: "ok", stats: {} });
+
+      const trigger = {
+        ...baseTrigger,
+        type: "event",
+        config: { events: ["card.created"] },
+      } as TriggerRow;
+      await executeTrigger(trigger, {
+        eventType: "card.created",
+        eventData: { cardId: "c1" },
+      });
+
+      const { principal } = (mockGenerate.mock.calls[0][0] as GenerateArgs)
+        .scope;
+      if (principal.kind !== "trigger")
+        throw new Error("expected a trigger principal");
+      expect(principal.name).toBe("Grace Hopper");
+    });
+
     it("constructs a TriggerSink with the trigger id and event metadata", async () => {
-      mockDb.limit.mockResolvedValueOnce([mockWorkspace]);
+      mockDb.limit.mockResolvedValueOnce([mockScopeRow]);
       mockGenerate.mockResolvedValueOnce({ text: "ok", stats: {} });
 
       await executeTrigger(baseTrigger, {
@@ -147,7 +171,7 @@ describe("trigger-execution", () => {
     });
 
     it("propagates a search override from the trigger to the run input", async () => {
-      mockDb.limit.mockResolvedValueOnce([mockWorkspace]);
+      mockDb.limit.mockResolvedValueOnce([mockScopeRow]);
       mockGenerate.mockResolvedValueOnce({ text: "ok", stats: {} });
 
       const trigger = { ...baseTrigger, search: true };
@@ -167,7 +191,7 @@ describe("trigger-execution", () => {
     });
 
     it("rethrows runner failures so callers can log/observe", async () => {
-      mockDb.limit.mockResolvedValueOnce([mockWorkspace]);
+      mockDb.limit.mockResolvedValueOnce([mockScopeRow]);
       mockGenerate.mockRejectedValueOnce(new Error("Model error"));
 
       await expect(executeTrigger(baseTrigger as TriggerRow)).rejects.toThrow(

--- a/apps/backend/src/services/trigger-execution.ts
+++ b/apps/backend/src/services/trigger-execution.ts
@@ -5,6 +5,7 @@ import { db } from "../index.ts";
 import {
   trigger as triggerTable,
   triggerRun as triggerRunTable,
+  user as userTable,
   workspace as workspaceTable,
 } from "../db/schema.ts";
 import { logger } from "../logger.ts";
@@ -72,12 +73,20 @@ export const executeTrigger = async (
   const { id, workspaceId, agentId, instruction } = trigger;
   const runId = nanoid();
 
-  // Workspace is fetched up-front to derive the run scope. The runner
-  // re-reads it for system-prompt context — at trigger volumes the extra
-  // round-trip is acceptable.
+  // Workspace is fetched up-front to derive the run scope, joined to its
+  // owner because the scope names the user the run acts on behalf of and that
+  // name lives on the user row. The join is inner: `ownerId` is a non-null FK
+  // under cascade delete, so a Workspace that loads always has an owner. The
+  // runner re-reads the Workspace for system-prompt context — at trigger
+  // volumes the extra round-trip is acceptable.
   const [workspace] = await db
-    .select()
+    .select({
+      organizationId: workspaceTable.organizationId,
+      ownerId: workspaceTable.ownerId,
+      ownerName: userTable.name,
+    })
     .from(workspaceTable)
+    .innerJoin(userTable, eq(userTable.id, workspaceTable.ownerId))
     .where(eq(workspaceTable.id, workspaceId))
     .limit(1);
 
@@ -92,7 +101,7 @@ export const executeTrigger = async (
     workspaceId,
     organizationId: workspace.organizationId,
     ownerUserId: workspace.ownerId,
-    ownerName: "Trigger User",
+    ownerName: workspace.ownerName,
   });
 
   const effectiveInstruction = eventContext


### PR DESCRIPTION
Closes #697

## Problem

A Trigger run told the model it was acting on behalf of a user called **"Trigger User"**, then handed it the real user's hand-written context.

The trigger execution path hardcoded the run principal's display name to that literal while passing the Workspace owner's genuine user id. The headless User fragment renders the name; the User Contexts fragment immediately after it resolves against the same real id and injects the owner's global and per-Workspace context in full. So the model was told the actor was someone called "Trigger User" and was then given a profile written by, and about, a real person.

## Fix

The scope builder was never the problem — it already accepts the owner's name as a parameter, and its unit test exercises it with a real name. Its single production call site supplied a literal where a real value belonged.

The Workspace lookup that derives the run scope now inner-joins the owner row and passes `user.name` through verbatim:

```ts
.select({
  organizationId: workspaceTable.organizationId,
  ownerId: workspaceTable.ownerId,
  ownerName: userTable.name,
})
.from(workspaceTable)
.innerJoin(userTable, eq(userTable.id, workspaceTable.ownerId))
```

A join rather than a second round trip: one query instead of two. The join is inner because `workspace.ownerId` is a non-null FK under cascade delete — a Workspace that loads always has an owner, so there is no missing-owner state to guard and no fallback name to invent.

Headless framing is unchanged: no live participant, do not address them directly, operate autonomously. That wording is what marks a run as unattended, and the name is now real rather than re-encoding the same signal. Interactive Chat identity is untouched.

## The `"Sub-agent"` literal

Verified unreachable and deliberately left alone. `name: "Sub-agent"` in the same derivation fires only for a `subAgent` principal; those scopes are built solely at `tools/sub-agent.ts:302` and flow into `startRun`, never into `agentRunner.generate`/`stream` — the only callers of the derivation. Consistent with ADR-0016: a sub-agent composes its own prompt from its Instructions plus its Provider's guardrails.

## Verification

- Built test-first at the trigger execution seam. Tests went red (`expected 'Trigger User' to be 'Ada Lovelace'`) before the fix, green after. Both the cron and event paths assert the looked-up name reaches `principal.name` on the constructed scope — the value travelling into the scope, not merely that the prompt renders.
- Chain confirmed end to end: scope principal → `userFromScope` → `prepareChatTurn` → `ctx.user.name` → the headless fragment.
- `"Trigger User"` no longer appears anywhere in the repo.
- `pnpm typecheck`, `pnpm lint`, `pnpm format`, and `pnpm test` all pass (2269 backend, 613 frontend, 208 across the other packages).

## Not a breaking change

No configuration or API shape changes — only the value rendered into a prompt fragment. No docs owed: the diff touches only `apps/backend/src/services/**`, which does not intersect the CLAUDE.md docs table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
