### PR TITLE
fix(backend): scope a Chat's file deletion to its own keys

### DIFF
--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -289,14 +289,19 @@ chat.delete(
   requireWorkspaceOwner,
   async (c) => {
     const chatId = c.req.param("chatId");
-    const { workspaceId } = workspaceScopeOf(c);
+    const { orgId, workspaceId } = workspaceScopeOf(c);
 
     // First fetch the chat to get its messages for file cleanup
     const chatRecord = await requireOwned(db, "chat", chatId, workspaceId);
 
-    // Delete associated files from storage (best-effort)
+    // Delete associated files from storage (best-effort). Scoped to this Chat,
+    // so a planted file part naming another tenant's key deletes nothing.
     if (chatRecord.messages) {
-      await deleteFiles(chatRecord.messages as PlatypusUIMessage[]);
+      await deleteFiles(chatRecord.messages as PlatypusUIMessage[], {
+        orgId,
+        workspaceId,
+        chatId,
+      });
     }
 
     // Delete the chat record

--- a/apps/backend/src/storage/keys.ts
+++ b/apps/backend/src/storage/keys.ts
@@ -57,3 +57,33 @@ export function assertValidStorageKey(key: string): void {
     throw new ValidationError("Invalid file key");
   }
 }
+
+/** The Chat a File part's key belongs to — the key's first three segments. */
+export interface ChatKeyScope {
+  orgId: string;
+  workspaceId: string;
+  chatId: string;
+}
+
+/**
+ * The prefix every File part key for one Chat shares. `generateStorageKey`
+ * builds keys from this and {@link isKeyUnderChat} reads them back with it, so
+ * the writer and the ownership check cannot drift apart.
+ */
+export function chatStorageKeyPrefix(scope: ChatKeyScope): string {
+  return `${scope.orgId}/${scope.workspaceId}/${scope.chatId}/`;
+}
+
+/**
+ * Whether a key names an object stored for this Chat.
+ *
+ * Validity is not ownership. `isValidStorageKey` answers "could Platypus have
+ * stored this?", which every well-formed key satisfies — including one naming
+ * another tenant's file. A client can put any URL on a file part (`extractFiles`
+ * stores a non-`data:` URL verbatim), so a key read back out of a message part
+ * says only what the client claimed, not what this Chat owns. Anything
+ * destructive must ask this question instead.
+ */
+export function isKeyUnderChat(key: string, scope: ChatKeyScope): boolean {
+  return isValidStorageKey(key) && key.startsWith(chatStorageKeyPrefix(scope));
+}

--- a/apps/backend/src/storage/utils.test.ts
+++ b/apps/backend/src/storage/utils.test.ts
@@ -407,7 +407,7 @@ describe("Storage Utils", () => {
       expect(metaFilesBefore.length).toBe(1);
 
       // Delete files
-      await deleteFiles(storedMessages);
+      await deleteFiles(storedMessages, context);
 
       // Verify files are deleted (directories may remain)
       const filesAfterDelete = await fs.readdir(tempDir, { recursive: true });
@@ -432,7 +432,13 @@ describe("Storage Utils", () => {
       ];
 
       // Should not throw
-      await expect(deleteFiles(messages)).resolves.not.toThrow();
+      await expect(
+        deleteFiles(messages, {
+          orgId: "org-1",
+          workspaceId: "ws-1",
+          chatId: "chat-1",
+        }),
+      ).resolves.not.toThrow();
     });
 
     // Issue #715: a file attached on the second turn onward is stored in the
@@ -464,9 +470,50 @@ describe("Storage Utils", () => {
       const pngBefore = await countPngFiles(tempDir);
       expect(pngBefore).toBe(1);
 
-      await deleteFiles(httpMessages);
+      await deleteFiles(httpMessages, context);
 
       expect(await countPngFiles(tempDir)).toBe(0);
+    });
+
+    // A client can put any URL on a file part, and `extractFiles` stores a
+    // non-`data:` URL verbatim. Without an ownership filter, planting another
+    // tenant's key in a Chat you own and deleting that Chat destroys their
+    // file — and reading any Chat reveals such a key, because
+    // `rewriteStorageUrls` puts it in the URL it hands every reader.
+    it("does not delete a file belonging to another Chat", async () => {
+      const victim = {
+        orgId: "org-victim",
+        workspaceId: "ws-victim",
+        chatId: "chat-victim",
+      };
+      const attacker = {
+        orgId: "org-attacker",
+        workspaceId: "ws-attacker",
+        chatId: "chat-attacker",
+      };
+
+      // The victim's file, stored the ordinary way.
+      const victimMessages = await extractFiles(
+        [createMessageWithFile("msg-victim", createPngDataUrl())],
+        victim,
+      );
+      const victimKey = extractStorageKeys(victimMessages)[0];
+      expect(victimKey).toBeDefined();
+      expect(await countPngFiles(tempDir)).toBe(1);
+
+      // The attacker's own Chat, carrying a part that points at the victim's
+      // key in both reachable forms.
+      const plantedMessages: PlatypusUIMessage[] = [
+        createMessageWithFile("msg-1", `storage://${victimKey}`),
+        createMessageWithFile(
+          "msg-2",
+          `https://attacker.example.com/files/${victimKey}`,
+        ),
+      ];
+
+      await deleteFiles(plantedMessages, attacker);
+
+      expect(await countPngFiles(tempDir)).toBe(1);
     });
   });
 

--- a/apps/backend/src/storage/utils.ts
+++ b/apps/backend/src/storage/utils.ts
@@ -3,7 +3,13 @@ import type { PlatypusUIMessage } from "../types.ts";
 import type { FileExtractionContext } from "./types.ts";
 import { getStorage } from "./index.ts";
 import { logger } from "../logger.ts";
-import { assertValidStorageKey, isValidStorageKey } from "./keys.ts";
+import {
+  assertValidStorageKey,
+  chatStorageKeyPrefix,
+  isKeyUnderChat,
+  isValidStorageKey,
+  type ChatKeyScope,
+} from "./keys.ts";
 
 /**
  * Storage URL prefix used to identify storage references.
@@ -55,7 +61,7 @@ function generateStorageKey(
 ): string {
   const hash8 = contentHash.slice(0, 8);
   const messageId = context.messageId || "unknown";
-  const key = `${context.orgId}/${context.workspaceId}/${context.chatId}/${messageId}/${partIndex}-${hash8}.${extension}`;
+  const key = `${chatStorageKeyPrefix(context)}${messageId}/${partIndex}-${hash8}.${extension}`;
   assertValidStorageKey(key);
   return key;
 }
@@ -230,8 +236,14 @@ export function rewriteStorageUrls(
  * - `<filesBase>/<key>` (the HTTP form the client returns on later turns, via
  *   `rewriteStorageUrls`)
  *
- * Both forms must be recognised so cleanup never orphans a file. This mirrors
- * `inlineFileUrls`, which already accepts both URL forms.
+ * Both forms must be recognised so cleanup never orphans a file. The HTTP match
+ * is deliberately looser than `inlineFileUrls`, which anchors on the request's
+ * own origin: a deployment whose origin has changed still has rows carrying the
+ * old one, and failing to recognise those would leak files forever.
+ *
+ * The cost of that tolerance is that the key here is only what the client
+ * claimed. These keys therefore name candidates, not property — a caller that
+ * deletes must filter them with `isKeyUnderChat`, as {@link deleteFiles} does.
  *
  * @param messages - Array of chat messages
  * @returns Array of storage keys found in the messages
@@ -407,12 +419,24 @@ export async function inlineFileUrls(
  * Delete all files associated with a chat's messages.
  * Best-effort operation - errors are logged but don't fail the operation.
  *
+ * Only keys under this Chat's own prefix are deleted. The keys come out of
+ * message parts, and a client can put any URL on a part, so an unfiltered
+ * delete lets a user plant `…/files/{another org}/…` in a Chat they own and
+ * destroy another tenant's files by deleting it. Reading a Chat is enough to
+ * learn such a key: `rewriteStorageUrls` hands every reader HTTP URLs with the
+ * keys in them, so without this filter read access to a Chat implies the power
+ * to delete its files.
+ *
  * @param messages - Array of chat messages
+ * @param scope - The Chat being deleted, whose files these must be
  */
 export async function deleteFiles(
   messages: PlatypusUIMessage[],
+  scope: ChatKeyScope,
 ): Promise<void> {
-  const keys = extractStorageKeys(messages);
+  const keys = extractStorageKeys(messages).filter((key) =>
+    isKeyUnderChat(key, scope),
+  );
   if (keys.length === 0) {
     return;
   }


### PR DESCRIPTION
Found by the deep review during `/pre-release-check` on the 3.1.0 range.

## The bug

`deleteFiles` deleted every storage key it could read out of a Chat's message parts, with no check that the key belonged to that Chat.

Those keys are not Platypus's own word. `extractFiles` stores a file part's URL verbatim unless it is a `data:` URL, so a part can name any key at all, and the messages array is taken as `data.messages as PlatypusUIMessage[]` with no schema validation of parts. So a user could put another Chat's key on a file part in a Chat they own, delete that Chat, and take the other Chat's files with it — across Workspace and Organization boundaries.

Knowing a key to name is not much of a barrier: `rewriteStorageUrls` hands every reader of a Chat HTTP URLs with the keys in them, and an Org Admin or Operator can read another Workspace's Chats read-only. That turned read access into the power to delete.

## Not a regression

v3.0.0 had the same missing check for the `storage://` form — `extractStorageKeys` sliced the prefix and `deleteFiles` deleted the result unchecked. #719 widened the reachable URL forms rather than introducing the hole.

## The change

`isKeyUnderChat` joins the key rules in `storage/keys.ts`, and `deleteFiles` filters on it before deleting anything. Validity and ownership are different questions: `isValidStorageKey` asks whether Platypus *could* have stored a key, which a well-formed key naming someone else's file also satisfies. Anything destructive has to ask the second question.

`generateStorageKey` now composes its prefix from the same `chatStorageKeyPrefix` the check reads back, so the writer and the ownership check cannot drift apart.

`extractStorageKeys` keeps its tolerant HTTP match on purpose: anchoring on the request origin, the way `inlineFileUrls` does, would silently orphan files for any deployment whose origin has changed. Its docstring claimed to mirror `inlineFileUrls` — corrected to say what it actually does, and to send destructive callers through the filter.

## Tests

One added, and it earns its place: with the filter removed it fails, and the victim's file is gone (`expected +0 to be 1`). It plants the victim's key in both reachable forms — `storage://<key>` and `https://attacker.example.com/files/<key>` — in a Chat owned by someone else, deletes that Chat, and asserts the file survives.

The three existing `deleteFiles` tests now pass the Chat scope they already had in hand.

`@platypus/backend`: 2385 passed. Root `lint`, `typecheck`, `build` and `format` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)