### PR TITLE
fix: bind workspace creation to route organization

### DIFF
--- a/apps/backend/src/routes/workspace.test.ts
+++ b/apps/backend/src/routes/workspace.test.ts
@@ -42,7 +42,6 @@ describe("Workspace Routes", () => {
         method: "POST",
         body: JSON.stringify({
           name: "New Workspace",
-          organizationId: "org-1",
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -68,7 +67,6 @@ describe("Workspace Routes", () => {
         method: "POST",
         body: JSON.stringify({
           name: "New Workspace",
-          organizationId: "org-1",
         }),
         headers: { "Content-Type": "application/json" },
       });
@@ -90,7 +88,6 @@ describe("Workspace Routes", () => {
         method: "POST",
         body: JSON.stringify({
           name: "Member Workspace",
-          organizationId: "org-1",
           ownerId: "member-2",
         }),
         headers: { "Content-Type": "application/json" },
@@ -115,7 +112,6 @@ describe("Workspace Routes", () => {
         method: "POST",
         body: JSON.stringify({
           name: "Member Workspace",
-          organizationId: "org-1",
           ownerId: "outsider",
         }),
         headers: { "Content-Type": "application/json" },
@@ -126,6 +122,34 @@ describe("Workspace Routes", () => {
         error: "Owner must be a member of the organization",
       });
       expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    // The organization id is a tenancy boundary. It is derived from the path
+    // after requireOrgAccess, rather than accepted from the request body.
+    it("binds a workspace to the authorized organization", async () => {
+      mockSession({ id: "admin-1", role: "user" });
+      mockDb.limit.mockResolvedValueOnce([{ role: "admin" }]);
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "ws-1", name: "Bound Workspace", organizationId: "org-1" },
+      ]);
+
+      const res = await app.request("/organizations/org-1/workspaces", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "Bound Workspace",
+          // A stale or malicious client cannot redirect creation into org-2.
+          organizationId: "org-2",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockDb.values).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: "org-1",
+          ownerId: "admin-1",
+        }),
+      );
     });
   });
 

--- a/apps/backend/src/routes/workspace.ts
+++ b/apps/backend/src/routes/workspace.ts
@@ -66,6 +66,10 @@ workspace.post(
       .values({
         id: nanoid(),
         ...data,
+        // The route's organization has already passed requireOrgAccess. Never
+        // take this tenancy boundary from client input: an admin of one org
+        // must not be able to create a workspace in another org.
+        organizationId: orgId,
         ownerId,
       })
       .returning();

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -198,7 +198,6 @@ const WorkspaceForm = ({
           mcpSelfManagement: formData.mcpSelfManagement,
         }
       : {
-          organizationId: orgId,
           name: formData.name,
           context: formData.context || null,
           // ADR-0008: an admin assigns the owner; defaults to themselves.

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -332,6 +332,18 @@ describe("Workspace Create Schema", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  // The organization is a tenancy boundary, taken from the route rather than
+  // the body. Pinned here so the field cannot drift back into the create
+  // contract: a body that names one is accepted, but the name is dropped.
+  it("drops an organizationId supplied in the payload", () => {
+    const result = workspaceCreateSchema.safeParse({
+      name: "Test Workspace",
+      organizationId: "org-2",
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).not.toHaveProperty("organizationId");
+  });
 });
 
 describe("Invitation Create Schema", () => {

--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -321,7 +321,6 @@ describe("Workspace Create Schema", () => {
   it("accepts an optional ownerId", () => {
     const result = workspaceCreateSchema.safeParse({
       name: "Test Workspace",
-      organizationId: "org-1",
       ownerId: "member-2",
     });
     expect(result.success).toBe(true);
@@ -330,7 +329,6 @@ describe("Workspace Create Schema", () => {
   it("is valid without an ownerId", () => {
     const result = workspaceCreateSchema.safeParse({
       name: "Test Workspace",
-      organizationId: "org-1",
     });
     expect(result.success).toBe(true);
   });

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -59,7 +59,6 @@ export type Workspace = z.infer<typeof workspaceSchema>;
 export const workspaceCreateSchema = workspaceSchema
   .pick({
     name: true,
-    organizationId: true,
     context: true,
   })
   // ownerId is admin-assignable (ADR-0008). When omitted, the create handler


### PR DESCRIPTION
## Summary

Bind new workspaces to the organization authorized by the route. The create payload no longer controls `organizationId`, preventing cross-organization workspace creation.

## Testing

* `pnpm --filter @platypus/backend test -- workspace.test.ts`
* `pnpm --filter @platypus/schemas test -- index.test.ts`
* `pnpm --filter @platypus/backend typecheck`
* `pnpm --filter @platypus/schemas typecheck`
