### PR TITLE
fix(backend): dispose a Tool session on every path out of Turn resolution

### DIFF
--- a/apps/backend/src/runs/agent-runner.test.ts
+++ b/apps/backend/src/runs/agent-runner.test.ts
@@ -112,6 +112,7 @@ import { AgentRunner } from "./agent-runner.ts";
 import { ConflictError, mapError } from "../errors.ts";
 import { logger } from "../logger.ts";
 import { runRegistry, TimeoutError } from "./run-registry.ts";
+import { openToolSession } from "../tools/tool-session.ts";
 import type { ResolvedRunPlan, RunInput, RunSink, RunStats } from "./types.ts";
 import type { WorkspaceScope } from "../scope.ts";
 
@@ -1103,6 +1104,111 @@ const primeStreamText = () => {
     },
   );
 };
+
+// Issue #630, Path B. Both run timers are armed when the run is registered,
+// which happens BEFORE Turn resolution is awaited — so a resolution slower
+// than the per-step bound terminates the run while it is still in flight.
+// The turn then arrives at a run that can no longer dispose it: the session,
+// its MCP clients and every closer a Contribution registered stayed open for
+// the life of the process, and the run — already recorded as failed — went
+// on to spend a provider call the caller was handed as a success.
+describe("a turn that resolves after its run has already terminated", () => {
+  let runner: AgentRunner;
+  beforeEach(() => {
+    runner = new AgentRunner();
+    vi.clearAllMocks();
+  });
+
+  /** Resolves a turn well after the 5ms per-step bound below has fired. */
+  const slowPrepare = (dispose: () => Promise<void>) =>
+    mockPrepareChatTurn.mockImplementationOnce(async () => {
+      await new Promise((r) => setTimeout(r, 60));
+      return fakeTurn({ dispose });
+    });
+
+  const timedOutRun = (sink: RunSink, dispose: () => Promise<void>) => {
+    slowPrepare(dispose);
+    return runner.generate({
+      scope,
+      input: { ...baseInput, runId: "late-prepare" },
+      sink,
+      options: {
+        timeouts: { perStepTimeoutMs: 5, perRunTimeoutMs: 1_000_000 },
+      },
+    });
+  };
+
+  it("disposes it, since the run's own teardown has already been and gone", async () => {
+    const dispose = vi.fn().mockResolvedValue(undefined);
+
+    await expect(timedOutRun(new RecordingSink(), dispose)).rejects.toThrow(
+      TimeoutError,
+    );
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  // Against a REAL session, not a stub `dispose`: what leaks on this path is
+  // whatever the session holds, and a Contribution's closers are the half that
+  // a fake turn cannot speak for. `registerCloser` is the seam `ctx.registerCloser`
+  // reaches, so this is the Plugin-facing promise — "core runs your closer once,
+  // when the turn ends" — asserted on the path that used to break it.
+  it("runs a closer a Contribution registered, exactly once", async () => {
+    const session = await openToolSession(
+      {
+        orgId: "org-1",
+        workspaceId: "ws-1",
+        userId: "user-1",
+        frontendUrl: undefined,
+      },
+      undefined,
+      { getMcp: () => Promise.resolve(null) },
+    );
+    const close = vi.fn().mockResolvedValue(undefined);
+    session.registerCloser(close);
+
+    await expect(
+      timedOutRun(new RecordingSink(), session.dispose),
+    ).rejects.toThrow(TimeoutError);
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not invoke the model", async () => {
+    mockGenerateText.mockResolvedValue(fakeGenerateResult);
+    const sink = new RecordingSink();
+
+    await expect(
+      timedOutRun(sink, vi.fn().mockResolvedValue(undefined)),
+    ).rejects.toThrow(TimeoutError);
+
+    expect(mockGenerateText).not.toHaveBeenCalled();
+    // The run was told it failed and nothing walked that back — no second
+    // terminal write, and no `onResolved` for a plan that never ran.
+    expect(sink.names()).toEqual(["onStart", "onFinish"]);
+    const finish = sink.events.at(-1) as Extract<
+      LifecycleEvent,
+      { name: "onFinish" }
+    >;
+    expect(finish.status).toBe("failed");
+    expect(finish.error).toMatch(/per-step timeout/);
+    expect(runRegistry.has("late-prepare")).toBe(false);
+  });
+
+  // The caller has to be able to tell. Before the fix `generate` returned the
+  // model's text as though nothing had happened.
+  it("fails the caller with the error the run terminated on", async () => {
+    const inFlight = timedOutRun(
+      new RecordingSink(),
+      vi.fn().mockResolvedValue(undefined),
+    );
+
+    await expect(inFlight).rejects.toMatchObject({
+      name: "TimeoutError",
+      kind: "step",
+    });
+  });
+});
 
 describe("AgentRunner.stream — success & interruption", () => {
   let runner: AgentRunner;

--- a/apps/backend/src/runs/agent-runner.ts
+++ b/apps/backend/src/runs/agent-runner.ts
@@ -61,9 +61,13 @@ const userFromScope = (scope: WorkspaceScope): { id: string; name: string } => {
 /** Mutable per-run state shared by `setup`, the timeout handler, and the
  *  consumer-shaped entry point. A background timer (the timeout) and the
  *  foreground model call both read/write it, so it lives in one object both
- *  can reach. */
+ *  can reach.
+ *
+ *  The turn is deliberately NOT here. Disposing it goes through
+ *  `run.adoptOrDispose`, which either holds it for a run that can still close
+ *  it or closes it on the spot — a `turn?` read by the terminal callback is the
+ *  shape that let a turn resolving after a timeout go undisposed (issue #630). */
 type RunState = {
-  turn?: ChatTurn;
   messages: PlatypusUIMessage[];
 };
 
@@ -181,11 +185,6 @@ export class AgentRunner {
       timeouts: params.timeouts,
       onTerminate: async ({ status, error, stats }) => {
         try {
-          await state.turn?.dispose();
-        } catch (err) {
-          logger.error({ err, runId: input.runId }, "Error disposing turn");
-        }
-        try {
           await sink.onFinish({
             runId: input.runId,
             status,
@@ -223,8 +222,9 @@ export class AgentRunner {
       throw err;
     }
 
+    let turn: ChatTurn;
     try {
-      state.turn = await this.prepare(
+      turn = await this.prepare(
         scope,
         input,
         params.origin,
@@ -238,11 +238,32 @@ export class AgentRunner {
         { error, runId: input.runId },
         "Run prepare failed before model invocation",
       );
+      // Nothing to dispose here: a resolution that throws closes its own Tool
+      // session on the way out (`prepareChatTurn`), so there is no session
+      // object at this frame to leak.
       await run.finish("failed", err);
       throw err;
     }
 
-    const turn = state.turn;
+    // The run's timers were armed at registration, above — a resolution slower
+    // than the per-step bound has already terminated it, and its teardown has
+    // already been and gone. This is where that is settled: either the run takes
+    // the turn and will dispose it, or it disposes it here and says so.
+    if (!(await run.adoptOrDispose(turn.dispose))) {
+      // The caller is told what the sink was told, so the rejection and the
+      // run's terminal record name one failure. `statusFromSignal` types the
+      // error as optional because a cancelled run has none; a run that reached
+      // here was stopped by a timer, which always carries one.
+      const { error } = run.statusFromSignal();
+      const err =
+        error ?? new Error(`Run '${input.runId}' ended before it could start`);
+      logger.error(
+        { err, runId: input.runId },
+        "Run terminated while its turn was still resolving; not invoking the model",
+      );
+      throw err;
+    }
+
     const plan: ResolvedRunPlan = { resolved: turn.resolved };
     await sink.onResolved({ runId: input.runId, plan });
 

--- a/apps/backend/src/runs/run-lifecycle.ts
+++ b/apps/backend/src/runs/run-lifecycle.ts
@@ -45,6 +45,24 @@ export type RunLifecycle = {
   /** Terminate once, with the outcome. Repeat calls are no-ops. */
   finish: (status: RunStatus, error?: Error) => Promise<void>;
   /**
+   * Hand the run a Tool session's `dispose` to close when it ends — or, if the
+   * run has already ended, have it closed here and be told so. `false` means
+   * the second: `dispose` has been run, and the caller must not go on.
+   *
+   * Both halves are the method, which is why the name carries them. A run's
+   * timers are armed the moment it registers, and that is *before* Turn
+   * resolution is awaited — so a resolution slower than the per-step bound
+   * reaches a run whose teardown has already been and gone. A caller that
+   * simply stored the disposer would have stored it where nothing will ever
+   * read it again (issue #630), and a caller that checked first would be
+   * checking across an await. Nothing here awaits between the check and the
+   * store, so no termination can land in the middle of one.
+   *
+   * The invariant this exists to make true by construction: **a disposer is
+   * only ever held by a run that can still run it.**
+   */
+  adoptOrDispose: (dispose: () => Promise<void>) => Promise<boolean>;
+  /**
    * How this run ended, as far as its abort signal knows: `succeeded` while the
    * signal is clear, `cancelled` where someone stopped it, and `failed` with the
    * `TimeoutError` where a timer did. The one place that reading is made, so no
@@ -85,16 +103,47 @@ export const startRun = (params: {
   const logFields = { runId, ...params.log };
   let stats: RunStats = {};
   let terminated = false;
+  /** The Tool session this run must close, once it has one — see
+   *  {@link RunLifecycle.adoptOrDispose}. One, not a list: a run resolves one
+   *  turn, and a turn has exactly one session to dispose however many tool
+   *  sources it reached (`CONTEXT.md`, **Tool session**). */
+  let disposer: (() => Promise<void>) | undefined;
+
+  /** Run the disposer without letting it break the path it is on — the guard
+   *  `AgentRunner`'s terminal callback used to hold, moved here with the
+   *  disposal it protects. A teardown that throws must not stop the run being
+   *  finished, nor a failure from reaching the caller. */
+  const runDisposer = async (dispose: () => Promise<void>): Promise<void> => {
+    try {
+      await dispose();
+    } catch (err) {
+      logger.error({ err, ...logFields }, "Error disposing turn");
+    }
+  };
 
   const finish = async (status: RunStatus, error?: Error): Promise<void> => {
     if (terminated) return;
     terminated = true;
+    // Before `onTerminate`, so the connections a turn opened are closed by the
+    // time the sink writes the run's terminal record.
+    if (disposer) await runDisposer(disposer);
     try {
       await onTerminate({ status, error, stats });
     } catch (err) {
       logger.error({ err, ...logFields }, "Error terminating run");
     }
     runRegistry.unregister(runId);
+  };
+
+  const adoptOrDispose = async (
+    dispose: () => Promise<void>,
+  ): Promise<boolean> => {
+    if (terminated) {
+      await runDisposer(dispose);
+      return false;
+    }
+    disposer = dispose;
+    return true;
   };
 
   const handle = runRegistry.register(runId, {
@@ -190,6 +239,7 @@ export const startRun = (params: {
     onStreamChunk: () => handle.noteActivity(),
     onActivity,
     finish,
+    adoptOrDispose,
     statusFromSignal,
     abortReason,
   };

--- a/apps/backend/src/services/chat-execution.test.ts
+++ b/apps/backend/src/services/chat-execution.test.ts
@@ -84,6 +84,20 @@ vi.mock("@ai-sdk/mcp", () => ({
   auth: vi.fn(),
 }));
 
+// Passed through to the real implementation for every test but one: issue
+// #630's Path A needs a failure AFTER the concurrently-resolved group, and file
+// inlining is the step that reaches a store which can genuinely be unreachable.
+const { mockInlineFileUrls } = vi.hoisted(() => ({
+  mockInlineFileUrls: vi.fn(),
+}));
+vi.mock("../storage/utils.ts", async () => {
+  const actual = await vi.importActual<typeof import("../storage/utils.ts")>(
+    "../storage/utils.ts",
+  );
+  mockInlineFileUrls.mockImplementation(actual.inlineFileUrls);
+  return { ...actual, inlineFileUrls: mockInlineFileUrls };
+});
+
 import {
   prepareChatTurn,
   validateTurnAttachments,
@@ -105,6 +119,7 @@ import { FileValidationError } from "./file-gate.ts";
 import { resetExtractedTextCache } from "./file-extraction.ts";
 import { buildTestPdf } from "./file-extraction.test-fixtures.ts";
 import { createInMemoryChatTurnQueries } from "./chat-execution.test-fixtures.ts";
+import type { ChatTurnQueries } from "./chat-execution.ts";
 import { formatSummariesForSystemPrompt } from "./memory-retrieval.ts";
 import { DEFAULT_DIRECT_MAX_STEPS } from "@platypus/schemas";
 import type { Provider } from "@platypus/schemas";
@@ -2217,6 +2232,185 @@ describe("chat-execution", () => {
 
       expect(turn.stream.tools).not.toHaveProperty("mcpTool");
       await turn.dispose();
+    });
+  });
+
+  // Issue #630, Path A. The Tool session is opened early — before the group of
+  // lookups the turn resolves concurrently — and its `dispose` reaches the
+  // caller only on the success path. Any failure in between and the session,
+  // its MCP clients and every closer a Contribution registered are unreachable
+  // for the life of the process.
+  //
+  // The window opens at the concurrent group itself, not after it: a rejection
+  // there settles the group immediately while the session goes on resolving
+  // beside it, unowned. A transient database error is enough.
+  describe("Tool session disposal when Turn resolution fails", () => {
+    const baseMcp = {
+      id: "mcp-630",
+      organizationId: null as string | null,
+      workspaceId: "ws-1" as string | null,
+      name: "Test MCP",
+      slug: "test_mcp",
+      url: "https://mcp.example.com",
+      headers: null,
+      authType: "None",
+      bearerToken: null,
+      oauthAccessToken: null,
+      oauthRefreshToken: null,
+      oauthTokenExpiresAt: null,
+      oauthScope: null,
+      oauthRequestedScope: null,
+      oauthClientId: null,
+      oauthClientSecret: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const agentWithMcp = {
+      ...baseAgent,
+      id: "agent-630",
+      toolSetIds: [baseMcp.id],
+    };
+
+    /** An MCP that connects successfully, so the session really does hold a
+     *  client that something has to close. */
+    const mcpClientWithClose = () => {
+      const close = vi.fn().mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValueOnce({
+        listTools: vi.fn().mockResolvedValue({ tools: [{ name: "mcpTool" }] }),
+        toolsFromDefinitions: vi
+          .fn()
+          .mockReturnValue({ mcpTool: { description: "x" } }),
+        close,
+      });
+      return close;
+    };
+
+    const queriesWith = (
+      overrides: Partial<ChatTurnQueries>,
+    ): ChatTurnQueries => ({
+      ...createInMemoryChatTurnQueries({
+        workspaces: [baseWorkspace],
+        agents: [agentWithMcp],
+        providers: [baseProvider],
+        mcps: [baseMcp],
+      }),
+      ...overrides,
+    });
+
+    const turnWith = (queries: ChatTurnQueries) =>
+      prepareChatTurn(
+        { ...baseInput, request: { agentId: agentWithMcp.id } },
+        queries,
+      );
+
+    it("closes the session's MCP client when a concurrently-resolved lookup rejects", async () => {
+      const close = mcpClientWithClose();
+      const boom = new ValidationError("sandbox lookup failed");
+
+      await expect(
+        turnWith(
+          queriesWith({ getSandboxEnvKeys: () => Promise.reject(boom) }),
+        ),
+      ).rejects.toBe(boom);
+
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    // Not the same lookup twice over: the group settles on the FIRST rejection,
+    // so which member fails decides how much of the group is still in flight
+    // when the session resolves. Both have to close it.
+    it("closes it when a different member of the same group rejects", async () => {
+      const close = mcpClientWithClose();
+      const boom = new Error("user contexts unavailable");
+
+      await expect(
+        turnWith(queriesWith({ getUserContexts: () => Promise.reject(boom) })),
+      ).rejects.toBe(boom);
+
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes it when resolution fails after the group, on the way to the plan", async () => {
+      const close = mcpClientWithClose();
+      const boom = new Error("attachment store unreachable");
+      mockInlineFileUrls.mockRejectedValueOnce(boom);
+
+      await expect(turnWith(queriesWith({}))).rejects.toBe(boom);
+
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    // The caller's error handling is downstream of this: `AgentRunner` records
+    // the failure and the central `onError` maps it to a status code, both off
+    // the error's own type. Disposal must not launder it.
+    it("lets the original error through unchanged", async () => {
+      mcpClientWithClose();
+      const boom = new NotFoundError("provider row vanished mid-turn");
+
+      const caught = await turnWith(
+        queriesWith({ getSandboxEnvKeys: () => Promise.reject(boom) }),
+      ).catch((e: unknown) => e);
+
+      expect(caught).toBeInstanceOf(NotFoundError);
+      expect((caught as Error).message).toBe("provider row vanished mid-turn");
+    });
+
+    // A Contribution's closers live on the session, so they leak exactly like an
+    // MCP client does — and the deferred registrar the search path is handed
+    // only runs a closer itself when the session promise REJECTS. A session that
+    // opened and was abandoned still holds them.
+    it("runs a closer a Web-search backend registered", async () => {
+      const close = vi.fn().mockResolvedValue(undefined);
+      registerWebBackend(
+        composeWebBackend({
+          contribution: {
+            backend: "searx",
+            name: "SearXNG",
+            createExecutors: (ctx) => {
+              ctx.registerCloser?.(close);
+              return { web_search: () => ({ query: "q", results: [] }) };
+            },
+          },
+          pluginName: "@acme/searx",
+          plugin: makePluginContext(),
+        }),
+      );
+      const boom = new Error("sandbox lookup failed");
+
+      await expect(
+        prepareChatTurn(
+          {
+            ...baseInput,
+            request: {
+              providerId: baseProvider.id,
+              modelId: "gpt-4",
+              search: true,
+            },
+          },
+          {
+            ...createInMemoryChatTurnQueries({
+              workspaces: [baseWorkspace],
+              providers: [{ ...baseProvider, searchSource: "searx" }],
+            }),
+            getSandboxEnvKeys: () => Promise.reject(boom),
+          },
+        ),
+      ).rejects.toBe(boom);
+
+      expect(close).toHaveBeenCalledTimes(1);
+      clearWebBackends();
+    });
+
+    // `openToolSession` fails soft per tool source, but the session itself can
+    // still fail to open — and then the rejection the caller is about to see IS
+    // that failure. Disposal has nothing to close and must not replace it with
+    // an error of its own.
+    it("still reports the original failure when there is no session to dispose", async () => {
+      const boom = new Error("mcp lookup exploded");
+
+      await expect(
+        turnWith(queriesWith({ getMcp: () => Promise.reject(boom) })),
+      ).rejects.toBe(boom);
     });
   });
 

--- a/apps/backend/src/services/chat-execution.ts
+++ b/apps/backend/src/services/chat-execution.ts
@@ -583,195 +583,212 @@ export const prepareChatTurn = async (
   // built alongside it nest their own sessions into this one — they take the
   // promise, not the session, and await it only if they are ever invoked.
   const sessionPromise = openToolSession(scope, agent, queries);
-  // The search path is awaited *beside* the session below, not after it, so it
-  // cannot be handed the session itself — it gets a registrar that defers onto
-  // the promise. See `deferCloserRegistrar`.
-  const registerCloser = deferCloserRegistrar(sessionPromise);
+  // From here down this function OWNS the session: `dispose` is the only
+  // handle on it and it reaches the caller only on the successful return
+  // below, so a throw in between leaves the session — its MCP clients, and
+  // every closer a Contribution registered — with nothing that will ever
+  // close it (issue #630). The window opens here rather than at the
+  // `Promise.all`: a rejection there settles the group while the session goes
+  // on resolving beside it, unowned.
+  try {
+    // The search path is awaited *beside* the session below, not after it, so it
+    // cannot be handed the session itself — it gets a registrar that defers onto
+    // the promise. See `deferCloserRegistrar`.
+    const registerCloser = deferCloserRegistrar(sessionPromise);
 
-  // Hoisted out of the `Promise.all` argument list so the resolution and the
-  // tools it produced are both in scope below — the pair is what says whether
-  // search was promised and not delivered. Pure and synchronous, so nothing
-  // about the awaited work moves.
-  const searchResolution = resolveSearchMode(request.search, provider);
+    // Hoisted out of the `Promise.all` argument list so the resolution and the
+    // tools it produced are both in scope below — the pair is what says whether
+    // search was promised and not delivered. Pure and synchronous, so nothing
+    // about the awaited work moves.
+    const searchResolution = resolveSearchMode(request.search, provider);
 
-  // Absent means yes, which is what every interactive Chat turn relies on.
-  // Resolved once, here, so the retrieval below and the block composed further
-  // down read the same decision rather than each re-deriving it (#645).
-  const includeMemories = input.includeMemories ?? true;
+    // Absent means yes, which is what every interactive Chat turn relies on.
+    // Resolved once, here, so the retrieval below and the block composed further
+    // down read the same decision rather than each re-deriving it (#645).
+    const includeMemories = input.includeMemories ?? true;
 
-  const [
-    session,
-    skills,
-    { subAgents, unavailableSubAgents, subAgentTools },
-    userContexts,
-    memories,
-    sandboxEnvKeys,
-    searchTools,
-  ] = await Promise.all([
-    sessionPromise,
-    loadSkills(queries, agent, orgId, workspaceId),
-    loadSubAgents(queries, agent, scope, sessionPromise, run),
-    queries.getUserContexts(user.id, workspaceId),
-    resolveMemories(
-      queries,
-      user.id,
-      workspaceId,
-      input.memorySnapshot,
-      input.memoriesReferenceDate,
-      includeMemories,
-    ),
-    queries.getSandboxEnvKeys(workspaceId),
-    resolveSearchTools(searchResolution, opened, provider, {
-      orgId,
-      workspaceId,
-      userId: user.id,
-      registerCloser,
-    }),
-  ]);
-
-  // Search was asked for, resolution had somewhere to send it, and nothing came
-  // back (issue #522). Outcome-based rather than a branch per cause, so an
-  // unregistered backend, a factory that threw or timed out and a missing
-  // `web_search` executor are all one condition — as is whatever cause is added
-  // next. An empty native tool set would land here too, though nothing can
-  // produce one today. The three server-side warns still name the specific
-  // fault for the Operator; this is what the person reading the reply is told.
-  const searchUnavailable =
-    searchResolution.kind !== "none" && Object.keys(searchTools).length === 0;
-
-  // Assignment order is the precedence order, and it is deliberate: search lands
-  // after the session's tools so it wins over an agent/MCP tool that happens to
-  // share a name (exactly as native search already did), and before
-  // `subAgentTools` so a sub-agent's tools still win over search.
-  const tools: Record<string, Tool> = { ...session.tools };
-  Object.assign(tools, searchTools);
-  Object.assign(tools, subAgentTools);
-
-  // The turn half carries what this turn resolved — the live retrieval when no
-  // pin was supplied (headless). The renderer receives only the stable half,
-  // with the memories folded into a byte-stable `memoriesBlock`: for a pinned
-  // interactive turn that is the snapshot verbatim, for a headless turn it is
-  // the live retrieval's formatted text. Nothing per-turn reaches composition
-  // directly (ADR-0020).
-  const turn: SystemPromptTurnContext = { memories };
-
-  const stable: SystemPromptStableContext = {
-    workspace: { id: workspaceId, context: workspace.context ?? undefined },
-    agent: agent ?? null,
-    user: {
-      id: user.id,
-      name: user.name,
-      globalContext: userContexts.global,
-      workspaceContext: userContexts.workspace,
-    },
-    // The flag gates the block; the pin and the live retrieval are only sources
-    // for it. Gating here rather than trusting the sources to be empty is what
-    // makes "off means no `<memories>`" true by construction: `turn.memories` is
-    // already empty when off, but a pin would otherwise slip past the gate and
-    // make the flag's name a lie for a caller that supplied both.
-    memoriesBlock: includeMemories
-      ? (input.memorySnapshot ?? formatSummariesForSystemPrompt(turn.memories))
-      : "",
-    skills,
-    subAgents,
-    unavailableSubAgents,
-    sandboxEnvKeys,
-    fallbackInstructions: request.instructions,
-    runMode,
-    securityGuardrails: context.guardrails,
-    organizationIdentityContext: organization?.identityContext,
-  };
-
-  const systemPrompt = renderSystemPrompt(stable);
-
-  if (skills.length > 0) {
-    tools[LOAD_SKILL_TOOL_NAME] = createLoadSkillTool(orgId, workspaceId);
-  }
-
-  // Activity events only. Result normalization (#321) is no longer bolted on
-  // here: it happens for every tool the Tool session loads, whether or not this
-  // turn is being observed. The tools core adds itself above — search, the
-  // sub-agent delegates, `loadSkill` — return core-owned JSON shapes.
-  const wrappedTools = onActivity
-    ? wrapToolsWithActivity(tools, onActivity)
-    : tools;
-
-  // Inline file URLs to `data:` bytes when we have an origin, then ALWAYS
-  // normalize (issues #328, #342): text-like files become annotated text,
-  // PDF/DOCX are extracted to capped annotated text, native files pass through
-  // untouched, and any part that couldn't be inlined — a storage miss, or a
-  // headless turn with no origin — is announced as unavailable rather than
-  // forwarded raw. Normalizing even without an origin keeps a stray file part on
-  // a headless turn from hard-failing conversion. The pre-persist gate
-  // (`validateTurnAttachments`) has already rejected files nothing can convert,
-  // so the normalizer here never throws.
-  const passthroughFileTypes = passthroughFileTypesForModel(
-    provider,
-    resolvedModelId,
-  );
-  const inlinedMessages = await normalizeFileParts(
-    origin ? await inlineFileUrls(messages, origin) : messages,
-    passthroughFileTypes,
-    {
-      maxExtractedTextChars: maxExtractedTextCharsForModel(
-        provider,
-        resolvedModelId,
+    const [
+      session,
+      skills,
+      { subAgents, unavailableSubAgents, subAgentTools },
+      userContexts,
+      memories,
+      sandboxEnvKeys,
+      searchTools,
+    ] = await Promise.all([
+      sessionPromise,
+      loadSkills(queries, agent, orgId, workspaceId),
+      loadSubAgents(queries, agent, scope, sessionPromise, run),
+      queries.getUserContexts(user.id, workspaceId),
+      resolveMemories(
+        queries,
+        user.id,
+        workspaceId,
+        input.memorySnapshot,
+        input.memoriesReferenceDate,
+        includeMemories,
       ),
-    },
-  );
+      queries.getSandboxEnvKeys(workspaceId),
+      resolveSearchTools(searchResolution, opened, provider, {
+        orgId,
+        workspaceId,
+        userId: user.id,
+        registerCloser,
+      }),
+    ]);
 
-  // Read from the INCOMING history, before this turn appends anything — Tool-
-  // result clearing's only reading for the first model call of the turn
-  // (ADR-0018 Notes, issue #524). Left off entirely rather than sent as
-  // `undefined` when there is no prior reading, matching every other optional
-  // field on this plan.
-  const initialOccupancy = initialOccupancyFrom(messages);
+    // Search was asked for, resolution had somewhere to send it, and nothing came
+    // back (issue #522). Outcome-based rather than a branch per cause, so an
+    // unregistered backend, a factory that threw or timed out and a missing
+    // `web_search` executor are all one condition — as is whatever cause is added
+    // next. An empty native tool set would land here too, though nothing can
+    // produce one today. The three server-side warns still name the specific
+    // fault for the Operator; this is what the person reading the reply is told.
+    const searchUnavailable =
+      searchResolution.kind !== "none" && Object.keys(searchTools).length === 0;
 
-  return {
-    stream: {
-      ...context.plan,
-      tools: wrappedTools,
-      system: systemPrompt,
-      messages: inlinedMessages,
-      // Tool-result clearing's other input beyond the core allowlist
-      // (ADR-0021, issue #626): only the session's OWN MCP resolutions, never
-      // a delegate's — a Sub-Agent's plan carries its own nested session's
-      // hints (`createSubAgentDelegate`), resolved under its own rule.
-      readOnlyToolNames: session.readOnlyToolNames,
-      ...(initialOccupancy !== undefined ? { initialOccupancy } : {}),
-    },
-    resolved: {
-      agentId: context.resolvedAgentId,
-      providerId: context.resolvedProviderId,
-      // The reference, not the resolution — see `ChatContext.modelReference`.
-      modelId: context.modelReference,
-      // Only Direct (no-Agent) turns persist generation params on the row;
-      // Agent-driven turns read them back from the Agent record.
-      //
-      // What is persisted here is the user's OWN instructions, never the
-      // composed system prompt above: this column backs the editable
-      // Instructions box in Chat settings, so writing the composite made the
-      // workspace context, the user's identity, memories and the provider's
-      // guardrails reappear as editable text — and compound on every turn
-      // (issue #365). What the model receives is unaffected; `stream.system`
-      // still carries the composite.
-      instructions: agent ? undefined : request.instructions,
-      temperature: agent ? undefined : context.plan.temperature,
-      topP: agent ? undefined : context.plan.topP,
-      topK: agent ? undefined : context.plan.topK,
-      frequencyPenalty: agent ? undefined : context.plan.frequencyPenalty,
-      presencePenalty: agent ? undefined : context.plan.presencePenalty,
-      seed: agent ? undefined : context.plan.seed,
-      // The REQUESTED value, not the plan's resolved ceiling — see
-      // `ResolvedGeneration.maxSteps`. Normalised to undefined so a cleared
-      // null writes null to the column like every other unset field here.
-      maxSteps: agent ? undefined : (request.maxSteps ?? undefined),
-    },
-    searchUnavailable,
-    // The session closes what it opened, delegates' nested sessions included —
-    // the caller no longer reconciles two lists of clients to get there.
-    dispose: session.dispose,
-  };
+    // Assignment order is the precedence order, and it is deliberate: search lands
+    // after the session's tools so it wins over an agent/MCP tool that happens to
+    // share a name (exactly as native search already did), and before
+    // `subAgentTools` so a sub-agent's tools still win over search.
+    const tools: Record<string, Tool> = { ...session.tools };
+    Object.assign(tools, searchTools);
+    Object.assign(tools, subAgentTools);
+
+    // The turn half carries what this turn resolved — the live retrieval when no
+    // pin was supplied (headless). The renderer receives only the stable half,
+    // with the memories folded into a byte-stable `memoriesBlock`: for a pinned
+    // interactive turn that is the snapshot verbatim, for a headless turn it is
+    // the live retrieval's formatted text. Nothing per-turn reaches composition
+    // directly (ADR-0020).
+    const turn: SystemPromptTurnContext = { memories };
+
+    const stable: SystemPromptStableContext = {
+      workspace: { id: workspaceId, context: workspace.context ?? undefined },
+      agent: agent ?? null,
+      user: {
+        id: user.id,
+        name: user.name,
+        globalContext: userContexts.global,
+        workspaceContext: userContexts.workspace,
+      },
+      // The flag gates the block; the pin and the live retrieval are only sources
+      // for it. Gating here rather than trusting the sources to be empty is what
+      // makes "off means no `<memories>`" true by construction: `turn.memories` is
+      // already empty when off, but a pin would otherwise slip past the gate and
+      // make the flag's name a lie for a caller that supplied both.
+      memoriesBlock: includeMemories
+        ? (input.memorySnapshot ??
+          formatSummariesForSystemPrompt(turn.memories))
+        : "",
+      skills,
+      subAgents,
+      unavailableSubAgents,
+      sandboxEnvKeys,
+      fallbackInstructions: request.instructions,
+      runMode,
+      securityGuardrails: context.guardrails,
+      organizationIdentityContext: organization?.identityContext,
+    };
+
+    const systemPrompt = renderSystemPrompt(stable);
+
+    if (skills.length > 0) {
+      tools[LOAD_SKILL_TOOL_NAME] = createLoadSkillTool(orgId, workspaceId);
+    }
+
+    // Activity events only. Result normalization (#321) is no longer bolted on
+    // here: it happens for every tool the Tool session loads, whether or not this
+    // turn is being observed. The tools core adds itself above — search, the
+    // sub-agent delegates, `loadSkill` — return core-owned JSON shapes.
+    const wrappedTools = onActivity
+      ? wrapToolsWithActivity(tools, onActivity)
+      : tools;
+
+    // Inline file URLs to `data:` bytes when we have an origin, then ALWAYS
+    // normalize (issues #328, #342): text-like files become annotated text,
+    // PDF/DOCX are extracted to capped annotated text, native files pass through
+    // untouched, and any part that couldn't be inlined — a storage miss, or a
+    // headless turn with no origin — is announced as unavailable rather than
+    // forwarded raw. Normalizing even without an origin keeps a stray file part on
+    // a headless turn from hard-failing conversion. The pre-persist gate
+    // (`validateTurnAttachments`) has already rejected files nothing can convert,
+    // so the normalizer here never throws.
+    const passthroughFileTypes = passthroughFileTypesForModel(
+      provider,
+      resolvedModelId,
+    );
+    const inlinedMessages = await normalizeFileParts(
+      origin ? await inlineFileUrls(messages, origin) : messages,
+      passthroughFileTypes,
+      {
+        maxExtractedTextChars: maxExtractedTextCharsForModel(
+          provider,
+          resolvedModelId,
+        ),
+      },
+    );
+
+    // Read from the INCOMING history, before this turn appends anything — Tool-
+    // result clearing's only reading for the first model call of the turn
+    // (ADR-0018 Notes, issue #524). Left off entirely rather than sent as
+    // `undefined` when there is no prior reading, matching every other optional
+    // field on this plan.
+    const initialOccupancy = initialOccupancyFrom(messages);
+
+    return {
+      stream: {
+        ...context.plan,
+        tools: wrappedTools,
+        system: systemPrompt,
+        messages: inlinedMessages,
+        // Tool-result clearing's other input beyond the core allowlist
+        // (ADR-0021, issue #626): only the session's OWN MCP resolutions, never
+        // a delegate's — a Sub-Agent's plan carries its own nested session's
+        // hints (`createSubAgentDelegate`), resolved under its own rule.
+        readOnlyToolNames: session.readOnlyToolNames,
+        ...(initialOccupancy !== undefined ? { initialOccupancy } : {}),
+      },
+      resolved: {
+        agentId: context.resolvedAgentId,
+        providerId: context.resolvedProviderId,
+        // The reference, not the resolution — see `ChatContext.modelReference`.
+        modelId: context.modelReference,
+        // Only Direct (no-Agent) turns persist generation params on the row;
+        // Agent-driven turns read them back from the Agent record.
+        //
+        // What is persisted here is the user's OWN instructions, never the
+        // composed system prompt above: this column backs the editable
+        // Instructions box in Chat settings, so writing the composite made the
+        // workspace context, the user's identity, memories and the provider's
+        // guardrails reappear as editable text — and compound on every turn
+        // (issue #365). What the model receives is unaffected; `stream.system`
+        // still carries the composite.
+        instructions: agent ? undefined : request.instructions,
+        temperature: agent ? undefined : context.plan.temperature,
+        topP: agent ? undefined : context.plan.topP,
+        topK: agent ? undefined : context.plan.topK,
+        frequencyPenalty: agent ? undefined : context.plan.frequencyPenalty,
+        presencePenalty: agent ? undefined : context.plan.presencePenalty,
+        seed: agent ? undefined : context.plan.seed,
+        // The REQUESTED value, not the plan's resolved ceiling — see
+        // `ResolvedGeneration.maxSteps`. Normalised to undefined so a cleared
+        // null writes null to the column like every other unset field here.
+        maxSteps: agent ? undefined : (request.maxSteps ?? undefined),
+      },
+      searchUnavailable,
+      // The session closes what it opened, delegates' nested sessions included —
+      // the caller no longer reconciles two lists of clients to get there.
+      dispose: session.dispose,
+    };
+  } catch (error) {
+    // Awaited, so what the session opened is closed before the failure
+    // reaches the caller. `.catch` swallows only the case where the session
+    // is what failed — there is then nothing to dispose, and the rejection
+    // the caller is about to see is that failure itself.
+    await sessionPromise.then((session) => session.dispose()).catch(() => {});
+    throw error;
+  }
 };
 
 /**

--- a/apps/backend/src/tools/tool-session.ts
+++ b/apps/backend/src/tools/tool-session.ts
@@ -52,9 +52,12 @@ export type ToolSessionScope = Omit<
  * latency — so the search path cannot be handed a session it would have to wait
  * for. It gets this instead, which defers onto the promise.
  *
- * Registration therefore lands a microtask after the Contribution's call. Safe:
- * `dispose` is unreachable until `prepareChatTurn` has returned it, and a late
- * registration closes immediately anyway.
+ * Registration therefore lands a microtask after the Contribution's call, and
+ * `prepareChatTurn` can now dispose the session before it returns — on the
+ * failing path it opened for issue #630. Still safe, and no longer because
+ * disposal is out of reach: this `then` is attached before that path's, so a
+ * registration always wins the race, and one that somehow did not would be
+ * closed on the spot by `registerCloser`'s already-disposed branch.
  */
 export const deferCloserRegistrar =
   (session: Promise<ToolSession>): CoreCloserRegistrar =>


### PR DESCRIPTION
## What

Closes #630 — both paths, in one PR.

A Tool session was disposed through exactly one route: the run's terminal callback calling `dispose` on the turn the prepare step had stored. Two windows existed where the session was open but that route could not reach it, and in both the callback disposed `undefined` while the session — every MCP client, plus every closer a Contribution registered through `ctx.registerCloser` — stayed open for the life of the process.

**Path A — Turn resolution fails after the session opened.** `prepareChatTurn` now opens the session at the top of a `try` whose `catch` disposes it and rethrows the original error untouched. The `try` opens at `openToolSession`, not at the `Promise.all`: the window really starts there, because a rejection from any member of that group settles it while the session goes on resolving beside it, unowned. A transient database error during resolution is enough.

**Path B — the run terminates while Turn resolution is still in flight.** `state.turn` is gone. `RunLifecycle` grew `adoptOrDispose(dispose)`, which either stores the disposer for a run that can still run it, or disposes it on the spot and returns `false`. `AgentRunner.setup` stops on `false` — no `onResolved`, no model call — and fails with the error the run terminated on. Nothing awaits between the `terminated` check and the store, so no termination can land mid-handoff. The invariant, stated on the method: _a disposer is only ever held by a run that can still run it._

Neither sketch in the issue was taken verbatim, but both halves land where the issue suggested they belong: ownership never leaves `prepareChatTurn` on Path A, and Path B is closed by construction in `run-lifecycle` rather than by a check each future caller has to remember. `prepareChatTurn`'s signature is unchanged.

## Why

Path B cost more than the leak. Reproduced with a per-step bound of 5ms and a resolution taking 60ms: the sink was told `failed` with the timeout error, and _then_ the model call went out and the caller received a normal successful result. A run recorded as failed still spent a provider call, and the caller could not tell.

The leak itself has no reported Operator-facing symptom yet; the observable one would be MCP connections accumulating in a long-lived backend process. #629's per-turn closer registrar widened what leaks — a Web-search backend's browser page or keep-alive connection is dropped exactly like an MCP client — and the contract it publishes ("core runs your closer once, when the turn ends") is only as strong as the disposal path behind it. This makes that existing promise true; it does not extend it.

### Two notes for the reviewer

- **The abort signal.** The issue puts "anything that reads the abort signal to decide disposal" out of scope, and this stays inside that fence: disposal is decided by the run's `terminated` latch alone. The `adoptOrDispose`-false branch does call `run.statusFromSignal()`, but only to pick _which error to throw_ — never whether to dispose.
- **Cancellation is untouched.** Cancelling only aborts the controller; termination happens later, with the turn already adopted, so disposal runs as it always did. No cancel-path code or test was modified.

## Testing

Both paths are covered, and each new test was confirmed to fail against the old behaviour before the fix went in — including a deliberate re-break of `adoptOrDispose` to prove none of the Path B tests are vacuous.

`chat-execution.test.ts` — six cases: two _different_ members of the concurrent group rejecting (which member fails decides how much of the group is still in flight when the session resolves), a failure after the group on the way to the plan, error identity preserved through disposal, a closer a Web-search backend registered through `ctx.registerCloser`, and a session that never opened not masking the original failure.

`agent-runner.test.ts` — four cases for a turn resolving after the per-step timeout has fired: the session is disposed, a Contribution's closer runs exactly once _against a real `ToolSession`_ rather than a stub `dispose`, the model is not invoked (`onStart` → `onFinish` only, status `failed`), and the caller is rejected with the `TimeoutError`.

No path disposes twice: `adoptOrDispose`-true is the only thing that stores a disposer, `finish` is latched, and `ToolSession.dispose` is idempotent.

## Docs

None owed, as the issue anticipated. The diff touches only `src/runs/**`, `src/services/**` and `src/tools/tool-session.ts` — no `.env.example`, no user-facing limit or enum in `packages/schemas`, nothing under `apps/backend/src/plugins`, no frontend label. The Plugin-author docs and the SDK README already say a registered closer runs when the turn ends; that claim is what these two paths broke, so the fix makes the existing wording true rather than needing an edit. `CONTEXT.md`'s **Tool session** entry describes shape rather than timing and holds as written.

One comment _was_ corrected: `deferCloserRegistrar`'s doc justified itself with "`dispose` is unreachable until `prepareChatTurn` has returned it", which Path A's fix makes false. It now cites the real reason — its `then` is attached before the disposing path's, and a late registration closes immediately anyway.

## Checklist

- [x] The **PR title** is a Conventional Commit subject (`feat:`, `fix:` or `chore:`, optional scope).
- [x] **The change is covered by tests.** Every new test was verified red against the old behaviour.
- [x] Docs in `apps/docs/content` are updated **in this PR** if needed — none needed here; see **Docs** above.
- [x] `pnpm test` (2400 tests, 143 files), `pnpm typecheck` and `pnpm format` pass locally. `pnpm lint` too: 0 errors, and the 3 remaining warnings are pre-existing, in frontend files this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
