### PR TITLE
feat: security improvements for path traversal and non-root container

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -55,11 +55,14 @@ RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 hono && \
     mkdir -p /data/files && chown hono:nodejs /data/files
 
+# Switch to the non-root user
+USER hono
+
 # Copy prod dependencies (includes root node_modules and workspace node_modules)
-COPY --from=prod-deps /app .
+COPY --from=prod-deps --chown=hono:nodejs /app .
 
 # Copy source code
-COPY --from=builder /app/out/full/ .
+COPY --from=builder --chown=hono:nodejs /app/out/full/ .
 
 # Expose port
 EXPOSE 4000

--- a/apps/backend/src/storage/disk.ts
+++ b/apps/backend/src/storage/disk.ts
@@ -17,21 +17,34 @@ export class DiskStorage implements StorageBackend {
   constructor(
     basePath: string = process.env.STORAGE_DISK_PATH || "./data/files",
   ) {
-    this.basePath = basePath;
+    this.basePath = path.resolve(basePath);
+  }
+
+  /**
+   * Safely resolves a key against the base path, preventing directory traversal.
+   */
+  private resolveKey(key: string, suffix: string = ""): string {
+    const targetPath = path.resolve(this.basePath, key + suffix);
+    // Ensure the resolved path strictly resides within the base directory.
+    // Appending path.sep ensures we don't match sibling directories (e.g., /data/files_secret).
+    if (!targetPath.startsWith(this.basePath + path.sep)) {
+      throw new Error(`Invalid storage key (path traversal detected): ${key}`);
+    }
+    return targetPath;
   }
 
   /**
    * Get the full filesystem path for a storage key.
    */
   private getFilePath(key: string): string {
-    return path.join(this.basePath, key);
+    return this.resolveKey(key);
   }
 
   /**
    * Get the path to the metadata sidecar file.
    */
   private getMetaPath(key: string): string {
-    return path.join(this.basePath, `${key}.meta`);
+    return this.resolveKey(key, ".meta");
   }
 
   /**


### PR DESCRIPTION
Hey! 👋

I was reviewing the project and noticed a couple of security improvements that may be worth considering. The project looks great overall, and these changes could help harden the application further.

### 1. Potential path traversal in `disk.ts`

In `disk.ts`, `path.join()` is currently used to construct paths from storage keys.

Depending on how the key value is obtained and validated, a malicious value containing traversal sequences such as `../` could potentially escape the intended storage directory.

A safer approach would be to resolve the final path and explicitly verify that it remains within the configured base directory.

This PR adds a `resolveKey` function that ensures resolved paths cannot point outside the intended storage directory.

### 2. Docker container running as root

I also noticed that the backend Docker image appears to run as root, even though the `hono` user is already created in the Dockerfile.

Running the application as a non-root user reduces the potential impact of a container compromise.

This PR updates the final stage to switch to the existing `hono` user and preserves the correct ownership of copied files using `--chown=hono:nodejs`.

These are relatively small changes, but they provide some additional defense-in-depth.

Great work on the project!
