### PR TITLE
feat(frontend): edit messages through the composer, preserving all message parts

### DIFF
--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -111,6 +111,9 @@ a Provider uses is in [Providers & models](/concepts/providers#web-search).
 
 A microphone button next to it transcribes speech into the input box. The text
 lands in the box rather than sending, so you can edit before pressing **Enter**.
+The same button is in the box you get when [rewriting a
+message](#rewriting-a-message), and it writes into that message rather than into
+the one below.
 
 ## How long a Tool took
 
@@ -297,21 +300,46 @@ above.
 
 Hover a message for its actions:
 
-| Action         | On                       | Does                                                                |
-| -------------- | ------------------------ | ------------------------------------------------------------------- |
-| **Edit**       | Your own messages        | Rewrites the message and re-runs from there — see the warning below |
-| **Copy**       | Any message              | Copies the message text to the clipboard                            |
-| **Delete**     | Any message              | Removes it from the view                                            |
-| **Regenerate** | The last assistant reply | Runs the turn again, same message, fresh response                   |
+| Action         | On                       | Does                                              |
+| -------------- | ------------------------ | ------------------------------------------------- |
+| **Edit**       | Your own messages        | Reopens the message for rewriting — see below     |
+| **Copy**       | Any message              | Copies the message text to the clipboard          |
+| **Delete**     | Any message              | Removes it from the view                          |
+| **Regenerate** | The last assistant reply | Runs the turn again, same message, fresh response |
 
-The actions are hidden while the last reply is still streaming.
+The actions are hidden while the last reply is still streaming. **Edit**,
+**Delete** and **Regenerate** are absent entirely if you cannot send messages in
+this Chat — see [Sharing a Chat](#sharing-a-chat). **Copy** stays.
+
+### Rewriting a message
+
+**Edit** reopens the message in a prompt input holding everything it carried:
+the text, selected so typing replaces it, and the files attached to it. It works
+like the one at the bottom of the screen — attach more files, remove the ones
+that are there, dictate into it, pick a different model.
+
+**Enter** saves, **Shift+Enter** adds a line, and **Escape** cancels; the **✕**
+beside the send button cancels too.
+
+The model picker is in the box because an edit runs against whatever this Chat
+is currently set to, not against the model that answered the first time. Change
+the picker an hour ago and the edit re-runs on the new selection, so the box
+names what it is about to use. Changing it there changes it for the Chat, the
+same as changing it below.
 
 <Callout type="warning">
-  **Edit discards everything after the message you edited.** Submitting the edit
-  drops that message and every message below it, then sends your new text as a
-  fresh turn. That is usually what you want — you're correcting a wrong turn and
-  re-running from there — but there is no undo, so an edit near the top of a
-  long conversation throws away the rest of it.
+  **Edit discards everything after the message you edited.** Saving the edit
+  drops that message and every message below it, then sends the rewritten
+  message as a fresh turn. That is usually what you want — you're correcting a
+  wrong turn and re-running from there — but there is no undo, so an edit near
+  the top of a long conversation throws away the rest of it.
+</Callout>
+
+<Callout type="warning">
+  **A file you remove while editing is gone from the resubmitted message.** The
+  attachments in the box are what the new turn is sent with, so removing one and
+  saving asks the model the same question without it. If you only wanted to
+  reword the question, leave the files alone.
 </Callout>
 
 <Callout type="warning">
@@ -437,8 +465,15 @@ raise it.
 
 Chats belong to the Workspace Owner. Anyone else who can reach the Chat sees it
 read-only: the input is replaced with a note saying only the Workspace Owner can
-send messages. They can read the whole conversation, including tool calls; they
-cannot continue it.
+send messages, and the per-message **Edit**, **Delete** and **Regenerate**
+actions are not offered. They can read the whole conversation, including tool
+calls, and copy from it; they cannot change it or continue it.
+
+<Callout type="info">
+  This includes an Org Admin and an Operator. Reaching a Workspace's Chats and
+  writing to them are separate things: the Chat is the Owner's conversation, and
+  everyone else reads it.
+</Callout>
 
 ## Where to next
 

--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -318,14 +318,15 @@ the text, selected so typing replaces it, and the files attached to it. It works
 like the one at the bottom of the screen — attach more files, remove the ones
 that are there, dictate into it, pick a different model.
 
-**Enter** saves, **Shift+Enter** adds a line, and **Escape** cancels; the **✕**
-beside the send button cancels too.
+On a full-width screen **Enter** saves and **Shift+Enter** adds a line; on a
+narrow one Enter adds a line and the send button saves, the same as the input
+below. **Escape** cancels, and so does the **✕** beside the send button.
 
-The model picker is in the box because an edit runs against whatever this Chat
-is currently set to, not against the model that answered the first time. Change
-the picker an hour ago and the edit re-runs on the new selection, so the box
-names what it is about to use. Changing it there changes it for the Chat, the
-same as changing it below.
+The box carries a model picker, and it is the picker that matters: an edit
+re-runs on whatever this Chat is set to **now**, not on the model that answered
+the first time. Change the picker earlier in the session and the edit goes to
+the new selection. Read the picker in the box before saving, and change it there
+if that isn't what you want — it changes the Chat's selection too.
 
 <Callout type="warning">
   **Edit discards everything after the message you edited.** Saving the edit

--- a/apps/frontend/components/ai-elements/prompt-input.test.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.test.tsx
@@ -179,6 +179,78 @@ describe("PromptInput attachments", () => {
   });
 });
 
+/**
+ * Two inputs on one page (issue #710: the composer plus an inline edit
+ * surface). The composer claims the window-level drop; the edit surface must
+ * still keep a file dropped on itself, and exactly one of them may take it.
+ */
+describe("PromptInput drop routing with two inputs", () => {
+  const named = (label: string, globalDrop: boolean) => (
+    <PromptInput globalDrop={globalDrop} multiple onSubmit={vi.fn()}>
+      <PromptInputAttachments className="w-full">
+        {(attachment) => (
+          <PromptInputAttachment
+            data={attachment}
+            data-testid={`${label}-chip`}
+          />
+        )}
+      </PromptInputAttachments>
+      <PromptInputBody>
+        <PromptInputTextarea />
+      </PromptInputBody>
+    </PromptInput>
+  );
+
+  const dropOn = (target: Element | Document) =>
+    fireEvent.drop(target, {
+      dataTransfer: {
+        types: ["Files"],
+        files: [new File(["hi"], "dropped.png", { type: "image/png" })],
+      },
+    });
+
+  const chips = (label: string) => screen.queryAllByTestId(`${label}-chip`);
+
+  const renderBoth = () =>
+    render(
+      <>
+        {named("composer", true)}
+        {named("editor", false)}
+      </>,
+    ).container.querySelectorAll("form");
+
+  // The defect: the edit surface's own drop never bound (the ref was resolved
+  // by walking up from a span rendered OUTSIDE the form), so the file fell
+  // through to the composer's window-level listener — landing in the composer
+  // and never in the surface it was dropped on.
+  it("gives a file dropped on the inline input to that input alone", () => {
+    const forms = renderBoth();
+
+    dropOn(forms[1]);
+
+    expect(chips("editor")).toHaveLength(1);
+    expect(chips("composer")).toHaveLength(0);
+  });
+
+  it("takes a file dropped on the composer once, not twice", () => {
+    const forms = renderBoth();
+
+    dropOn(forms[0]);
+
+    expect(chips("composer")).toHaveLength(1);
+    expect(chips("editor")).toHaveLength(0);
+  });
+
+  it("leaves a drop on neither input to whichever claimed the window", () => {
+    renderBoth();
+
+    dropOn(document);
+
+    expect(chips("composer")).toHaveLength(1);
+    expect(chips("editor")).toHaveLength(0);
+  });
+});
+
 describe("PromptInputAttachment image parts", () => {
   // issue #579: a part can carry an image media type with nothing a client
   // can fetch (e.g. Provider-reference-only). It should render as the plain

--- a/apps/frontend/components/ai-elements/prompt-input.test.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import {
   PromptInput,
   PromptInputAttachment,
   PromptInputAttachments,
   PromptInputBody,
+  PromptInputSubmit,
   PromptInputTextarea,
 } from "./prompt-input";
 
@@ -220,5 +221,168 @@ describe("PromptInputAttachment image parts", () => {
       "src",
       "https://example.com/photo.png",
     );
+  });
+});
+
+const seededPdf = {
+  type: "file" as const,
+  url: "https://example.com/report.pdf",
+  mediaType: "application/pdf",
+  filename: "report.pdf",
+};
+
+describe("PromptInput initialAttachments", () => {
+  // issue #710: an inline edit surface has to open holding the parts the
+  // message already carries. Without a seed the only way in is `add()`, which
+  // takes `File[]` — something a persisted `FileUIPart` cannot be turned back
+  // into, because its bytes were never in this browser.
+  it("opens holding the parts it was seeded with", () => {
+    render(
+      <PromptInput initialAttachments={[seededPdf]} onSubmit={vi.fn()}>
+        <PromptInputAttachments className="w-full">
+          {(attachment) => <PromptInputAttachment data={attachment} />}
+        </PromptInputAttachments>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+      </PromptInput>,
+    );
+
+    expect(screen.getByText("report.pdf")).toBeInTheDocument();
+  });
+
+  it("submits a seeded part alongside one added afterwards", async () => {
+    // A newly attached file is held as a `blob:` URL and read back through
+    // fetch on submit; jsdom serves no blob URLs, so the read is stubbed with
+    // the Blob it would have returned.
+    global.fetch = vi.fn().mockResolvedValue({
+      blob: async () => new Blob(["hi"], { type: "text/plain" }),
+    }) as unknown as typeof global.fetch;
+    const onSubmit = vi.fn();
+    render(
+      <PromptInput
+        initialAttachments={[seededPdf]}
+        multiple
+        onSubmit={onSubmit}
+      >
+        <PromptInputAttachments className="w-full">
+          {(attachment) => <PromptInputAttachment data={attachment} />}
+        </PromptInputAttachments>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+        <PromptInputSubmit />
+      </PromptInput>,
+    );
+
+    fireFileChange(getFileInput(), [
+      new File(["hi"], "extra.txt", { type: "text/plain" }),
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0].files).toEqual([
+      expect.objectContaining({
+        url: "https://example.com/report.pdf",
+        filename: "report.pdf",
+      }),
+      expect.objectContaining({ filename: "extra.txt" }),
+    ]);
+  });
+
+  it("drops a seeded part the user removes", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <PromptInput initialAttachments={[seededPdf]} onSubmit={onSubmit}>
+        <PromptInputAttachments className="w-full">
+          {(attachment) => <PromptInputAttachment data={attachment} />}
+        </PromptInputAttachments>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+        <PromptInputSubmit />
+      </PromptInput>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove attachment" }));
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0].files).toEqual([]);
+  });
+
+  // The seed is an opening position, not a binding: re-rendering with a
+  // different array must not throw away what the user has done since. An edit
+  // surface's parent re-renders on every keystroke elsewhere on the page.
+  it("keeps the live list when the seed prop changes", () => {
+    const view = render(
+      <PromptInput initialAttachments={[seededPdf]} onSubmit={vi.fn()}>
+        <PromptInputAttachments className="w-full">
+          {(attachment) => <PromptInputAttachment data={attachment} />}
+        </PromptInputAttachments>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+      </PromptInput>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove attachment" }));
+    view.rerender(
+      <PromptInput initialAttachments={[seededPdf]} onSubmit={vi.fn()}>
+        <PromptInputAttachments className="w-full">
+          {(attachment) => <PromptInputAttachment data={attachment} />}
+        </PromptInputAttachments>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+      </PromptInput>,
+    );
+
+    expect(screen.queryByText("report.pdf")).not.toBeInTheDocument();
+  });
+});
+
+describe("PromptInputTextarea onKeyDown", () => {
+  // issue #710: an inline edit surface needs Escape to cancel. Spreading a
+  // caller's handler through `props` would replace the built-in one outright,
+  // taking Enter-to-submit and Backspace-removes-attachment with it.
+  it("runs a caller's handler and still submits on Enter", async () => {
+    const onKeyDown = vi.fn();
+    const onSubmit = vi.fn();
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputTextarea onKeyDown={onKeyDown} />
+        </PromptInputBody>
+        <PromptInputSubmit />
+      </PromptInput>,
+    );
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onKeyDown).toHaveBeenCalled();
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+  });
+
+  it("lets a caller claim a key by preventing the default", () => {
+    const onSubmit = vi.fn();
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputTextarea
+            onKeyDown={(e) => {
+              if (e.key === "Enter") e.preventDefault();
+            }}
+          />
+        </PromptInputBody>
+        <PromptInputSubmit />
+      </PromptInput>,
+    );
+
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/components/ai-elements/prompt-input.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.tsx
@@ -265,6 +265,14 @@ export type PromptInputProps = Omit<
 > & {
   accept?: string; // e.g., "image/*", ".pdf", or a comma-separated list of either
   multiple?: boolean;
+  /**
+   * Parts the input opens holding, for a surface editing a message that already
+   * carries attachments (issue #710). Read once, on mount: after that the list
+   * is the user's, so a later change to this prop leaves it alone. Persisted
+   * parts carry a fetchable URL rather than a `blob:` one, so they pass through
+   * submit untouched.
+   */
+  initialAttachments?: FileUIPart[];
   // When true, accepts drops anywhere on document. Default false (opt-in).
   globalDrop?: boolean;
   // Minimal constraints
@@ -284,6 +292,7 @@ export const PromptInput = ({
   className,
   accept,
   multiple,
+  initialAttachments,
   globalDrop,
   maxFiles,
   maxFileSize,
@@ -305,7 +314,9 @@ export const PromptInput = ({
     }
   }, []);
 
-  const [files, setItems] = useState<(FileUIPart & { id: string })[]>([]);
+  const [files, setItems] = useState<(FileUIPart & { id: string })[]>(() =>
+    (initialAttachments ?? []).map((part) => ({ ...part, id: nanoid() })),
+  );
 
   const openFileDialog = useCallback(() => {
     inputRef.current?.click();
@@ -565,6 +576,7 @@ export const PromptInputTextarea = ({
   className,
   placeholder = "What would you like to know?",
   status,
+  onKeyDown,
   ...props
 }: PromptInputTextareaProps) => {
   const attachments = usePromptInputAttachments();
@@ -572,6 +584,15 @@ export const PromptInputTextarea = ({
   const isMobile = useIsMobile();
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+    // A caller's handler runs first and claims the key by preventing the
+    // default — Escape cancelling an inline edit, say (issue #710). Leaving
+    // `onKeyDown` in the spread below would replace this handler outright
+    // instead, taking Enter-to-submit and Backspace-removes-attachment with it.
+    onKeyDown?.(e);
+    if (e.defaultPrevented) {
+      return;
+    }
+
     if (e.key === "Enter") {
       if (isComposing || e.nativeEvent.isComposing) {
         return;

--- a/apps/frontend/components/ai-elements/prompt-input.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.tsx
@@ -303,16 +303,13 @@ export const PromptInput = ({
 }: PromptInputProps) => {
   // Refs
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const anchorRef = useRef<HTMLSpanElement>(null);
+  // Held on the form element itself. It used to be resolved by walking up from
+  // a hidden anchor span with `closest("form")` — but that span renders as a
+  // SIBLING of the form, so the walk found nothing and the form-scoped drop
+  // below never bound. Harmless while one input on the page claimed the
+  // window-level drop; with a second, inline input (issue #710) a file dropped
+  // on that one landed in the other.
   const formRef = useRef<HTMLFormElement | null>(null);
-
-  // Find nearest form to scope drag & drop
-  useEffect(() => {
-    const root = anchorRef.current?.closest("form");
-    if (root instanceof HTMLFormElement) {
-      formRef.current = root;
-    }
-  }, []);
 
   const [files, setItems] = useState<(FileUIPart & { id: string })[]>(() =>
     (initialAttachments ?? []).map((part) => ({ ...part, id: nanoid() })),
@@ -404,7 +401,7 @@ export const PromptInput = ({
     });
   }, []);
 
-  // Attach drop handlers on nearest form and document (opt-in)
+  // Attach drop handlers on this input's own form and document (opt-in)
   useEffect(() => {
     const form = formRef.current;
     if (!form) return;
@@ -418,6 +415,11 @@ export const PromptInput = ({
       if (e.dataTransfer?.types?.includes("Files")) {
         e.preventDefault();
       }
+      // A drop that landed on this input is this input's, so it stops here
+      // rather than bubbling on to a window-level listener — which belongs to
+      // whichever OTHER input on the page set `globalDrop`, and would take the
+      // same file a second time.
+      e.stopPropagation();
       if (e.dataTransfer?.files && e.dataTransfer.files.length > 0) {
         add(e.dataTransfer.files);
       }
@@ -535,7 +537,6 @@ export const PromptInput = ({
 
   return (
     <PromptInputAttachmentsContext.Provider value={ctx}>
-      <span aria-hidden="true" className="hidden" ref={anchorRef} />
       <input
         accept={accept}
         aria-label="Upload files"
@@ -549,6 +550,7 @@ export const PromptInput = ({
       <form
         className={cn("w-full", className)}
         onSubmit={handleSubmit}
+        ref={formRef}
         {...props}
       >
         <InputGroup className="overflow-hidden">{children}</InputGroup>

--- a/apps/frontend/components/chat-message.test.tsx
+++ b/apps/frontend/components/chat-message.test.tsx
@@ -42,24 +42,23 @@ const assistantMessage = (
   parts: [{ type: "text", text: "Hello" }],
 });
 
-function renderMessage(message: PlatypusUIMessage) {
+function renderMessage(
+  message: PlatypusUIMessage,
+  overrides: Partial<React.ComponentProps<typeof ChatMessage>> = {},
+) {
   return render(
     <ChatMessage
       message={message}
       isLastMessage
       status="ready"
-      isEditing={false}
-      editContent=""
-      editTextareaRef={{ current: null }}
+      canSendMessages
       agents={agents}
-      setEditContent={vi.fn()}
       onEditStart={vi.fn()}
-      onEditCancel={vi.fn()}
-      onEditSubmit={vi.fn()}
       onMessageDelete={vi.fn()}
       onRegenerate={vi.fn()}
       onCopyMessage={vi.fn()}
       copiedMessageId={null}
+      {...overrides}
     />,
   );
 }
@@ -923,5 +922,100 @@ describe("ChatMessage tool duration", () => {
     renderMessage(withToolPart(staticToolPart({ durationMs: 1234 })));
 
     expect(screen.getByText(/1\.2s/).textContent).toBe(live);
+  });
+});
+
+const userMessage = (): PlatypusUIMessage => ({
+  id: "u1",
+  role: "user",
+  parts: [{ type: "text", text: "Ask" }],
+});
+
+/**
+ * Sending is workspace ownership, and until issue #710 the client gated only
+ * the composer on it. The action bar was ungated, so an Org Admin or Operator
+ * reading someone else's Chat got Edit, Delete and Regenerate — and Delete
+ * mutated their transcript with no server call to refuse it.
+ */
+describe("ChatMessage action bar permissions", () => {
+  it("offers Edit, Delete and Copy on a user message to someone who can send", () => {
+    renderMessage(userMessage());
+
+    for (const action of ["Edit", "Delete", "Copy"]) {
+      expect(screen.getByRole("button", { name: action })).toBeInTheDocument();
+    }
+  });
+
+  it("offers Regenerate on the last reply to someone who can send", () => {
+    renderMessage(assistantMessage());
+
+    expect(
+      screen.getByRole("button", { name: "Regenerate" }),
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    ["a user message", userMessage()],
+    ["an assistant reply", assistantMessage()],
+  ])("withholds every write action on %s from a reader", (_, message) => {
+    renderMessage(message, { canSendMessages: false });
+
+    for (const action of ["Edit", "Delete", "Regenerate"]) {
+      expect(screen.queryByRole("button", { name: action })).toBeNull();
+    }
+  });
+
+  // Reading is not writing: Copy takes nothing away from the Chat.
+  it("still offers Copy to a reader", () => {
+    renderMessage(userMessage(), { canSendMessages: false });
+
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
+});
+
+describe("ChatMessage while editing", () => {
+  const editing = { editor: <div data-testid="editor">editing</div> };
+
+  it("renders the edit surface in the message's place", () => {
+    renderMessage(userMessage(), editing);
+
+    expect(screen.getByTestId("editor")).toBeInTheDocument();
+    expect(screen.queryByText("Ask")).toBeNull();
+  });
+
+  // The edit surface carries its own Save and Cancel; the message's own
+  // actions would act on a message that is no longer on screen.
+  it("withholds the message's own actions", () => {
+    renderMessage(userMessage(), editing);
+
+    for (const action of ["Edit", "Copy", "Delete"]) {
+      expect(screen.queryByRole("button", { name: action })).toBeNull();
+    }
+  });
+
+  // A message being edited shows its attachments inside the edit surface, not
+  // above it — the transcript's copy would be a second, unremovable list.
+  it("withholds the attachments the transcript would show", () => {
+    const withImage: PlatypusUIMessage = {
+      id: "u1",
+      role: "user",
+      parts: [
+        {
+          type: "file",
+          url: "https://example.com/shot.png",
+          mediaType: "image/png",
+          filename: "shot.png",
+        },
+        { type: "text", text: "Ask" },
+      ],
+    };
+
+    const { unmount } = renderMessage(withImage);
+    expect(screen.getByAltText("shot.png")).toBeInTheDocument();
+    unmount();
+
+    renderMessage(withImage, editing);
+
+    expect(screen.queryByAltText("shot.png")).toBeNull();
   });
 });

--- a/apps/frontend/components/chat-message.tsx
+++ b/apps/frontend/components/chat-message.tsx
@@ -38,17 +38,14 @@ import {
   type ChatStatus,
 } from "ai";
 import { Agent, isPresentableUrl } from "@platypus/schemas";
-import { isImageAttachment } from "@/lib/message-parts";
+import { isImageAttachment, messageText } from "@/lib/message-parts";
 import {
   BotIcon,
-  CheckIcon,
   PencilIcon,
   CopyIcon,
   TrashIcon,
   RefreshCwIcon,
-  XIcon,
 } from "lucide-react";
-import { Textarea } from "./ui/textarea";
 import { toolCallDurationMs } from "@/lib/tool-duration";
 import { ResponseMetricsPopover } from "./response-metrics-popover";
 import { TurnNotice } from "./turn-notice";
@@ -148,22 +145,22 @@ interface ChatMessageProps {
   isLastMessage: boolean;
   /** Current chat status from useChat hook */
   status: ChatStatus;
-  /** Whether this message is currently being edited */
-  isEditing: boolean;
-  /** Current content of the message being edited */
-  editContent: string;
-  /** Ref to the textarea element for editing */
-  editTextareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  /**
+   * Whether the reader may write to this Chat — the same condition that gates
+   * the composer. Every action that changes the transcript hangs off it; Copy
+   * and the metrics popover do not (issue #710).
+   */
+  canSendMessages: boolean;
+  /**
+   * The edit surface for this message, when it is the one being edited. It
+   * replaces the message entirely — its parts, its attachments and its action
+   * bar — because the surface shows all three itself.
+   */
+  editor?: ReactNode;
   /** Available agents for resolving avatars */
   agents: Agent[];
-  /** Callback to update the edit content */
-  setEditContent: (content: string) => void;
   /** Callback when user starts editing a message */
-  onEditStart: (messageId: string, content: string) => void;
-  /** Callback when user cancels editing */
-  onEditCancel: () => void;
-  /** Callback when user submits edited message */
-  onEditSubmit: () => void;
+  onEditStart: (messageId: string) => void;
   /** Callback when user deletes a message */
   onMessageDelete: (messageId: string) => void;
   /** Callback when user regenerates the last assistant message */
@@ -185,20 +182,27 @@ export const ChatMessage = memo(function ChatMessage({
   message,
   isLastMessage,
   status,
-  isEditing,
-  editContent,
-  editTextareaRef,
+  canSendMessages,
+  editor,
   agents,
-  setEditContent,
   onEditStart,
-  onEditCancel,
-  onEditSubmit,
   onMessageDelete,
   onRegenerate,
   onCopyMessage,
   copiedMessageId,
   staleToolCallIds,
 }: ChatMessageProps) {
+  // An edit takes the message's place rather than sitting inside it: the
+  // surface holds the text, the attachments and its own Save/Cancel, so
+  // rendering the stored parts alongside it would show each of those twice.
+  if (editor) {
+    return (
+      <div key={message.id} className="w-full">
+        {editor}
+      </div>
+    );
+  }
+
   const messageAgentId = message.metadata?.agentId;
   const messageAgent = messageAgentId
     ? agents.find((a) => a.id === messageAgentId)
@@ -255,11 +259,7 @@ export const ChatMessage = memo(function ChatMessage({
   const sourceCount =
     (nativeSourceParts?.length ?? 0) + pluginSearchSources.length;
 
-  const textContent =
-    message.parts
-      ?.filter((part): part is TextUIPart => part.type === "text")
-      .map((part) => part.text)
-      .join("") || "";
+  const textContent = messageText(message.parts);
 
   // Each entry's `matches` is mutually exclusive with every other entry's by
   // construction (see `isGenericToolPart`), so this list can be extended or
@@ -270,30 +270,6 @@ export const ChatMessage = memo(function ChatMessage({
       matches: (part) => part.type === "text",
       render: (part, i) => {
         const textPart = part as TextUIPart;
-        if (isEditing) {
-          const isFirstTextPart =
-            i === (message.parts ?? []).findIndex((p) => p.type === "text");
-          if (!isFirstTextPart) return null;
-
-          return (
-            <Message
-              key={`${message.id}-${i}`}
-              from={message.role}
-              avatar={assistantAvatar}
-            >
-              <MessageContent className="max-w-full">
-                <Textarea
-                  ref={editTextareaRef}
-                  value={editContent}
-                  onChange={(e) => setEditContent(e.target.value)}
-                  className="min-h-[100px]"
-                  autoFocus
-                />
-              </MessageContent>
-            </Message>
-          );
-        }
-
         return (
           <Message
             key={`${message.id}-${i}`}
@@ -496,58 +472,42 @@ export const ChatMessage = memo(function ChatMessage({
           )}
         </>
       )}
-      {!(isLastMessage && status === "streaming") &&
-        (isEditing ? (
-          <MessageActions className="justify-end">
+      {!(isLastMessage && status === "streaming") && (
+        <MessageActions
+          className={message.role === "user" ? "justify-end" : "pl-8"}
+        >
+          {message.role === "assistant" && (
+            // Leftmost, before Copy, and deliberately not adjacent to
+            // Delete — a frequently-poked new control beside an
+            // undoable action invites mis-clicks (issue #354).
+            <ResponseMetricsPopover metadata={message.metadata} />
+          )}
+          {/* Edit, Delete and Regenerate all change the transcript, so all
+          three hang off the same condition as the composer. Delete is the one
+          that made the gap visible: it mutates the local transcript with no
+          server call to refuse it, so an ungated button was a real write for
+          anyone who could reach the Chat (issue #710). */}
+          {canSendMessages && message.role === "user" && (
             <MessageAction
               className="cursor-pointer text-muted-foreground"
-              onClick={onEditSubmit}
+              onClick={() => onEditStart(message.id)}
               variant="ghost"
               size="icon"
-              label="Save"
+              label="Edit"
             >
-              <CheckIcon className="size-4" />
+              <PencilIcon className="size-4" />
             </MessageAction>
-            <MessageAction
-              className="cursor-pointer text-muted-foreground"
-              onClick={onEditCancel}
-              variant="ghost"
-              size="icon"
-              label="Cancel"
-            >
-              <XIcon className="size-4" />
-            </MessageAction>
-          </MessageActions>
-        ) : (
-          <MessageActions
-            className={message.role === "user" ? "justify-end" : "pl-8"}
+          )}
+          <MessageAction
+            className="cursor-pointer text-muted-foreground"
+            onClick={() => onCopyMessage(textContent, message.id)}
+            variant={copiedMessageId === message.id ? "secondary" : "ghost"}
+            size="icon"
+            label="Copy"
           >
-            {message.role === "assistant" && (
-              // Leftmost, before Copy, and deliberately not adjacent to
-              // Delete — a frequently-poked new control beside an
-              // undoable action invites mis-clicks (issue #354).
-              <ResponseMetricsPopover metadata={message.metadata} />
-            )}
-            {message.role === "user" && (
-              <MessageAction
-                className="cursor-pointer text-muted-foreground"
-                onClick={() => onEditStart(message.id, textContent)}
-                variant="ghost"
-                size="icon"
-                label="Edit"
-              >
-                <PencilIcon className="size-4" />
-              </MessageAction>
-            )}
-            <MessageAction
-              className="cursor-pointer text-muted-foreground"
-              onClick={() => onCopyMessage(textContent, message.id)}
-              variant={copiedMessageId === message.id ? "secondary" : "ghost"}
-              size="icon"
-              label="Copy"
-            >
-              <CopyIcon className="size-4" />
-            </MessageAction>
+            <CopyIcon className="size-4" />
+          </MessageAction>
+          {canSendMessages && (
             <MessageAction
               className="cursor-pointer text-muted-foreground"
               onClick={() => onMessageDelete(message.id)}
@@ -557,19 +517,20 @@ export const ChatMessage = memo(function ChatMessage({
             >
               <TrashIcon className="size-4" />
             </MessageAction>
-            {message.role === "assistant" && isLastMessage && (
-              <MessageAction
-                className="cursor-pointer text-muted-foreground"
-                onClick={onRegenerate}
-                variant="ghost"
-                size="icon"
-                label="Regenerate"
-              >
-                <RefreshCwIcon className="size-4" />
-              </MessageAction>
-            )}
-          </MessageActions>
-        ))}
+          )}
+          {canSendMessages && message.role === "assistant" && isLastMessage && (
+            <MessageAction
+              className="cursor-pointer text-muted-foreground"
+              onClick={onRegenerate}
+              variant="ghost"
+              size="icon"
+              label="Regenerate"
+            >
+              <RefreshCwIcon className="size-4" />
+            </MessageAction>
+          )}
+        </MessageActions>
+      )}
     </Fragment>
   );
 });

--- a/apps/frontend/components/chat.test.tsx
+++ b/apps/frontend/components/chat.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render } from "@testing-library/react";
-import type { ChatStatus } from "ai";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ChatStatus, FileUIPart } from "ai";
 import type { PlatypusUIMessage } from "@platypus/backend/src/types";
 
 /**
@@ -139,7 +139,59 @@ vi.mock("@/components/ai-elements/prompt-input", () => ({
   ),
 }));
 
-vi.mock("./chat-message", () => ({ ChatMessage: () => null }));
+// Stubbed to the edit seam: an Edit button per message, and whatever edit
+// surface the Chat hands down for the one being edited. The transcript itself
+// is `chat-message`'s own test's business.
+vi.mock("./chat-message", () => ({
+  ChatMessage: ({
+    message,
+    editor,
+    onEditStart,
+  }: {
+    message: PlatypusUIMessage;
+    editor?: React.ReactNode;
+    onEditStart: (messageId: string) => void;
+  }) => (
+    <div>
+      {editor ?? (
+        <button type="button" onClick={() => onEditStart(message.id)}>
+          Edit {message.id}
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+// Stubbed to what the Chat hands the edit surface, and to the one thing the
+// surface hands back: the whole message, attachments included.
+vi.mock("./message-editor", () => ({
+  MessageEditor: ({
+    initialText,
+    initialAttachments,
+    onSubmit,
+  }: {
+    initialText: string;
+    initialAttachments: FileUIPart[];
+    onSubmit: (message: { text: string; files: FileUIPart[] }) => void;
+  }) => (
+    <div data-testid="editor" data-text={initialText}>
+      {initialAttachments.map((file) => (
+        <span key={file.url}>{file.filename}</span>
+      ))}
+      <button
+        type="button"
+        onClick={() =>
+          onSubmit({
+            text: `${initialText} (edited)`,
+            files: initialAttachments,
+          })
+        }
+      >
+        Save
+      </button>
+    </div>
+  ),
+}));
 vi.mock("./context-meter", () => ({ ContextMeter: () => null }));
 vi.mock("./file-compatibility-warning", () => ({
   FileCompatibilityWarning: () => null,
@@ -474,5 +526,90 @@ describe("holding the composer", () => {
     const { getByTestId } = renderThrough(...DROPPED);
 
     expect(getByTestId("submit")).toHaveAttribute("data-status", "error");
+  });
+});
+
+/**
+ * The wiring an edit runs through (issue #710). The pieces have their own
+ * tests; what those cannot see is whether the Chat actually hands the edit
+ * surface the message's parts and resubmits what comes back. The original
+ * defect was exactly here: the surface was handed a string, so a message with
+ * a file resubmitted without it.
+ */
+describe("editing a message", () => {
+  const report: FileUIPart = {
+    type: "file",
+    url: "https://files.example.com/report.pdf",
+    mediaType: "application/pdf",
+    filename: "report.pdf",
+  };
+
+  const withAttachment = (): PlatypusUIMessage =>
+    ({
+      id: "u1",
+      role: "user",
+      parts: [report, { type: "text", text: "What does this say?" }],
+    }) as PlatypusUIMessage;
+
+  const openEditOn = (id: string) => {
+    renderChat();
+    fireEvent.click(screen.getByRole("button", { name: `Edit ${id}` }));
+  };
+
+  it("opens the edit surface on the message's text and attachments", () => {
+    harness.turn.messages = [withAttachment()];
+
+    openEditOn("u1");
+
+    expect(screen.getByTestId("editor")).toHaveAttribute(
+      "data-text",
+      "What does this say?",
+    );
+    expect(screen.getByText("report.pdf")).toBeInTheDocument();
+  });
+
+  it("resubmits the edit with its attachments and the current request body", () => {
+    harness.turn.messages = [withAttachment()];
+
+    openEditOn("u1");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(harness.sendMessage).toHaveBeenCalledWith(
+      { text: "What does this say? (edited)", files: [report] },
+      { body: expect.objectContaining({ providerId: expect.anything() }) },
+    );
+  });
+
+  it("truncates the transcript at the edited message", () => {
+    harness.turn.messages = [
+      withAttachment(),
+      message("a1", "It says X."),
+      message("u2", "And this?"),
+    ];
+
+    openEditOn("u2");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(harness.setMessages).toHaveBeenCalledWith(
+      harness.turn.messages.slice(0, 2),
+    );
+  });
+
+  it("closes the surface once the edit is sent", () => {
+    harness.turn.messages = [withAttachment()];
+
+    openEditOn("u1");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.queryByTestId("editor")).toBeNull();
+  });
+
+  it("edits one message at a time", () => {
+    harness.turn.messages = [withAttachment(), message("u2", "And this?")];
+
+    openEditOn("u1");
+
+    expect(screen.getAllByTestId("editor")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "Edit u2" })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -57,6 +57,7 @@ import { clearedToolCallIds } from "@/lib/tool-result-clearing";
 import { ContextMeter } from "./context-meter";
 import { FileCompatibilityWarning } from "./file-compatibility-warning";
 import { useMessageEditing } from "@/hooks/use-message-editing";
+import { ATTACHMENTS_ONLY_TEXT } from "@/lib/message-parts";
 import { useChatTitlePoll } from "@/hooks/use-chat-title-poll";
 import { useChatUI } from "@/hooks/use-chat-ui";
 import { Dialog, DialogTrigger } from "./ui/dialog";
@@ -76,6 +77,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ChatMessage } from "./chat-message";
+import { MessageEditor } from "./message-editor";
 import { ChatReconnectingNotice } from "./chat-reconnecting-notice";
 import { ModelSelectorDialog } from "./model-selector-dialog";
 import { toast } from "sonner";
@@ -347,20 +349,12 @@ export const Chat = ({
   }, [getRequestBody]);
 
   // Message editing hook (needs getRequestBody to be defined)
-  const messageEditing = useMessageEditing(
-    messages,
-    setMessages,
-    sendMessage,
-    getRequestBody,
-  );
   const {
-    editingMessageId,
-    editContent,
-    editTextareaRef,
+    editing,
     handleMessageEditStart,
     handleMessageEditCancel,
     handleMessageEditSubmit,
-  } = messageEditing;
+  } = useMessageEditing(messages, setMessages, sendMessage, getRequestBody);
 
   // Hydrate chat from persisted data on load (or when chatData changes).
   // We use a ref for status so that this effect only fires when chatData
@@ -561,7 +555,7 @@ export const Chat = ({
 
     sendMessage(
       {
-        text: message.text || "Sent with attachments",
+        text: message.text || ATTACHMENTS_ONLY_TEXT,
         files: message.files,
       },
       { body },
@@ -591,14 +585,33 @@ export const Chat = ({
                   message={message}
                   isLastMessage={messageIndex === messages.length - 1}
                   status={status}
-                  isEditing={editingMessageId === message.id}
-                  editContent={editContent}
-                  editTextareaRef={editTextareaRef}
+                  canSendMessages={canSendMessages}
+                  editor={
+                    editing?.messageId === message.id ? (
+                      <MessageEditor
+                        // Remounted per message, so the surface reseeds from
+                        // the message it was opened on rather than carrying
+                        // the last one's text and attachments over.
+                        key={editing.messageId}
+                        initialText={editing.text}
+                        initialAttachments={editing.attachments}
+                        agents={agents}
+                        providers={providers}
+                        agentId={agentId}
+                        modelId={modelId}
+                        providerId={providerId}
+                        onModelChange={handleModelChange}
+                        maxOutputTokens={resolvedModel?.maxOutputTokens}
+                        passthroughFileTypes={
+                          resolvedModel?.passthroughFileTypes ?? []
+                        }
+                        onSubmit={handleMessageEditSubmit}
+                        onCancel={handleMessageEditCancel}
+                      />
+                    ) : undefined
+                  }
                   agents={agents}
-                  setEditContent={messageEditing.setEditContent}
                   onEditStart={handleMessageEditStart}
-                  onEditCancel={handleMessageEditCancel}
-                  onEditSubmit={handleMessageEditSubmit}
                   onMessageDelete={handleMessageDelete}
                   onRegenerate={handleRegenerate}
                   onCopyMessage={handleCopyMessage}

--- a/apps/frontend/components/message-editor.test.tsx
+++ b/apps/frontend/components/message-editor.test.tsx
@@ -221,6 +221,16 @@ describe("MessageEditor", () => {
     }
   });
 
+  // Opening on a message means opening ready to replace it, not ready to
+  // append to it.
+  it("selects the text it opens on", () => {
+    renderEditor();
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.selectionStart).toBe(0);
+    expect(textarea.selectionEnd).toBe("What does this say?".length);
+  });
+
   // The composer owns the window-level drop (`globalDrop`); a second input
   // claiming it would take the same file a second time.
   it("does not claim a file dropped on the window", () => {
@@ -234,6 +244,29 @@ describe("MessageEditor", () => {
     });
 
     expect(screen.queryByText("dropped.png")).toBeNull();
+  });
+
+  // …but a file dropped ON the edit surface is the edit's, and it must not fall
+  // through to the composer's window-level listener.
+  it("keeps a file dropped on itself, and stops it bubbling onward", () => {
+    const onWindowDrop = vi.fn();
+    document.addEventListener("drop", onWindowDrop);
+    // Both types read natively, so the compatibility notice stays out of the
+    // way — it would otherwise name the dropped file a second time.
+    const { container } = renderEditor({
+      passthroughFileTypes: ["application/pdf", "image/png"],
+    });
+
+    fireEvent.drop(container.querySelector("form")!, {
+      dataTransfer: {
+        types: ["Files"],
+        files: [new File(["hi"], "dropped.png", { type: "image/png" })],
+      },
+    });
+
+    expect(screen.getByText("dropped.png")).toBeInTheDocument();
+    expect(onWindowDrop).not.toHaveBeenCalled();
+    document.removeEventListener("drop", onWindowDrop);
   });
 
   it("writes dictation into the edited message", async () => {

--- a/apps/frontend/components/message-editor.test.tsx
+++ b/apps/frontend/components/message-editor.test.tsx
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { FileUIPart } from "ai";
+import type { Provider } from "@platypus/schemas";
+
+/**
+ * The edit surface (issue #710). The defect it exists to fix is invisible in a
+ * unit test of any one piece: editing resubmitted a bare string, so a message
+ * with a file came back without it. So these tests drive the surface the way a
+ * user does — open it on a message that carries a file, press Save, and read
+ * what it hands back.
+ */
+
+// The picker has its own tests; here it stands in for "the surface names what
+// it will re-run on", which is the reason the ticket keeps it.
+vi.mock("./model-selector-dialog", () => ({
+  ModelSelectorDialog: ({ modelId }: { modelId: string }) => (
+    <button type="button">{modelId || "Select model"}</button>
+  ),
+}));
+
+import { MessageEditor } from "./message-editor";
+
+class FakeSpeechRecognition extends EventTarget {
+  continuous = false;
+  interimResults = false;
+  lang = "";
+  start = vi.fn(() => this.onstart?.(new Event("start")));
+  stop = vi.fn(() => this.onend?.(new Event("end")));
+  onstart: ((ev: Event) => void) | null = null;
+  onend: ((ev: Event) => void) | null = null;
+  onresult: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+
+  emitFinalResult(transcript: string) {
+    this.onresult?.({
+      resultIndex: 0,
+      results: {
+        length: 1,
+        0: { isFinal: true, length: 1, 0: { transcript, confidence: 1 } },
+      },
+    });
+  }
+}
+
+let lastRecognition: FakeSpeechRecognition | null = null;
+
+const registerRecognition = (instance: FakeSpeechRecognition) => {
+  lastRecognition = instance;
+};
+
+class TrackingSpeechRecognition extends FakeSpeechRecognition {
+  constructor() {
+    super();
+    registerRecognition(this);
+  }
+}
+
+beforeEach(() => {
+  // jsdom has no matchMedia; PromptInputTextarea subscribes to it.
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }) as unknown as typeof window.matchMedia;
+  lastRecognition = null;
+  window.SpeechRecognition =
+    TrackingSpeechRecognition as unknown as Window["SpeechRecognition"];
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(window, "SpeechRecognition");
+  Reflect.deleteProperty(window, "webkitSpeechRecognition");
+});
+
+const report: FileUIPart = {
+  type: "file",
+  url: "https://files.example.com/report.pdf",
+  mediaType: "application/pdf",
+  filename: "report.pdf",
+};
+
+const provider = {
+  id: "p1",
+  name: "OpenRouter",
+  modelIds: [{ id: "m1", passthroughFileTypes: [] }],
+} as unknown as Provider;
+
+const renderEditor = (
+  overrides: Partial<React.ComponentProps<typeof MessageEditor>> = {},
+) => {
+  const onSubmit = vi.fn();
+  const onCancel = vi.fn();
+  const view = render(
+    <MessageEditor
+      initialText="What does this say?"
+      initialAttachments={[report]}
+      agents={[]}
+      providers={[provider]}
+      agentId=""
+      modelId="m1"
+      providerId="p1"
+      onModelChange={vi.fn()}
+      // The seeded PDF reads natively by default, so the compatibility notice
+      // stays out of the way of every test that isn't about it.
+      passthroughFileTypes={["application/pdf"]}
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+      {...overrides}
+    />,
+  );
+  return { ...view, onSubmit, onCancel };
+};
+
+const save = () =>
+  fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+describe("MessageEditor", () => {
+  it("opens holding the message's text and its attachments", () => {
+    renderEditor();
+
+    expect(screen.getByRole("textbox")).toHaveValue("What does this say?");
+    expect(screen.getByText("report.pdf")).toBeInTheDocument();
+  });
+
+  // The regression the ticket exists for.
+  it("saves an edited message with its original attachments intact", async () => {
+    const { onSubmit } = renderEditor();
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "What does this actually say?" },
+    });
+    save();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0]).toEqual({
+      text: "What does this actually say?",
+      files: [report],
+    });
+  });
+
+  it("saves without an attachment the user removed", async () => {
+    const { onSubmit } = renderEditor();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove attachment" }));
+    save();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0].files).toEqual([]);
+  });
+
+  it("attaches a file added while editing", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      blob: async () => new Blob(["hi"], { type: "text/plain" }),
+    }) as unknown as typeof global.fetch;
+    const { onSubmit } = renderEditor();
+
+    const input = screen.getByLabelText("Upload files") as HTMLInputElement;
+    Object.defineProperty(input, "files", {
+      value: [new File(["hi"], "extra.txt", { type: "text/plain" })],
+      configurable: true,
+    });
+    fireEvent.change(input);
+
+    expect(screen.getByText("extra.txt")).toBeInTheDocument();
+
+    save();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0].files).toEqual([
+      expect.objectContaining({ filename: "report.pdf" }),
+      expect.objectContaining({ filename: "extra.txt" }),
+    ]);
+  });
+
+  it("cancels on Escape without saving", () => {
+    const { onSubmit, onCancel } = renderEditor();
+
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Escape" });
+
+    expect(onCancel).toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("cancels from the Cancel action", () => {
+    const { onCancel } = renderEditor();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("saves on Enter", async () => {
+    const { onSubmit } = renderEditor();
+
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" });
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+  });
+
+  it("keeps Shift+Enter as a newline rather than a save", () => {
+    const { onSubmit } = renderEditor();
+
+    fireEvent.keyDown(screen.getByRole("textbox"), {
+      key: "Enter",
+      shiftKey: true,
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  // Anything that shapes the message's parts stays; anything that configures
+  // the Chat or the run goes. The picker is the exception the ticket argues
+  // for: an edit re-runs on live composer state, so the surface has to name it.
+  it("carries the model picker and nothing that configures the Chat", () => {
+    renderEditor();
+
+    expect(screen.getByRole("button", { name: "m1" })).toBeInTheDocument();
+    for (const gone of ["Settings", "Search", "Agent Information"]) {
+      expect(screen.queryByRole("button", { name: gone })).toBeNull();
+    }
+  });
+
+  // The composer owns the window-level drop (`globalDrop`); a second input
+  // claiming it would take the same file a second time.
+  it("does not claim a file dropped on the window", () => {
+    renderEditor();
+
+    fireEvent.drop(document, {
+      dataTransfer: {
+        types: ["Files"],
+        files: [new File(["hi"], "dropped.png", { type: "image/png" })],
+      },
+    });
+
+    expect(screen.queryByText("dropped.png")).toBeNull();
+  });
+
+  it("writes dictation into the edited message", async () => {
+    const { onSubmit } = renderEditor({ initialText: "" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Microphone" }));
+    lastRecognition?.emitFinalResult("dictated words");
+
+    await waitFor(() =>
+      expect(screen.getByRole("textbox")).toHaveValue("dictated words"),
+    );
+
+    save();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(onSubmit.mock.calls[0][0].text).toBe("dictated words");
+  });
+
+  it("warns when the selected model cannot read an attached type", () => {
+    renderEditor({ passthroughFileTypes: ["image/png"] });
+
+    expect(screen.getByRole("status")).toHaveTextContent("report.pdf");
+  });
+});

--- a/apps/frontend/components/message-editor.tsx
+++ b/apps/frontend/components/message-editor.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { FileUIPart } from "ai";
+import type { Agent, Provider } from "@platypus/schemas";
+import { XIcon } from "lucide-react";
+import {
+  PromptInput,
+  PromptInputActionAddAttachments,
+  PromptInputActionMenu,
+  PromptInputActionMenuContent,
+  PromptInputActionMenuTrigger,
+  PromptInputAttachment,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputButton,
+  PromptInputFooter,
+  PromptInputSpeechButton,
+  PromptInputSubmit,
+  PromptInputTextarea,
+  PromptInputTools,
+  type PromptInputMessage,
+} from "./ai-elements/prompt-input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { FileCompatibilityWarning } from "./file-compatibility-warning";
+import { ModelSelectorDialog } from "./model-selector-dialog";
+
+interface MessageEditorProps {
+  /** The message's text as it stands, which the editor opens on. */
+  initialText: string;
+  /** The attachments it already carries, which the editor opens holding. */
+  initialAttachments: FileUIPart[];
+  agents: Agent[];
+  providers: Provider[];
+  agentId: string;
+  modelId: string;
+  providerId: string;
+  onModelChange: (value: string) => void;
+  /** The resolved model's Output ceiling, for the picker's tooltip. */
+  maxOutputTokens?: number;
+  /** What the resolved model reads natively, for the compatibility notice. */
+  passthroughFileTypes: string[];
+  onSubmit: (message: PromptInputMessage) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Editing a message in place, through the same composer the message was
+ * written with (issue #710).
+ *
+ * The rule for what this carries: anything that shapes the message's parts
+ * stays — attachments, the compatibility notice, dictation — and anything that
+ * configures the Chat or the run goes: no Agent info, no Chat settings, no
+ * context meter, no search toggle.
+ *
+ * The model picker is the exception, and deliberately so. An edit resubmits
+ * against live composer state, not against the model that produced the original
+ * turn, so a user who changed the picker an hour ago and then edits an old
+ * message gets a different model whether the picker is on screen or not.
+ * Showing it is what makes that visible before saving — and re-running on
+ * another model is a leading reason to edit at all on a multi-provider
+ * platform. Picking one here changes the Chat's selection, exactly as picking
+ * one in the composer does.
+ *
+ * `globalDrop` is deliberately absent: the composer claims the window-level
+ * drop, and two inputs claiming it would both take the same file.
+ */
+export const MessageEditor = ({
+  initialText,
+  initialAttachments,
+  agents,
+  providers,
+  agentId,
+  modelId,
+  providerId,
+  onModelChange,
+  maxOutputTokens,
+  passthroughFileTypes,
+  onSubmit,
+  onCancel,
+}: MessageEditorProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [text, setText] = useState(initialText);
+  // The edit surface's own picker state: sharing the composer's would open both
+  // dialogs at once.
+  const [isModelSelectorOpen, setIsModelSelectorOpen] = useState(false);
+
+  // Opening an edit selects what is there, so retyping the message replaces it
+  // rather than appending to it.
+  useEffect(() => {
+    textareaRef.current?.select();
+  }, []);
+
+  return (
+    <PromptInput
+      className="w-full"
+      onSubmit={onSubmit}
+      initialAttachments={initialAttachments}
+      multiple
+    >
+      <PromptInputAttachments className="w-full">
+        {(attachment) => <PromptInputAttachment data={attachment} />}
+      </PromptInputAttachments>
+      <FileCompatibilityWarning passthroughFileTypes={passthroughFileTypes} />
+      <PromptInputBody>
+        <PromptInputTextarea
+          ref={textareaRef}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          // Escape belongs to the edit; claiming it here keeps the built-in
+          // Enter-to-submit and Backspace-removes-attachment intact.
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              e.stopPropagation();
+              onCancel();
+            }
+          }}
+          autoFocus
+        />
+      </PromptInputBody>
+      <PromptInputFooter className="flex-wrap">
+        <PromptInputTools>
+          <PromptInputActionMenu>
+            <PromptInputActionMenuTrigger className="cursor-pointer" />
+            <PromptInputActionMenuContent>
+              <PromptInputActionAddAttachments className="cursor-pointer" />
+            </PromptInputActionMenuContent>
+          </PromptInputActionMenu>
+          <Tooltip delayDuration={1000}>
+            <TooltipTrigger asChild>
+              <PromptInputSpeechButton
+                aria-label="Microphone"
+                className="cursor-pointer"
+                textareaRef={textareaRef}
+                onTranscriptionChange={setText}
+              />
+            </TooltipTrigger>
+            <TooltipContent>Microphone</TooltipContent>
+          </Tooltip>
+          <ModelSelectorDialog
+            agents={agents}
+            providers={providers}
+            agentId={agentId}
+            modelId={modelId}
+            providerId={providerId}
+            isOpen={isModelSelectorOpen}
+            onOpenChange={(open) => {
+              setIsModelSelectorOpen(open);
+              if (!open) {
+                setTimeout(() => textareaRef.current?.focus(), 250);
+              }
+            }}
+            onModelChange={onModelChange}
+            maxOutputTokens={maxOutputTokens}
+          />
+        </PromptInputTools>
+        <div className="flex items-center gap-1">
+          <PromptInputButton
+            aria-label="Cancel"
+            className="cursor-pointer"
+            onClick={onCancel}
+          >
+            <XIcon className="size-4" />
+          </PromptInputButton>
+          <PromptInputSubmit aria-label="Save" className="cursor-pointer" />
+        </div>
+      </PromptInputFooter>
+    </PromptInput>
+  );
+};

--- a/apps/frontend/hooks/use-message-editing.test.tsx
+++ b/apps/frontend/hooks/use-message-editing.test.tsx
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { FileUIPart, UIMessage } from "ai";
+import { useMessageEditing } from "./use-message-editing";
+
+/**
+ * Editing used to resubmit `{ text }` and nothing else, so a message that
+ * carried a file came back without it — the model answered a different
+ * question and nothing on screen said why (issue #710). These tests pin the
+ * round trip at the hook: what an edit opens holding, and what it resubmits.
+ */
+
+const report: FileUIPart = {
+  type: "file",
+  url: "https://files.example.com/report.pdf",
+  mediaType: "application/pdf",
+  filename: "report.pdf",
+};
+
+const screenshot: FileUIPart = {
+  type: "file",
+  url: "https://files.example.com/shot.png",
+  mediaType: "image/png",
+  filename: "shot.png",
+};
+
+const transcript: UIMessage[] = [
+  {
+    id: "u1",
+    role: "user",
+    parts: [report, screenshot, { type: "text", text: "What does this say?" }],
+  },
+  {
+    id: "a1",
+    role: "assistant",
+    parts: [{ type: "text", text: "It says X." }],
+  },
+  { id: "u2", role: "user", parts: [{ type: "text", text: "And this?" }] },
+];
+
+const harness = (messages: UIMessage[] = transcript) => {
+  const setMessages = vi.fn();
+  const sendMessage = vi.fn();
+  const getRequestBody = vi.fn().mockReturnValue({ providerId: "p1" });
+  const view = renderHook(() =>
+    useMessageEditing(messages, setMessages, sendMessage, getRequestBody),
+  );
+  return { ...view, setMessages, sendMessage, getRequestBody };
+};
+
+describe("useMessageEditing opening an edit", () => {
+  it("edits nothing until a message is named", () => {
+    const { result } = harness();
+
+    expect(result.current.editing).toBeNull();
+  });
+
+  it("opens holding the message's text and every file it carries", () => {
+    const { result } = harness();
+
+    act(() => result.current.handleMessageEditStart("u1"));
+
+    expect(result.current.editing).toEqual({
+      messageId: "u1",
+      text: "What does this say?",
+      attachments: [report, screenshot],
+    });
+  });
+
+  it("joins a message written across several text parts", () => {
+    const { result } = harness([
+      {
+        id: "u1",
+        role: "user",
+        parts: [
+          { type: "text", text: "First half. " },
+          { type: "text", text: "Second half." },
+        ],
+      },
+    ]);
+
+    act(() => result.current.handleMessageEditStart("u1"));
+
+    expect(result.current.editing?.text).toBe("First half. Second half.");
+  });
+
+  it("closes on cancel without touching the transcript", () => {
+    const { result, setMessages, sendMessage } = harness();
+
+    act(() => result.current.handleMessageEditStart("u1"));
+    act(() => result.current.handleMessageEditCancel());
+
+    expect(result.current.editing).toBeNull();
+    expect(setMessages).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("useMessageEditing submitting an edit", () => {
+  it("resubmits the attachments the edit surface hands back", () => {
+    const { result, sendMessage } = harness();
+
+    act(() => result.current.handleMessageEditStart("u1"));
+    act(() =>
+      result.current.handleMessageEditSubmit({
+        text: "What does this actually say?",
+        files: [report, screenshot],
+      }),
+    );
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      {
+        text: "What does this actually say?",
+        files: [report, screenshot],
+      },
+      { body: { providerId: "p1" } },
+    );
+  });
+
+  it("truncates the transcript at the edited message and closes", () => {
+    const { result, setMessages } = harness();
+
+    act(() => result.current.handleMessageEditStart("u1"));
+    act(() =>
+      result.current.handleMessageEditSubmit({ text: "Rewritten", files: [] }),
+    );
+
+    expect(setMessages).toHaveBeenCalledWith([]);
+    expect(result.current.editing).toBeNull();
+  });
+
+  it("truncates at a message part-way down the transcript", () => {
+    const { result, setMessages } = harness();
+
+    act(() => result.current.handleMessageEditStart("u2"));
+    act(() =>
+      result.current.handleMessageEditSubmit({ text: "Rewritten", files: [] }),
+    );
+
+    expect(setMessages).toHaveBeenCalledWith([transcript[0], transcript[1]]);
+  });
+
+  it("sends attachments the user added while editing", () => {
+    const added: FileUIPart = {
+      type: "file",
+      url: "data:text/plain;base64,aGk=",
+      mediaType: "text/plain",
+      filename: "extra.txt",
+    };
+    const { result, sendMessage } = harness();
+
+    act(() => result.current.handleMessageEditStart("u1"));
+    act(() =>
+      result.current.handleMessageEditSubmit({
+        text: "Both, please",
+        files: [report, added],
+      }),
+    );
+
+    expect(sendMessage.mock.calls[0][0].files).toEqual([report, added]);
+  });
+
+  // An attachment-only edit is a real edit: the question was the file.
+  it("stands in a text for an edit left with attachments and no words", () => {
+    const { result, sendMessage } = harness();
+
+    act(() => result.current.handleMessageEditStart("u1"));
+    act(() =>
+      result.current.handleMessageEditSubmit({ text: "", files: [report] }),
+    );
+
+    expect(sendMessage.mock.calls[0][0]).toEqual({
+      text: "Sent with attachments",
+      files: [report],
+    });
+  });
+
+  // Truncating the transcript and sending nothing is how a stray Enter would
+  // wipe a conversation with no way back.
+  it("refuses an edit with neither text nor attachments", () => {
+    const { result, setMessages, sendMessage } = harness();
+
+    act(() => result.current.handleMessageEditStart("u1"));
+    act(() => result.current.handleMessageEditSubmit({ text: "", files: [] }));
+
+    expect(setMessages).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result.current.editing).not.toBeNull();
+  });
+
+  it("ignores a submit for a message that has since gone", () => {
+    const { result, setMessages, sendMessage } = harness();
+
+    act(() => result.current.handleMessageEditStart("gone"));
+    act(() =>
+      result.current.handleMessageEditSubmit({ text: "Rewritten", files: [] }),
+    );
+
+    expect(setMessages).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/hooks/use-message-editing.ts
+++ b/apps/frontend/hooks/use-message-editing.ts
@@ -1,59 +1,95 @@
-import { useState, useRef, useEffect } from "react";
-import { UIMessage } from "ai";
+import { useCallback, useMemo, useState } from "react";
+import { FileUIPart, UIMessage } from "ai";
+import {
+  ATTACHMENTS_ONLY_TEXT,
+  messageAttachments,
+  messageText,
+} from "@/lib/message-parts";
 
+/** What an edit resubmits: the whole message, not just its words. */
+export type EditedMessage = {
+  text: string;
+  files?: FileUIPart[];
+};
+
+/**
+ * The message an edit surface should open with. `null` when nothing is being
+ * edited, or when the named message has left the transcript — a run that
+ * hydrated a fresh snapshot underneath an open editor, say.
+ */
+export type MessageBeingEdited = {
+  messageId: string;
+  text: string;
+  attachments: FileUIPart[];
+};
+
+/**
+ * Editing a message: which one, what the surface opens holding, and what
+ * resubmitting does to the transcript.
+ *
+ * Editing stays destructive — the edited message and everything below it goes,
+ * and the edit is sent as a fresh turn. What changed in issue #710 is that the
+ * message survives the round trip whole: it opens from its parts and resubmits
+ * with the attachments the surface hands back, rather than being flattened to
+ * its text on the way in and rebuilt from a bare string on the way out.
+ */
 export const useMessageEditing = <T extends UIMessage = UIMessage>(
   messages: T[],
   setMessages: (messages: T[]) => void,
   sendMessage: (
-    message: { text: string },
+    message: EditedMessage,
     options?: { body?: Record<string, unknown> },
   ) => void,
   getRequestBody: () => Record<string, unknown>,
 ) => {
-  const editTextareaRef = useRef<HTMLTextAreaElement>(null);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
-  const [editContent, setEditContent] = useState("");
 
-  // Select all text in edit textarea when editing starts
-  useEffect(() => {
-    if (editingMessageId && editTextareaRef.current) {
-      editTextareaRef.current.select();
-    }
-  }, [editingMessageId]);
+  const editing = useMemo<MessageBeingEdited | null>(() => {
+    if (!editingMessageId) return null;
+    const message = messages.find((m) => m.id === editingMessageId);
+    if (!message) return null;
+    return {
+      messageId: message.id,
+      text: messageText(message.parts),
+      attachments: messageAttachments(message.parts),
+    };
+  }, [editingMessageId, messages]);
 
-  const handleMessageEditStart = (messageId: string, content: string) => {
+  const handleMessageEditStart = useCallback((messageId: string) => {
     setEditingMessageId(messageId);
-    setEditContent(content);
-  };
+  }, []);
 
-  const handleMessageEditCancel = () => {
+  const handleMessageEditCancel = useCallback(() => {
     setEditingMessageId(null);
-    setEditContent("");
-  };
+  }, []);
 
-  const handleMessageEditSubmit = () => {
-    if (!editingMessageId) return;
-    const messageIndex = messages.findIndex((m) => m.id === editingMessageId);
-    if (messageIndex === -1) return;
+  const handleMessageEditSubmit = useCallback(
+    (edited: EditedMessage) => {
+      if (!editingMessageId) return;
+      const messageIndex = messages.findIndex((m) => m.id === editingMessageId);
+      if (messageIndex === -1) return;
 
-    // Remove messages after this one (including this one)
-    const newMessages = messages.slice(0, messageIndex);
-    setMessages(newMessages);
+      const files = edited.files ?? [];
+      // An edit emptied of both its words and its files would truncate the
+      // transcript and send nothing in its place — the one edit with no way
+      // back. Left open instead, so the user can see what they are about to do.
+      if (!edited.text && files.length === 0) return;
 
-    // Submit the edited message to backend (will append it)
-    const body = getRequestBody();
-    sendMessage({ text: editContent }, { body });
+      // Remove the edited message and everything after it
+      setMessages(messages.slice(0, messageIndex));
 
-    // Reset edit state
-    setEditingMessageId(null);
-    setEditContent("");
-  };
+      sendMessage(
+        { text: edited.text || ATTACHMENTS_ONLY_TEXT, files },
+        { body: getRequestBody() },
+      );
+
+      setEditingMessageId(null);
+    },
+    [editingMessageId, getRequestBody, messages, sendMessage, setMessages],
+  );
 
   return {
-    editTextareaRef,
-    editingMessageId,
-    editContent,
-    setEditContent,
+    editing,
     handleMessageEditStart,
     handleMessageEditCancel,
     handleMessageEditSubmit,

--- a/apps/frontend/lib/message-parts.test.ts
+++ b/apps/frontend/lib/message-parts.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isImageAttachment } from "./message-parts";
+import {
+  isImageAttachment,
+  messageAttachments,
+  messageText,
+} from "./message-parts";
 
 describe("isImageAttachment", () => {
   it("is true for an image media type with a URL", () => {
@@ -19,5 +23,49 @@ describe("isImageAttachment", () => {
         url: "https://x/a.pdf",
       }),
     ).toBe(false);
+  });
+});
+
+const pdf = {
+  type: "file" as const,
+  url: "https://x/a.pdf",
+  mediaType: "application/pdf",
+  filename: "a.pdf",
+};
+
+const png = {
+  type: "file" as const,
+  url: "https://x/a.png",
+  mediaType: "image/png",
+  filename: "a.png",
+};
+
+describe("messageText", () => {
+  it("joins every text part in order", () => {
+    expect(
+      messageText([
+        { type: "text", text: "First. " },
+        pdf,
+        { type: "text", text: "Second." },
+      ]),
+    ).toBe("First. Second.");
+  });
+
+  it("is empty for a message with no text and for no parts at all", () => {
+    expect(messageText([pdf])).toBe("");
+    expect(messageText(undefined)).toBe("");
+  });
+});
+
+describe("messageAttachments", () => {
+  it("keeps every file part, images included, in order", () => {
+    expect(
+      messageAttachments([png, { type: "text", text: "Look" }, pdf]),
+    ).toEqual([png, pdf]);
+  });
+
+  it("is empty for a message with no files and for no parts at all", () => {
+    expect(messageAttachments([{ type: "text", text: "Look" }])).toEqual([]);
+    expect(messageAttachments(undefined)).toEqual([]);
   });
 });

--- a/apps/frontend/lib/message-parts.ts
+++ b/apps/frontend/lib/message-parts.ts
@@ -1,4 +1,19 @@
-import type { FileUIPart } from "ai";
+import type { FileUIPart, TextUIPart } from "ai";
+
+/**
+ * The loosest shape these readers need: a part is anything with a `type`, and
+ * whatever else that type brings with it. Deliberately not `UIMessage["parts"]`
+ * — the part union is generic over a Chat's tools and data parts, and these
+ * readers only ever ask what kind of part they are looking at.
+ */
+type UnknownPart = { type: string; [key: string]: unknown };
+
+/**
+ * What a message carrying files and no words of its own is sent as. Shared by
+ * the composer and the edit surface, so an attachment-only turn reads the same
+ * whether it was sent or edited into being.
+ */
+export const ATTACHMENTS_ONLY_TEXT = "Sent with attachments";
 
 /**
  * Whether a file part should render as an image rather than a generic file
@@ -10,3 +25,28 @@ import type { FileUIPart } from "ai";
 export const isImageAttachment = (
   part: Pick<FileUIPart, "mediaType" | "url">,
 ): boolean => Boolean(part.mediaType?.startsWith("image/") && part.url);
+
+/**
+ * The message as one string: every text part, in order, joined. A turn can
+ * carry several — a model that wrote, called a tool, and wrote again — and
+ * they are one message to a reader, so Copy and the edit surface both open
+ * from this rather than each keeping their own idea of it.
+ */
+export const messageText = (
+  parts: readonly UnknownPart[] | undefined,
+): string =>
+  (parts ?? [])
+    .filter((part): part is TextUIPart => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+
+/**
+ * Every file the message carries, in the order it carries them. Images are
+ * included: they render inline in the transcript but are attachments in an
+ * edit surface, and an edit that kept only the non-image ones would drop the
+ * screenshot the question was about (issue #710).
+ */
+export const messageAttachments = (
+  parts: readonly UnknownPart[] | undefined,
+): FileUIPart[] =>
+  (parts ?? []).filter((part): part is FileUIPart => part.type === "file");


### PR DESCRIPTION
Closes #710.

## The defect

Editing a message resubmitted a bare string, so every part that was not text was
discarded. Editing a message with file attachments silently dropped them: the
resubmitted turn carried no files, the model answered without them, and nothing
on screen said why the answer had changed.

## The change

The bare textarea is replaced with an inline prompt input that operates on the
message's parts. The rule for what it carries: anything that shapes the
message's parts stays, anything that configures the Chat or the run goes.

**Kept** — the attachment list and action menu, the file compatibility warning,
the textarea, the speech button, the model picker, and a Save/Cancel pair.

**Dropped** — Agent Information, Chat Settings, the context meter, and the
search toggle.

The model picker stays because an edit resubmits against **live** composer
state, not against the model that produced the original turn. That coupling
exists whether or not the picker is on screen; showing it is the only thing
that makes it visible before saving, and re-running on a different model is a
leading reason to edit at all on a multi-provider platform. Picking one in the
edit surface changes the Chat's selection, the same as picking one below.

Escape cancels, Enter saves, and neither collides with the composer: the
vendored textarea now composes a caller's `onKeyDown` with its own instead of
being replaced by it, so Enter-to-submit and Backspace-removes-attachment
survive. The edit surface deliberately does not claim the window-level file
drop — the composer has it, and two inputs claiming it would both take the
same file.

Editing stays **destructive**: it still truncates at the edited message and
resubmits. Branching is not part of this.

## Also fixed: the message action bar was ungated

Sending is workspace ownership, and the client gated only the composer on it.
Edit, Delete and Regenerate were not gated at all, so an Org Admin or Operator
reading another Workspace's Chat saw all three and could fire them — Delete in
particular mutates the local transcript with no server call to refuse it. All
three now hang off the same condition as the composer. Copy and the metrics
popover are unchanged: reading is not writing.

## Behaviour worth knowing

An edit emptied of both its words and its attachments is now refused rather
than truncating the transcript and sending nothing in its place. That was the
one edit with no way back.

## Docs

`building-with-platypus/chat.mdx` gains a **Rewriting a message** section, an
updated per-message action table, and a note in **Sharing a Chat** that a
read-only viewer is not offered the write actions.

## Tests

44 new tests at four seams:

- `lib/message-parts.test.ts` — the shared part readers.
- `hooks/use-message-editing.test.tsx` — what an edit opens holding and what it
  resubmits, including the attachment round trip and the empty-edit refusal.
- `components/message-editor.test.tsx` — the surface driven as a user does:
  save with attachments intact, add one, remove one, Escape, Enter,
  Shift+Enter, dictation landing in the edited message, no double-attach from a
  window drop, and that the surface carries the picker and nothing that
  configures the Chat.
- `components/ai-elements/prompt-input.test.tsx` and
  `components/chat.test.tsx` — the seeding prop and the wiring the pieces'
  own tests cannot see.

`pnpm typecheck`, `pnpm lint`, `pnpm test` and `pnpm build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
