### PR TITLE
chore(frontend): extract a shared composer for the chat input and the message editor

### DIFF
--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -67,7 +67,7 @@ import { ChatMessage } from "./chat-message";
 import { MessageEditor } from "./message-editor";
 import { ChatReconnectingNotice } from "./chat-reconnecting-notice";
 import { toast } from "sonner";
-import { Composer } from "./composer";
+import { Composer, type ModelSelection } from "./composer";
 
 export const Chat = ({
   orgId,
@@ -266,6 +266,16 @@ export const Chat = ({
     agents,
     selection: { agentId, modelId, providerId },
   });
+  // What the model picker on both surfaces is configured with (issue #724).
+  const modelSelection: ModelSelection = {
+    agents,
+    providers,
+    agentId,
+    modelId,
+    providerId,
+    onModelChange: handleModelChange,
+    maxOutputTokens: resolvedModel?.maxOutputTokens,
+  };
   const [search, setSearch] = useSearchToggle(resolvedModel);
   const {
     instructions,
@@ -580,15 +590,7 @@ export const Chat = ({
                         key={editing.messageId}
                         initialText={editing.text}
                         initialAttachments={editing.attachments}
-                        modelSelection={{
-                          agents,
-                          providers,
-                          agentId,
-                          modelId,
-                          providerId,
-                          onModelChange: handleModelChange,
-                          maxOutputTokens: resolvedModel?.maxOutputTokens,
-                        }}
+                        modelSelection={modelSelection}
                         passthroughFileTypes={
                           resolvedModel?.passthroughFileTypes ?? []
                         }
@@ -623,15 +625,7 @@ export const Chat = ({
                 }}
                 globalDrop
                 passthroughFileTypes={resolvedModel?.passthroughFileTypes ?? []}
-                modelSelection={{
-                  agents,
-                  providers,
-                  agentId,
-                  modelId,
-                  providerId,
-                  onModelChange: handleModelChange,
-                  maxOutputTokens: resolvedModel?.maxOutputTokens,
-                }}
+                modelSelection={modelSelection}
                 textarea={{
                   ref: textareaRef,
                   value: inputValue,

--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -6,20 +6,8 @@ import {
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
 import {
-  PromptInput,
-  PromptInputActionAddAttachments,
-  PromptInputActionMenu,
-  PromptInputActionMenuContent,
-  PromptInputActionMenuTrigger,
-  PromptInputAttachment,
-  PromptInputAttachments,
-  PromptInputBody,
   PromptInputButton,
-  PromptInputFooter,
-  PromptInputSpeechButton,
   PromptInputSubmit,
-  PromptInputTextarea,
-  PromptInputTools,
   type PromptInputMessage,
 } from "@/components/ai-elements/prompt-input";
 import { useChat } from "@ai-sdk/react";
@@ -55,7 +43,6 @@ import { useModelSelection } from "@/hooks/use-model-selection";
 import { resolveModel } from "@/lib/resolve-model";
 import { clearedToolCallIds } from "@/lib/tool-result-clearing";
 import { ContextMeter } from "./context-meter";
-import { FileCompatibilityWarning } from "./file-compatibility-warning";
 import { useMessageEditing } from "@/hooks/use-message-editing";
 import { ATTACHMENTS_ONLY_TEXT } from "@/lib/message-parts";
 import { useChatTitlePoll } from "@/hooks/use-chat-title-poll";
@@ -79,8 +66,8 @@ import {
 import { ChatMessage } from "./chat-message";
 import { MessageEditor } from "./message-editor";
 import { ChatReconnectingNotice } from "./chat-reconnecting-notice";
-import { ModelSelectorDialog } from "./model-selector-dialog";
 import { toast } from "sonner";
+import { Composer } from "./composer";
 
 export const Chat = ({
   orgId,
@@ -291,8 +278,6 @@ export const Chat = ({
     maxSteps,
   } = settings;
   const {
-    isModelSelectorOpen,
-    setIsModelSelectorOpen,
     isSettingsDialogOpen,
     setIsSettingsDialogOpen,
     isAgentInfoDialogOpen,
@@ -595,13 +580,15 @@ export const Chat = ({
                         key={editing.messageId}
                         initialText={editing.text}
                         initialAttachments={editing.attachments}
-                        agents={agents}
-                        providers={providers}
-                        agentId={agentId}
-                        modelId={modelId}
-                        providerId={providerId}
-                        onModelChange={handleModelChange}
-                        maxOutputTokens={resolvedModel?.maxOutputTokens}
+                        modelSelection={{
+                          agents,
+                          providers,
+                          agentId,
+                          modelId,
+                          providerId,
+                          onModelChange: handleModelChange,
+                          maxOutputTokens: resolvedModel?.maxOutputTokens,
+                        }}
                         passthroughFileTypes={
                           resolvedModel?.passthroughFileTypes ?? []
                         }
@@ -629,57 +616,38 @@ export const Chat = ({
           <div className="w-full xl:w-4/5 max-w-4xl min-w-0">
             {isRecoveringRun && <ChatReconnectingNotice />}
             {canSendMessages ? (
-              <PromptInput
+              <Composer
                 onSubmit={(message) => {
                   handleSubmit(message);
                   setInputValue("");
                 }}
                 globalDrop
-                multiple
-              >
-                <PromptInputAttachments className="w-full">
-                  {(attachment) => <PromptInputAttachment data={attachment} />}
-                </PromptInputAttachments>
-                <FileCompatibilityWarning
-                  passthroughFileTypes={
-                    resolvedModel?.passthroughFileTypes ?? []
-                  }
-                />
-                <PromptInputBody>
-                  <PromptInputTextarea
-                    ref={textareaRef}
-                    value={inputValue}
-                    onChange={(e) => setInputValue(e.target.value)}
-                    className={messages.length === 0 ? "min-h-24" : undefined}
-                    placeholder={
-                      runHeldElsewhere
-                        ? "Run in progress…"
-                        : selectedAgent?.inputPlaceholder ||
-                          "What would you like to know?"
-                    }
-                    autoFocus
-                    status={effectiveStatus}
-                    disabled={runHeldElsewhere}
-                  />
-                </PromptInputBody>
-                <PromptInputFooter className="flex-wrap">
-                  <PromptInputTools>
-                    <PromptInputActionMenu>
-                      <PromptInputActionMenuTrigger className="cursor-pointer" />
-                      <PromptInputActionMenuContent>
-                        <PromptInputActionAddAttachments className="cursor-pointer" />
-                      </PromptInputActionMenuContent>
-                    </PromptInputActionMenu>
-                    <Tooltip delayDuration={1000}>
-                      <TooltipTrigger asChild>
-                        <PromptInputSpeechButton
-                          className="cursor-pointer"
-                          textareaRef={textareaRef}
-                          onTranscriptionChange={setInputValue}
-                        />
-                      </TooltipTrigger>
-                      <TooltipContent>Microphone</TooltipContent>
-                    </Tooltip>
+                passthroughFileTypes={resolvedModel?.passthroughFileTypes ?? []}
+                modelSelection={{
+                  agents,
+                  providers,
+                  agentId,
+                  modelId,
+                  providerId,
+                  onModelChange: handleModelChange,
+                  maxOutputTokens: resolvedModel?.maxOutputTokens,
+                }}
+                textarea={{
+                  ref: textareaRef,
+                  value: inputValue,
+                  onChange: (e) => setInputValue(e.target.value),
+                  className: messages.length === 0 ? "min-h-24" : undefined,
+                  placeholder: runHeldElsewhere
+                    ? "Run in progress…"
+                    : selectedAgent?.inputPlaceholder ||
+                      "What would you like to know?",
+                  autoFocus: true,
+                  status: effectiveStatus,
+                  disabled: runHeldElsewhere,
+                }}
+                onTranscriptionChange={setInputValue}
+                tools={
+                  <>
                     {resolvedModel?.canSearch && (
                       <Tooltip delayDuration={1000}>
                         <TooltipTrigger asChild>
@@ -694,22 +662,6 @@ export const Chat = ({
                         <TooltipContent>Search</TooltipContent>
                       </Tooltip>
                     )}
-                    <ModelSelectorDialog
-                      agents={agents}
-                      providers={providers}
-                      agentId={agentId}
-                      modelId={modelId}
-                      providerId={providerId}
-                      isOpen={isModelSelectorOpen}
-                      onOpenChange={(open) => {
-                        setIsModelSelectorOpen(open);
-                        if (!open) {
-                          setTimeout(() => textareaRef.current?.focus(), 250);
-                        }
-                      }}
-                      onModelChange={handleModelChange}
-                      maxOutputTokens={resolvedModel?.maxOutputTokens}
-                    />
                     {agentId && selectedAgent && (
                       <Dialog
                         open={isAgentInfoDialogOpen}
@@ -766,28 +718,28 @@ export const Chat = ({
                         />
                       </Dialog>
                     )}
-                  </PromptInputTools>
-                  {/*
-                    Two placements from one element, because the footer wraps.
-                    Narrow: ordered last onto a row of its own, so the tools and
-                    Send keep the first row to themselves and Send is never
-                    pushed off the edge. The row bleeds back over the footer's
-                    own padding — hence the negative margins and the width that
-                    adds them back — so the tint reaches the composer's edges and
-                    reads as a band rather than a chip floating in the middle.
-                    Wide: back in source order with `mr-auto` eating the free
-                    space, which reads as the last item of the tool row rather
-                    than drifting into the middle the way `justify-between`
-                    alone would leave it.
-                  */}
+                  </>
+                }
+                footerContent={
+                  // Two placements from one element, because the footer wraps.
+                  // Narrow: ordered last onto a row of its own, so the tools and
+                  // Send keep the first row to themselves and Send is never
+                  // pushed off the edge. The row bleeds back over the footer's
+                  // own padding — hence the negative margins and the width that
+                  // adds them back — so the tint reaches the composer's edges and
+                  // reads as a band rather than a chip floating in the middle.
+                  // Wide: back in source order with `mr-auto` eating the free
+                  // space, which reads as the last item of the tool row rather
+                  // than drifting into the middle the way `justify-between`
+                  // alone would leave it.
                   <ContextMeter
                     className="order-last -mx-3 -mb-3 mt-1.5 w-[calc(100%+1.5rem)] justify-center rounded-b-md bg-foreground/5 px-3 py-1.5 sm:order-none sm:mx-0 sm:mt-0 sm:mb-0 sm:w-auto sm:justify-start sm:rounded-none sm:bg-transparent sm:p-0 sm:mr-auto"
                     occupancy={projectedOccupancy}
                     contextWindow={resolvedModel?.contextWindow}
                   />
-                  <PromptInputSubmit status={effectiveStatus} />
-                </PromptInputFooter>
-              </PromptInput>
+                }
+                submit={<PromptInputSubmit status={effectiveStatus} />}
+              />
             ) : (
               <div className="flex items-center justify-center py-4 px-6 border rounded-lg bg-muted/50">
                 <p className="text-sm text-muted-foreground">

--- a/apps/frontend/components/composer.tsx
+++ b/apps/frontend/components/composer.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+import type { ChangeEvent, KeyboardEvent, ReactNode, RefObject } from "react";
+import type { FileUIPart, ChatStatus } from "ai";
+import type { Agent, Provider } from "@platypus/schemas";
+import {
+  PromptInput,
+  PromptInputActionAddAttachments,
+  PromptInputActionMenu,
+  PromptInputActionMenuContent,
+  PromptInputActionMenuTrigger,
+  PromptInputAttachment,
+  PromptInputAttachments,
+  PromptInputBody,
+  PromptInputFooter,
+  PromptInputSpeechButton,
+  PromptInputTextarea,
+  PromptInputTools,
+  type PromptInputMessage,
+} from "./ai-elements/prompt-input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { FileCompatibilityWarning } from "./file-compatibility-warning";
+import { ModelSelectorDialog } from "./model-selector-dialog";
+
+/**
+ * What a composer needs to render the model picker. The pieces travel together
+ * only to reach `ModelSelectorDialog`, so they are bundled rather than threaded
+ * individually through every surface (issue #724).
+ */
+export interface ModelSelection {
+  agents: Agent[];
+  providers: Provider[];
+  agentId: string;
+  modelId: string;
+  providerId: string;
+  onModelChange: (value: string) => void;
+  /** The resolved model's Output ceiling, for the picker's tooltip. */
+  maxOutputTokens?: number;
+}
+
+/** The textarea's own controls, which are the one truly per-surface part. */
+export interface ComposerTextareaProps {
+  ref: RefObject<HTMLTextAreaElement | null>;
+  value: string;
+  onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
+  placeholder?: string;
+  status?: ChatStatus;
+  disabled?: boolean;
+  className?: string;
+  autoFocus?: boolean;
+}
+
+interface ComposerProps {
+  onSubmit: (message: PromptInputMessage) => void;
+  passthroughFileTypes: string[];
+  modelSelection: ModelSelection;
+  textarea: ComposerTextareaProps;
+  /** What dictation writes into the textarea. */
+  onTranscriptionChange: (text: string) => void;
+  className?: string;
+  initialAttachments?: FileUIPart[];
+  globalDrop?: boolean;
+  /** Extra tools, rendered after the model picker (search toggle, dialogs). */
+  tools?: ReactNode;
+  /** Rendered between the tools and the submit control (the context meter). */
+  footerContent?: ReactNode;
+  /** The submit control, and anything beside it (the editor's Cancel). */
+  submit: ReactNode;
+}
+
+/**
+ * The stack every message-composing surface shares (issue #724): the
+ * attachments strip, the compatibility notice, the textarea, the tool row —
+ * action menu, dictation and model picker — and whatever submit control the
+ * caller supplies. What differs between surfaces is passed in: the textarea's
+ * own props, extra tools, the context meter and the submit control.
+ */
+export const Composer = ({
+  onSubmit,
+  passthroughFileTypes,
+  modelSelection,
+  textarea,
+  onTranscriptionChange,
+  className,
+  initialAttachments,
+  globalDrop,
+  tools,
+  footerContent,
+  submit,
+}: ComposerProps) => {
+  // The picker's own open state: sharing it across surfaces would open both
+  // dialogs at once.
+  const [isModelSelectorOpen, setIsModelSelectorOpen] = useState(false);
+  const { ref: textareaRef, ...textareaProps } = textarea;
+
+  return (
+    <PromptInput
+      className={className}
+      onSubmit={onSubmit}
+      initialAttachments={initialAttachments}
+      globalDrop={globalDrop}
+      multiple
+    >
+      <PromptInputAttachments className="w-full">
+        {(attachment) => <PromptInputAttachment data={attachment} />}
+      </PromptInputAttachments>
+      <FileCompatibilityWarning passthroughFileTypes={passthroughFileTypes} />
+      <PromptInputBody>
+        <PromptInputTextarea ref={textareaRef} {...textareaProps} />
+      </PromptInputBody>
+      <PromptInputFooter className="flex-wrap">
+        <PromptInputTools>
+          <PromptInputActionMenu>
+            <PromptInputActionMenuTrigger className="cursor-pointer" />
+            <PromptInputActionMenuContent>
+              <PromptInputActionAddAttachments className="cursor-pointer" />
+            </PromptInputActionMenuContent>
+          </PromptInputActionMenu>
+          <Tooltip delayDuration={1000}>
+            <TooltipTrigger asChild>
+              <PromptInputSpeechButton
+                aria-label="Microphone"
+                className="cursor-pointer"
+                textareaRef={textareaRef}
+                onTranscriptionChange={onTranscriptionChange}
+              />
+            </TooltipTrigger>
+            <TooltipContent>Microphone</TooltipContent>
+          </Tooltip>
+          <ModelSelectorDialog
+            agents={modelSelection.agents}
+            providers={modelSelection.providers}
+            agentId={modelSelection.agentId}
+            modelId={modelSelection.modelId}
+            providerId={modelSelection.providerId}
+            isOpen={isModelSelectorOpen}
+            onOpenChange={(open) => {
+              setIsModelSelectorOpen(open);
+              if (!open) {
+                setTimeout(() => textareaRef.current?.focus(), 250);
+              }
+            }}
+            onModelChange={modelSelection.onModelChange}
+            maxOutputTokens={modelSelection.maxOutputTokens}
+          />
+          {tools}
+        </PromptInputTools>
+        {footerContent}
+        {submit}
+      </PromptInputFooter>
+    </PromptInput>
+  );
+};

--- a/apps/frontend/components/message-editor.test.tsx
+++ b/apps/frontend/components/message-editor.test.tsx
@@ -95,12 +95,14 @@ const renderEditor = (
     <MessageEditor
       initialText="What does this say?"
       initialAttachments={[report]}
-      agents={[]}
-      providers={[provider]}
-      agentId=""
-      modelId="m1"
-      providerId="p1"
-      onModelChange={vi.fn()}
+      modelSelection={{
+        agents: [],
+        providers: [provider],
+        agentId: "",
+        modelId: "m1",
+        providerId: "p1",
+        onModelChange: vi.fn(),
+      }}
       // The seeded PDF reads natively by default, so the compatibility notice
       // stays out of the way of every test that isn't about it.
       passthroughFileTypes={["application/pdf"]}

--- a/apps/frontend/components/message-editor.tsx
+++ b/apps/frontend/components/message-editor.tsx
@@ -2,46 +2,20 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { FileUIPart } from "ai";
-import type { Agent, Provider } from "@platypus/schemas";
 import { XIcon } from "lucide-react";
 import {
-  PromptInput,
-  PromptInputActionAddAttachments,
-  PromptInputActionMenu,
-  PromptInputActionMenuContent,
-  PromptInputActionMenuTrigger,
-  PromptInputAttachment,
-  PromptInputAttachments,
-  PromptInputBody,
   PromptInputButton,
-  PromptInputFooter,
-  PromptInputSpeechButton,
   PromptInputSubmit,
-  PromptInputTextarea,
-  PromptInputTools,
   type PromptInputMessage,
 } from "./ai-elements/prompt-input";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { FileCompatibilityWarning } from "./file-compatibility-warning";
-import { ModelSelectorDialog } from "./model-selector-dialog";
+import { Composer, type ModelSelection } from "./composer";
 
 interface MessageEditorProps {
   /** The message's text as it stands, which the editor opens on. */
   initialText: string;
   /** The attachments it already carries, which the editor opens holding. */
   initialAttachments: FileUIPart[];
-  agents: Agent[];
-  providers: Provider[];
-  agentId: string;
-  modelId: string;
-  providerId: string;
-  onModelChange: (value: string) => void;
-  /** The resolved model's Output ceiling, for the picker's tooltip. */
-  maxOutputTokens?: number;
+  modelSelection: ModelSelection;
   /** What the resolved model reads natively, for the compatibility notice. */
   passthroughFileTypes: string[];
   onSubmit: (message: PromptInputMessage) => void;
@@ -72,22 +46,13 @@ interface MessageEditorProps {
 export const MessageEditor = ({
   initialText,
   initialAttachments,
-  agents,
-  providers,
-  agentId,
-  modelId,
-  providerId,
-  onModelChange,
-  maxOutputTokens,
+  modelSelection,
   passthroughFileTypes,
   onSubmit,
   onCancel,
 }: MessageEditorProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [text, setText] = useState(initialText);
-  // The edit surface's own picker state: sharing the composer's would open both
-  // dialogs at once.
-  const [isModelSelectorOpen, setIsModelSelectorOpen] = useState(false);
 
   // Opening an edit selects what is there, so retyping the message replaces it
   // rather than appending to it.
@@ -96,69 +61,29 @@ export const MessageEditor = ({
   }, []);
 
   return (
-    <PromptInput
+    <Composer
       className="w-full"
       onSubmit={onSubmit}
       initialAttachments={initialAttachments}
-      multiple
-    >
-      <PromptInputAttachments className="w-full">
-        {(attachment) => <PromptInputAttachment data={attachment} />}
-      </PromptInputAttachments>
-      <FileCompatibilityWarning passthroughFileTypes={passthroughFileTypes} />
-      <PromptInputBody>
-        <PromptInputTextarea
-          ref={textareaRef}
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          // Escape belongs to the edit; claiming it here keeps the built-in
-          // Enter-to-submit and Backspace-removes-attachment intact.
-          onKeyDown={(e) => {
-            if (e.key === "Escape") {
-              e.preventDefault();
-              e.stopPropagation();
-              onCancel();
-            }
-          }}
-          autoFocus
-        />
-      </PromptInputBody>
-      <PromptInputFooter className="flex-wrap">
-        <PromptInputTools>
-          <PromptInputActionMenu>
-            <PromptInputActionMenuTrigger className="cursor-pointer" />
-            <PromptInputActionMenuContent>
-              <PromptInputActionAddAttachments className="cursor-pointer" />
-            </PromptInputActionMenuContent>
-          </PromptInputActionMenu>
-          <Tooltip delayDuration={1000}>
-            <TooltipTrigger asChild>
-              <PromptInputSpeechButton
-                aria-label="Microphone"
-                className="cursor-pointer"
-                textareaRef={textareaRef}
-                onTranscriptionChange={setText}
-              />
-            </TooltipTrigger>
-            <TooltipContent>Microphone</TooltipContent>
-          </Tooltip>
-          <ModelSelectorDialog
-            agents={agents}
-            providers={providers}
-            agentId={agentId}
-            modelId={modelId}
-            providerId={providerId}
-            isOpen={isModelSelectorOpen}
-            onOpenChange={(open) => {
-              setIsModelSelectorOpen(open);
-              if (!open) {
-                setTimeout(() => textareaRef.current?.focus(), 250);
-              }
-            }}
-            onModelChange={onModelChange}
-            maxOutputTokens={maxOutputTokens}
-          />
-        </PromptInputTools>
+      passthroughFileTypes={passthroughFileTypes}
+      modelSelection={modelSelection}
+      textarea={{
+        ref: textareaRef,
+        value: text,
+        onChange: (e) => setText(e.target.value),
+        // Escape belongs to the edit; claiming it here keeps the built-in
+        // Enter-to-submit and Backspace-removes-attachment intact.
+        onKeyDown: (e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            e.stopPropagation();
+            onCancel();
+          }
+        },
+        autoFocus: true,
+      }}
+      onTranscriptionChange={setText}
+      submit={
         <div className="flex items-center gap-1">
           <PromptInputButton
             aria-label="Cancel"
@@ -169,7 +94,7 @@ export const MessageEditor = ({
           </PromptInputButton>
           <PromptInputSubmit aria-label="Save" className="cursor-pointer" />
         </div>
-      </PromptInputFooter>
-    </PromptInput>
+      }
+    />
   );
 };

--- a/apps/frontend/hooks/use-chat-ui.ts
+++ b/apps/frontend/hooks/use-chat-ui.ts
@@ -12,7 +12,6 @@ export const useChatUI = (
    */
   errorTreatment: ChatErrorTreatment,
 ) => {
-  const [isModelSelectorOpen, setIsModelSelectorOpen] = useState(false);
   const [isSettingsDialogOpen, setIsSettingsDialogOpen] = useState(false);
   const [isAgentInfoDialogOpen, setIsAgentInfoDialogOpen] = useState(false);
   const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
@@ -29,8 +28,6 @@ export const useChatUI = (
   });
 
   return {
-    isModelSelectorOpen,
-    setIsModelSelectorOpen,
     isSettingsDialogOpen,
     setIsSettingsDialogOpen,
     isAgentInfoDialogOpen,

--- a/apps/frontend/hooks/use-message-editing.ts
+++ b/apps/frontend/hooks/use-message-editing.ts
@@ -1,16 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
 import { FileUIPart, UIMessage } from "ai";
+import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import {
   ATTACHMENTS_ONLY_TEXT,
   messageAttachments,
   messageText,
 } from "@/lib/message-parts";
-
-/** What an edit resubmits: the whole message, not just its words. */
-export type EditedMessage = {
-  text: string;
-  files?: FileUIPart[];
-};
 
 /**
  * The message an edit surface should open with. `null` when nothing is being
@@ -37,7 +32,7 @@ export const useMessageEditing = <T extends UIMessage = UIMessage>(
   messages: T[],
   setMessages: (messages: T[]) => void,
   sendMessage: (
-    message: EditedMessage,
+    message: PromptInputMessage,
     options?: { body?: Record<string, unknown> },
   ) => void,
   getRequestBody: () => Record<string, unknown>,
@@ -64,12 +59,12 @@ export const useMessageEditing = <T extends UIMessage = UIMessage>(
   }, []);
 
   const handleMessageEditSubmit = useCallback(
-    (edited: EditedMessage) => {
+    (edited: PromptInputMessage) => {
       if (!editingMessageId) return;
       const messageIndex = messages.findIndex((m) => m.id === editingMessageId);
       if (messageIndex === -1) return;
 
-      const files = edited.files ?? [];
+      const files = edited.files;
       // An edit emptied of both its words and its files would truncate the
       // transcript and send nothing in its place — the one edit with no way
       // back. Left open instead, so the user can see what they are about to do.


### PR DESCRIPTION
## What

`components/message-editor.tsx` and the composer in `components/chat.tsx` render the same stack and had already produced a byte-identical copy of a workaround (the `setTimeout(…, 250)` focus hack). A fix to one silently left the other behind.

Extract that shared stack into `components/composer.tsx` with slots for what differs, and point both surfaces at it. Two smaller findings from the same review ride along:

- `MessageEditorProps`'s seven model-picker fields (`agents`, `providers`, `agentId`, `modelId`, `providerId`, `onModelChange`, `maxOutputTokens`) were a data clump that only ever travelled to reach `ModelSelectorDialog` — now bundled into one `ModelSelection`.
- `EditedMessage` and `PromptInputMessage` described the same payload; collapsed to `PromptInputMessage` with the editing hook's optionality made explicit at its own boundary.

## No behaviour change

- The shared stack and the focus hack now exist in exactly one file.
- `PromptInputActionAddAttachments` is rendered only by the composer.
- Escape still cancels an edit, Enter still submits, the edit surface still shows no agent info / settings / context meter / search toggle, and the edit instance still sets no `globalDrop`.
- `message-editor.test.tsx`, `chat.test.tsx` and `chat-message.test.tsx` pass with their assertions unchanged (only `message-editor.test.tsx`'s setup moved to the new `modelSelection` prop shape).

Two deviations within the issue's stated latitude: the chat surface now carries `aria-label="Microphone"` (matches the editor; harmless a11y), and the search toggle renders after the model picker since the picker is part of the shared stack.

## Verification

`pnpm typecheck`, `pnpm lint` and `pnpm test` pass.