### PR TITLE
fix(docs): move the Docker image tag examples to the 3.x line

### DIFF
--- a/apps/docs/content/self-hosting/docker-compose.mdx
+++ b/apps/docs/content/self-hosting/docker-compose.mdx
@@ -42,8 +42,8 @@ moves under you on the next `docker compose pull`:
 | Tag           | Example                            | What a pull fetches                     |
 | ------------- | ---------------------------------- | --------------------------------------- |
 | Latest        | `willdady/platypus-backend:latest` | The newest release, major bump included |
-| Major line    | `willdady/platypus-backend:2`      | The newest `2.x.y`, never `3.0.0`       |
-| Exact version | `willdady/platypus-backend:2.7.1`  | That release and nothing else           |
+| Major line    | `willdady/platypus-backend:3`      | The newest `3.x.y`, never `4.0.0`       |
+| Exact version | `willdady/platypus-backend:3.0.0`  | That release and nothing else           |
 
 **Pin something other than `:latest`.** It is the only tag that can carry a
 breaking major change into a running deployment, and it leaves you unable to say
@@ -59,9 +59,9 @@ Override the images in a `compose.override.yaml` alongside `compose.yaml`:
 ```yaml
 services:
   backend:
-    image: willdady/platypus-backend:2.7.1
+    image: willdady/platypus-backend:3.0.0
   frontend:
-    image: willdady/platypus-frontend:2.7.1
+    image: willdady/platypus-frontend:3.0.0
 ```
 
 Compose merges `compose.override.yaml` automatically, so `docker compose up -d`


### PR DESCRIPTION
**`main` is red.** `docs-contract.test.ts` has failed since the 3.0.0 release commit (`c72576b`).

## What broke

The contract test pins the image tags shown on `self-hosting/docker-compose.mdx` against the root `package.json` major. The release bumped that to `3.0.0`; the page still showed `:2` and `:2.7.1`, so four assertions now fail:

```
self-hosting/docker-compose.mdx shows `willdady/platypus-backend:2`, which is not
`:latest`, the floating `:3`, or an exact `3.y.z`.
Source of truth: the root package.json version. A major bump is meant to fail
here — update the page's examples with it.
```

## Why no pre-release gate could have caught it

The check cannot fail before the release. Ahead of the bump the page says `2` and the version says `2.11.0` — consistent, green. The mismatch comes into existence only when release-please writes the new version, so this is a post-release chore by construction, not a gap in the pre-release run.

Worth knowing for the next major: this will fire again on 4.0.0, and the fix is always this page.

## The change

Four tag references moved to the 3.x line — the major-line row (`:2` → `:3`, and its "never `3.0.0`" note to "never `4.0.0`"), the exact-version row, and both `image:` lines in the compose example.

The `:latest` references are untouched; the contract accepts them.

## Impact

Self-hosters copying the compose example were being handed the previous major.

## Verification

`@platypus/docs` test suite: 45 passed (was 1 failed / 44 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)