### PR TITLE
fix(backend): validate a Trigger's config when its type changes

### DIFF
--- a/apps/backend/src/services/trigger.test.ts
+++ b/apps/backend/src/services/trigger.test.ts
@@ -244,6 +244,57 @@ describe("trigger module", () => {
       expect(setArg.nextRunAt).toBeNull();
     });
 
+    // A type change re-reads the stored config under the other shape's schema.
+    // Without it, a cron config survives under `type: "event"`: the cron
+    // scheduler skips it (nextRunAt is nulled) and the event dispatcher never
+    // matches it (no `events`), so the Trigger looks configured and can never
+    // fire. The cron branch already guarded the mirror case.
+    it("throws ValidationError when flipping to event type without a config", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "cron",
+          config: { cronExpression: "0 9 * * *", timezone: "UTC" },
+        },
+      ]);
+
+      await expect(
+        updateTrigger(ctx, "trig-1", { type: "event" }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    // The mirror of the above, kept alongside it so the symmetry is visible.
+    it("throws ValidationError when flipping to cron type without a config", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "trig-1", type: "event", config: { events: ["card.created"] } },
+      ]);
+
+      await expect(
+        updateTrigger(ctx, "trig-1", { type: "cron" }),
+      ).rejects.toThrow(ValidationError);
+    });
+
+    // The guard keys on the type *field being present*, not on it changing, so
+    // a caller that re-sends the type it already has must still succeed — the
+    // stored config revalidates cleanly under its own schema.
+    it("accepts a no-op event type on update, leaving the stored config alone", async () => {
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "event",
+          config: { events: ["card.created"], filters: { boardId: "board-1" } },
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([{ id: "trig-1", type: "event" }]);
+
+      await updateTrigger(ctx, "trig-1", { type: "event", name: "renamed" });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.name).toBe("renamed");
+      // Untouched: validated, not rewritten, because no config was supplied.
+      expect(setArg.config).toBeUndefined();
+    });
+
     it("throws ValidationError for an empty events array on update", async () => {
       mockDb.limit.mockResolvedValueOnce([
         { id: "trig-1", type: "event", config: { events: ["card.created"] } },

--- a/apps/backend/src/services/trigger.ts
+++ b/apps/backend/src/services/trigger.ts
@@ -196,10 +196,17 @@ export async function updateTrigger(
   // `config`, when supplied, is set below alongside validation — normalized
   // (Zod defaults applied), not the raw input.
   if (effectiveType === "event") {
-    // Event triggers don't have nextRunAt; only (re)validate when config
-    // actually changed on this update.
-    if (fields.config !== undefined) {
-      updateData.config = parseEventConfig(fields.config);
+    // Event triggers don't have nextRunAt. Revalidate when the config changed
+    // *or* when the type did: a change of type re-reads the stored config under
+    // the other shape's schema, so flipping a cron Trigger to `event` without
+    // supplying a config fails loud here rather than storing a cron config under
+    // `type: "event"` — a Trigger that looks configured and can never fire. The
+    // cron branch below guards the mirror case; this is the same guard.
+    if (fields.config !== undefined || fields.type !== undefined) {
+      const parsed = parseEventConfig(fields.config ?? existing.config);
+      if (fields.config !== undefined) {
+        updateData.config = parsed;
+      }
     }
     updateData.nextRunAt = null;
   } else if (effectiveType === "cron") {


### PR DESCRIPTION
Follow-up from `/pre-release-check` on the 3.0.0 range. Not a release blocker — pre-existing and identical in 2.11.0.

> Depends on #706, which fixes a red `main` (the docs contract fires on any major bump). CI here will stay red until that merges.

## The bug

`updateTrigger`'s event branch revalidated only when a config was supplied:

```ts
if (fields.config !== undefined) {          // event branch
if (fields.config !== undefined || fields.type !== undefined) {   // cron branch
```

So `PUT {"type":"event"}` on a Cron Trigger succeeds, leaves the stored cron config in place, sets `nextRunAt = null`, and produces an Event Trigger holding a cron config. The cron scheduler skips it (`nextRunAt` is null) and the event dispatcher never matches it (no `events` array). It looks configured and can never fire — no error, no log line.

The reverse direction was already correct: flipping to `cron` re-parses the stored config and throws.

## Reachability

| Surface | Can flip type on an existing Trigger? |
| --- | --- |
| Frontend form | **No** — the type `Select` is `disabled` once `triggerId` is set |
| REST API | **Yes** — `triggerUpdateSchema` is `.partial()` with `type`; the route adds no guard |
| Agent Trigger tool | **Yes** — one create-or-update call with `type` an optional enum, passed straight to `updateTrigger` |

No human can trip this by clicking. The surviving path is the one #694's brief named — *"an Agent could write an invalid event name that silently produces a Trigger that looks configured but can never fire"* — and an Agent is the caller most likely to send a partial update, since every field on that tool is optional.

## Not a regression

v2.11.0's pre-consolidation route carried the identical asymmetry (`if (data.config)` vs `if (data.config || data.type)`), so #694 preserved the bug rather than introducing it. 3.0.0 is no worse than 2.11.0 here.

## The change

The event branch takes the cron branch's guard and validates `fields.config ?? existing.config`. Config is still written only when supplied, so a no-op type on an update revalidates the stored config without rewriting it.

## Tests

Three added, and I checked they earn their place — with the source fix reverted, exactly one fails:

- **flip to event without a config → `ValidationError`** — fails without the fix; this is the bug.
- **flip to cron without a config → `ValidationError`** — passes either way, kept as a regression guard so the symmetry is visible in one place.
- **no-op event type leaves the stored config alone** — guards the obvious over-correction, since the guard keys on the type field being *present*, not on it *changing*.

`@platypus/backend`: 2316 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)