### PR TITLE
chore(ci): verify main on every push and read that result before a release

### DIFF
--- a/.agents/skills/pre-release-check/SKILL.md
+++ b/.agents/skills/pre-release-check/SKILL.md
@@ -34,18 +34,45 @@ git fetch --tags && git fetch origin main
 git status --short && git log --oneline origin/main..HEAD
 ```
 
-Then run the gate from the repo root:
+Lint, typecheck and tests are **not** re-run here. CI runs them on every push to `main`,
+so the tip has already been through them — but "CI runs on main" is only a guarantee if
+you look at the result. Read it:
 
 ```bash
-pnpm lint && pnpm typecheck && pnpm test && pnpm build
+git rev-parse origin/main
+gh run list --branch main --workflow ci.yml --limit 1 \
+  --json headSha,status,conclusion,url --jq '.[0]'
+```
+
+The run's `headSha` must equal `origin/main` and its conclusion must be `success`. Three
+ways that goes wrong, all holds:
+
+- **The newest run is for an older commit.** The tip is unverified — most likely it
+  arrived by a push that bypassed the pull request, which is how a security fix lands off
+  a private advisory. Wait for its run, or trigger one.
+- **No run at all**, or one still in progress. Wait for it. An absent result is not a
+  passing one.
+- **A failing run.** Stop here.
+
+Do not accept the release PR's own green check as evidence. CI skips lint, typecheck and
+tests on any branch starting `release-please--`, and the `gate` job passes on skipped
+jobs — so the release PR is green whatever state the code is in. The run that means
+something is the one on `main`.
+
+Then run what CI does **not** cover, from the repo root:
+
+```bash
+pnpm build
 ```
 
 Then `pnpm format` followed by `git status --short`. `format` **writes**, so a dirty tree
-afterwards means formatting has drifted on `main` and needs its own commit.
+afterwards means formatting has drifted on `main` and needs its own commit. Neither the
+build nor formatting drift is checked anywhere upstream of here.
 
-Report each check as pass or fail with the failing output. **Green is every check passing
-on an unmodified tree.** Anything red is a hold — say so and stop; do not carry a failure
-forward into the later steps hoping it looks smaller in a summary.
+Report the CI run and each local check as pass or fail, with the failing output. **Green
+is a CI success on this exact commit plus every local check passing on an unmodified
+tree.** Anything red is a hold — say so and stop; do not carry a failure forward into the
+later steps hoping it looks smaller in a summary.
 
 ## Step 2 — Reconcile the release
 
@@ -89,17 +116,17 @@ The remedy for a mismatched bump is the user's call, not yours. Surface it and s
 
 ## Step 3 — Sweep what CI can't see
 
-The gate in Step 1 is a floor. These four hold the release and none of them go red:
+The gate Step 1 confirmed is a floor. These four hold the release and none of them go red:
 
 - **Focused or disabled tests.** `grep -rn "\.only(\|\.skip(\|todo(" --include="*.test.ts"
 --include="*.test.tsx" apps packages` — a `.only` left in the range silently disables the
-  rest of its file, so Step 1 went green over tests that never ran. Any hit introduced in
+  rest of its file, so CI went green over tests that never ran. Any hit introduced in
   this range is a hold until it's removed or justified.
 - **Docs that ship with the code.** `CLAUDE.md` maps changed paths to the docs page that
   must change with them — `.env.example`, `packages/schemas` limits, `apps/backend/src/plugins/**`,
   and visible frontend labels. Apply that table to the range's paths: if a mapped path
   changed and `apps/docs/content` didn't, the release ships a docs lie. `docs-contract.test.ts`
-  already passed in Step 1 and cannot see UI labels; for those, ask the user to run
+  already passed in CI and cannot see UI labels; for those, ask the user to run
   `/docs-audit` — it is user-invoked and you cannot start it yourself.
 - **The plugin SDK version.** If the range touches `packages/plugin-sdk`, its
   `package.json` version must already be bumped by hand. `publish-sdk.yml` fires on release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,21 @@
 name: CI
 
-# Pre-merge gate: lint and tests must pass on every PR into main. This catches
-# problems at the merge boundary, before release-please and the release/deploy
-# workflows ever see the code. Enforced as required status checks on main, so
-# nothing merges without it.
+# Lint and tests run twice: on every PR into main as the pre-merge gate, and on
+# main itself after every push. The PR run catches problems at the merge
+# boundary, before release-please and the release/deploy workflows ever see the
+# code, and is enforced as a required status check so nothing merges without it.
+#
+# The push run is what verifies main itself, and it exists because a green PR is
+# not a promise about the branch it lands on. Two PRs can each pass alone and
+# break together, and a change can reach main without a PR at all — the ruleset
+# lets a repository admin bypass both the pull request and this check, which is
+# how a security fix lands from a private advisory. Neither case is visible to a
+# pull_request trigger. Nothing gates on the push run; it is there to fail
+# loudly on main so the next person is not debugging someone else's merge.
 on:
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
 
 permissions:
@@ -15,9 +25,12 @@ env:
   TURBO_TELEMETRY_DISABLED: "1"
 
 # Cancel superseded runs for the same ref (e.g. a new push to a PR branch).
+# Never on main: each merge is a distinct commit that release and deploy may be
+# cut from, so cancelling an in-flight run would leave that commit unverified
+# with nothing to say so.
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Skip on release-please's release PR: it only bumps the version and


### PR DESCRIPTION
## What

Two halves of one change:

1. CI gains a `push: branches: [main]` trigger, so lint, typecheck and tests run on `main` itself and not only on pull requests. `cancel-in-progress` no longer cancels runs on `main`.
2. `pre-release-check` stops re-running that gate locally and reads the result of the `main` run instead.

## Why

CI ran only on `pull_request`, so **nothing ever verified `main` itself**. That leaves two gaps a green PR cannot close:

- **Semantic conflicts.** Two PRs can each pass in isolation and break in combination. `strict_required_status_checks_policy` covers this today by forcing every open PR to rebuild against the new tip, which is what makes it expensive to keep several PRs open at once — and it stops covering anything the moment strict is relaxed.
- **Changes that never see a PR.** The `main: land via green PR (admin bypass)` ruleset lets a repository admin bypass both the pull request requirement and the `gate` check. That is not hypothetical: it is the path a security fix takes when it comes off a private advisory, because a temporary private fork can never run CI — GitHub blocks integrations there so embargoed details cannot leak.

`4c6a6a2` — the user Context scoping fix released in v3.1.1 — reached `main` exactly that way. It was verified locally and by review, but no CI run exists for it.

Once `main` is verified on every push, `pre-release-check` re-running `pnpm lint && pnpm typecheck && pnpm test` is duplicated work on a commit that already passed them.

## What Step 1 does now

It reads the run rather than repeating it:

```bash
git rev-parse origin/main
gh run list --branch main --workflow ci.yml --limit 1 \
  --json headSha,status,conclusion,url --jq '.[0]'
```

The run's `headSha` must equal `origin/main` and conclude `success`. Three ways that goes wrong, all holds: a run for an **older commit** than the tip (which is what an admin-bypass push looks like), **no run yet**, and a **failing run**. "CI runs on main" is only a guarantee if someone looks at the result.

It also names a trap that already existed and was never written down: CI skips lint, typecheck and tests on any branch starting `release-please--`, and the `gate` job passes on skipped jobs. **The release PR is therefore green whatever state the code is in.** The run that means something is the one on `main`.

**`pnpm build` and the formatting-drift check stay.** CI runs neither — `build` is not a CI job at all, and `format` is `prettier --write`, used there as a drift detector. Step 1 is the only place either happens before a release.

## Notes

- **Nothing gates on the push run.** `gate` stays the single required check on pull requests.
- **Runs are no longer cancelled on `main`.** `cancel-in-progress` becomes `${{ github.event_name == 'pull_request' }}`. Superseded PR runs still cancel, which was the original intent, but each merge to `main` is a distinct commit a release may be tagged from — cancelling it would leave that commit unverified with nothing to say so.
- **The release commit gets a full run.** The `release-please--` skip evaluates true on push events, because `head_ref` is empty there. That is what we want: the release commit is the tip that gets tagged, built and deployed.
- **Cost:** roughly one extra ~2 minute run per merge.

## Tests

No test accompanies this. One half is a workflow trigger and the other is a Markdown skill; the only demonstration is the workflow running on `main`, observable on the first merge after this lands. Flagging it here rather than ticking the box, per the checklist.

I did run the new Step 1 command against the current repo, which returned a run for `075fe22a` while `origin/main` is at `fd69e534` — the "newest run is for an older commit" hold, correctly reported. That is the state this PR fixes.

## Follow-up, not in this PR

With `main` verified after merge, dropping `strict_required_status_checks_policy` becomes a reasonable trade: it costs an update-and-CI cycle on every other open PR each time one merges. Worth deciding separately, once this has run a few times.