### PR TITLE
chore: route vulnerability reports to private disclosure

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: Report a security vulnerability
     url: https://github.com/willdady/platypus/security/advisories/new
-    about: Report privately — not as an issue or a pull request. Platypus is self-hosted, so a public report exposes every deployment that has not upgraded yet. See SECURITY.md.
+    about: Report privately — not as an issue or a pull request. A public report exposes every deployment that has not upgraded yet. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/willdady/platypus/security/advisories/new
+    about: Report privately — not as an issue or a pull request. Platypus is self-hosted, so a public report exposes every deployment that has not upgraded yet. See SECURITY.md.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+  ⚠️  Does this fix a security vulnerability?
+
+  Close this tab and report it privately instead:
+  https://github.com/willdady/platypus/security/advisories/new
+
+  Platypus is self-hosted. Opening the pull request tells every deployment that
+  has not upgraded where the hole is, before a release exists for them to
+  upgrade to — and the branch name, the commit message and a test named after
+  the attack disclose it just as loudly as the diff. See SECURITY.md.
+-->
+
+## What
+
+## Why
+
+## Checklist
+
+- [ ] The **PR title** is a Conventional Commit subject (`feat:`, `fix:` or `chore:`, optional scope). This is squash-merged as the commit on `main` and is what the changelog and version bump are built from — a title without one means the change ships with neither.
+- [ ] Docs in `apps/docs/content` are updated **in this PR** if it touched an `.env.example`, a user-facing limit or enum in `packages/schemas`, anything under `apps/backend/src/plugins`, or a visible label or field in the frontend.
+- [ ] `pnpm test`, `pnpm typecheck` and `pnpm format` pass locally.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,10 @@
   Close this tab and report it privately instead:
   https://github.com/willdady/platypus/security/advisories/new
 
-  Platypus is self-hosted. Opening the pull request tells every deployment that
-  has not upgraded where the hole is, before a release exists for them to
-  upgrade to — and the branch name, the commit message and a test named after
-  the attack disclose it just as loudly as the diff. See SECURITY.md.
+  Opening the pull request tells every deployment that has not upgraded where
+  the hole is, before a release exists for them to upgrade to — and the branch
+  name, the commit message and a test named after the attack disclose it just as
+  loudly as the diff. See SECURITY.md.
 -->
 
 ## What
@@ -17,5 +17,6 @@
 ## Checklist
 
 - [ ] The **PR title** is a Conventional Commit subject (`feat:`, `fix:` or `chore:`, optional scope). This is squash-merged as the commit on `main` and is what the changelog and version bump are built from — a title without one means the change ships with neither.
+- [ ] **The change is covered by tests.** New behaviour gets tests; a bug fix gets a test that fails without the fix. A change with no test is one nothing stops from coming back — say so in the description if you believe this one genuinely cannot be tested.
 - [ ] Docs in `apps/docs/content` are updated **in this PR** if it touched an `.env.example`, a user-facing limit or enum in `packages/schemas`, anything under `apps/backend/src/plugins`, or a visible label or field in the frontend.
 - [ ] `pnpm test`, `pnpm typecheck` and `pnpm format` pass locally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ Platypus is a monorepo managed by [Turborepo](https://turbo.build/) with the fol
 
 If you find a bug or have a feature request, please [open an issue](https://github.com/willdady/platypus/issues) with a clear description and, if applicable, steps to reproduce.
 
-**Security vulnerabilities are the exception — do not open an issue or a pull request.** [Report it privately](https://github.com/willdady/platypus/security/advisories/new) instead. Platypus is self-hosted, so until a release exists a public report tells every deployment that has not upgraded exactly where the hole is, and offers them nothing to upgrade to. See [SECURITY.md](SECURITY.md) for what to include and what happens next.
+**Security vulnerabilities are the exception — do not open an issue or a pull request.** [Report it privately](https://github.com/willdady/platypus/security/advisories/new) instead. Until a release exists, a public report tells every deployment that has not upgraded exactly where the hole is, and offers them nothing to upgrade to. See [SECURITY.md](SECURITY.md) for what to include and what happens next.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,12 @@ chore(tests): add missing test coverage
 
 ## Submitting a Pull Request
 
+> **Fixing a security vulnerability? Do not open a pull request.** Report it
+> privately first — see [Reporting Issues](#reporting-issues) and
+> [SECURITY.md](SECURITY.md). A branch name and a commit message disclose a
+> vulnerability as surely as an issue does. We can share a private fork with you
+> so the fix still lands as your work.
+
 1. Ensure your code passes all tests (`pnpm test`) and is formatted (`pnpm format`).
 2. Write clear, descriptive commit messages following the conventions above.
 3. Update the docs in `apps/docs/content` in the same PR, not a follow-up one.
@@ -156,6 +162,8 @@ Platypus is a monorepo managed by [Turborepo](https://turbo.build/) with the fol
 ## Reporting Issues
 
 If you find a bug or have a feature request, please [open an issue](https://github.com/willdady/platypus/issues) with a clear description and, if applicable, steps to reproduce.
+
+**Security vulnerabilities are the exception — do not open an issue or a pull request.** [Report it privately](https://github.com/willdady/platypus/security/advisories/new) instead. Platypus is self-hosted, so until a release exists a public report tells every deployment that has not upgraded exactly where the hole is, and offers them nothing to upgrade to. See [SECURITY.md](SECURITY.md) for what to include and what happens next.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,10 +19,10 @@ have. A short reproduction beats a long description.
 
 ### Why not a pull request
 
-Platypus is self-hosted. Every deployment is upgraded by its own Operator, on
-their own schedule — there is no central instance a maintainer can patch on
-everyone's behalf. Until a release exists, a public fix tells every unpatched
-deployment where the hole is and gives them nothing to upgrade to.
+Every deployment is upgraded by its own Operator, on their own schedule — there
+is no central instance a maintainer can patch on everyone's behalf. Until a
+release exists, a public fix tells every unpatched deployment where the hole is
+and gives them nothing to upgrade to.
 
 A pull request discloses as surely as an issue does, and it is easy to disclose
 without meaning to. The branch name, the commit message, a test named after the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Report it privately. Do not open an issue, a pull request, or a public branch.**
+
+Use GitHub's private reporting form:
+
+**[Report a vulnerability](https://github.com/willdady/platypus/security/advisories/new)**
+
+You can also reach it from the **Security** tab → **Advisories** → **Report a
+vulnerability**. The report is visible only to you and the maintainers, and it
+becomes the draft advisory the fix is tracked against — so nothing has to be
+re-typed later.
+
+Include what you would want if you were fixing it: the endpoint or screen, who
+has to be signed in as what, the steps, and what you got that you should not
+have. A short reproduction beats a long description.
+
+### Why not a pull request
+
+Platypus is self-hosted. Every deployment is upgraded by its own Operator, on
+their own schedule — there is no central instance a maintainer can patch on
+everyone's behalf. Until a release exists, a public fix tells every unpatched
+deployment where the hole is and gives them nothing to upgrade to.
+
+A pull request discloses as surely as an issue does, and it is easy to disclose
+without meaning to. The branch name, the commit message, a test named after the
+attack, and the shape of the diff itself all say where the missing check was.
+Report it privately instead, and the fix and the advisory can be published
+together.
+
+If you already have a patch, say so in the report and keep it to yourself for
+now. We can open a temporary private fork and invite you to it, so your fix
+still lands as your work.
+
+### What happens next
+
+1. We confirm the report and open (or reuse) a private draft advisory.
+2. The fix is written against that advisory, not on a public branch.
+3. A release goes out, and the advisory is published against it, naming the
+   patched version.
+4. You are credited in the advisory unless you would rather not be.
+
+We will tell you what we think the severity is and why. If you disagree, say so
+— you have looked at it more closely than anyone.
+
+## Supported versions
+
+Fixes land in the next release cut from `main`. Only the most recent release is
+supported: there are no backports to earlier tags, so upgrading is the remedy
+for every advisory published here.
+
+## What is not a vulnerability
+
+Two things get reported often and are working as intended:
+
+- **The default `admin@example.com` / `admin123` account.** This is the
+  documented first-startup credential, overridden with `ADMIN_EMAIL` and
+  `ADMIN_PASSWORD`. A deployment left on the default is a deployment that
+  skipped its own setup.
+- **Anything that needs an Operator account first.** The Operator — the platform
+  super-admin — already controls the deployment, its environment, and its
+  database, and bypasses in-app authorization by design. A finding that begins
+  "as a super-admin" is describing that design.
+
+Crossing a tenancy boundary is always worth reporting: an Organization reaching
+another Organization's data, a Workspace Owner reaching a Workspace that is not
+theirs, or a Shared resource being reached without an Attachment.


### PR DESCRIPTION
## What

Adds `SECURITY.md`, an issue-chooser contact link, a pull request template, and two pointers in `CONTRIBUTING.md`, so a vulnerability report has an obvious private route and a public one has an obvious warning.

## Why

There was no `SECURITY.md`, no issue template and no PR template, so every documented path into the project led to the public tracker. #727 arrived as a public PR describing a live cross-tenant write — the branch name, the code comments and a test named after the attack all disclosed it before any release carried the fix. That is what the absence of a policy produces, not a contributor error.

Private vulnerability reporting is now enabled on the repository, so the form the policy links to exists.

## Where it appears

| Path a reporter takes | What they now see |
| --- | --- |
| New issue | A **Report a security vulnerability** contact link on the chooser, above the blank-issue option |
| New pull request | A comment at the top of the composer — visible while writing, absent from the posted body |
| `CONTRIBUTING.md` → Reporting Issues | The exception to "open an issue", with the reason |
| `CONTRIBUTING.md` → Submitting a Pull Request | A blockquote before step 1 |

`SECURITY.md` also sets out what happens after a report, that only the most recent release is supported, and what is *not* a vulnerability — the documented first-startup admin credentials, and anything that already requires an Operator account — so those stop arriving as reports.

## The pull request checklist

The template carries a checklist as well, covering the three things this repo already expects and one it did not state:

- **The PR title is a Conventional Commit subject** — it is squash-merged as the commit on `main`, so a title without one ships the change with no changelog entry and no version bump.
- **The change is covered by tests.** New behaviour gets tests; a bug fix gets a test that fails without the fix. Nothing said this before, and asking only that `pnpm test` pass is satisfied by a change carrying no test of its own.
- **Docs in `apps/docs/content` are updated in the same PR**, on the same trigger list `CONTRIBUTING.md` uses.
- **`pnpm test`, `pnpm typecheck` and `pnpm format` pass locally.**

## Notes

- `blank_issues_enabled: true` is deliberate: there are no issue forms in this repo, so disabling blank issues would leave no way to open one.
- The PR template's security warning is an HTML comment. That is visible in the composer, which is the moment it matters, and does not clutter every merged PR body.
- No docs change is owed — `apps/docs/content` is written for Operators and Workspace Owners, not contributors.