### PR TITLE
fix(backend): delete file parts stored as HTTP URLs when a chat is deleted

### DIFF
--- a/apps/backend/src/storage/utils.test.ts
+++ b/apps/backend/src/storage/utils.test.ts
@@ -37,6 +37,13 @@ function createPngDataUrl(): string {
   return `data:image/png;base64,${base64}`;
 }
 
+// Count stored object files (excluding .meta sidecars) under the given root.
+async function countPngFiles(root: string): Promise<number> {
+  const files = await fs.readdir(root, { recursive: true });
+  const all = files.flat();
+  return all.filter((f) => String(f).endsWith(".png")).length;
+}
+
 describe("Storage Utils", () => {
   let tempDir: string;
 
@@ -239,6 +246,124 @@ describe("Storage Utils", () => {
       expect(keys).toContain("org-1/ws-1/chat-1/msg-2/0-def67890.jpg");
     });
 
+    // The point of this test (issue #715): a test using only `storage://`
+    // fixtures would pass even while HTTP-form URLs — what the client actually
+    // returns on the second and later turns — leak on deletion.
+    it("should extract keys from HTTP-form URLs returned on later turns", () => {
+      const messages: PlatypusUIMessage[] = [
+        {
+          id: "msg-1",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: "http://localhost:4000/files/org-1/ws-1/chat-1/msg-1/1-abc12345.png",
+              mediaType: "image/png",
+            },
+          ],
+        },
+        {
+          id: "msg-2",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: "https://example.com/some/path/files/org-1/ws-1/chat-1/msg-2/0-def67890.jpg",
+              mediaType: "image/jpeg",
+            },
+          ],
+        },
+      ];
+
+      const keys = extractStorageKeys(messages);
+
+      expect(keys).toHaveLength(2);
+      expect(keys).toContain("org-1/ws-1/chat-1/msg-1/1-abc12345.png");
+      expect(keys).toContain("org-1/ws-1/chat-1/msg-2/0-def67890.jpg");
+    });
+
+    it("should extract keys from STORAGE_PUBLIC_URL URLs", () => {
+      process.env.STORAGE_PUBLIC_URL = "https://my-bucket.s3.amazonaws.com";
+
+      const messages: PlatypusUIMessage[] = [
+        {
+          id: "msg-1",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: "https://my-bucket.s3.amazonaws.com/org-1/ws-1/chat-1/msg-1/0-abc12345.png",
+              mediaType: "image/png",
+            },
+          ],
+        },
+      ];
+
+      const keys = extractStorageKeys(messages);
+
+      expect(keys).toContain("org-1/ws-1/chat-1/msg-1/0-abc12345.png");
+
+      delete process.env.STORAGE_PUBLIC_URL;
+    });
+
+    it("should extract a mix of storage and HTTP forms from the same chat", () => {
+      const messages: PlatypusUIMessage[] = [
+        {
+          id: "msg-1",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: "storage://org-1/ws-1/chat-1/msg-1/0-abc12345.png",
+              mediaType: "image/png",
+            },
+          ],
+        },
+        {
+          id: "msg-2",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: "http://localhost:4000/files/org-1/ws-1/chat-1/msg-2/1-def67890.jpg",
+              mediaType: "image/jpeg",
+            },
+          ],
+        },
+      ];
+
+      const keys = extractStorageKeys(messages);
+
+      expect(keys).toHaveLength(2);
+      expect(keys).toContain("org-1/ws-1/chat-1/msg-1/0-abc12345.png");
+      expect(keys).toContain("org-1/ws-1/chat-1/msg-2/1-def67890.jpg");
+    });
+
+    it("should ignore data URLs and external URLs", () => {
+      const messages: PlatypusUIMessage[] = [
+        {
+          id: "msg-1",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: createPngDataUrl(),
+              mediaType: "image/png",
+            },
+            {
+              type: "file",
+              url: "https://example.com/image.png",
+              mediaType: "image/png",
+            },
+            { type: "text", text: "Hello" },
+          ],
+        },
+      ];
+
+      const keys = extractStorageKeys(messages);
+      expect(keys).toHaveLength(0);
+    });
+
     it("should return empty array for messages without storage URLs", () => {
       const messages: PlatypusUIMessage[] = [
         {
@@ -308,6 +433,40 @@ describe("Storage Utils", () => {
 
       // Should not throw
       await expect(deleteFiles(messages)).resolves.not.toThrow();
+    });
+
+    // Issue #715: a file attached on the second turn onward is stored in the
+    // row as the HTTP form the client returned. Deleting the chat must still
+    // remove it from object storage. This exercises the full store → HTTP
+    // rewrite → delete cycle, so a regression to `extractStorageKeys` (failing
+    // to recognise the HTTP form) leaves a real file on disk.
+    it("should delete files whose stored URL is the HTTP form", async () => {
+      const dataUrl = createPngDataUrl();
+      const messages: PlatypusUIMessage[] = [
+        createMessageWithFile("msg-1", dataUrl),
+      ];
+
+      const context = {
+        orgId: "org-1",
+        workspaceId: "ws-1",
+        chatId: "chat-1",
+      };
+
+      const storedMessages = await extractFiles(messages, context);
+
+      // Simulate the second-turn read → write cycle: the client fetches the
+      // chat (storage:// → HTTP), then resubmits it on the next turn.
+      const httpMessages = rewriteStorageUrls(
+        storedMessages,
+        "http://localhost:4000",
+      );
+
+      const pngBefore = await countPngFiles(tempDir);
+      expect(pngBefore).toBe(1);
+
+      await deleteFiles(httpMessages);
+
+      expect(await countPngFiles(tempDir)).toBe(0);
     });
   });
 

--- a/apps/backend/src/storage/utils.ts
+++ b/apps/backend/src/storage/utils.ts
@@ -211,8 +211,17 @@ export function rewriteStorageUrls(
 }
 
 /**
- * Extract all storage:// keys from messages.
+ * Extract all storage keys from messages.
  * Useful for cleanup operations (e.g., when deleting a chat).
+ *
+ * Because a Chat resubmits its full history every turn, and the read path
+ * rewrites `storage://` URLs to HTTP URLs, stored rows carry either form:
+ * - `storage://<key>` (the canonical form)
+ * - `<filesBase>/<key>` (the HTTP form the client returns on later turns, via
+ *   `rewriteStorageUrls`)
+ *
+ * Both forms must be recognised so cleanup never orphans a file. This mirrors
+ * `inlineFileUrls`, which already accepts both URL forms.
  *
  * @param messages - Array of chat messages
  * @returns Array of storage keys found in the messages
@@ -227,17 +236,54 @@ export function extractStorageKeys(messages: PlatypusUIMessage[]): string[] {
 
     for (const part of message.parts) {
       if (
-        part.type === "file" &&
-        "url" in part &&
-        typeof part.url === "string" &&
-        part.url.startsWith(STORAGE_URL_PREFIX)
+        part.type !== "file" ||
+        !("url" in part) ||
+        typeof part.url !== "string"
       ) {
-        keys.push(part.url.slice(STORAGE_URL_PREFIX.length));
+        continue;
+      }
+
+      const key = storageKeyFromUrl(part.url);
+      if (key) {
+        keys.push(key);
       }
     }
   }
 
   return keys;
+}
+
+/**
+ * Extract the storage key from a file part URL, accepting both stored forms:
+ * `storage://<key>`, or the HTTP form `<filesBase>/<key>` that
+ * `rewriteStorageUrls` produces. Returns undefined when the URL is neither.
+ */
+function storageKeyFromUrl(url: string): string | undefined {
+  if (url.startsWith(STORAGE_URL_PREFIX)) {
+    return url.slice(STORAGE_URL_PREFIX.length);
+  }
+
+  // A data: URL is inline content, not a stored reference.
+  if (url.startsWith("data:")) {
+    return undefined;
+  }
+
+  // When STORAGE_PUBLIC_URL is set, `rewriteStorageUrls` writes
+  // `{publicUrl}/{key}` (no `/files/` segment).
+  const publicUrl = process.env.STORAGE_PUBLIC_URL;
+  const normalizedPublicUrl = publicUrl?.replace(/\/+$/, "");
+  if (normalizedPublicUrl && url.startsWith(`${normalizedPublicUrl}/`)) {
+    return url.slice(normalizedPublicUrl.length + 1);
+  }
+
+  // Default rewrite form: `<baseUrl>/files/<key>`.
+  const filesMarker = "/files/";
+  const markerIndex = url.lastIndexOf(filesMarker);
+  if (markerIndex !== -1) {
+    return url.slice(markerIndex + filesMarker.length);
+  }
+
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
Closes #715

## Problem

Deleting a Chat leaves its **File parts** orphaned in object storage. From the second turn onward, the stored URL is the HTTP form the client returns (`/files/<key>`), not `storage://<key>`, so `extractStorageKeys` — which matched only `STORAGE_URL_PREFIX` — collected no keys and `deleteFiles` deleted nothing. A **Workspace Owner** deleting a Chat reasonably expects its files to be gone (and self-hosters may have data-retention obligations).

## Fix

Make `extractStorageKeys` accept both URL forms, mirroring what `inlineFileUrls` already does:
- `storage://<key>` (canonical)
- the HTTP `/files/<key>` form the read path produces
- the `STORAGE_PUBLIC_URL/<key>` variant

This is deletion-only. The issue frames normalising HTTP-form URLs back to `storage://` on write (`extractFiles`) as a separate decision; it is intentionally not folded in here.

## Tests

- Dedicated deletion test runs the full store → HTTP rewrite → delete cycle and asserts the file is removed from disk (a `storage://`-only fixture test passes but still leaks, so the fixture form is the point).
- Coverage for `STORAGE_PUBLIC_URL`, mixed-form rows, and data:/external URL rejection.

## Verification

- `pnpm --filter backend test` — 2354 passed
- `pnpm --filter backend typecheck` — passes
- lint on changed files — clean

Note: repo-wide `lint` currently fails only on the gitignored `coverage/` artifact (absent on CI); root `typecheck`'s frontend failure is a pre-existing Vite/Rollup dependency type mismatch unrelated to this backend change.