### PR TITLE
feat!: require what core always supplied on the plugin API (v2)

### DIFF
--- a/apps/backend/src/plugins/contribution-pipeline.test.ts
+++ b/apps/backend/src/plugins/contribution-pipeline.test.ts
@@ -6,6 +6,7 @@ import {
   type ExtensionPoint,
   type RawContribution,
 } from "./contribution-pipeline.ts";
+import { makeFakePluginLogger } from "../test-utils.ts";
 
 // Every Extension point runs the same seven steps over its slice of a manifest —
 // shape check, id and name checks, namespacing, owner-attributed collision
@@ -13,7 +14,11 @@ import {
 // against a stand-in point, so `loader.test.ts` is left testing what each real
 // point *adds* rather than re-testing this sequence three times.
 
-const PLUGIN: PluginConfigContext = { config: { key: "k" }, credentials: {} };
+const PLUGIN: PluginConfigContext = {
+  config: { key: "k" },
+  credentials: {},
+  logger: makeFakePluginLogger(),
+};
 
 type Widget = { id: string; label: string; plugin: PluginConfigContext };
 

--- a/apps/backend/src/plugins/docker/backend.test.ts
+++ b/apps/backend/src/plugins/docker/backend.test.ts
@@ -280,6 +280,7 @@ import { loadPlugins } from "../loader.ts";
 import type { SandboxBackendContribution } from "@platypuschat/plugin-sdk";
 import {
   makeFakePluginLogger,
+  makePluginContext,
   type FakePluginLogger,
 } from "../../test-utils.ts";
 import {
@@ -383,7 +384,7 @@ describe("DockerSandboxTransport — provisioning", () => {
     // Plus an exec for the actual tool call.
     queueExec({ stdout: "hi", exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await backend.shellExec(ctx, { command: "echo hi" });
 
     expect(mockState.pullCalls).toEqual(["debian:stable-slim"]);
@@ -401,7 +402,7 @@ describe("DockerSandboxTransport — provisioning", () => {
     setupFreshProvision();
     queueExec({ exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await backend.shellExec(ctx, { command: "true" });
 
     const opts = mockState.createContainerCalls[0];
@@ -433,7 +434,7 @@ describe("DockerSandboxTransport — provisioning", () => {
     );
     queueExec({ stdout: "ok", exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await backend.shellExec(ctx, { command: "true" });
 
     expect(mockState.createContainerCalls).toHaveLength(0);
@@ -449,7 +450,7 @@ describe("DockerSandboxTransport — provisioning", () => {
     );
     queueExec({ exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await backend.shellExec(ctx, { command: "true" });
 
     expect(mockState.existingContainer.start).toHaveBeenCalledTimes(1);
@@ -462,7 +463,7 @@ describe("DockerSandboxTransport — provisioning", () => {
     queueExec({ exitCode: 0 });
     queueExec({ exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await Promise.all([
       backend.shellExec(ctx, { command: "a" }),
       backend.shellExec(ctx, { command: "b" }),
@@ -477,7 +478,7 @@ describe("DockerSandboxTransport — argv safety", () => {
     setupFreshProvision();
     queueExec({ stdout: "data", exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     const malicious = `foo";rm -rf /`;
     await backend.fsRead(ctx, { path: malicious });
 
@@ -493,7 +494,7 @@ describe("DockerSandboxTransport — argv safety", () => {
     setupFreshProvision();
     queueExec({ stdout: "a".repeat(MAX_READ_BYTES + 5_000), exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     const res = await backend.fsRead(ctx, { path: "big.txt" });
 
     expect(res.content).toHaveLength(MAX_READ_BYTES);
@@ -508,7 +509,7 @@ describe("DockerSandboxTransport — argv safety", () => {
     );
     queueExec({ stdout: "", exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await backend.fsList(ctx, { glob: "**/*.ts" });
 
     // What the glob rules *are* is core's business (posix.test.ts). What this
@@ -525,7 +526,7 @@ describe("DockerSandboxTransport — argv safety", () => {
     // probe — file exists (exit 0).
     queueExec({ exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await expect(
       backend.fsWrite(ctx, {
         path: "foo",
@@ -546,7 +547,7 @@ describe("DockerSandboxTransport — argv safety", () => {
       Promise.resolve({ State: { Running: true } }),
     );
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await backend.fsWrite(ctx, {
       path: "foo.txt",
       content: "hello",
@@ -652,7 +653,7 @@ describe("DockerSandboxTransport — shellExec output handling", () => {
     // Long-running exec — close after 200ms; timeout will be 20ms.
     queueExec({ closeDelayMs: 200, exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     const res = await backend.shellExec(ctx, {
       command: "sleep 5",
       timeoutMs: 20,
@@ -666,7 +667,7 @@ describe("DockerSandboxTransport — shellExec output handling", () => {
     const huge = "a".repeat(MAX_SHELL_OUTPUT_BYTES + 5_000);
     queueExec({ stdout: huge, exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     const res = await backend.shellExec(ctx, { command: "yes" });
 
     expect(res.stdout.length).toBe(MAX_SHELL_OUTPUT_BYTES);
@@ -682,6 +683,7 @@ describe("DockerSandboxTransport — host reachability (ADR-0005)", () => {
     const backend = createDockerSandboxBackend(
       { extraHosts: ["host.docker.internal:host-gateway"] },
       {},
+      withPluginLogger(),
     );
     await backend.shellExec(ctx, { command: "true" });
 
@@ -697,6 +699,7 @@ describe("DockerSandboxTransport — host reachability (ADR-0005)", () => {
     const backend = createDockerSandboxBackend(
       { networks: ["primary", "secondary", "tertiary"] },
       {},
+      withPluginLogger(),
     );
     await backend.shellExec(ctx, { command: "true" });
 
@@ -717,7 +720,11 @@ describe("DockerSandboxTransport — host reachability (ADR-0005)", () => {
     setupFreshProvision();
     queueExec({ exitCode: 0 });
 
-    const backend = createDockerSandboxBackend({ networks: ["only"] }, {});
+    const backend = createDockerSandboxBackend(
+      { networks: ["only"] },
+      {},
+      withPluginLogger(),
+    );
     await backend.shellExec(ctx, { command: "true" });
 
     expect(mockState.createContainerCalls[0].HostConfig?.NetworkMode).toBe(
@@ -731,37 +738,53 @@ describe("DockerSandboxTransport — host reachability (ADR-0005)", () => {
   // `allowedNetworks`, no longer from process.env.
   describe("dockerSandboxConfigSchema (factory of plugin config)", () => {
     it("defaults to empty arrays for {}", () => {
-      const parsed = dockerSandboxConfigSchema({ allowedNetworks: [] }).parse(
-        {},
-      );
+      const parsed = dockerSandboxConfigSchema(
+        makePluginContext({ config: { allowedNetworks: [] } }),
+      ).parse({});
       expect(parsed).toEqual({ networks: [], extraHosts: [] });
     });
 
     it("accepts networks that are in the operator allowlist", () => {
-      const parsed = dockerSandboxConfigSchema({
-        allowedNetworks: ["shared", "tools"],
-      }).parse({ networks: ["shared"] });
+      const parsed = dockerSandboxConfigSchema(
+        makePluginContext({
+          config: {
+            allowedNetworks: ["shared", "tools"],
+          },
+        }),
+      ).parse({ networks: ["shared"] });
       expect(parsed.networks).toEqual(["shared"]);
     });
 
     it("rejects networks outside the operator allowlist", () => {
-      const result = dockerSandboxConfigSchema({
-        allowedNetworks: ["shared"],
-      }).safeParse({ networks: ["not-allowed"] });
+      const result = dockerSandboxConfigSchema(
+        makePluginContext({
+          config: {
+            allowedNetworks: ["shared"],
+          },
+        }),
+      ).safeParse({ networks: ["not-allowed"] });
       expect(result.success).toBe(false);
     });
 
     it("rejects any network under an empty allowlist (default-deny)", () => {
-      const result = dockerSandboxConfigSchema({
-        allowedNetworks: [],
-      }).safeParse({ networks: ["shared"] });
+      const result = dockerSandboxConfigSchema(
+        makePluginContext({
+          config: {
+            allowedNetworks: [],
+          },
+        }),
+      ).safeParse({ networks: ["shared"] });
       expect(result.success).toBe(false);
     });
 
     it("names the plugin-config allowlist source in the error", () => {
-      const result = dockerSandboxConfigSchema({
-        allowedNetworks: [],
-      }).safeParse({ networks: ["nope"] });
+      const result = dockerSandboxConfigSchema(
+        makePluginContext({
+          config: {
+            allowedNetworks: [],
+          },
+        }),
+      ).safeParse({ networks: ["nope"] });
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error.issues[0].message).toContain(
@@ -771,9 +794,13 @@ describe("DockerSandboxTransport — host reachability (ADR-0005)", () => {
     });
 
     it("rejects malformed extraHosts entries", () => {
-      const result = dockerSandboxConfigSchema({
-        allowedNetworks: [],
-      }).safeParse({ extraHosts: ["not a valid entry"] });
+      const result = dockerSandboxConfigSchema(
+        makePluginContext({
+          config: {
+            allowedNetworks: [],
+          },
+        }),
+      ).safeParse({ extraHosts: ["not a valid entry"] });
       expect(result.success).toBe(false);
     });
   });
@@ -844,7 +871,7 @@ describe("DockerSandboxTransport — plugin-injected logger", () => {
     mockState.containerStop = () =>
       Promise.reject(makeStatusError("internal", 500));
 
-    const backend = createDockerSandboxBackend({}, {});
+    const backend = createDockerSandboxBackend({}, {}, withPluginLogger());
     await expect(backend.destroy(ctx)).resolves.toBeUndefined();
     expect(logger.warn).not.toHaveBeenCalled();
   });
@@ -904,7 +931,7 @@ describe("DockerSandboxTransport — plugin-injected logger", () => {
       baseLogger,
     });
 
-    const backend = captured[0].create({}, {});
+    const backend = captured[0].create({}, {}, withPluginLogger());
     await backend.shellExec(ctx, { command: "echo hi" });
 
     expect(lines).toContainEqual({

--- a/apps/backend/src/plugins/docker/backend.ts
+++ b/apps/backend/src/plugins/docker/backend.ts
@@ -82,14 +82,14 @@ export type DockerSandboxConfig = z.infer<typeof dockerSandboxConfigBase>;
 // Factory form (ADR-0013): the per-Workspace config schema closes over the
 // Operator's `allowedNetworks` from the plugin config injected at load, so an
 // out-of-allowlist `networks` entry is rejected at config-save time (ADR-0005).
-// The loader resolves this against the boot-validated plugin config into a
-// concrete schema before core's static safeParse consumers see it. The argument
+// The loader resolves this against the boot-validated plugin block into a
+// concrete schema before core's static safeParse consumers see it. `config`
 // arrives as `unknown` (the SDK's opaque plugin-config shape); we re-validate it
 // through the plugin schema so the factory is self-contained and defensively
 // defaults to an empty allowlist (default-deny).
-export const dockerSandboxConfigSchema = (pluginConfig: unknown) => {
+export const dockerSandboxConfigSchema = (plugin: PluginConfigContext) => {
   const { allowedNetworks } = dockerPluginConfigSchema.parse(
-    pluginConfig ?? {},
+    plugin.config ?? {},
   );
   const allowed = new Set(allowedNetworks);
   return dockerSandboxConfigBase.superRefine((cfg, ctx) => {
@@ -307,15 +307,14 @@ export class DockerSandboxTransport implements SandboxTransport {
    * The logger core bound to `@platypus/docker` and injected on the plugin's
    * deploy-time block (ADR-0013) — the same contract a third-party plugin gets,
    * rather than the relative import of core's logger only an in-tree plugin ever
-   * had. Optional because {@link PluginConfigContext.logger} is, so every call
-   * site below is written `this.logger?.…`.
+   * had. Required, as {@link PluginConfigContext.logger} has been since API v2.
    */
-  private logger?: PluginLogger;
+  private logger: PluginLogger;
 
   constructor(
     config: Partial<DockerSandboxConfig>,
     _credentials: DockerSandboxCredentials,
-    logger?: PluginLogger,
+    logger: PluginLogger,
   ) {
     this.docker = new Docker();
     this.inflight = new Map();
@@ -415,7 +414,7 @@ export class DockerSandboxTransport implements SandboxTransport {
     } catch (err) {
       if (!is404(err)) throw err;
     }
-    this.logger?.info({ image: IMAGE }, "Pulling sandbox image");
+    this.logger.info({ image: IMAGE }, "Pulling sandbox image");
     const stream = await this.docker.pull(IMAGE);
     await new Promise<void>((resolve, reject) => {
       this.docker.modem.followProgress(stream, (err: Error | null) =>
@@ -522,7 +521,7 @@ export class DockerSandboxTransport implements SandboxTransport {
         // Already stopped is 304 — swallow that too.
         const e = err as { statusCode?: number };
         if (e.statusCode !== 304) {
-          this.logger?.warn(
+          this.logger.warn(
             { workspaceId: ctx.workspaceId, err },
             "sandbox destroy: stop failed (continuing)",
           );
@@ -535,7 +534,7 @@ export class DockerSandboxTransport implements SandboxTransport {
       await this.docker.getContainer(name).remove({ force: true, v: false });
     } catch (err) {
       if (!is404(err)) {
-        this.logger?.warn(
+        this.logger.warn(
           { workspaceId: ctx.workspaceId, err },
           "sandbox destroy: container remove failed (continuing)",
         );
@@ -547,7 +546,7 @@ export class DockerSandboxTransport implements SandboxTransport {
       await this.docker.getVolume(vol).remove();
     } catch (err) {
       if (!is404(err)) {
-        this.logger?.warn(
+        this.logger.warn(
           { workspaceId: ctx.workspaceId, err },
           "sandbox destroy: volume remove failed",
         );
@@ -564,8 +563,8 @@ export class DockerSandboxTransport implements SandboxTransport {
 export const createDockerSandboxBackend = (
   config: Partial<DockerSandboxConfig>,
   credentials: DockerSandboxCredentials,
-  plugin?: PluginConfigContext,
+  plugin: PluginConfigContext,
 ): SandboxBackend =>
   createPosixSandbox(
-    new DockerSandboxTransport(config, credentials, plugin?.logger),
+    new DockerSandboxTransport(config, credentials, plugin.logger),
   );

--- a/apps/backend/src/plugins/extension-points.ts
+++ b/apps/backend/src/plugins/extension-points.ts
@@ -96,23 +96,28 @@ export const sandboxBackendPoint = (
   prepare: (raw, { pluginName, id, plugin }) => {
     const contribution = raw as unknown as SandboxBackendContribution;
 
-    // Resolve a factory-form configSchema against the boot-resolved plugin
-    // config so the three static `configSchema.safeParse` consumers (save route,
+    // Resolve a factory-form configSchema against the boot-resolved plugin block
+    // so the three static `configSchema.safeParse` consumers (save route,
     // teardown, tool resolver) always receive a concrete schema — they never see
-    // plugin config. A plain schema passes through untouched (append-only:
-    // plugin-config-agnostic backends are unaffected).
+    // plugin config. A plain schema passes through untouched: plugin-config-
+    // agnostic backends are unaffected.
     //
-    // The factory is third-party code reading a config block it narrows itself,
-    // so it can throw — a plugin that assumes an Operator supplied
-    // `config.region` raises a bare `Cannot read properties of undefined` naming
-    // nothing. Attributed here for the same reason the shape checks exist: the
-    // schema check below only catches a factory that *returns* a non-schema, not
-    // one that throws on the way there.
+    // The factory is handed the whole `PluginConfigContext`, the same object
+    // `create` gets, rather than the `config` half alone (API v2). It was the one
+    // factory on this surface that could reach neither the plugin's credentials
+    // nor its logger — so the one with no way to say why it refused a value.
+    //
+    // The factory is third-party code narrowing that block itself, so it can
+    // throw — a plugin that assumes an Operator supplied `config.region` raises a
+    // bare `Cannot read properties of undefined` naming nothing. Attributed here
+    // for the same reason the shape checks exist: the schema check below only
+    // catches a factory that *returns* a non-schema, not one that throws on the
+    // way there.
     let configSchema: SandboxBackendRegistration["configSchema"];
     try {
       configSchema =
         typeof contribution.configSchema === "function"
-          ? contribution.configSchema(plugin.config)
+          ? contribution.configSchema(plugin)
           : contribution.configSchema;
     } catch (cause) {
       throw new Error(

--- a/apps/backend/src/plugins/loader.test.ts
+++ b/apps/backend/src/plugins/loader.test.ts
@@ -16,6 +16,7 @@ import {
   MAX_WEB_TIMEOUT_MS,
   type WebBackendRegistration,
 } from "../web-backends/index.ts";
+import type { SandboxBackendRegistration } from "../sandbox/index.ts";
 import {
   loadPlugins,
   parsePluginConfig,
@@ -38,11 +39,14 @@ const makeRegister = () => {
   return { register, calls };
 };
 
-// A capturing `registerSandbox` for the Sandbox-backend extension point.
+// A capturing `registerSandbox` for the Sandbox-backend extension point. It
+// captures the *composed registration* — factory-form `configSchema` resolved
+// away, `create` already bound to the plugin's block — which is what the loader
+// hands this seam, not the raw contribution.
 const makeSandboxRegister = () => {
-  const calls: SandboxBackendContribution[] = [];
-  const registerSandbox = (contribution: SandboxBackendContribution) => {
-    calls.push(contribution);
+  const calls: SandboxBackendRegistration[] = [];
+  const registerSandbox = (registration: SandboxBackendRegistration) => {
+    calls.push(registration);
   };
   return { registerSandbox, calls };
 };
@@ -698,8 +702,8 @@ describe("loadPlugins — sandbox backends", () => {
     const factoryBackend: SandboxBackendContribution = {
       backend: "fenced",
       name: "Fenced",
-      configSchema: (pluginConfig) => {
-        const { allowed } = pluginConfig as { allowed: string[] };
+      configSchema: (plugin) => {
+        const { allowed } = plugin.config as { allowed: string[] };
         return z
           .object({ net: z.string() })
           .refine((c) => allowed.includes(c.net), { message: "not allowed" });
@@ -730,9 +734,11 @@ describe("loadPlugins — sandbox backends", () => {
 
     const [registered] = calls;
     // Registered as a CONCRETE schema (the factory is resolved away), reflecting
-    // the resolved plugin config.
+    // the resolved plugin config. The registration type says so — `configSchema`
+    // on it is a plain `z.ZodType`, with no factory arm left to narrow — so the
+    // runtime check below is the one that earns its keep.
     expect(typeof registered.configSchema).not.toBe("function");
-    const schema = registered.configSchema as z.ZodType;
+    const schema = registered.configSchema;
     expect(schema.safeParse({ net: "ok" }).success).toBe(true);
     expect(schema.safeParse({ net: "blocked" }).success).toBe(false);
   });
@@ -992,13 +998,20 @@ describe("loadPlugins — web-search backends", () => {
     // Core's own context; `providerId` is stripped before the plugin-facing
     // call, so the factory sees only the ADR-0014 shape.
     const pluginCtx = { orgId: "org-1", workspaceId: "ws-1", userId: "user-1" };
-    await calls[0].buildTurnTools({ ...pluginCtx, providerId: "provider-1" });
-
-    expect(createExecutors).toHaveBeenCalledWith(pluginCtx, {
-      config: { endpoint: "https://searx.internal" },
-      credentials: { apiKey: "sk-test" },
-      logger: A_LOGGER_MATCHER,
+    await calls[0].buildTurnTools({
+      ...pluginCtx,
+      providerId: "provider-1",
+      registerCloser: () => {},
     });
+
+    expect(createExecutors).toHaveBeenCalledWith(
+      { ...pluginCtx, registerCloser: expect.any(Function) as unknown },
+      {
+        config: { endpoint: "https://searx.internal" },
+        credentials: { apiKey: "sk-test" },
+        logger: A_LOGGER_MATCHER,
+      },
+    );
   });
 });
 
@@ -1101,8 +1114,8 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
     const register = (id: string, registration: ToolSetRegistration) => {
       registered[id] = registration;
     };
-    const sandboxCalls: SandboxBackendContribution[] = [];
-    const registerSandbox = (c: SandboxBackendContribution) => {
+    const sandboxCalls: SandboxBackendRegistration[] = [];
+    const registerSandbox = (c: SandboxBackendRegistration) => {
       sandboxCalls.push(c);
     };
 
@@ -1129,6 +1142,7 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
       orgId: "o",
       frontendUrl: undefined,
       userId: "u",
+      registerCloser: () => {},
     });
 
     // Sandbox create(): invoked as core would, with the per-Workspace values.
@@ -1155,7 +1169,7 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
     const register = (id: string, registration: ToolSetRegistration) => {
       registered[id] = registration;
     };
-    const sandboxCalls: SandboxBackendContribution[] = [];
+    const sandboxCalls: SandboxBackendRegistration[] = [];
 
     await loadPlugins({
       pluginNames: ["acmecloud"],
@@ -1178,6 +1192,7 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
       orgId: "o",
       frontendUrl: undefined,
       userId: "u",
+      registerCloser: () => {},
     });
     sandboxCalls[0].create({}, {});
 
@@ -1265,6 +1280,7 @@ describe("loadPlugins — deploy-time plugin config injection", () => {
       orgId: "o",
       frontendUrl: undefined,
       userId: "u",
+      registerCloser: () => {},
     });
 
     expect(seenPlugin).toEqual({
@@ -1333,7 +1349,7 @@ describe("loadPlugins — plugin logger injection", () => {
     seen: Record<string, PluginConfigContext | undefined>;
   }) => {
     const registered: Record<string, ToolSetRegistration> = {};
-    const sandboxCalls: SandboxBackendContribution[] = [];
+    const sandboxCalls: SandboxBackendRegistration[] = [];
     const { registerWeb, calls: webCalls } = makeWebRegister();
 
     await loadPlugins({
@@ -1357,6 +1373,7 @@ describe("loadPlugins — plugin logger injection", () => {
       orgId: "o",
       frontendUrl: undefined,
       userId: "u",
+      registerCloser: () => {},
     });
     sandboxCalls[0].create({}, {});
     await webCalls[0].buildTurnTools({
@@ -1364,6 +1381,7 @@ describe("loadPlugins — plugin logger injection", () => {
       workspaceId: "w",
       userId: "u",
       providerId: "p",
+      registerCloser: () => {},
     });
   };
 
@@ -1432,7 +1450,7 @@ describe("loadPlugins — example third-party plugin", () => {
   // BOTH its Sandbox backend and its management Tool set (ADR-0013).
   it("shares one credential block across its two contributions", async () => {
     const registered: Record<string, ToolSetRegistration> = {};
-    const sandboxCalls: SandboxBackendContribution[] = [];
+    const sandboxCalls: SandboxBackendRegistration[] = [];
 
     const { plugins: loaded } = await loadPlugins({
       pluginNames: ["example-cloud-sandbox"],
@@ -1476,6 +1494,7 @@ describe("loadPlugins — example third-party plugin", () => {
       orgId: "o",
       frontendUrl: undefined,
       userId: "u",
+      registerCloser: () => {},
     })) as unknown as Record<
       string,
       { execute: (i: unknown) => Promise<string> }
@@ -2000,6 +2019,7 @@ describe("loadPlugins — example third-party npm package (end to end)", () => {
       orgId: "org-1",
       frontendUrl: undefined,
       userId: "user-1",
+      registerCloser: () => {},
     });
     // The author writes `greet`; the model is offered `example__greet`
     // (issue #664). The bare name is gone, so core's own turn tools have nothing
@@ -2041,6 +2061,7 @@ describe("loadPlugins — example third-party npm package (end to end)", () => {
       orgId: "org-1",
       frontendUrl: undefined,
       userId: "user-1",
+      registerCloser: () => {},
     });
 
     expect(lines).toEqual([]);

--- a/apps/backend/src/plugins/loader.ts
+++ b/apps/backend/src/plugins/loader.ts
@@ -4,13 +4,15 @@ import {
   type PlatypusPlugin,
   type PluginConfigContext,
   type PluginLogger,
-  type SandboxBackendContribution,
 } from "@platypuschat/plugin-sdk";
 import { MAX_PLUGIN_NAME_LENGTH } from "@platypus/schemas";
 import { logger } from "../logger.ts";
 import { ALWAYS_ON_PLUGINS, BUILTIN_PLUGINS } from "./builtin.ts";
 import { registerToolSet, type ToolSetRegistration } from "../tools/index.ts";
-import { registerSandboxBackend } from "../sandbox/index.ts";
+import {
+  registerSandboxBackend,
+  type SandboxBackendRegistration,
+} from "../sandbox/index.ts";
 import {
   registerWebBackend,
   type WebBackendRegistration,
@@ -123,8 +125,14 @@ export interface LoadPluginsOptions {
    * Defaults to the core `registerToolSet`.
    */
   register?: (id: string, registration: ToolSetRegistration) => void;
-  /** Registers one Sandbox-backend contribution. Defaults to core `registerSandboxBackend`. */
-  registerSandbox?: (contribution: SandboxBackendContribution) => void;
+  /**
+   * Registers one Sandbox backend. Takes the *composed* registration — core has
+   * already resolved the contribution's `configSchema` factory form away and
+   * bound its `create` to the plugin's config block — rather than the raw
+   * contribution, for the same reason `register` and `registerWeb` do
+   * (ADR-0013/0014). Defaults to core `registerSandboxBackend`.
+   */
+  registerSandbox?: (registration: SandboxBackendRegistration) => void;
   /**
    * Registers one Web-search backend. Takes the *composed* registration — core
    * has already wrapped the contribution's executors in its own Tools — rather

--- a/apps/backend/src/plugins/ssh/backend.test.ts
+++ b/apps/backend/src/plugins/ssh/backend.test.ts
@@ -396,7 +396,11 @@ describe("sshSandboxConfigSchema / credentialsSchema", () => {
 describe("SshSandboxTransport — connect", () => {
   it("connects with public-key auth and creates the default workspace root", async () => {
     queueExec({ stdout: "hi", exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.shellExec(ctx, { command: "echo hi" });
 
     expect(mockState.connectConfigs).toHaveLength(1);
@@ -416,10 +420,14 @@ describe("SshSandboxTransport — connect", () => {
 
   it("passes the passphrase through when provided", async () => {
     queueExec({ exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, {
-      privateKey: "K",
-      passphrase: "secret",
-    });
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      {
+        privateKey: "K",
+        passphrase: "secret",
+      },
+      withPluginLogger(),
+    );
     await backend.shellExec(ctx, { command: "true" });
     expect(mockState.connectConfigs[0].passphrase).toBe("secret");
   });
@@ -443,6 +451,7 @@ describe("SshSandboxTransport — connect", () => {
     const backend = createSshSandboxBackend(
       { ...CONFIG, rootDir: "/srv/agent" },
       CREDENTIALS,
+      withPluginLogger(),
     );
     await backend.shellExec(ctx, { command: "true" });
     expect(mockState.execCommands[0]).toContain("ROOT='/srv/agent'");
@@ -450,7 +459,11 @@ describe("SshSandboxTransport — connect", () => {
 
   it("rejects when the SSH connection errors", async () => {
     mockState.connectShouldFail = new Error("auth failed");
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
       /auth failed/,
     );
@@ -458,7 +471,11 @@ describe("SshSandboxTransport — connect", () => {
 
   it("throws when the workspace root cannot be created", async () => {
     mockState.rootCreateFails = true;
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
       /failed to create workspace root/,
     );
@@ -491,6 +508,7 @@ describe("SshSandboxTransport — host-key verification", () => {
     const backend = createSshSandboxBackend(
       { ...CONFIG, hostKey: WRONG_HOST_KEY_B64 },
       CREDENTIALS,
+      withPluginLogger(),
     );
     await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
       /host-key verification failed/,
@@ -520,6 +538,7 @@ describe("SshSandboxTransport — host-key verification", () => {
     const backend = createSshSandboxBackend(
       { ...CONFIG, hostKey: "# not a key" },
       CREDENTIALS,
+      withPluginLogger(),
     );
     await expect(backend.shellExec(ctx, { command: "true" })).rejects.toThrow(
       /hostKey/,
@@ -532,7 +551,11 @@ describe("SshSandboxTransport — host-key verification", () => {
 describe("SshSandboxTransport — shellExec", () => {
   it("prefixes cd <rootDir> and returns stdout/stderr/exitCode/durationMs", async () => {
     queueExec({ stdout: "out", stderr: "err", exitCode: 3 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     const res = await backend.shellExec(ctx, { command: "run" });
 
     // Core hands the transport an argv (`/bin/sh -c <command>`); a login shell
@@ -550,7 +573,11 @@ describe("SshSandboxTransport — shellExec", () => {
 
   it("resolves cwd relative to the rootDir", async () => {
     queueExec({ exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.shellExec(ctx, { command: "ls", cwd: "sub/dir" });
     expect(mockState.execCommands[1]).toBe(
       "cd '/home/platypus/platypus-workspace/sub/dir' && '/bin/sh' '-c' 'ls'",
@@ -559,7 +586,11 @@ describe("SshSandboxTransport — shellExec", () => {
 
   it("applies env via export statements (not the ssh2 env option)", async () => {
     queueExec({ exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.shellExec(ctx, {
       command: "printenv",
       env: { FOO: "bar", TOKEN: "a b'c" },
@@ -574,7 +605,11 @@ describe("SshSandboxTransport — shellExec", () => {
 
   it("drops env keys that are not valid POSIX identifiers", async () => {
     queueExec({ exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.shellExec(ctx, {
       command: "run",
       // A malformed key (model-supplied env is not schema-key-validated) must
@@ -591,7 +626,11 @@ describe("SshSandboxTransport — shellExec", () => {
     // fake emits more than the cap in one chunk and only the cap is retained.
     const huge = "a".repeat(MAX_SHELL_OUTPUT_BYTES + 5_000);
     queueExec({ stdout: huge, exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     const res = await backend.shellExec(ctx, { command: "yes" });
     expect(res.stdout.length).toBe(MAX_SHELL_OUTPUT_BYTES);
     expect(res.truncated).toBe(true);
@@ -600,7 +639,11 @@ describe("SshSandboxTransport — shellExec", () => {
   it("returns exit code 124 when a command exceeds its timeout", async () => {
     // Channel closes after 200ms; timeout is 20ms, so the adapter closes first.
     queueExec({ closeDelayMs: 200, exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     const res = await backend.shellExec(ctx, {
       command: "sleep 5",
       timeoutMs: 20,
@@ -613,7 +656,11 @@ describe("SshSandboxTransport — connection lifecycle", () => {
   it("reuses a single connection across tool calls within a turn", async () => {
     queueExec({ exitCode: 0 });
     queueExec({ exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.shellExec(ctx, { command: "a" });
     await backend.shellExec(ctx, { command: "b" });
 
@@ -625,7 +672,11 @@ describe("SshSandboxTransport — connection lifecycle", () => {
   it("concurrent first-callers share one connect (inflight promise)", async () => {
     queueExec({ exitCode: 0 });
     queueExec({ exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await Promise.all([
       backend.shellExec(ctx, { command: "a" }),
       backend.shellExec(ctx, { command: "b" }),
@@ -637,7 +688,11 @@ describe("SshSandboxTransport — connection lifecycle", () => {
     vi.useFakeTimers();
     try {
       queueExec({ exitCode: 0 });
-      const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+      const backend = createSshSandboxBackend(
+        CONFIG,
+        CREDENTIALS,
+        withPluginLogger(),
+      );
       await backend.shellExec(ctx, { command: "true" });
       expect(mockState.ended).toBe(0);
 
@@ -658,7 +713,11 @@ describe("SshSandboxTransport — connection lifecycle", () => {
 describe("SshSandboxTransport — destroy() is a no-op", () => {
   it("disconnects without running any remote mutation command", async () => {
     queueExec({ exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.shellExec(ctx, { command: "true" });
     const execCountBefore = mockState.execCommands.length;
 
@@ -670,7 +729,11 @@ describe("SshSandboxTransport — destroy() is a no-op", () => {
   });
 
   it("is safe to call when never connected", async () => {
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await expect(backend.destroy(ctx)).resolves.toBeUndefined();
     expect(mockState.connectConfigs).toHaveLength(0);
     expect(mockState.ended).toBe(0);
@@ -693,7 +756,11 @@ function seedFile(rel: string, content: string | Buffer) {
 describe("SshSandboxTransport — fs.write (SFTP)", () => {
   it("create mode fails cleanly when the target already exists", async () => {
     seedFile("exists.txt", "old");
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await expect(
       backend.fsWrite(ctx, {
         path: "exists.txt",
@@ -708,7 +775,11 @@ describe("SshSandboxTransport — fs.write (SFTP)", () => {
   });
 
   it("auto-creates parent directories (mkdir -p) before writing", async () => {
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.fsWrite(ctx, {
       path: "a/b/c/deep.txt",
       content: "x",
@@ -723,7 +794,11 @@ describe("SshSandboxTransport — fs.write (SFTP)", () => {
   });
 
   it("writes paths literally over SFTP (no shell quoting/injection)", async () => {
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     const weird = `foo";rm -rf /.txt`;
     await backend.fsWrite(ctx, {
       path: weird,
@@ -744,7 +819,11 @@ describe("SshSandboxTransport — fs.read (SFTP)", () => {
     // file costs the cap and no more. What that means for `truncated` is core's
     // call, not this adapter's — see sandbox/posix.test.ts.
     seedFile("big.txt", "a".repeat(MAX_READ_BYTES + 5_000));
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     const res = await backend.fsRead(ctx, { path: "big.txt" });
     expect(res.content.length).toBe(MAX_READ_BYTES);
   });
@@ -753,7 +832,11 @@ describe("SshSandboxTransport — fs.read (SFTP)", () => {
     // min(size, cap) must not over-request either: asking for `cap` bytes of a
     // short file is what a naive read would do, and SFTP would pad the buffer.
     seedFile("small.txt", "abc");
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     const res = await backend.fsRead(ctx, { path: "small.txt" });
     expect(res.content).toBe("abc");
   });
@@ -761,7 +844,11 @@ describe("SshSandboxTransport — fs.read (SFTP)", () => {
 
 describe("SshSandboxTransport — SFTP session lifecycle", () => {
   it("opens the SFTP subsystem once and reuses it across fs calls in a turn", async () => {
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.fsWrite(ctx, { path: "a.txt", content: "1", mode: "create" });
     await backend.fsRead(ctx, { path: "a.txt" });
     await backend.fsEdit(ctx, {
@@ -776,7 +863,11 @@ describe("SshSandboxTransport — SFTP session lifecycle", () => {
 
   it("propagates an SFTP subsystem open failure", async () => {
     mockState.sftpShouldFail = new Error("sftp channel refused");
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await expect(backend.fsRead(ctx, { path: "a.txt" })).rejects.toThrow(
       /sftp channel refused/,
     );
@@ -795,7 +886,11 @@ const PRINTF_ARG = String.raw`'-printf' '%y\t%s\t%P\n'`;
 describe("SshSandboxTransport — fs.list (exec find)", () => {
   it("quotes every element of the find argv core handed it", async () => {
     queueExec({ stdout: "", exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.fsList(ctx, {});
     // Core passes cwd=rootDir, so the `cd` prefix precedes find as well; the
     // argv itself (find, its target, its flags) is core's — this only asserts
@@ -807,7 +902,11 @@ describe("SshSandboxTransport — fs.list (exec find)", () => {
 
   it("single-quotes the list path so shell metacharacters cannot break out", async () => {
     queueExec({ stdout: "", exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     // A metachar-laden path (schema rejects absolute/`..`, but quote defensively).
     await backend.fsList(ctx, { path: `foo; rm -rf ~` });
     // The whole path is inside one single-quoted argument.
@@ -818,7 +917,11 @@ describe("SshSandboxTransport — fs.list (exec find)", () => {
 
   it("escapes an embedded single quote in the path", async () => {
     queueExec({ stdout: "", exitCode: 0 });
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await backend.fsList(ctx, { path: `it's` });
     // classic '\'' escape idiom, matching shQuote.
     expect(lastFindCommand()).toContain(`'find' '${ROOT}/it'\\''s'`);
@@ -854,7 +957,11 @@ describe("SshSandboxTransport — plugin-injected logger", () => {
     // and the connection must still be made rather than throwing.
     queueExec({ exitCode: 0 });
 
-    const backend = createSshSandboxBackend(CONFIG, CREDENTIALS);
+    const backend = createSshSandboxBackend(
+      CONFIG,
+      CREDENTIALS,
+      withPluginLogger(),
+    );
     await expect(
       backend.shellExec(ctx, { command: "true" }),
     ).resolves.toBeDefined();
@@ -916,7 +1023,7 @@ describe("SshSandboxTransport — plugin-injected logger", () => {
       baseLogger,
     });
 
-    const backend = captured[0].create(CONFIG, CREDENTIALS);
+    const backend = captured[0].create(CONFIG, CREDENTIALS, withPluginLogger());
     await backend.shellExec(ctx, { command: "true" });
 
     expect(lines).toContainEqual({

--- a/apps/backend/src/plugins/ssh/backend.ts
+++ b/apps/backend/src/plugins/ssh/backend.ts
@@ -256,16 +256,15 @@ export class SshSandboxTransport implements SandboxTransport {
    * The logger core bound to `@platypus/ssh` and injected on the plugin's
    * deploy-time block (ADR-0013) — see the Docker transport for why an in-tree
    * plugin consumes the third-party contract rather than importing core's
-   * logger. Optional because {@link PluginConfigContext.logger} is, so the one
-   * call site below is written `this.logger?.…`; the connection is still made
-   * when it is absent, silently.
+   * logger. Required, as {@link PluginConfigContext.logger} has been since API
+   * v2.
    */
-  private logger?: PluginLogger;
+  private logger: PluginLogger;
 
   constructor(
     config: SshSandboxConfig,
     credentials: SshSandboxCredentials,
-    logger?: PluginLogger,
+    logger: PluginLogger,
   ) {
     this.config = config;
     this.credentials = credentials;
@@ -314,7 +313,7 @@ export class SshSandboxTransport implements SandboxTransport {
       // Public-key auth still prevents credential theft by an impostor host; the
       // residual risk is session/output exposure to a MITM. Pin `hostKey` on
       // internet-facing hosts.
-      this.logger?.warn(
+      this.logger.warn(
         { host, port },
         "SSH sandbox connecting WITHOUT host-key verification — session and injected env are exposed to a MITM. Set `hostKey` to pin the host.",
       );
@@ -640,8 +639,8 @@ export class SshSandboxTransport implements SandboxTransport {
 export const createSshSandboxBackend = (
   config: SshSandboxConfig,
   credentials: SshSandboxCredentials,
-  plugin?: PluginConfigContext,
+  plugin: PluginConfigContext,
 ): SandboxBackend =>
   createPosixSandbox(
-    new SshSandboxTransport(config, credentials, plugin?.logger),
+    new SshSandboxTransport(config, credentials, plugin.logger),
   );

--- a/apps/backend/src/plugins/tools-platform/index.test.ts
+++ b/apps/backend/src/plugins/tools-platform/index.test.ts
@@ -53,6 +53,7 @@ const ctx: ToolSetContext = {
   orgId: "org-1",
   frontendUrl: "http://localhost:3000",
   userId: "u-1",
+  registerCloser: () => {},
 };
 
 describe("@platypus/tools-platform plugin manifest", () => {

--- a/apps/backend/src/plugins/web-fetch/index.test.ts
+++ b/apps/backend/src/plugins/web-fetch/index.test.ts
@@ -3,6 +3,7 @@ import { PLUGIN_API_VERSION } from "@platypuschat/plugin-sdk";
 import { plugin } from "./index.ts";
 import { loadPlugins } from "../loader.ts";
 import { getToolSet, getToolSets } from "../../tools/index.ts";
+import { makePluginContext } from "../../test-utils.ts";
 
 describe("@platypus/web-fetch plugin manifest", () => {
   it("declares its identity and API version", () => {
@@ -37,8 +38,9 @@ describe("@platypus/web-fetch plugin manifest", () => {
         orgId: "o",
         frontendUrl: undefined,
         userId: "u",
+        registerCloser: () => {},
       },
-      { config: { ignoreRobotsTxt: false }, credentials: undefined },
+      makePluginContext({ config: { ignoreRobotsTxt: false } }),
     );
     expect(tools).toHaveProperty("fetchUrl");
   });
@@ -71,6 +73,7 @@ describe("@platypus/web-fetch plugin manifest", () => {
       orgId: "o",
       frontendUrl: undefined,
       userId: "u",
+      registerCloser: () => {},
     });
     expect(tools).toHaveProperty("fetchUrl");
   });

--- a/apps/backend/src/plugins/web-fetch/index.ts
+++ b/apps/backend/src/plugins/web-fetch/index.ts
@@ -36,8 +36,7 @@ export const plugin: PlatypusPlugin = {
         // tool reads `ignoreRobotsTxt` from deploy-time config, not process.env.
         tools: (_ctx, plugin) =>
           createWebFetchTools(
-            (plugin?.config as WebFetchConfig | undefined)?.ignoreRobotsTxt ??
-              false,
+            (plugin.config as WebFetchConfig).ignoreRobotsTxt,
           ),
       },
     ],

--- a/apps/backend/src/runs/tool-result-clearing-coverage.test.ts
+++ b/apps/backend/src/runs/tool-result-clearing-coverage.test.ts
@@ -87,6 +87,7 @@ const STUB_CONTEXT: ToolSetContext = {
   orgId: "org-1",
   frontendUrl: "http://localhost:3000",
   userId: "user-1",
+  registerCloser: () => {},
 };
 
 let materializedNames: string[] = [];

--- a/apps/backend/src/sandbox/types.ts
+++ b/apps/backend/src/sandbox/types.ts
@@ -1,14 +1,35 @@
 import { z } from "zod";
+import type {
+  FsEditInput as SdkFsEditInput,
+  FsEditOutput,
+  FsListInput as SdkFsListInput,
+  FsListEntry,
+  FsListOutput,
+  FsReadInput as SdkFsReadInput,
+  FsReadOutput,
+  FsWriteInput as SdkFsWriteInput,
+  FsWriteOutput,
+  SandboxBackend,
+  SandboxContext,
+  ShellExecInput as SdkShellExecInput,
+  ShellExecOutput,
+} from "@platypuschat/plugin-sdk";
 
-// Context handed to every adapter call. The (orgId, workspaceId) tuple is the
-// stable identity key for the Sandbox; adapters use it to find or provision
-// their external resource. userId is the Workspace owner and is included for
-// audit/identification, not isolation (Workspaces are single-user — see
-// CONTEXT.md).
-export type SandboxContext = {
-  orgId: string;
-  workspaceId: string;
-  userId: string;
+// The adapter contract itself is published in `@platypuschat/plugin-sdk` — a
+// Sandbox backend is an Extension point, so its shape belongs to the SDK a
+// third-party author compiles against, not to core. Core re-exports it here so
+// its own modules keep one import path, and so there is exactly one definition
+// to change. These were duplicated verbatim until the API v2 sweep; identical
+// twins with no compiler link between them is the drift this removes.
+export type {
+  FsEditOutput,
+  FsListEntry,
+  FsListOutput,
+  FsReadOutput,
+  FsWriteOutput,
+  SandboxBackend,
+  SandboxContext,
+  ShellExecOutput,
 };
 
 // All paths are workspace-root-relative. The workspace root is conventionally
@@ -30,14 +51,6 @@ export const shellExecInputSchema = z.object({
 });
 export type ShellExecInput = z.infer<typeof shellExecInputSchema>;
 
-export type ShellExecOutput = {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-  truncated: boolean;
-  durationMs: number;
-};
-
 // fs.read ---------------------------------------------------------------------
 
 export const fsReadInputSchema = z.object({
@@ -48,12 +61,6 @@ export const fsReadInputSchema = z.object({
 });
 export type FsReadInput = z.infer<typeof fsReadInputSchema>;
 
-export type FsReadOutput = {
-  content: string;
-  lineCount: number;
-  truncated: boolean;
-};
-
 // fs.write --------------------------------------------------------------------
 
 export const fsWriteInputSchema = z.object({
@@ -62,10 +69,6 @@ export const fsWriteInputSchema = z.object({
   mode: z.enum(["create", "overwrite"]),
 });
 export type FsWriteInput = z.infer<typeof fsWriteInputSchema>;
-
-export type FsWriteOutput = {
-  bytesWritten: number;
-};
 
 // fs.edit ---------------------------------------------------------------------
 
@@ -76,10 +79,6 @@ export const fsEditInputSchema = z.object({
 });
 export type FsEditInput = z.infer<typeof fsEditInputSchema>;
 
-export type FsEditOutput = {
-  replacements: 1;
-};
-
 // fs.list ---------------------------------------------------------------------
 
 export const fsListInputSchema = z.object({
@@ -89,36 +88,25 @@ export const fsListInputSchema = z.object({
 });
 export type FsListInput = z.infer<typeof fsListInputSchema>;
 
-export type FsListEntry = {
-  path: string;
-  type: "file" | "dir";
-  size?: number;
-};
-
-export type FsListOutput = {
-  entries: FsListEntry[];
-  truncated: boolean;
-};
-
-// Backend interface -----------------------------------------------------------
-
-// Implemented by every Sandbox adapter. Methods take a SandboxContext plus
-// their typed input; they MUST honour the Platypus-defined output bounds from
-// ./index.ts and set the `truncated` flag when they apply them.
-//
-// destroy() MUST be idempotent: safe to call on a resource that's already gone.
-// See ADR-0001 for the teardown contract.
-export interface SandboxBackend {
-  shellExec(
-    ctx: SandboxContext,
-    input: ShellExecInput,
-  ): Promise<ShellExecOutput>;
-  fsRead(ctx: SandboxContext, input: FsReadInput): Promise<FsReadOutput>;
-  fsWrite(ctx: SandboxContext, input: FsWriteInput): Promise<FsWriteOutput>;
-  fsEdit(ctx: SandboxContext, input: FsEditInput): Promise<FsEditOutput>;
-  fsList(ctx: SandboxContext, input: FsListInput): Promise<FsListOutput>;
-  destroy(ctx: SandboxContext): Promise<void>;
-}
+// Input types stay inferred from the schemas above, because core owns the
+// validation an adapter is handed values through — but they must stay the shape
+// the published `SandboxBackend` declares, or a core adapter and a third-party
+// one would be implementing two different interfaces. Asserted both ways, so a
+// drift in either the schema or the SDK is a type error here rather than a
+// mismatch nobody notices until an adapter is written against the wrong one.
+type MutuallyAssignable<A extends B, B extends C, C = A> = true;
+export type SandboxInputTypesMatchSdk = [
+  MutuallyAssignable<ShellExecInput, SdkShellExecInput>,
+  MutuallyAssignable<SdkShellExecInput, ShellExecInput>,
+  MutuallyAssignable<FsReadInput, SdkFsReadInput>,
+  MutuallyAssignable<SdkFsReadInput, FsReadInput>,
+  MutuallyAssignable<FsWriteInput, SdkFsWriteInput>,
+  MutuallyAssignable<SdkFsWriteInput, FsWriteInput>,
+  MutuallyAssignable<FsEditInput, SdkFsEditInput>,
+  MutuallyAssignable<SdkFsEditInput, FsEditInput>,
+  MutuallyAssignable<FsListInput, SdkFsListInput>,
+  MutuallyAssignable<SdkFsListInput, FsListInput>,
+];
 
 // Registered once per backend type. The discriminator string lives in the
 // `sandbox.backend` column. configSchema and credentialsSchema validate the

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { Mock } from "vitest";
+import { makePluginContext } from "../test-utils.ts";
 
 type NativeSearchTool = Mock<() => { _nativeSearch: true }>;
 
@@ -1394,6 +1395,7 @@ describe("chat-execution", () => {
               ...overrides,
             },
             pluginName: "@acme/searx",
+            plugin: makePluginContext(),
           }),
         );
 
@@ -1551,6 +1553,7 @@ describe("chat-execution", () => {
               },
             },
             pluginName: "@acme/searx",
+            plugin: makePluginContext(),
           }),
         );
 
@@ -1897,6 +1900,7 @@ describe("chat-execution", () => {
               .fn()
               .mockRejectedValue(new Error("tool-set factory failed")),
           },
+          plugin: makePluginContext(),
         }),
       );
 
@@ -1912,6 +1916,7 @@ describe("chat-execution", () => {
             category: "Test",
             tools: { stillHere: { description: "x" } as never },
           },
+          plugin: makePluginContext(),
         }),
       );
 
@@ -1958,6 +1963,7 @@ describe("chat-execution", () => {
           pluginName: "acme",
           isCore: false,
           contribution: { name: "Acme", category: "Test", tools },
+          plugin: makePluginContext(),
         }),
       );
       return { ...baseAgent, toolSetIds: [id] };
@@ -1982,6 +1988,7 @@ describe("chat-execution", () => {
             }),
           },
           pluginName: "@acme/searx",
+          plugin: makePluginContext(),
         }),
       );
       const provider = { ...baseProvider, searchSource: "searx-664" };

--- a/apps/backend/src/test-utils.ts
+++ b/apps/backend/src/test-utils.ts
@@ -1,5 +1,8 @@
 import { vi, type Mock } from "vitest";
-import type { PluginLogger } from "@platypuschat/plugin-sdk";
+import type {
+  PluginConfigContext,
+  PluginLogger,
+} from "@platypuschat/plugin-sdk";
 import type {
   ContributionOwners,
   LoadedPlugin,
@@ -302,4 +305,22 @@ export const makeFakePluginLogger = (): FakePluginLogger => ({
   info: vi.fn(),
   warn: vi.fn(),
   error: vi.fn(),
+});
+
+/**
+ * A plugin's deploy-time block, as core resolves it once per plugin and hands to
+ * every one of that plugin's contribution factories (ADR-0013).
+ *
+ * Required on all three factories as of API v2, so a test that composes a
+ * contribution supplies one rather than omitting it. `config` and `credentials`
+ * default to `undefined` — what a manifest declaring no schema resolves to — and
+ * the logger is a spy, so a test can assert on what the contribution wrote.
+ */
+export const makePluginContext = (
+  over: Partial<PluginConfigContext> = {},
+): PluginConfigContext => ({
+  config: undefined,
+  credentials: undefined,
+  logger: makeFakePluginLogger(),
+  ...over,
 });

--- a/apps/backend/src/tools/closers.ts
+++ b/apps/backend/src/tools/closers.ts
@@ -101,7 +101,7 @@ export type CoreCloserRegistrar = (
  * context, so what reaches a Contribution is still the published shape.
  */
 export type WithCoreRegistrar<T> = Omit<T, "registerCloser"> & {
-  registerCloser?: CoreCloserRegistrar;
+  registerCloser: CoreCloserRegistrar;
 };
 
 /**
@@ -130,18 +130,15 @@ export const attributeCloser = (
  * seam by accident — core-only fields have to be stripped by the caller *before*
  * this point, and one shared helper is one place to check that.
  *
- * A context that carries no registrar is returned as-is, so a core that never
- * supplies one hands a Contribution exactly the object it did before.
+ * There is no "context without a registrar" branch: `registerCloser` is required
+ * on both published contexts as of API v2, and core has always supplied one.
  */
 export const withAttributedRegistrar = <
-  T extends { registerCloser?: CoreCloserRegistrar },
+  T extends { registerCloser: CoreCloserRegistrar },
 >(
   ctx: T,
   attribution: Record<string, unknown>,
-): Omit<T, "registerCloser"> & { registerCloser?: CloserRegistrar } => {
-  if (!ctx.registerCloser) return ctx;
-  return {
-    ...ctx,
-    registerCloser: attributeCloser(ctx.registerCloser, attribution),
-  };
-};
+): Omit<T, "registerCloser"> & { registerCloser: CloserRegistrar } => ({
+  ...ctx,
+  registerCloser: attributeCloser(ctx.registerCloser, attribution),
+});

--- a/apps/backend/src/tools/index.test.ts
+++ b/apps/backend/src/tools/index.test.ts
@@ -42,6 +42,7 @@ import {
   RESERVED_TURN_TOOL_NAMES,
   WEB_SEARCH_TOOL_NAME,
 } from "./turn-tool-names.ts";
+import { makePluginContext } from "../test-utils.ts";
 
 // The store's own contract — miss semantics, duplicate rejection, prototype-key
 // safety, listing, reset — is covered once in
@@ -117,6 +118,7 @@ describe("Tool Set Registry", () => {
         id,
         pluginName: "test-plugin",
         isCore: false,
+        plugin: makePluginContext(),
         contribution: { name, category: "Test", tools: {} },
       });
 
@@ -148,6 +150,7 @@ describe("composeToolSet", () => {
     agentId: "agent-1",
     userId: "user-1",
     frontendUrl: undefined,
+    registerCloser: () => {},
   };
 
   // Third-party by default, which is the interesting origin: its tool names are
@@ -161,6 +164,7 @@ describe("composeToolSet", () => {
       id: isCore ? "widgets" : "acme.widgets",
       pluginName,
       isCore,
+      plugin: makePluginContext(),
       contribution: { name: "Widgets", category: "Test", tools },
     });
 
@@ -180,24 +184,20 @@ describe("composeToolSet", () => {
     );
   });
 
-  // The Tool-set half of the version-skew guarantee the Web-search side pins in
-  // `web-backends/index.test.ts`. `ctx` above carries no `registerCloser`, which
-  // is exactly what a factory compiled against a newer SDK meets on an older
-  // core — the member is optional precisely so this is a guarded call.
-  it("serves no tools when a factory calls the registrar unguarded on an older core", async () => {
+  // The Tool-set half of what API v2 settled: `registerCloser` is required and
+  // core supplies one on every turn, so the guarded call a v1 author had to write
+  // is no longer what stands between a factory and its tools. The Web-search side
+  // pins the same property in `web-backends/index.test.ts`.
+  it("hands every turn a registrar, so an unguarded call is not a fault", async () => {
     const registration = compose((ctx) => {
-      // The `!` this contract's docs tell an author never to write. On a core
-      // without the member it is a TypeError out of the factory.
-      ctx.registerCloser!(() => {});
-      return {};
+      ctx.registerCloser(() => {});
+      return { widget: { description: "w" } as unknown as Tool };
     });
 
-    await expect(registration.buildTurnTools(ctx)).resolves.toEqual({});
-    expect(logger.warn).toHaveBeenCalledTimes(1);
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ plugin: "acme", toolSet: "acme.widgets" }),
-      expect.stringContaining("Tool set factory threw"),
+    await expect(registration.buildTurnTools(ctx)).resolves.toHaveProperty(
+      "acme__widget",
     );
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("serves no tools when a factory resolves to something that is not a tool map", async () => {
@@ -282,7 +282,7 @@ describe("composeToolSet", () => {
 
   it("binds the plugin's deploy-time config into the factory", async () => {
     const tools = vi.fn().mockResolvedValue({});
-    const plugin = { config: { region: "eu" }, credentials: undefined };
+    const plugin = makePluginContext({ config: { region: "eu" } });
     await composeToolSet({
       id: "acme.widgets",
       pluginName: "acme",
@@ -291,7 +291,12 @@ describe("composeToolSet", () => {
       contribution: { name: "Widgets", category: "Test", tools },
     }).buildTurnTools(ctx);
 
-    expect(tools).toHaveBeenCalledWith(ctx, plugin);
+    // The registrar the factory meets is core's, re-bound to this Tool set's
+    // attribution, so it is matched as any function rather than by identity.
+    expect(tools).toHaveBeenCalledWith(
+      { ...ctx, registerCloser: expect.any(Function) as unknown },
+      plugin,
+    );
   });
 
   it("exposes a static map to the catalogs, and a factory's tools not at all", () => {
@@ -317,6 +322,7 @@ describe("composeToolSet tool-name namespacing", () => {
     agentId: "agent-1",
     userId: "user-1",
     frontendUrl: undefined,
+    registerCloser: () => {},
   };
 
   const stub = (description: string) => ({ description }) as unknown as Tool;
@@ -329,6 +335,7 @@ describe("composeToolSet tool-name namespacing", () => {
       id: isCore ? "widgets" : `${pluginName}.widgets`,
       pluginName,
       isCore,
+      plugin: makePluginContext(),
       contribution: { name: "Widgets", category: "Test", tools },
     });
 

--- a/apps/backend/src/tools/index.ts
+++ b/apps/backend/src/tools/index.ts
@@ -163,8 +163,15 @@ export interface ComposeToolSetOptions {
   contribution: Omit<ToolSetContribution, "id">;
   /** The id this Tool set registers under (namespaced, for a third-party plugin). */
   id: string;
-  /** The plugin's boot-resolved deploy-time config/credentials (ADR-0013). */
-  plugin?: PluginConfigContext;
+  /**
+   * The plugin's boot-resolved deploy-time config/credentials (ADR-0013).
+   * Required, as the contribution-facing argument it is forwarded to has been
+   * since API v2. A core registration that is not a plugin contribution — there
+   * is one, the `sandbox` Tool set below — builds {@link CORE_PLUGIN_CONTEXT}
+   * rather than passing nothing, so "core always supplies it" is true in the
+   * code and not only in the SDK's prose.
+   */
+  plugin: PluginConfigContext;
   /**
    * Owning plugin's manifest name, for attribution in every log line — and, for
    * a third-party plugin, the namespace its tool names enter a turn under.
@@ -410,6 +417,29 @@ export const composeToolSet = (
   };
 };
 
+/**
+ * The deploy-time block for a core registration that no plugin contributes.
+ *
+ * Every Tool set factory is handed a {@link PluginConfigContext} (required as of
+ * API v2), and the loader builds one per plugin. The `sandbox` Tool set below is
+ * the lone Tool set that does not come from a manifest, so it has no Operator-
+ * supplied config or credentials to resolve — both are `undefined`, exactly as
+ * they are for a plugin whose manifest declares no schema. The logger is bound
+ * the same way the loader binds a plugin's, so a line this factory writes is
+ * attributed like every other Tool set's.
+ */
+const CORE_PLUGIN_CONTEXT: PluginConfigContext = {
+  config: undefined,
+  credentials: undefined,
+  // A getter, so the child is derived on read rather than at module load.
+  // `logger` is a module singleton that tests replace wholesale, and calling
+  // `child()` while this module is still being imported would make importing it
+  // at all depend on the shape of whatever replaced it.
+  get logger() {
+    return logger.child({ plugin: CORE_BUILTIN_OWNER });
+  },
+};
+
 // Tool set ID constants for referencing registered tool sets by name
 export const MEMORY_TOOLSET_ID = "memory";
 
@@ -440,6 +470,7 @@ registerToolSet(
   composeToolSet({
     id: SANDBOX_TOOLSET_ID,
     pluginName: CORE_BUILTIN_OWNER,
+    plugin: CORE_PLUGIN_CONTEXT,
     isCore: true,
     contribution: {
       name: "Sandbox",

--- a/apps/backend/src/tools/tool-session.test.ts
+++ b/apps/backend/src/tools/tool-session.test.ts
@@ -44,6 +44,11 @@ import { composeToolSet, registerToolSet } from "./index.ts";
 import { CORE_BUILTIN_OWNER } from "../plugins/registry.ts";
 import { logger } from "../logger.ts";
 import type { mcp as mcpTable } from "../db/schema.ts";
+import { makePluginContext } from "../test-utils.ts";
+
+// The deploy-time block core resolves per plugin. One shared instance, so a test
+// asserting on what a factory was handed can compare identity.
+const PLUGIN = makePluginContext();
 
 type McpRow = typeof mcpTable.$inferSelect;
 
@@ -115,6 +120,7 @@ const register = (
       pluginName,
       isCore,
       contribution: { name: id, category: "Test", tools },
+      plugin: PLUGIN,
     }),
   );
 };
@@ -182,7 +188,7 @@ describe("openToolSession", () => {
         // The scope's fields, plus the one capability on the context.
         registerCloser: expect.any(Function) as unknown,
       },
-      undefined,
+      PLUGIN,
     );
   });
 
@@ -874,7 +880,7 @@ describe("openToolSession", () => {
           workspaceId: "ws-1",
           userId: "user-1",
         }),
-        undefined,
+        PLUGIN,
       );
     });
 

--- a/apps/backend/src/web-backends/index.test.ts
+++ b/apps/backend/src/web-backends/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Tool } from "ai";
 import { WEB_BACKEND_TOOL_MARKER } from "@platypus/schemas";
-import { callTool } from "../test-utils.ts";
+import { callTool, makePluginContext } from "../test-utils.ts";
 import { EGRESS_BLOCKED_MESSAGE } from "../utils/egress-guard.ts";
 import { logger } from "../logger.ts";
 import { runCloser, type CoreCloserRegistrar } from "../tools/closers.ts";
@@ -48,14 +48,25 @@ const CTX = {
   workspaceId: "ws-1",
   userId: "user-1",
   providerId: "provider-1",
+  registerCloser: () => {},
 };
 
-// The plugin-facing subset, fixed by ADR-0014 at `{ orgId, workspaceId, userId }`.
+// The plugin-facing subset, fixed by ADR-0014 at `{ orgId, workspaceId, userId }`
+// plus the one capability the context carries. `registerCloser` is required as of
+// API v2, so it is part of the exact shape a backend is handed — matched as any
+// function, because what crosses the seam is core's registrar re-bound to this
+// backend's attribution rather than the one core holds.
 const PLUGIN_CTX = {
   orgId: CTX.orgId,
   workspaceId: CTX.workspaceId,
   userId: CTX.userId,
+  registerCloser: expect.any(Function) as unknown,
 };
+
+// The deploy-time block core resolves per plugin and forwards to
+// `createExecutors`. One shared instance, so a test that asserts on the forward
+// can compare identity.
+const PLUGIN = makePluginContext();
 
 // A public address for the injected resolver, so the real egress guard stays in
 // the path (these tests assert core's guarding, not DNS).
@@ -79,6 +90,7 @@ const buildTools = (
     contribution: contribution(executors, overrides),
     pluginName: "@acme/searx",
     resolveHostname: resolvePublic,
+    plugin: PLUGIN,
   }).buildTurnTools(CTX);
 
 const search = (tool: Tool, query: string) =>
@@ -107,6 +119,7 @@ describe("web-backend registry", () => {
         { backend },
       ),
       pluginName: "@acme/searx",
+      plugin: PLUGIN,
     });
 
   // The store's own contract — miss semantics, duplicate rejection,
@@ -173,7 +186,10 @@ describe("composeWebBackend — tool construction", () => {
     const createExecutors = vi.fn(() => ({
       web_search: () => ({ query: "q", results: [] }),
     }));
-    const plugin = { config: { region: "eu" }, credentials: { apiKey: "k" } };
+    const plugin = makePluginContext({
+      config: { region: "eu" },
+      credentials: { apiKey: "k" },
+    });
 
     await composeWebBackend({
       contribution: contribution({}, { createExecutors }),
@@ -220,6 +236,7 @@ describe("composeWebBackend — tool construction", () => {
         },
       ),
       pluginName: "@acme/searx",
+      plugin: PLUGIN,
     }).buildTurnTools(CTX);
 
     expect(tools).toEqual({});
@@ -248,6 +265,7 @@ describe("composeWebBackend — tool construction", () => {
         },
       ),
       pluginName: "@acme/searx",
+      plugin: PLUGIN,
     }).buildTurnTools(CTX);
 
     expect(tools).toEqual({});
@@ -980,6 +998,7 @@ describe("composeWebBackend — the contribution is not copied", () => {
       // The loader's namespaced id rides alongside, not over, the contribution.
       backend: "acme.searx",
       pluginName: "@acme/searx",
+      plugin: PLUGIN,
     });
 
     expect(registration.backend).toBe("acme.searx");
@@ -1122,6 +1141,7 @@ describe("the signal an executor is handed", () => {
       }),
       pluginName: "@acme/searx",
       resolveHostname,
+      plugin: PLUGIN,
     }).buildTurnTools(CTX);
 
     const result = (await callTool(
@@ -1186,15 +1206,13 @@ describe("the closer a backend registers", () => {
     await composeWebBackend({
       contribution: contribution({}, { createExecutors }),
       pluginName: "@acme/searx",
+      plugin: PLUGIN,
     }).buildTurnTools(ctxWith(() => {}));
 
     // An exact match, not `objectContaining`: deriving this context is a spread
     // of core's own, so it is the one path a core-only field can ride across the
     // seam on. A leaked `providerId` fails here.
-    expect(createExecutors).toHaveBeenCalledWith(
-      { ...PLUGIN_CTX, registerCloser: expect.any(Function) as unknown },
-      undefined,
-    );
+    expect(createExecutors).toHaveBeenCalledWith(PLUGIN_CTX, PLUGIN);
   });
 
   it("attributes what it registers to the plugin and the backend", async () => {
@@ -1213,6 +1231,7 @@ describe("the closer a backend registers", () => {
       ),
       backend: "acme.searx",
       pluginName: "@acme/searx",
+      plugin: PLUGIN,
     }).buildTurnTools(ctxWith(register));
 
     // The closer itself passes through unwrapped, so a session still dedupes on
@@ -1238,6 +1257,7 @@ describe("the closer a backend registers", () => {
         },
       ),
       pluginName: "@acme/searx",
+      plugin: PLUGIN,
     }).buildTurnTools(
       ctxWith((close, attribution) => {
         registered.push(() => runCloser(close, attribution));
@@ -1254,28 +1274,26 @@ describe("the closer a backend registers", () => {
     );
   });
 
-  it("degrades to no search tools when a backend calls the registrar unguarded on an older core", async () => {
+  it("hands every turn a registrar, so an unguarded call is not a fault", async () => {
     const tools = await composeWebBackend({
       contribution: contribution(
         {},
         {
           createExecutors: (ctx) => {
-            // The `!` this contract's docs tell an author not to write. On a core
-            // without the member it is a TypeError out of the factory.
-            ctx.registerCloser!(() => {});
+            // Unguarded, which is what the v2 contract tells an author to write:
+            // `registerCloser` is required and core always supplies one, so there
+            // is no core left for this call to be a TypeError on.
+            ctx.registerCloser(() => {});
             return { web_search: () => ({ query: "q", results: [] }) };
           },
         },
       ),
       pluginName: "@acme/searx",
+      plugin: PLUGIN,
     }).buildTurnTools(CTX);
 
-    expect(tools).toEqual({});
-    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ plugin: "@acme/searx", backend: "searx" }),
-      expect.stringContaining("createExecutors threw"),
-    );
+    expect(Object.keys(tools)).toContain("web_search");
+    expect(mockLogger.warn).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/backend/src/web-backends/index.ts
+++ b/apps/backend/src/web-backends/index.ts
@@ -286,8 +286,13 @@ export interface ComposeWebBackendOptions {
    * contribution's own bare id is already the effective one.
    */
   backend?: string;
-  /** The plugin's boot-resolved deploy-time config/credentials (ADR-0013). */
-  plugin?: PluginConfigContext;
+  /**
+   * The plugin's boot-resolved deploy-time config/credentials (ADR-0013).
+   * Required, as the contribution-facing argument it is forwarded to has been
+   * since API v2 — every web backend reaches core through the loader, which
+   * always resolves one.
+   */
+  plugin: PluginConfigContext;
   /** Owning plugin's manifest name, for attribution in every log line. */
   pluginName: string;
   /**

--- a/apps/docs/content/extending/plugin-api-and-config.mdx
+++ b/apps/docs/content/extending/plugin-api-and-config.mdx
@@ -110,18 +110,35 @@ The practical consequence for you: a two-argument `create` keeps working after
 core started passing a third argument, and a single-argument factory keeps working
 after core started passing a second. Consume the new argument when you want it.
 
-The same rule cuts the other way on the contexts core hands you. A capability
-that arrived after your Plugin was written is an **optional** field, so call it
-guarded:
+## Moving to API v2
 
-- `ctx.registerCloser?.(close)` — register something to close when the turn ends,
+v2 is the first major bump, and it does one thing: everything core has always
+supplied on every turn is now **required** rather than optional. Set your
+`apiVersion` to 2 and you can write these without a guard:
+
+- `ctx.registerCloser(close)` — register something to close when the turn ends,
   on a [Tool set](/extending/tool-sets#releasing-what-a-factory-opened) or a
   [Web-search backend](/extending/web-search-backends#releasing-what-you-opened).
-- `plugin?.logger?.info(...)` — the [logger](#logging) core binds to your name.
+- `plugin.logger.info(...)` — the [logger](#logging) core binds to your name.
+- `plugin` itself, on all three contribution factories.
 
-Writing `ctx.registerCloser!(close)` to silence the compiler is the trap: on a
-core that predates the field it is a `TypeError` thrown out of your factory, and
-your Contribution serves nothing that turn.
+One member changed shape rather than optionality. A Sandbox backend's
+`configSchema` **factory** now receives the whole deploy-time block, where before
+it received the `config` half on its own. Read `plugin.config` where the argument
+used to be the config itself — and you can now reach `plugin.credentials` and
+`plugin.logger` from there too.
+
+<Callout type="warning">
+  Upgrading the SDK without raising `apiVersion` to 2 is the trap. Nothing stops
+  you dropping the guards while your manifest still says 1, and it will run
+  correctly on a current core — then a self-hoster on the previous release
+  installs it, core loads it because 1 is inside the window, and your first
+  unguarded call throws inside somebody's Chat turn. Raising the number is what
+  makes that core refuse the Plugin at boot instead.
+</Callout>
+
+Staying on `apiVersion: 1` is also fine: core supports 1 and 2 together, so an
+unmigrated Plugin keeps loading. Keep the guards while you do.
 
 ## Deploy-time config and credentials
 
@@ -140,7 +157,8 @@ injects the resolved block into **every one** of your contributions:
 - a **Web-search backend** `createExecutors` receives it as a second argument,
   alongside the request context.
 
-All three are optional to consume.
+You can ignore the argument in all three. What you cannot do from `apiVersion: 2`
+on is receive nothing: core always passes it.
 
 **One block is shared** across all of a plugin's contributions and all tenants.
 That is deliberate, and it is the mechanism that lets a plugin's Sandbox backend
@@ -168,7 +186,7 @@ message, or a message on its own:
 
 ```ts
 tools: (ctx, plugin) => {
-  plugin?.logger?.info({ workspaceId: ctx.workspaceId }, "Resolving tool set");
+  plugin.logger.info({ workspaceId: ctx.workspaceId }, "Resolving tool set");
   return {
     /* … */
   };
@@ -198,9 +216,10 @@ Three things core does for you, and one thing to get right yourself:
   lands in the Operator's pipeline as an unparseable line between two JSON ones.
 </Callout>
 
-Write `plugin?.logger?.` — both are optional members, which is what lets one
-build of your plugin run on a core new enough to supply the logger and one that
-predates it. Core always supplies it.
+On `apiVersion: 2` both the block and its logger are required, so write
+`plugin.logger.` — no chaining, no fallback. On `apiVersion: 1` keep
+`plugin?.logger?.`, which is what lets one build run on a core that predates the
+member.
 
 Deploy-time scope is all a logger line carries. Workspace, Agent and run ids are
 not bound for you; include the ones you have from your own context, as the

--- a/apps/docs/content/extending/sandbox-backends.mdx
+++ b/apps/docs/content/extending/sandbox-backends.mdx
@@ -80,8 +80,10 @@ Add an entry to `contributes.sandboxBackends`. A
 - **`name`** — the label an Org Admin picks from.
 - **`configSchema`** — a Zod schema for the non-secret per-Workspace settings
   (region, image, host). It may also be a **factory** taking the plugin's
-  deploy-time config, when the allowed shape depends on what the Operator
-  configured.
+  deploy-time block, when the allowed shape depends on what the Operator
+  configured. Read the allowed shape off `plugin.config`; `plugin.credentials`
+  and `plugin.logger` are there too, so the factory can say why it refused a
+  value.
 - **`credentialsSchema`** — a Zod schema for the secret per-Workspace material
   (API tokens, private keys).
 - **`create`** — returns your adapter, given the validated per-Workspace config

--- a/apps/docs/content/extending/tool-sets.mdx
+++ b/apps/docs/content/extending/tool-sets.mdx
@@ -123,7 +123,7 @@ connection, a pool, a watcher — register a way to close it:
   category: "Productivity",
   tools: (ctx) => {
     const client = connect(ctx.workspaceId);
-    ctx.registerCloser?.(() => client.close());
+    ctx.registerCloser(() => client.close());
     return createKanbanTools(client);
   },
 }
@@ -143,13 +143,12 @@ way to building their tools. Teardown gets a ceiling because core knows what it
 is delaying; your factory's ceiling is a number only you know.
 
 <Callout type="warning">
-  **Write `ctx.registerCloser?.(...)`, not `ctx.registerCloser!(...)`.** Your
-  manifest's `apiVersion` names a *major*, so it cannot ask for a core new
-  enough to have this — on an older one the field is genuinely absent, and the
-  unguarded call throws out of your factory. The turn then serves **none of this
-  set's tools**, with a warning in the Operator's log as the only sign. The
-  guard is the difference between "no teardown on old core" and "no tools on old
-  core".
+  The call above is unguarded, and that is only safe on **`apiVersion: 2`**.
+  Writing it on a manifest that still says 1 is the trap: a self-hoster on an
+  older core loads your Plugin, the field is genuinely absent there, and the call
+  throws out of your factory. The turn then serves **none of this set's tools**,
+  with a warning in the Operator's log as the only sign. Either raise the number
+  or keep `ctx.registerCloser?.(...)`.
 </Callout>
 
 <Callout type="info">

--- a/apps/docs/content/extending/web-search-backends.mdx
+++ b/apps/docs/content/extending/web-search-backends.mdx
@@ -147,8 +147,8 @@ browser page, a pool, a keep-alive connection — register a way to close it:
 
 ```ts
 createExecutors(ctx, plugin) {
-  const pool = createPool(plugin?.config.endpoint);
-  ctx.registerCloser?.(() => pool.close());
+  const pool = createPool(plugin.config.endpoint);
+  ctx.registerCloser(() => pool.close());
   return { web_search: (input, { signal }) => pool.search(input.query, signal) };
 }
 ```
@@ -159,13 +159,12 @@ rest still run; one that never settles is abandoned after **5 seconds**, because
 teardown happens while the reader is still waiting on the reply.
 
 <Callout type="warning">
-  **Write `ctx.registerCloser?.(...)`, not `ctx.registerCloser!(...)`.** Your
-  manifest's `apiVersion` names a *major*, so it cannot ask for a core new
-  enough to have this — on an older one the field is genuinely absent, and the
-  unguarded call throws out of your factory. The turn then serves **no search
-  tools at all**, with a warning in the Operator's log as the only sign. The
-  guard is the difference between "no teardown on old core" and "no search on
-  old core".
+  The call above is unguarded, and that is only safe on **`apiVersion: 2`**.
+  Writing it on a manifest that still says 1 is the trap: a self-hoster on an
+  older core loads your Plugin, the field is genuinely absent there, and the call
+  throws out of `createExecutors`. The turn then serves **no search tools at
+  all**, with a warning in the Operator's log as the only sign. Either raise the
+  number or keep `ctx.registerCloser?.(...)`.
 </Callout>
 
 <Callout type="info">
@@ -268,7 +267,7 @@ inside the factory:
 ```ts
 createExecutors(ctx, plugin) {
   const endpoint =
-    plugin?.config.endpoints[ctx.orgId] ?? plugin?.config.endpoints.default;
+    plugin.config.endpoints[ctx.orgId] ?? plugin.config.endpoints.default;
   // ...
 }
 ```

--- a/apps/docs/content/extending/your-first-plugin.mdx
+++ b/apps/docs/content/extending/your-first-plugin.mdx
@@ -30,7 +30,7 @@ export const plugin: PlatypusPlugin = {
         category: "Examples",
         tools: (ctx, plugin) => {
           // Core's logger, already tagged with `example`
-          plugin?.logger?.debug({ workspaceId: ctx.workspaceId }, "Resolving");
+          plugin.logger.debug({ workspaceId: ctx.workspaceId }, "Resolving");
           return {
             // bare — core namespaces it to `example__greet`
             greet: tool({

--- a/packages/example-plugin/index.test.ts
+++ b/packages/example-plugin/index.test.ts
@@ -12,11 +12,24 @@ const CTX: ToolSetContext = {
   orgId: "org-1",
   frontendUrl: undefined,
   userId: "user-1",
+  registerCloser: () => {},
 };
 
+const pluginContext = (
+  over: Partial<PluginConfigContext> = {},
+): PluginConfigContext => ({
+  config: undefined,
+  credentials: undefined,
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  ...over,
+});
+
 // Resolve the tool set the way core does at Chat-turn time: the factory, the
-// runtime scope, and the plugin's deploy-time block (optional to consume).
-const resolveTools = async (pluginCtx?: PluginConfigContext) => {
+// runtime scope, and the plugin's deploy-time block. Both arguments are
+// required as of API v2, and core supplies both on every turn.
+const resolveTools = async (
+  pluginCtx: PluginConfigContext = pluginContext(),
+) => {
   const toolSet = plugin.contributes.toolSets?.[0];
   if (!toolSet || typeof toolSet.tools !== "function") {
     throw new Error("expected a tool-set factory");
@@ -59,7 +72,7 @@ describe("@platypus-examples/tool-set", () => {
       error: vi.fn(),
     };
 
-    await resolveTools({ config: undefined, credentials: undefined, logger });
+    await resolveTools(pluginContext({ logger }));
 
     // Structured fields, not an interpolated string: they stay queryable in the
     // Operator's log pipeline. The plugin's name is NOT among them — core binds
@@ -71,12 +84,12 @@ describe("@platypus-examples/tool-set", () => {
     expect(logger.info).not.toHaveBeenCalled();
   });
 
-  it("resolves on a core that supplies no logger (both are optional)", async () => {
-    // The append-only contract in practice: `logger` arrived after this SDK's
-    // first release, so the plugin must still resolve where it is absent.
-    await expect(
-      resolveTools({ config: undefined, credentials: undefined }),
-    ).resolves.toHaveProperty("greet");
+  it("declares the API major whose contract it reads unguarded", async () => {
+    // The plugin reads `plugin.logger` and would read `ctx.registerCloser`
+    // without a guard. Both are required from v2 on, so the manifest has to ask
+    // for a core that supplies them — a v1 core refuses this plugin at boot
+    // rather than letting it fail inside somebody's Chat turn.
+    expect(plugin.apiVersion).toBeGreaterThanOrEqual(2);
     await expect(resolveTools()).resolves.toHaveProperty("greet");
   });
 });

--- a/packages/example-plugin/index.ts
+++ b/packages/example-plugin/index.ts
@@ -28,10 +28,10 @@ export const plugin: PlatypusPlugin = {
           "A tiny example tool set contributed by a third-party plugin",
         // A factory rather than a static map, because only a factory is handed
         // the deploy-time block — and with it the logger core has already bound
-        // to this manifest's name. Optional-chained the whole way so the same
-        // code runs on a core that predates the field.
+        // to this manifest's name. Both are required as of API v2, so neither
+        // reads through a `?.`.
         tools: (ctx, plugin) => {
-          plugin?.logger?.debug(
+          plugin.logger.debug(
             { workspaceId: ctx.workspaceId, agentId: ctx.agentId },
             "Resolving the greeting tool set for a turn",
           );

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -78,6 +78,19 @@ after a core upgrade; a genuinely breaking change is a windowed major bump. Boot
 is fail-loud: a plugin outside the supported window is rejected with a
 plugin-named error.
 
+**v2 is the current major**, and a v1 plugin still loads on it. v2 made required
+everything core had always supplied on every turn — `ctx.registerCloser`,
+`plugin.logger`, and the `plugin` argument on all three contribution factories —
+so none of them needs a `?.` any more. It also re-signed one member: a Sandbox
+backend's `configSchema` **factory** now receives the whole deploy-time block
+rather than the `config` half alone, so read `plugin.config` where the argument
+used to be the config itself.
+
+Raising `apiVersion` to 2 is what makes those unguarded reads safe. Dropping the
+guards while the manifest still says 1 is the trap — a core on the previous
+release will load the plugin, because 1 is inside its window, and the first
+unguarded read throws mid-turn.
+
 ## What you can contribute
 
 - **Tool sets** (`contributes.toolSets`) — named, categorised groups of
@@ -102,15 +115,15 @@ the Operator set with `LOG_LEVEL`:
 tools: (ctx, plugin) => {
   // `debug` / `info` / `warn` / `error`, each taking a fields object with an
   // optional message, or a message on its own.
-  plugin?.logger?.info({ workspaceId: ctx.workspaceId }, "Resolving tool set");
+  plugin.logger.info({ workspaceId: ctx.workspaceId }, "Resolving tool set");
   return {/* … */};
 };
 ```
 
 Prefer the object form — those fields stay queryable where an interpolated string
-does not. Don't put your plugin's name in them; core binds it for you. And keep
-the optional chaining: `logger` is an appended optional member, so
-`plugin?.logger?.` is what lets the same code run on a core that predates it.
+does not. Don't put your plugin's name in them; core binds it for you. The block
+and its `logger` are both required from `apiVersion: 2` on, so neither needs a
+`?.`; on `apiVersion: 1` write `plugin?.logger?.` instead.
 
 ## Closing what a factory opened
 
@@ -121,7 +134,7 @@ socket — hand core its close:
 ```ts
 tools: (ctx) => {
   const client = connect(ctx.workspaceId);
-  ctx.registerCloser?.(() => client.close());
+  ctx.registerCloser(() => client.close());
   return createTools(client);
 };
 ```
@@ -133,10 +146,11 @@ to keep between turns. A closer that throws is logged against your plugin and th
 rest still run; one that never settles is abandoned after 5 seconds, because
 teardown happens while the reader is still waiting on the reply.
 
-Keep the optional chaining here too, for the same reason as the logger — and with
-a sharper consequence. `registerCloser!(…)` on a core that predates the member is
-a `TypeError` thrown out of your factory, and your contribution then serves
-**nothing** that turn.
+The unguarded call above needs `apiVersion: 2`. Writing it while your manifest
+still says 1 is the trap: an older core loads the plugin, the member is genuinely
+absent there, and the call is a `TypeError` thrown out of your factory — your
+contribution then serves **nothing** that turn. Either raise the number or write
+`ctx.registerCloser?.(…)`.
 
 ## Web-search backends
 
@@ -176,13 +190,13 @@ export const plugin: PlatypusPlugin = {
         // web tools that turn (warn-logged, never fatal).
         timeoutMs: 5_000,
         createExecutors: (ctx, plugin) => {
-          const pool = createPool(plugin?.config.endpoint);
+          const pool = createPool(plugin.config.endpoint);
           // Anything with a lifetime gets a close core will run when the turn
           // ends — on a normal finish and on a cancellation alike. Guarded,
           // never `!`: the member is optional so this plugin still loads on a
           // core that predates it, and an unguarded call would cost the turn
           // its search tools entirely.
-          ctx.registerCloser?.(() => pool.close());
+          ctx.registerCloser(() => pool.close());
           return {
             // Mandatory. Return results; never truncate or paginate — core does.
             // `signal` fires when the User cancels or `timeoutMs` runs out;

--- a/packages/plugin-sdk/index.test.ts
+++ b/packages/plugin-sdk/index.test.ts
@@ -12,9 +12,19 @@ import {
   type WebBackendContribution,
 } from "./index.ts";
 
+// A `PluginLogger` that records nothing, for the blocks below that are not
+// asserting on log output. Required on the block as of API v2, so every context
+// a test builds carries one.
+const silentLogger = (): PluginLogger => ({
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+});
+
 describe("@platypuschat/plugin-sdk", () => {
   it("pins the plugin API version", () => {
-    expect(PLUGIN_API_VERSION).toBe(1);
+    expect(PLUGIN_API_VERSION).toBe(2);
   });
 
   it("supports one previous major (N and N−1), floored at 1 (no phantom v0)", () => {
@@ -23,6 +33,14 @@ describe("@platypuschat/plugin-sdk", () => {
     );
     // There is no major 0, so the oldest supported major is never below 1.
     expect(OLDEST_SUPPORTED_API_VERSION).toBeGreaterThanOrEqual(1);
+  });
+
+  it("opens a genuine N−1 slot at v2, so a v1 plugin still loads", () => {
+    // The floor stopped deciding the window at v2: a plugin built against v1 is
+    // inside `[1, 2]` and keeps loading on this core. That is the whole of what
+    // the major bump promises an author who has not migrated yet.
+    expect(OLDEST_SUPPORTED_API_VERSION).toBe(1);
+    expect(PLUGIN_API_VERSION).toBeGreaterThan(OLDEST_SUPPORTED_API_VERSION);
   });
 
   it("accepts a well-formed manifest with a static-map tool set", () => {
@@ -78,22 +96,24 @@ describe("@platypuschat/plugin-sdk", () => {
     expect(plugin.configSchema).toBeDefined();
   });
 
-  it("injects a shared PluginConfigContext into factories (optional to consume)", () => {
+  it("injects a shared PluginConfigContext into every factory", () => {
     const shared: PluginConfigContext<
       { region: string },
       { apiToken: string }
     > = {
       config: { region: "eu" },
       credentials: { apiToken: "tok" },
+      logger: silentLogger(),
     };
 
-    // A tool-set factory may accept the appended `plugin` argument…
+    // A tool-set factory may ignore the `plugin` argument, or read it — and read
+    // it unguarded, since core always supplies it.
     const toolSet: ToolSetContribution = {
       id: "scoped",
       name: "Scoped",
       category: "Productivity",
       tools: (_ctx, plugin) => {
-        expect(plugin?.credentials).toEqual({ apiToken: "tok" });
+        expect(plugin.credentials).toEqual({ apiToken: "tok" });
         return {};
       },
     };
@@ -146,11 +166,11 @@ describe("@platypuschat/plugin-sdk", () => {
       id: "scoped",
       name: "Scoped",
       category: "Productivity",
-      // The shape an author writes: optional chaining all the way, because the
-      // field is appended and a plugin may run on a core that predates it.
+      // The shape an author writes from API v2 on: no chaining, because both
+      // the block and its logger are required and core always supplies them.
       tools: (ctx, plugin) => {
-        plugin?.logger?.info({ workspaceId: ctx.workspaceId }, "Resolving");
-        plugin?.logger?.warn("Bare message, no fields");
+        plugin.logger.info({ workspaceId: ctx.workspaceId }, "Resolving");
+        plugin.logger.warn("Bare message, no fields");
         return {};
       },
     };
@@ -171,21 +191,54 @@ describe("@platypuschat/plugin-sdk", () => {
     ]);
   });
 
-  it("leaves a logger-less block usable (the field is optional)", () => {
-    // A plugin compiled against this SDK must still work where `logger` is
-    // absent — that is the whole point of appending it as optional.
-    const shared: PluginConfigContext = { config: {}, credentials: {} };
+  it("hands a Sandbox backend's create the same block, logger included", () => {
+    // `logger` is required from API v2 on, so `create` reads it the same way a
+    // Tool-set factory does — no chaining, no fallback.
+    const written: string[] = [];
+    const shared: PluginConfigContext = {
+      config: {},
+      credentials: {},
+      logger: { ...silentLogger(), debug: (m) => written.push(String(m)) },
+    };
     const backend: SandboxBackendContribution = {
       backend: "cloud",
       name: "Cloud",
       configSchema: z.object({}),
       credentialsSchema: z.object({}),
       create: (_config, _credentials, plugin) => {
-        plugin?.logger?.debug("never written");
+        plugin.logger.debug("instantiating");
         return {} as never;
       },
     };
-    expect(() => backend.create({}, {}, shared)).not.toThrow();
+    backend.create({}, {}, shared);
+    expect(written).toEqual(["instantiating"]);
+  });
+
+  it("resolves a configSchema factory against the whole block, not just config", () => {
+    // Re-signed in API v2: the factory sees the same `PluginConfigContext` that
+    // `create` does, so a per-Workspace schema can read the plugin's credentials
+    // and write to the plugin's logger rather than narrowing a bare `unknown`.
+    const seen: PluginConfigContext[] = [];
+    const backend: SandboxBackendContribution = {
+      backend: "fenced",
+      name: "Fenced",
+      configSchema: (plugin) => {
+        seen.push(plugin);
+        return z.object({ net: z.string() });
+      },
+      credentialsSchema: z.object({}),
+      create: () => ({}) as never,
+    };
+    const shared: PluginConfigContext = {
+      config: { allowed: ["shared"] },
+      credentials: { token: "t" },
+      logger: silentLogger(),
+    };
+    if (typeof backend.configSchema !== "function") {
+      throw new Error("expected a factory");
+    }
+    backend.configSchema(shared);
+    expect(seen).toEqual([shared]);
   });
 
   it("satisfies PluginLogger with a pino-shaped logger (no adapter)", () => {
@@ -246,8 +299,13 @@ describe("@platypuschat/plugin-sdk", () => {
     // The executors are plain functions, not AI SDK Tools: core owns the schemas,
     // the caps, the slicing, the timeout, and the egress guard (ADR-0014).
     const executors = await contribution.createExecutors(
-      { orgId: "o", workspaceId: "w", userId: "u" },
-      { config: {}, credentials: { apiKey: "k" } },
+      {
+        orgId: "o",
+        workspaceId: "w",
+        userId: "u",
+        registerCloser: () => {},
+      },
+      { config: {}, credentials: { apiKey: "k" }, logger: silentLogger() },
     );
     // Core supplies the call's signal as an appended second argument. Reading it
     // is the executor's choice; passing it is not core's.
@@ -272,8 +330,13 @@ describe("@platypuschat/plugin-sdk", () => {
     };
 
     const executors = await contribution.createExecutors(
-      { orgId: "o", workspaceId: "w", userId: "u" },
-      undefined,
+      {
+        orgId: "o",
+        workspaceId: "w",
+        userId: "u",
+        registerCloser: () => {},
+      },
+      { config: undefined, credentials: undefined, logger: silentLogger() },
     );
     const cancelled = new AbortController();
     cancelled.abort();
@@ -288,9 +351,9 @@ describe("@platypuschat/plugin-sdk", () => {
       backend: "searx",
       name: "SearXNG",
       createExecutors: (ctx) => {
-        // Guarded, never `!`: the member is optional so that a plugin built
-        // against this SDK still loads on a core that predates it.
-        ctx.registerCloser?.(() => {
+        // Unguarded: `registerCloser` is required from API v2 on, and a manifest
+        // declaring v2 cannot be loaded by a core that lacks it.
+        ctx.registerCloser(() => {
           closed.push("pool");
         });
         return { web_search: () => ({ query: "q", results: [] }) };
@@ -305,7 +368,7 @@ describe("@platypuschat/plugin-sdk", () => {
         userId: "u",
         registerCloser: (close) => registered.push(close),
       },
-      undefined,
+      { config: undefined, credentials: undefined, logger: silentLogger() },
     );
 
     expect(registered).toHaveLength(1);
@@ -320,20 +383,23 @@ describe("@platypuschat/plugin-sdk", () => {
       name: "Kanban",
       category: "Productivity",
       tools: (ctx) => {
-        ctx.registerCloser?.(() => {});
+        ctx.registerCloser(() => {});
         return {};
       },
     };
 
     if (typeof contribution.tools === "function") {
-      contribution.tools({
-        orgId: "o",
-        workspaceId: "w",
-        agentId: "a",
-        userId: "u",
-        frontendUrl: undefined,
-        registerCloser: (close) => registered.push(close),
-      });
+      contribution.tools(
+        {
+          orgId: "o",
+          workspaceId: "w",
+          agentId: "a",
+          userId: "u",
+          frontendUrl: undefined,
+          registerCloser: (close) => registered.push(close),
+        },
+        { config: undefined, credentials: undefined, logger: silentLogger() },
+      );
     }
     expect(registered).toHaveLength(1);
   });

--- a/packages/plugin-sdk/index.ts
+++ b/packages/plugin-sdk/index.ts
@@ -33,8 +33,29 @@ import type { z } from "zod";
  * A genuinely **breaking** change — removing or re-signing a required member — is
  * a **windowed major bump**: the major increments, and during the window core
  * runs both N and N−1 so authors have a release to migrate.
+ *
+ * ## What v2 changed
+ *
+ * v2 is the first such bump, and it spends the window on one thing: every member
+ * core has always supplied unconditionally is now **required** rather than
+ * optional. `ToolSetContext.registerCloser`, `WebBackendContext.registerCloser`,
+ * `PluginConfigContext.logger` and the trailing `plugin` argument on all three
+ * contribution factories were optional only because a v1 manifest could not ask
+ * for a core new enough to have them. A v2 manifest can: a v1 core rejects
+ * `apiVersion: 2` at boot and names the upgrade, so the guard those members
+ * needed — `ctx.registerCloser?.(…)`, `plugin?.logger?.…` — is no longer
+ * load-bearing.
+ *
+ * {@link SandboxConfigSchema}'s factory form is re-signed in the same window: it
+ * receives the whole {@link PluginConfigContext} rather than the `config` half
+ * alone, so a per-Workspace schema can read the plugin's credentials and write to
+ * the plugin's logger like every other factory.
+ *
+ * Migrating a v1 plugin: set `apiVersion` to 2, drop the `?.` guards, and — if
+ * you use the `configSchema` factory form — read `plugin.config` where the
+ * argument itself used to be the config.
  */
-export const PLUGIN_API_VERSION = 1 as const;
+export const PLUGIN_API_VERSION = 2 as const;
 
 /**
  * The oldest plugin API major core still accepts — one below the current major
@@ -42,8 +63,9 @@ export const PLUGIN_API_VERSION = 1 as const;
  * targets a dropped major and is rejected at boot. See {@link PLUGIN_API_VERSION}.
  *
  * Floored at `1`: there is no major `0`, so at the first major (N = 1) the window
- * collapses to `[1, 1]` rather than admitting a phantom `v0`. Once core reaches
- * major 2 this becomes `1`, opening the genuine N−1 slot.
+ * collapsed to `[1, 1]` rather than admitting a phantom `v0`. At v2 the floor is
+ * no longer what decides it — the window is a genuine `[1, 2]`, and every v1
+ * plugin in the field keeps loading on a v2 core.
  */
 export const OLDEST_SUPPORTED_API_VERSION = Math.max(1, PLUGIN_API_VERSION - 1);
 
@@ -84,14 +106,15 @@ export interface ToolSetContext {
    * Register something to close when this turn ends — see
    * {@link CloserRegistrar}.
    *
-   * **Optional on purpose, and it must stay optional.** A manifest declares a
-   * *major* `apiVersion` only, so a plugin cannot ask for a core new enough to
-   * have this member; on an older core it is genuinely absent. Call it guarded —
-   * `ctx.registerCloser?.(close)` — and never with `!`: an unguarded call on
-   * older core throws out of your factory, which costs the turn every tool in
-   * this set. Core always supplies it.
+   * **Required as of API v2** (see {@link PLUGIN_API_VERSION}), and core has
+   * always supplied it. Call it directly — `ctx.registerCloser(close)`. It was
+   * optional through v1 for one reason: a v1 manifest could not ask for a core
+   * new enough to have the member, so on an older core it was genuinely absent
+   * and an unguarded call threw out of the factory, costing the turn every tool
+   * in this set. A v2 manifest cannot reach such a core — it is refused at boot —
+   * so the guard has nothing left to protect against.
    */
-  registerCloser?: CloserRegistrar;
+  registerCloser: CloserRegistrar;
 }
 
 /**
@@ -146,11 +169,11 @@ export interface PluginConfigContext<
    * line the plugin writes lands in core's stream already attributed and at the
    * verbosity the Operator asked for. Reach for it instead of `console.*`.
    *
-   * Optional, and appended (append-only compatibility, ADR-0013) — write
-   * `plugin?.logger?.info(...)`. Core always supplies it; the optionality is
-   * what keeps a plugin built against an earlier SDK compiling unchanged.
+   * **Required as of API v2** (see {@link PLUGIN_API_VERSION}), and core has
+   * always supplied it — write `plugin.logger.info(...)` rather than the doubly
+   * guarded `plugin?.logger?.info(...)` a v1 plugin had to.
    */
-  logger?: PluginLogger;
+  logger: PluginLogger;
 }
 
 /**
@@ -160,9 +183,11 @@ export interface PluginConfigContext<
  *
  * The factory's second argument is the deploy-time {@link PluginConfigContext}
  * — the plugin's shared config/credentials block, the same object handed to
- * every one of the plugin's contribution factories. It is appended and optional
- * so existing single-argument factories keep working unchanged (append-only
- * compatibility, ADR-0013). Core always supplies it at Chat-turn time.
+ * every one of the plugin's contribution factories. **Required as of API v2**
+ * (see {@link PLUGIN_API_VERSION}), which costs a single-argument factory
+ * nothing: TypeScript lets a function ignore arguments it is passed, so
+ * `(ctx) => …` still satisfies this type. What it buys a factory that *does*
+ * read the block is a value that is never `undefined`.
  *
  * Write **bare** tool names. For a third-party plugin core namespaces each one
  * under the manifest {@link PlatypusPlugin.name} before the model sees it, so
@@ -176,7 +201,7 @@ export type ToolSetTools =
   | Record<string, Tool>
   | ((
       ctx: ToolSetContext,
-      plugin?: PluginConfigContext,
+      plugin: PluginConfigContext,
     ) => Record<string, Tool> | Promise<Record<string, Tool>>);
 
 /**
@@ -291,15 +316,20 @@ export interface SandboxBackend {
  * The factory form lets a backend derive its per-Workspace validation from
  * Operator-owned plugin config — e.g. `@platypus/docker` closes over the
  * Operator's network allowlist so an out-of-allowlist `networks` entry is
- * rejected at config-save time. This is **append-only** within the major API
- * version: a plain schema stays valid, so backends that don't need plugin config
- * are untouched. Core resolves the factory against the boot-validated {@link
- * PluginConfigContext.config} before the three static `configSchema.safeParse`
- * consumers (save route, teardown, tool resolver) ever see it — they always
- * receive a concrete schema.
+ * rejected at config-save time. A plain schema stays valid, so backends that
+ * don't need plugin config are untouched. Core resolves the factory before the
+ * three static `configSchema.safeParse` consumers (save route, teardown, tool
+ * resolver) ever see it — they always receive a concrete schema.
+ *
+ * **Re-signed in API v2** (see {@link PLUGIN_API_VERSION}): the factory receives
+ * the whole {@link PluginConfigContext}, where through v1 it received the
+ * `config` half alone, as `unknown`. It was the one factory in this SDK that
+ * could reach neither the plugin's credentials nor its logger — so the one
+ * factory with no way to say *why* it refused a value. A v1 factory migrates by
+ * reading `plugin.config` where its argument used to be the config itself.
  */
 export type SandboxConfigSchema<TConfig = unknown> =
-  z.ZodType<TConfig> | ((pluginConfig: unknown) => z.ZodType<TConfig>);
+  z.ZodType<TConfig> | ((plugin: PluginConfigContext) => z.ZodType<TConfig>);
 
 /**
  * A single Sandbox-backend contribution — the payload core's internal
@@ -308,10 +338,9 @@ export type SandboxConfigSchema<TConfig = unknown> =
  * per-Workspace jsonb columns before `create()` instantiates an adapter.
  *
  * `configSchema` may be a plain Zod schema or a {@link SandboxConfigSchema}
- * factory of the plugin's deploy-time config (resolved at load, append-only).
- * The factory receives the boot-validated {@link PluginConfigContext.config} as
- * `unknown` — the same opaque shape `create()`'s `plugin` argument carries — and
- * narrows it itself (a plugin knows its own config schema).
+ * factory of the plugin's deploy-time block (resolved at load). The factory
+ * receives the same {@link PluginConfigContext} `create()` does, and narrows
+ * `config` / `credentials` itself — a plugin knows its own schemas.
  */
 export interface SandboxBackendContribution<
   TConfig = unknown,
@@ -325,14 +354,15 @@ export interface SandboxBackendContribution<
    * Instantiate the adapter. `config` / `credentials` are the per-Workspace
    * values validated against the schemas above; `plugin` is the deploy-time
    * {@link PluginConfigContext} shared across every one of the plugin's
-   * contributions (ADR-0013). `plugin` is appended and optional so existing
-   * two-argument factories keep working unchanged (append-only compatibility).
-   * Core always supplies it when instantiating the adapter.
+   * contributions (ADR-0013). **Required as of API v2** (see {@link
+   * PLUGIN_API_VERSION}), which costs a two-argument `create` nothing — it still
+   * satisfies this type — and gives one that reads the block a value that is
+   * never `undefined`.
    */
   create(
     config: TConfig,
     credentials: TCredentials,
-    plugin?: PluginConfigContext,
+    plugin: PluginConfigContext,
   ): SandboxBackend;
 }
 
@@ -344,7 +374,7 @@ export interface SandboxBackendContribution<
  * upstream does so as its own implementation detail, using its own Plugin
  * credentials (ADR-0014).
  *
- * No longer plain data: it carries exactly one capability, `registerCloser`.
+ * Not plain data: it carries exactly one capability, `registerCloser`.
  * Everything else on it is still a value to read.
  */
 export interface WebBackendContext {
@@ -356,14 +386,14 @@ export interface WebBackendContext {
    * {@link CloserRegistrar}. This is where a browser pool or a keep-alive
    * connection opened by `createExecutors` gets released.
    *
-   * **Optional on purpose, and it must stay optional.** A manifest declares a
-   * *major* `apiVersion` only, so a plugin cannot ask for a core new enough to
-   * have this member; on an older core it is genuinely absent. Call it guarded —
-   * `ctx.registerCloser?.(close)` — and never with `!`: an unguarded call on
-   * older core throws out of `createExecutors`, which costs the turn its search
-   * tools entirely. Core always supplies it.
+   * **Required as of API v2** (see {@link PLUGIN_API_VERSION}), and core has
+   * always supplied it. Call it directly — `ctx.registerCloser(close)`. It was
+   * optional through v1 for one reason: a v1 manifest could not ask for a core
+   * new enough to have the member, so on an older core it was genuinely absent
+   * and an unguarded call threw out of `createExecutors`, costing the turn its
+   * search tools entirely. A v2 manifest cannot reach such a core.
    */
-  registerCloser?: CloserRegistrar;
+  registerCloser: CloserRegistrar;
 }
 
 /** One search hit. Core caps the count and truncates the strings (ADR-0014). */
@@ -488,9 +518,10 @@ export interface WebBackendContribution {
   /**
    * Build this backend's executors for one Chat turn. `plugin` is the deploy-time
    * {@link PluginConfigContext} shared across every one of the plugin's
-   * contributions (ADR-0013) — where a backend's endpoint and API key live. It is
-   * appended and optional so a single-argument factory keeps working unchanged
-   * (append-only compatibility); core always supplies it.
+   * contributions (ADR-0013) — where a backend's endpoint and API key live.
+   * **Required as of API v2** (see {@link PLUGIN_API_VERSION}), which costs a
+   * single-argument factory nothing — it still satisfies this type — and gives
+   * one that reads the block a value that is never `undefined`.
    *
    * Boot is fail-loud, runtime is graceful: a contribution that omits this
    * function is rejected at load by plugin name, but a factory that *throws* or
@@ -500,7 +531,7 @@ export interface WebBackendContribution {
    */
   createExecutors(
     ctx: WebBackendContext,
-    plugin?: PluginConfigContext,
+    plugin: PluginConfigContext,
   ): WebBackendExecutors | Promise<WebBackendExecutors>;
 }
 

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platypuschat/plugin-sdk",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Plugin SDK for Platypus — the manifest type and extension-point surface third-party plugins depend on.",
   "license": "MIT",
   "author": "Will Dady",


### PR DESCRIPTION
The pending release is already a major, so this spends that window on the plugin
API surface: everything that was optional only because we could not break it.

## Why these were optional

A manifest declares a major `apiVersion`, so a plugin could not ask for a core
new enough to have a newly-appended member — on an older core it was genuinely
absent. Six members sat behind that reasoning. Core has supplied all six
unconditionally for several releases. What the optionality bought was ceremony:
18 places across 5 files existed to teach `?.`-not-`!`, three of them warning
callouts, plus a branch in core that could not be reached.

## The version bump is the gate

`PLUGIN_API_VERSION` goes to 2, so `OLDEST_SUPPORTED_API_VERSION` computes to 1
and the window becomes a genuine `[1, 2]`. Every `apiVersion: 1` plugin in the
field keeps loading. A plugin declaring 2 is refused at boot by a core that
cannot honour it, with the existing "Upgrade core" error. Nothing below is safe
without this.

## Now required

- `ToolSetContext.registerCloser`
- `WebBackendContext.registerCloser`
- `PluginConfigContext.logger`
- the trailing `plugin` argument on all three contribution factories

The three arguments cost an existing factory nothing — TypeScript lets a function
ignore arguments it is passed, so `(ctx) => …` still satisfies the type. What
they buy a factory that *does* read the block is a value that is never
`undefined`.

## Re-signed

A Sandbox backend's `configSchema` factory receives the whole
`PluginConfigContext` rather than the `config` half alone. It was the one factory
on this surface that could reach neither the plugin's credentials nor its logger,
so the one with no way to say *why* it refused a value. `@platypus/docker` reads
`plugin.config`.

## Two corrections in the same sweep

The loader's `registerSandbox` option declared it received a contribution when it
receives the composed registration — it typechecked only because the one happens
to be assignable to the other, and its two siblings already documented the
composed form. Correcting it immediately surfaced three test capture arrays typed
as contributions while calling a two-argument `create` on them, and a
now-redundant cast that lint caught.

The SDK's Sandbox types were also duplicated verbatim in the backend: identical
twins with no compiler link between them. Core now re-exports the published ones
and asserts, both ways, that the input types it infers from its own schemas still
match the SDK's.

## Behaviour removed on purpose

Two tests pinned "degrades when a factory calls the registrar unguarded on an
older core". That case no longer exists — core always supplies a registrar — so
both are rewritten to assert the opposite: an unguarded call is served rather
than costing the turn its tools.

## Not in scope

A `timeoutMs` on `ToolSetContribution`, so a hanging Tool-set factory cannot pin
a turn open. Adding the field is additive; choosing a default is the breaking
half, and it is a feature decision rather than a cleanup.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm build`, and `pnpm test` all pass — 3,143
tests across six packages. Docs ship here: the four `extending/` pages and the
SDK README all taught the guarded form.

## Worth a follow-up

`packages/plugin-sdk/tsconfig.build.json` excludes `**/*.test.ts` and the SDK's
`typecheck` script points at it, so the SDK's own test file is type-checked by
nothing and had accumulated real errors. They are fixed here; pointing the gate
at a config that includes tests is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

BREAKING CHANGE: The plugin API is now major 2. Core accepts 1 and 2 together, so a plugin already in the field keeps loading and an Operator has a release to migrate. For plugin authors: raise `apiVersion` to 2 and you can drop the guards — `ctx.registerCloser(close)` and `plugin.logger.info(...)` rather than `ctx.registerCloser?.(close)` and `plugin?.logger?.info(...)`. Dropping the guards while the manifest still says 1 is the trap: a core on the previous release will load the plugin, because 1 is inside its window, and the first unguarded read throws inside a Chat turn. One member changed shape rather than optionality: a Sandbox backend's `configSchema` factory now receives the whole deploy-time block, so read `plugin.config` where the argument used to be the config itself. `@platypuschat/plugin-sdk` goes to 1.0.0 for this.
