### PR TITLE
chore(docs): record ADR-0022 on ambient event causation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -138,7 +138,7 @@ A typed tile on a **Dashboard** — metric, text/markdown, image, weather, or ch
 _Avoid_: tile, panel, component.
 
 **Trigger**:
-A saved automation that runs an Agent unattended against a fixed Instruction — no Chat, nobody watching. One of two shapes: a **Cron Trigger**, firing on a schedule evaluated in the Trigger's own timezone, or an **Event Trigger**, firing when a subscribed **Webhook event** occurs in the Workspace, debounced so a burst coalesces into one run. The event's payload arrives above the Instruction, so the Instruction can point at it. An Agent's own writes never fire that Agent's own Event Trigger.
+A saved automation that runs an Agent unattended against a fixed Instruction — no Chat, nobody watching. One of two shapes: a **Cron Trigger**, firing on a schedule evaluated in the Trigger's own timezone, or an **Event Trigger**, firing when a subscribed **Webhook event** occurs in the Workspace, debounced so a burst coalesces into one run. The event's payload arrives above the Instruction, so the Instruction can point at it. An Agent's own writes never fire that Agent's own Event Trigger — including writes made on its behalf by a Sub-Agent, at any depth.
 _Avoid_: automation, job, scheduler, webhook (that delivers events out; it runs nothing).
 
 **Trigger run**:

--- a/docs/adr/0022-event-causation-is-ambient-run-context.md
+++ b/docs/adr/0022-event-causation-is-ambient-run-context.md
@@ -1,0 +1,62 @@
+---
+status: accepted-pending-implementation
+implemented-by: "#668"
+---
+
+# Event causation is ambient run context, not a plugin-boundary parameter
+
+> **In the code today.** None of this is built yet. `dispatchEvent` takes an
+> optional `actorAgentId` that each write path passes explicitly, and skips an
+> Event Trigger when that id equals the Trigger's own Agent. The Kanban Tool set
+> passes it; the Notification Tool set does not, so `notification.*` events are
+> unguarded. The id is the leaf Agent that performed the write, so a Sub-Agent's
+> write is not attributed to the Agent that delegated it. See
+> `apps/backend/src/services/event-dispatch.ts`.
+
+A Workspace write emits a **Webhook event**, and an **Event Trigger** may run an
+Agent in response. Where the Agent that caused the write is the Trigger's own,
+running it again is a loop: the run writes, the write fires the Trigger, the
+Trigger starts the run. #267 closed that by having each write path hand
+`dispatchEvent` the acting Agent's id, which the dispatcher compares against the
+Trigger's `agentId`.
+
+That design makes every write path responsible for volunteering its own cause,
+and one already forgot. The Notification Tool set has the Agent id in hand — it
+writes it into the row it is inserting — and then dispatches three events
+without it, so `notification.*` has never engaged the guard for any Agent at any
+depth. Nothing caught it: a missing optional argument is indistinguishable from
+a human-originated write, which is precisely the case that argument exists to
+leave unguarded. The obvious extension — also hand each call site the
+originating Trigger, to fix the delegation hole in #668 — would have doubled
+what a call site has to remember, and extended that obligation across the plugin
+boundary to third-party Tool sets this project never reviews.
+
+The decision is that **causation is ambient to a run, and read by the
+dispatcher, never passed by the writer**. A **Drive** establishes what caused it
+— the chain of Agents acting, parent through delegates — and `dispatchEvent`
+reads that context directly. A write path says nothing about its own cause and
+cannot get it wrong; a human-originated HTTP write establishes no context and so
+remains unsuppressed, as before.
+
+The rejected alternative was to widen `ToolSetContext` with the ancestor Agents
+(or the originating Trigger id). It is the more explicit design and it is where
+`agentId` already crosses. It was rejected because that type is a published,
+versioned SDK surface (`@platypuschat/plugin-sdk`, API v2, released on its own
+cadence), so the correctness of the loop guard would come to depend on every
+plugin author forwarding causation faithfully — generalising the failure that
+produced the Notification gap to code outside this repo. Keeping causation
+backend-internal also leaves the boundary as ADR-0013 drew it: ids the plugin
+needs to do its job, and no model of who is responsible for the run.
+
+The consequences worth naming. A Tool set cannot opt out of the guard by
+omission, and the Notification gap closes with no change to its call sites.
+Because the ambient record carries the whole acting chain rather than the leaf,
+an Agent's Sub-Agent writes are attributed to it, which is what makes the
+glossary's rule ("an Agent's own writes never fire that Agent's own Event
+Trigger") true at any delegation depth rather than only at depth zero. The cost
+is that the attribution is implicit: a Tool that detaches work outside the run's
+context loses it, and the guard then silently does not apply — a failure that
+reads as a spurious Trigger run, not as an error. Suppressing a _cycle between
+different Triggers_ (#669) is a different rule that this one cannot express, since
+no Agent appears in the other Trigger's chain; the ambient record is the
+extension point where the originating Trigger id belongs when that is built.


### PR DESCRIPTION
Records the design decision settled while triaging #668. Documentation only — no
code changes, and no behaviour changes until #668 is implemented.

## ADR-0022 — event causation is ambient run context

An Event Trigger must not be re-fired by the writes its own run produced. Today
the dispatcher decides that by comparing the acting Agent's id, which each write
path passes explicitly.

That design asks every write path to volunteer its own cause, and one already
forgot: the Notification Tool set has the Agent id in hand — it writes it into
the row it is inserting — and then dispatches three events without it. So
`notification.*` has never engaged the guard, for any Agent, at any depth.
Nothing caught it, because a missing optional argument is indistinguishable from
a human-originated write, which is exactly the case that argument exists to
leave unguarded.

The decision is that causation is **ambient to a run and read by the
dispatcher**, never passed by the writer. The rejected alternative — widening
`ToolSetContext`, where `agentId` already crosses — would have made the loop
guard's correctness depend on every third-party plugin author forwarding
causation faithfully, generalising the failure above to code this project never
reviews. The ADR records that trade-off and the cost of the choice: attribution
becomes implicit, so work detached from the run's context loses it, and the
guard then silently does not apply.

Status is `accepted-pending-implementation` with `implemented-by: "#668"`.
Flipping it to `accepted` is an acceptance criterion on that issue's agent
brief, per the convention in `docs/adr/README.md`.

## CONTEXT.md

The glossary's Trigger entry asserted "An Agent's own writes never fire that
Agent's own Event Trigger" without saying whether a Sub-Agent's write counts as
the Agent's own — the exact ambiguity behind #668. It now names delegation
explicitly.

Worth being clear about what this sentence is: it describes the rule #668 will
make true at any depth. Today it holds only at depth zero. The glossary states
the domain rule rather than the current implementation's reach, and the issue
that closes the gap is open and specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
