### PR TITLE
fix(backend): restart a cron Trigger's schedule when it is enabled

### DIFF
--- a/apps/backend/src/services/trigger.test.ts
+++ b/apps/backend/src/services/trigger.test.ts
@@ -187,11 +187,12 @@ describe("trigger module", () => {
       expect(setArg.nextRunAt).toEqual(new Date("2026-01-01T10:00:00Z"));
     });
 
-    it("leaves nextRunAt untouched when a cron trigger's config/type are not part of the update", async () => {
+    it("leaves nextRunAt untouched when a cron trigger is disabled", async () => {
       mockDb.limit.mockResolvedValueOnce([
         {
           id: "trig-1",
           type: "cron",
+          enabled: true,
           config: { cronExpression: "0 9 * * *", timezone: "UTC" },
         },
       ]);
@@ -203,6 +204,64 @@ describe("trigger module", () => {
 
       const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
       expect(setArg).not.toHaveProperty("nextRunAt");
+    });
+
+    it("recomputes nextRunAt when a disabled cron trigger is enabled", async () => {
+      // The regression: disabling leaves `nextRunAt` in the past, so without a
+      // recompute here the scheduler's `nextRunAt <= NOW()` due query fires an
+      // off-schedule catch-up run on the next tick.
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "cron",
+          enabled: false,
+          nextRunAt: new Date("2020-01-01T00:00:00Z"),
+          config: { cronExpression: "0 9 * * *", timezone: "UTC" },
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([{ id: "trig-1", enabled: true }]);
+
+      await updateTrigger(ctx, "trig-1", { enabled: true });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.nextRunAt).toEqual(new Date("2026-01-01T10:00:00Z"));
+    });
+
+    it("leaves nextRunAt untouched when an already-enabled cron trigger is updated", async () => {
+      // Only the false -> true edge restarts the schedule. A no-op `enabled:
+      // true` on a running Trigger must not push its next run out.
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "cron",
+          enabled: true,
+          config: { cronExpression: "0 9 * * *", timezone: "UTC" },
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([{ id: "trig-1" }]);
+
+      await updateTrigger(ctx, "trig-1", { enabled: true, name: "Renamed" });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg).not.toHaveProperty("nextRunAt");
+    });
+
+    it("does not recompute nextRunAt when an event trigger is enabled", async () => {
+      // Event triggers have no schedule; enabling one must still clear it.
+      mockDb.limit.mockResolvedValueOnce([
+        {
+          id: "trig-1",
+          type: "event",
+          enabled: false,
+          config: { events: ["card.created"] },
+        },
+      ]);
+      mockDb.returning.mockResolvedValueOnce([{ id: "trig-1", enabled: true }]);
+
+      await updateTrigger(ctx, "trig-1", { enabled: true });
+
+      const setArg = mockDb.set.mock.calls[0][0] as Record<string, unknown>;
+      expect(setArg.nextRunAt).toBeNull();
     });
 
     it("throws ValidationError for an invalid cron expression on update", async () => {

--- a/apps/backend/src/services/trigger.ts
+++ b/apps/backend/src/services/trigger.ts
@@ -160,8 +160,8 @@ export async function createTrigger(
  * Updates a Trigger in this Workspace. Throws `NotFoundError` when it does
  * not exist here. `config`, if supplied, replaces the stored value wholesale
  * and is (re)validated against the effective type; `nextRunAt` is recomputed
- * for a cron trigger whose `config`/`type` changed, and cleared for an event
- * trigger.
+ * for a cron trigger whose `config`/`type` changed or which is being enabled,
+ * and cleared for an event trigger.
  */
 export async function updateTrigger(
   ctx: ScopeContext,
@@ -217,6 +217,17 @@ export async function updateTrigger(
       if (fields.config !== undefined) {
         updateData.config = parsed.config;
       }
+    } else if (fields.enabled === true && !existing.enabled) {
+      // Re-enabling restarts the schedule. Disabling leaves `nextRunAt` at
+      // whatever it was, so by the time a Trigger is switched back on that
+      // value is in the past — and the scheduler's due query is
+      // `nextRunAt <= NOW()`, which reads a stale timestamp as "due" and fires
+      // an off-schedule catch-up run on the very next tick. The run after that
+      // one is scheduled from *its* completion time, so the catch-up and the
+      // first real slot can land a minute apart before the cadence settles.
+      // Recomputing here means an enabled Trigger's first run is always a slot
+      // its own expression actually names.
+      updateData.nextRunAt = parseCronConfig(existing.config).nextRunAt;
     }
   } else {
     throw new ValidationError(

--- a/apps/docs/content/building-with-platypus/triggers.mdx
+++ b/apps/docs/content/building-with-platypus/triggers.mdx
@@ -111,7 +111,10 @@ A few details worth knowing:
 
 - **Scheduled (cron) runs** are checked about once a minute; a due Trigger is
   claimed and executed, then its next run time is recomputed from the cadence
-  (one-off Triggers disable themselves instead).
+  (one-off Triggers disable themselves instead). Switching **Enabled** back on
+  restarts the cadence from that moment: the first run lands on the next slot
+  the schedule names, so a Trigger that was off over one of its slots does not
+  fire the moment you re-enable it to catch up.
 - **Event runs** fire when a matching event occurs, with a short debounce so a
   burst of rapid events coalesces into one run.
 - **No-progress runs stop early.** Because no one is watching a Trigger run,


### PR DESCRIPTION
## The bug

A Trigger on `*/5 * * * *` fired at `07:09:00Z` and again at `07:10:00Z` — one
minute apart. Only the second is a slot the expression names.

`updateTrigger` recomputed `nextRunAt` **only** when `config` or `type` changed,
and nothing cleared it on disable. A Trigger switched off kept the `nextRunAt`
it held at that moment; switching it back on left that stale timestamp in place.

The scheduler's due query is `nextRunAt <= NOW()`, which reads a past timestamp
as due and runs the Trigger on the next aligned tick whatever its cron says.
The run after that is scheduled from the catch-up run's own completion time, so
the catch-up and the first real slot can land a minute apart:

```
enable at 07:08 (stale nextRunAt in the past)
07:09:00Z  catch-up run          <- off-schedule
  next slot computed from completion 07:09:02.465Z -> 07:10:00Z
07:10:00Z  run                   <- 58s later
  next slot from 07:10:02.457Z -> 07:15:00Z, back on cadence
```

## The fix

Enabling recomputes `nextRunAt` from the stored config, so an enabled Trigger's
first run is always a slot its expression actually names. Only the `false ->
true` edge does this — a no-op `enabled: true` on a running Trigger must not
push its next run out.

## Tests

Three added. The first fails without the fix; the other two pin behaviour that
must not change (disable leaves the schedule alone; enabling an event Trigger
still clears it).

## Verified against a running instance

Disabled the Trigger while `nextRunAt` was `07:20:00Z`, waited until that was in
the past, then re-enabled at `07:20:21Z`:

- `nextRunAt` came back `07:25:00Z` — the correct next slot, not the stale value.
- The `07:21:00Z` tick passed with no run.

## Scope

Pre-existing, not a regression — none of the scheduler or Trigger-write paths
are touched by anything since `v3.1.1`.

Left deliberately out: whether a *genuinely* missed slot (backend down over a
deploy) should catch up or skip. That is a misfire policy and a larger call;
this only stops **enabling** from being mistaken for a missed slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)