### PR TITLE
fix(backend): validate storage keys where they enter Platypus

### DIFF
--- a/apps/backend/src/routes/files.test.ts
+++ b/apps/backend/src/routes/files.test.ts
@@ -46,6 +46,19 @@ describe("Files Routes", () => {
       expect(body.error).toBe("File key required");
     });
 
+    it.each([
+      ["percent-encoded traversal", "/files/..%2f..%2fetc%2fpasswd"],
+      ["percent-encoded dots", "/files/%2e%2e%2fsecret"],
+      ["backslash traversal", "/files/..%5c..%5cwindows%5cwin.ini"],
+    ])("should return 400 for a %s key", async (_label, url) => {
+      mockSession();
+      const res = await app.request(url);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.error).toBe("Invalid file key");
+      expect(mockStorageGet).not.toHaveBeenCalled();
+    });
+
     it("should return 400 for invalid key format with less than 2 segments", async () => {
       mockSession();
       const res = await app.request("/files/just-one-segment");

--- a/apps/backend/src/routes/files.test.ts
+++ b/apps/backend/src/routes/files.test.ts
@@ -46,10 +46,18 @@ describe("Files Routes", () => {
       expect(body.error).toBe("File key required");
     });
 
+    // Each key here carries enough leading segments to satisfy
+    // `parseStorageKey`, so it is the key check — not the org/workspace parse —
+    // that rejects them. `c.req.path` is not percent-decoded, hence the
+    // encoded forms.
     it.each([
-      ["percent-encoded traversal", "/files/..%2f..%2fetc%2fpasswd"],
-      ["percent-encoded dots", "/files/%2e%2e%2fsecret"],
-      ["backslash traversal", "/files/..%5c..%5cwindows%5cwin.ini"],
+      [
+        "percent-encoded traversal",
+        "/files/org-1/ws-1/..%2f..%2f..%2fetc%2fpasswd",
+      ],
+      ["percent-encoded dots", "/files/org-1/ws-1/%2e%2e%2fsecret"],
+      ["backslash traversal", "/files/org-1/ws-1/..%5c..%5cwindows%5cwin.ini"],
+      ["single-segment encoded traversal", "/files/..%2f..%2fetc%2fpasswd"],
     ])("should return 400 for a %s key", async (_label, url) => {
       mockSession();
       const res = await app.request(url);

--- a/apps/backend/src/routes/files.ts
+++ b/apps/backend/src/routes/files.ts
@@ -2,6 +2,7 @@ import { Hono } from "hono";
 import { eq, and } from "drizzle-orm";
 import { requireAuth } from "../middleware/authentication.ts";
 import { isSuperAdmin } from "../middleware/authorization.ts";
+import { assertValidStorageKey } from "../storage/keys.ts";
 import {
   organizationMember,
   workspace as workspaceTable,
@@ -48,6 +49,11 @@ files.get("/*", requireAuth, async (c) => {
   if (!key) {
     return c.json({ error: "File key required" }, 400);
   }
+
+  // The path is attacker-controlled and `c.req.path` is not percent-decoded,
+  // so reject anything Platypus could not have stored before it reaches a
+  // backend. Throws, so the `onError` seam answers 400 (ADR-0010).
+  assertValidStorageKey(key);
 
   // Parse org and workspace from the key
   const keyParts = parseStorageKey(key);

--- a/apps/backend/src/storage/disk.ts
+++ b/apps/backend/src/storage/disk.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import * as path from "node:path";
 import type { StorageBackend } from "./types.ts";
 import { logger } from "../logger.ts";
+import { ValidationError } from "../errors.ts";
 
 /**
  * Disk-based storage backend that stores files on the local filesystem.
@@ -17,21 +18,38 @@ export class DiskStorage implements StorageBackend {
   constructor(
     basePath: string = process.env.STORAGE_DISK_PATH || "./data/files",
   ) {
-    this.basePath = basePath;
+    this.basePath = path.resolve(basePath);
   }
 
   /**
    * Get the full filesystem path for a storage key.
+   *
+   * Keys are validated where they enter Platypus (`storage/keys.ts`), which is
+   * the gate that also covers `S3Storage`. This resolves and re-checks
+   * containment anyway: it is the last point before a path reaches the
+   * filesystem, and it is the only backend where escaping the root reads an
+   * unrelated host file.
    */
   private getFilePath(key: string): string {
-    return path.join(this.basePath, key);
+    const filePath = path.resolve(this.basePath, key);
+    // A trailing separator on the base stops a sibling root matching by prefix
+    // (`/data/files` must not admit `/data/files_secret`).
+    if (!filePath.startsWith(this.basePath + path.sep)) {
+      throw new ValidationError("Invalid file key");
+    }
+    return filePath;
   }
 
   /**
    * Get the path to the metadata sidecar file.
+   *
+   * Derived from the resolved object path, never from the key: appending
+   * `.meta` to the key before resolving lets the two paths disagree — a key
+   * ending in `..` would resolve one directory up for the object and stay put
+   * for the sidecar.
    */
   private getMetaPath(key: string): string {
-    return path.join(this.basePath, `${key}.meta`);
+    return `${this.getFilePath(key)}.meta`;
   }
 
   /**

--- a/apps/backend/src/storage/disk.ts
+++ b/apps/backend/src/storage/disk.ts
@@ -24,11 +24,14 @@ export class DiskStorage implements StorageBackend {
   /**
    * Get the full filesystem path for a storage key.
    *
-   * Keys are validated where they enter Platypus (`storage/keys.ts`), which is
-   * the gate that also covers `S3Storage`. This resolves and re-checks
-   * containment anyway: it is the last point before a path reaches the
-   * filesystem, and it is the only backend where escaping the root reads an
-   * unrelated host file.
+   * Keys reaching a backend from a client are validated where they enter
+   * Platypus (`storage/keys.ts`), which is the gate that also covers
+   * `S3Storage`. This check is not merely a second copy of that one: the Agent
+   * avatar path (`services/avatar.ts`) composes its own key and does not go
+   * through that gate, so for the disk backend this is the only containment
+   * guard it has. It is also the last point before a path reaches the
+   * filesystem, and this is the one backend where leaving the root reads an
+   * unrelated host file rather than missing an object.
    */
   private getFilePath(key: string): string {
     const filePath = path.resolve(this.basePath, key);

--- a/apps/backend/src/storage/keys.test.ts
+++ b/apps/backend/src/storage/keys.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { isValidStorageKey, assertValidStorageKey } from "./keys.ts";
+import { ValidationError } from "../errors.ts";
+
+describe("storage keys", () => {
+  describe("isValidStorageKey", () => {
+    it("accepts the File part key shape", () => {
+      expect(isValidStorageKey("org-1/ws-1/chat-1/msg-1/0-abc12345.png")).toBe(
+        true,
+      );
+    });
+
+    it("accepts the Agent avatar key shape", () => {
+      expect(isValidStorageKey("agents/agent-1/avatar-V1StGX_R7.webp")).toBe(
+        true,
+      );
+    });
+
+    it("accepts a single-segment key", () => {
+      expect(isValidStorageKey("file.png")).toBe(true);
+    });
+
+    it.each([
+      ["empty", ""],
+      ["parent segment", "../secret/creds.txt"],
+      ["nested parent segment", "org-1/ws-1/../../../etc/passwd"],
+      ["trailing parent segment", "org-1/ws-1/.."],
+      ["current-dir segment", "org-1/./ws-1"],
+      ["absolute", "/etc/passwd"],
+      ["empty segment", "org-1//ws-1"],
+      ["trailing slash", "org-1/ws-1/"],
+      ["percent-encoded separator", "..%2f..%2fetc%2fpasswd"],
+      ["percent-encoded dot", "%2e%2e/secret"],
+      ["backslash separator", "..\\..\\windows\\win.ini"],
+      ["NUL byte", "org-1/ws-1\0.png"],
+      ["newline", "org-1/ws-1\n.png"],
+      ["space", "org 1/ws-1.png"],
+      ["tilde", "~/.ssh/id_rsa"],
+    ])("rejects %s", (_label, key) => {
+      expect(isValidStorageKey(key)).toBe(false);
+    });
+
+    it("rejects a key longer than the cap", () => {
+      expect(isValidStorageKey("a".repeat(1025))).toBe(false);
+    });
+  });
+
+  describe("assertValidStorageKey", () => {
+    it("passes a valid key", () => {
+      expect(() =>
+        assertValidStorageKey("org-1/ws-1/chat-1/msg-1/0-abc12345.png"),
+      ).not.toThrow();
+    });
+
+    it("throws ValidationError so the seam answers 400", () => {
+      expect(() => assertValidStorageKey("../secret")).toThrow(ValidationError);
+    });
+  });
+});

--- a/apps/backend/src/storage/keys.ts
+++ b/apps/backend/src/storage/keys.ts
@@ -1,0 +1,59 @@
+import { ValidationError } from "../errors.ts";
+
+/**
+ * A storage key names one stored object relative to the backend's root. Two
+ * shapes are generated, and nothing else is: a File part's
+ * `{orgId}/{workspaceId}/{chatId}/{messageId}/{partIndex}-{hash8}.{ext}`
+ * (`generateStorageKey`), and an Agent avatar's
+ * `agents/{agentId}/avatar-{nanoid}.webp` (`storeAvatar`).
+ *
+ * Keys are not held only by Platypus. A File part's key round-trips through the
+ * client: the read path rewrites `storage://<key>` to an HTTP URL, the Chat
+ * resubmits its full history every turn, and `inlineFileUrls` reads the key back
+ * out of the URL the client returned. So a key arriving from a message part is
+ * untrusted input, and is validated here — at the boundary where it enters —
+ * rather than inside one backend, which would leave `S3Storage` uncovered.
+ */
+
+/**
+ * Every character a generated key can contain. Both generated shapes use only
+ * ids, hex hashes, `nanoid`'s alphabet (which adds `-` and `_`), and a file
+ * extension, so this admits every real key while excluding the separators a
+ * traversal needs: `/` is handled per segment, and `\`, `%` and NUL cannot
+ * appear at all. Rejecting `%` also refuses a percent-encoded separator
+ * (`..%2f`), which the `/files/*` route would otherwise pass through verbatim —
+ * `c.req.path` is not decoded.
+ */
+const SEGMENT_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+/** Generated keys are far shorter than this; the cap bounds a hostile one. */
+const MAX_KEY_LENGTH = 1024;
+
+/**
+ * Whether a key is one Platypus could have stored — a relative POSIX path whose
+ * every segment is safe. Rejects absolute keys, empty or `.`/`..` segments, and
+ * any character outside {@link SEGMENT_PATTERN}.
+ */
+export function isValidStorageKey(key: string): boolean {
+  if (!key || key.length > MAX_KEY_LENGTH) {
+    return false;
+  }
+
+  return key
+    .split("/")
+    .every(
+      (segment) =>
+        segment !== "." && segment !== ".." && SEGMENT_PATTERN.test(segment),
+    );
+}
+
+/**
+ * Assert a key is safe before it reaches a storage backend. Throws
+ * `ValidationError` so the `onError` seam answers 400 (ADR-0010) — a malformed
+ * key is a bad request, not a server fault.
+ */
+export function assertValidStorageKey(key: string): void {
+  if (!isValidStorageKey(key)) {
+    throw new ValidationError("Invalid file key");
+  }
+}

--- a/apps/backend/src/storage/utils.test.ts
+++ b/apps/backend/src/storage/utils.test.ts
@@ -569,5 +569,132 @@ describe("Storage Utils", () => {
       const filePart = inlined[0].parts[0];
       expect((filePart as FileUIPart).url).toBe(storageUrl);
     });
+
+    // A File part's key round-trips through the client, so a Chat turn can
+    // carry a key Platypus never generated. Before validation, a traversal key
+    // read a host file and inlined its bytes into the System prompt.
+    it("should not inline a file reached by traversing out of the storage root", async () => {
+      const secretPath = path.join(tempDir, "..", "outside-secret.txt");
+      await fs.writeFile(secretPath, "SUPER_SECRET_VALUE");
+      await fs.writeFile(
+        `${secretPath}.meta`,
+        JSON.stringify({ contentType: "text/plain" }),
+      );
+
+      const traversalUrl = "storage://../outside-secret.txt";
+      const messages: PlatypusUIMessage[] = [
+        {
+          id: "msg-1",
+          role: "user",
+          parts: [{ type: "file", url: traversalUrl, mediaType: "text/plain" }],
+        },
+      ];
+
+      const inlined = await inlineFileUrls(messages, backendOrigin);
+
+      const filePart = inlined[0].parts[0] as FileUIPart;
+      expect(filePart.url).toBe(traversalUrl);
+      expect(filePart.url).not.toContain("data:");
+    });
+
+    it("should not inline a traversal key arriving in the HTTP URL form", async () => {
+      const secretPath = path.join(tempDir, "..", "outside-secret-http.txt");
+      await fs.writeFile(secretPath, "SUPER_SECRET_VALUE");
+      await fs.writeFile(
+        `${secretPath}.meta`,
+        JSON.stringify({ contentType: "text/plain" }),
+      );
+
+      const traversalUrl = `${backendOrigin}/files/../outside-secret-http.txt`;
+      const messages: PlatypusUIMessage[] = [
+        {
+          id: "msg-1",
+          role: "user",
+          parts: [{ type: "file", url: traversalUrl, mediaType: "text/plain" }],
+        },
+      ];
+
+      const inlined = await inlineFileUrls(messages, backendOrigin);
+
+      expect((inlined[0].parts[0] as FileUIPart).url).toBe(traversalUrl);
+    });
+  });
+
+  describe("extractFiles - untrusted message id", () => {
+    // `message.id` is the client's, and it lands mid-key. Before validation a
+    // message id of `../../x` filed the file outside its own Chat and
+    // Workspace prefix — the prefix `/files/*` parses back to authorize.
+    it("should not store a file under a key escaping its chat prefix", async () => {
+      const messages: PlatypusUIMessage[] = [
+        {
+          id: "../../pwned",
+          role: "user",
+          parts: [
+            { type: "file", url: createPngDataUrl(), mediaType: "image/png" },
+          ],
+        },
+      ];
+
+      const processed = await extractFiles(messages, {
+        orgId: "org-1",
+        workspaceId: "ws-1",
+        chatId: "chat-1",
+      });
+
+      // The data URL is left in place, exactly as for any other store failure.
+      expect((processed[0].parts[0] as FileUIPart).url).toBe(
+        createPngDataUrl(),
+      );
+      expect(await countPngFiles(tempDir)).toBe(0);
+    });
+
+    it("should store a file under a well-formed message id", async () => {
+      const messages: PlatypusUIMessage[] = [
+        {
+          id: "msg-1",
+          role: "user",
+          parts: [
+            { type: "file", url: createPngDataUrl(), mediaType: "image/png" },
+          ],
+        },
+      ];
+
+      const processed = await extractFiles(messages, {
+        orgId: "org-1",
+        workspaceId: "ws-1",
+        chatId: "chat-1",
+      });
+
+      expect((processed[0].parts[0] as FileUIPart).url).toMatch(
+        /^storage:\/\/org-1\/ws-1\/chat-1\/msg-1\/0-[0-9a-f]{8}\.png$/,
+      );
+    });
+  });
+
+  describe("extractStorageKeys - untrusted keys", () => {
+    it("should skip a traversal key so deletion never leaves the root", () => {
+      const messages: PlatypusUIMessage[] = [
+        {
+          id: "msg-1",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              url: "storage://../../etc/passwd",
+              mediaType: "text/plain",
+            },
+            {
+              type: "file",
+              url: "storage://org-1/ws-1/chat-1/msg-1/0-abc12345.png",
+              mediaType: "image/png",
+            },
+          ],
+        },
+      ];
+
+      expect(extractStorageKeys(messages)).toEqual([
+        "org-1/ws-1/chat-1/msg-1/0-abc12345.png",
+      ]);
+    });
   });
 });

--- a/apps/backend/src/storage/utils.ts
+++ b/apps/backend/src/storage/utils.ts
@@ -3,6 +3,7 @@ import type { PlatypusUIMessage } from "../types.ts";
 import type { FileExtractionContext } from "./types.ts";
 import { getStorage } from "./index.ts";
 import { logger } from "../logger.ts";
+import { assertValidStorageKey, isValidStorageKey } from "./keys.ts";
 
 /**
  * Storage URL prefix used to identify storage references.
@@ -38,6 +39,13 @@ function getExtensionFromMimeType(mimeType: string): string {
 /**
  * Generate a storage key for a file.
  * Format: {orgId}/{workspaceId}/{chatId}/{messageId}/{partIndex}-{hash8}.{ext}
+ *
+ * `messageId` is the id the client put on the message, so the composed key is
+ * checked before it is returned: without that, a message id of `../../x` writes
+ * the file outside its own Chat and Workspace prefix — the prefix `/files/*`
+ * reads back to authorize. Throws rather than repairing the id, so the file is
+ * not quietly filed under a key that does not name where it came from; the
+ * caller already treats a failure here as "leave the data URL alone".
  */
 function generateStorageKey(
   context: FileExtractionContext,
@@ -47,7 +55,9 @@ function generateStorageKey(
 ): string {
   const hash8 = contentHash.slice(0, 8);
   const messageId = context.messageId || "unknown";
-  return `${context.orgId}/${context.workspaceId}/${context.chatId}/${messageId}/${partIndex}-${hash8}.${extension}`;
+  const key = `${context.orgId}/${context.workspaceId}/${context.chatId}/${messageId}/${partIndex}-${hash8}.${extension}`;
+  assertValidStorageKey(key);
+  return key;
 }
 
 /**
@@ -259,6 +269,23 @@ export function extractStorageKeys(messages: PlatypusUIMessage[]): string[] {
  * `rewriteStorageUrls` produces. Returns undefined when the URL is neither.
  */
 function storageKeyFromUrl(url: string): string | undefined {
+  const key = rawStorageKeyFromUrl(url);
+
+  // The URL came back from the client, so the key in it is untrusted. A key
+  // Platypus never generated names nothing it stored, so callers treat it the
+  // same as a URL that carried no key at all.
+  if (key === undefined || !isValidStorageKey(key)) {
+    return undefined;
+  }
+
+  return key;
+}
+
+/**
+ * Slice the key out of each URL form `rewriteStorageUrls` can produce, without
+ * judging it. Split out so {@link storageKeyFromUrl} has one place to validate.
+ */
+function rawStorageKeyFromUrl(url: string): string | undefined {
   if (url.startsWith(STORAGE_URL_PREFIX)) {
     return url.slice(STORAGE_URL_PREFIX.length);
   }
@@ -337,6 +364,18 @@ export async function inlineFileUrls(
           }
 
           if (!key) {
+            return part;
+          }
+
+          // The client returned this URL to us, so the key is untrusted: a
+          // traversal key here would otherwise read a host file and inline it
+          // into the System prompt. `normalizeFileParts` announces the part as
+          // unavailable, exactly as it does for a storage miss.
+          if (!isValidStorageKey(key)) {
+            logger.warn(
+              { key },
+              "Rejected invalid storage key during inlining",
+            );
             return part;
           }
 


### PR DESCRIPTION
Closes the path traversal reported by @PhoenixSemGarantia in #720, and supersedes that PR's storage half.

## The hole

A **File part**'s storage key round-trips through the client. The read path rewrites `storage://<key>` to an HTTP URL, the **Chat** resubmits its full history every turn, and `inlineFileUrls` reads the key back out of the URL the client returned. Nothing checked it on the way back in.

A part carrying `storage://../../etc/passwd` therefore had its bytes read off the host and inlined into the **System prompt**. Confirmed against a temp root before the fix — the file outside the storage root came back as a `data:` URL on the part.

The `GET /files/*` route turns out **not** to be exploitable this way: `new Request()` normalizes literal `..` segments away before routing, and `c.req.path` leaves the rest percent-encoded, so `..%2f` reaches the backend as a filename rather than a separator. It is still validated here, because that behaviour is the URL parser's and not something this route should depend on.

## The fix

Validation goes where keys **enter** Platypus, not inside one backend — otherwise `S3Storage`, which takes the same untrusted key from the same three callers, stays uncovered.

- **`storage/keys.ts`** states what a key may be: a relative POSIX path whose every segment matches `[A-Za-z0-9._-]`. That admits both shapes Platypus generates and excludes separators, `.`/`..` segments, and percent-encoded forms.
- **`storageKeyFromUrl`** and **`inlineFileUrls`** drop an invalid key, treating it as a URL that named nothing stored. `normalizeFileParts` then announces the part as unavailable, exactly as it already does for a storage miss.
- **`GET /files/*`** throws `ValidationError`, so the seam answers 400 (ADR-0010) rather than letting a filesystem error surface as a 500.
- **`generateStorageKey`** checks the key it composes. `messageId` is the client's, and a message id of `../../x` filed the file outside the Chat and Workspace prefix that `/files/*` parses back to authorize — a second traversal, on the write side, that #720 did not reach.

`DiskStorage` also resolves and re-checks containment as a last line before the filesystem, and derives the `.meta` path from the resolved object path so the object and its sidecar can no longer disagree.

## Not included

The non-root container half of #720 is deliberately left out. As written it moves to `USER hono` before the copies, leaving `WORKDIR /app` root-owned, so the default `STORAGE_DISK_PATH=./data/files` cannot be created and every upload fails with `EACCES`. It needs its own change, with the ownership fixed after the copies and a self-hosting docs note for the `/data` bind mount.

## Tests

`keys.test.ts` covers the key rules directly. Regression tests cover both traversal forms through `inlineFileUrls`, the write-side hostile message id, key-skipping in `extractStorageKeys`, and the route's 400. Backend 2383 passed, frontend 666 passed.

No docs page changes: no `.env.example`, schema limit, plugin, or user-facing label moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)