### PR TITLE
chore(backend): drive the stream-keepalive tests with fake timers

### DIFF
--- a/apps/backend/src/runs/stream-keepalive.test.ts
+++ b/apps/backend/src/runs/stream-keepalive.test.ts
@@ -45,16 +45,18 @@ describe("withHeartbeatFrames", () => {
   });
 
   it("puts bytes on the wire while the source says nothing", async () => {
+    vi.useFakeTimers();
     const source = controllable();
     const kept = withHeartbeatFrames(source.stream, HEARTBEAT_MS);
     const collected = readAll(kept);
 
     // Nothing from the model for several heartbeat intervals — the case a
-    // proxy's idle timeout would otherwise kill.
-    await new Promise((r) => setTimeout(r, HEARTBEAT_MS * 3.5));
+    // proxy's idle timeout would otherwise kill. Advanced asynchronously so the
+    // reader gets a turn to drain each heartbeat before the next fires.
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_MS * 3);
     source.end();
 
-    expect(heartbeats(await collected)).toBeGreaterThanOrEqual(3);
+    expect(heartbeats(await collected)).toBe(3);
   });
 
   it("passes the source's own frames through untouched", async () => {
@@ -159,6 +161,10 @@ describe("withHeartbeatFrames", () => {
 });
 
 describe("withStreamKeepalive", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   /** The response shape the runner hands over, built the way the SDK builds it. */
   const streamedRunResponse = () =>
     createUIMessageStreamResponse({
@@ -190,6 +196,7 @@ describe("withStreamKeepalive", () => {
   });
 
   it("beats on a real streamed run response that has gone quiet", async () => {
+    vi.useFakeTimers();
     let close!: () => void;
     const response = createUIMessageStreamResponse({
       stream: new ReadableStream({
@@ -201,9 +208,9 @@ describe("withStreamKeepalive", () => {
 
     const kept = withStreamKeepalive(response, HEARTBEAT_MS);
     const collected = readAll(kept.body!);
-    await new Promise((r) => setTimeout(r, HEARTBEAT_MS * 2.5));
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_MS * 2);
     close();
 
-    expect(heartbeats(await collected)).toBeGreaterThanOrEqual(2);
+    expect(heartbeats(await collected)).toBe(2);
   });
 });


### PR DESCRIPTION
Fixes #725

## What

Two tests in `apps/backend/src/runs/stream-keepalive.test.ts` spent real wall-clock time and asserted counts of real timer firings. Under a loaded machine the 50ms interval can slip past the 175ms/125ms margins, dropping a heartbeat and flaking the build (observed 1-in-4 full-suite failures on an M-series Mac).

## Change

Both tests now use vitest fake timers, advanced asynchronously so the stream reader gets a turn to drain each heartbeat before the next fires:

- `await vi.advanceTimersByTimeAsync(HEARTBEAT_MS * 3)` / `(HEARTBEAT_MS * 2)` instead of `setTimeout(...)`
- Heartbeat counts asserted exactly (`toBe(3)`, `toBe(2)`) — no more `toBeGreaterThanOrEqual` absorbing scheduling jitter
- Added the missing `afterEach(() => vi.useRealTimers())` teardown to the `withStreamKeepalive` describe, matching the sibling `withHeartbeatFrames` block (found in review)

No change to `src/runs/stream-keepalive.ts` — the production code was never at fault.

## Verification

- **Neuter check:** temporarily disabling the interval enqueue reds both rewritten tests (`expected 2 to be 0` etc.), confirming they still catch a broken `withHeartbeatFrames` — restored afterward.
- **20 consecutive** `pnpm --filter @platypus/backend test` runs green.
- `typecheck` and `eslint` clean on the changed file.

Note: the full Turborepo suite still reports pre-existing `@platypus/frontend` failures (343) — reproduced identically with this change stashed on clean `main`; unrelated to this backend-only test change.