### PR TITLE
fix(backend): move the Bedrock cache point instead of accumulating one per step

### DIFF
--- a/apps/backend/src/runs/run-plan-cache-steps.test.ts
+++ b/apps/backend/src/runs/run-plan-cache-steps.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import type { LanguageModel, ModelMessage } from "ai";
+import { buildModelInvocation, type RunPlan } from "./run-plan.ts";
+
+/**
+ * The Bedrock cache point across a multi-step turn.
+ *
+ * `prepareStep`'s `messages` override carries forward: the SDK computes the
+ * next step's input as `[...stepMessages, ...responseMessages]`, where
+ * `stepMessages` is the override when one was returned. So whatever this
+ * attaches on step one is still in the array on step two. These tests drive
+ * `prepareStep` the way the SDK does and assert the point *moves* rather than
+ * accumulating — a request may only carry so many checkpoints, so one per step
+ * eventually fails the whole call.
+ */
+
+const plan = (): RunPlan =>
+  ({
+    model: "test-model" as unknown as LanguageModel,
+    system: "system prompt",
+    tools: {},
+    maxSteps: 10,
+    contextWindow: 200_000,
+  }) as RunPlan;
+
+const invocation = () =>
+  buildModelInvocation(plan(), {
+    abortSignal: new AbortController().signal,
+  }) as unknown as {
+    prepareStep: (args: {
+      steps: unknown[];
+      messages: ModelMessage[];
+      stepNumber: number;
+    }) => { messages: ModelMessage[] };
+  };
+
+/** How many messages carry a Bedrock cache point. */
+const cachePointCount = (messages: ModelMessage[]): number =>
+  messages.filter((m) => m.providerOptions?.amazonBedrock?.cachePoint).length;
+
+/** Index of the messages carrying a cache point. */
+const cachePointIndexes = (messages: ModelMessage[]): number[] =>
+  messages.flatMap((m, i) =>
+    m.providerOptions?.amazonBedrock?.cachePoint ? [i] : [],
+  );
+
+/** Exactly what `ai` does between steps. */
+const nextStepMessages = (
+  override: ModelMessage[],
+  step: number,
+): ModelMessage[] => [
+  ...override,
+  { role: "assistant", content: `call ${step}` },
+  { role: "user", content: `result ${step}` },
+];
+
+describe("Bedrock cache point across steps", () => {
+  it("carries exactly one cache point however many steps a turn takes", () => {
+    const { prepareStep } = invocation();
+    let messages: ModelMessage[] = [{ role: "user", content: "start" }];
+
+    for (let step = 0; step < 6; step++) {
+      const { messages: override } = prepareStep({
+        steps: [],
+        messages,
+        stepNumber: step,
+      });
+
+      expect(cachePointCount(override)).toBe(1);
+      // ...and it is on the tail, not stranded behind it.
+      expect(cachePointIndexes(override)).toEqual([override.length - 1]);
+
+      messages = nextStepMessages(override, step);
+    }
+  });
+
+  it("strips the previous step's point when the conversation has grown", () => {
+    const { prepareStep } = invocation();
+
+    const first = prepareStep({
+      steps: [],
+      messages: [{ role: "user", content: "start" }],
+      stepNumber: 0,
+    }).messages;
+    expect(cachePointIndexes(first)).toEqual([0]);
+
+    const second = prepareStep({
+      steps: [],
+      messages: nextStepMessages(first, 0),
+      stepNumber: 1,
+    }).messages;
+
+    // The point that was on index 0 is gone; only the new tail carries one.
+    expect(cachePointIndexes(second)).toEqual([second.length - 1]);
+    expect(
+      second[0].providerOptions?.amazonBedrock?.cachePoint,
+    ).toBeUndefined();
+  });
+
+  it("leaves a message's other providerOptions intact when stripping", () => {
+    const { prepareStep } = invocation();
+
+    const first = prepareStep({
+      steps: [],
+      messages: [
+        {
+          role: "user",
+          content: "start",
+          providerOptions: {
+            amazonBedrock: { somethingElse: true },
+            anthropic: { cacheControl: { type: "ephemeral" } },
+          },
+        },
+      ],
+      stepNumber: 0,
+    }).messages;
+
+    const second = prepareStep({
+      steps: [],
+      messages: nextStepMessages(first, 0),
+      stepNumber: 1,
+    }).messages;
+
+    expect(second[0].providerOptions?.amazonBedrock).toEqual({
+      somethingElse: true,
+    });
+    expect(second[0].providerOptions?.anthropic).toEqual({
+      cacheControl: { type: "ephemeral" },
+    });
+  });
+});

--- a/apps/backend/src/runs/run-plan-cache-steps.test.ts
+++ b/apps/backend/src/runs/run-plan-cache-steps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { LanguageModel, ModelMessage } from "ai";
+import type { ModelMessage } from "ai";
 import { buildModelInvocation, type RunPlan } from "./run-plan.ts";
 
 /**
@@ -14,14 +14,13 @@ import { buildModelInvocation, type RunPlan } from "./run-plan.ts";
  * eventually fails the whole call.
  */
 
-const plan = (): RunPlan =>
-  ({
-    model: "test-model" as unknown as LanguageModel,
-    system: "system prompt",
-    tools: {},
-    maxSteps: 10,
-    contextWindow: 200_000,
-  }) as RunPlan;
+const plan = (): RunPlan => ({
+  model: "test-model",
+  system: "system prompt",
+  tools: {},
+  maxSteps: 10,
+  contextWindow: 200_000,
+});
 
 const invocation = () =>
   buildModelInvocation(plan(), {

--- a/apps/backend/src/runs/run-plan.ts
+++ b/apps/backend/src/runs/run-plan.ts
@@ -205,19 +205,52 @@ export const buildModelInvocation = (
 });
 
 /**
- * Attaches the Bedrock cache point to the final message of `messages`, without
+ * Removes a cache point this function placed on an earlier step, leaving any
+ * other `amazonBedrock` option on the message alone. A message carrying no
+ * point is returned as-is rather than needlessly cloned.
+ */
+const withoutBedrockCachePoint = (message: ModelMessage): ModelMessage => {
+  const bedrock = message.providerOptions?.amazonBedrock;
+  if (bedrock?.cachePoint === undefined) return message;
+  const { cachePoint: _removed, ...rest } = bedrock;
+  return {
+    ...message,
+    providerOptions: { ...message.providerOptions, amazonBedrock: rest },
+  };
+};
+
+/**
+ * Moves the Bedrock cache point to the final message of `messages`, without
  * mutating the array or the messages handed in — the last message is cloned
  * and its existing `providerOptions` are merged into, not replaced. An empty
  * conversation passes through untouched.
+ *
+ * Moves, not merely adds: `prepareStep`'s `messages` override carries forward
+ * into the next step (`stepMessages` becomes `[...override, ...response]`), so
+ * the point this placed on step one's final message is still sitting there,
+ * mid-conversation, when step two runs. Adding without removing accumulates one
+ * point per step — and Converse caps how many checkpoints a request may carry,
+ * so a long tool-using turn eventually exceeds it and the whole request fails.
+ * Stripping the previous point first is what makes the trailing point actually
+ * trail the conversation rather than leave a trail behind it.
  */
 const withBedrockCachePoint = (messages: ModelMessage[]): ModelMessage[] => {
   const final = messages.at(-1);
   if (final === undefined) return messages;
   return [
-    ...messages.slice(0, -1),
+    ...messages.slice(0, -1).map(withoutBedrockCachePoint),
     {
       ...final,
-      providerOptions: { ...final.providerOptions, ...BEDROCK_CACHE_POINT },
+      // Merged into the namespace, not over it: this function owns the
+      // `cachePoint` key and nothing else in `amazonBedrock`, which is the same
+      // contract `withoutBedrockCachePoint` keeps on the way back out.
+      providerOptions: {
+        ...final.providerOptions,
+        amazonBedrock: {
+          ...final.providerOptions?.amazonBedrock,
+          ...BEDROCK_CACHE_POINT.amazonBedrock,
+        },
+      },
     },
   ];
 };


### PR DESCRIPTION
Found by the pre-release review of `v3.1.1..main`. Regression in d595ae9 (#739),
which is unreleased — this is queued for the same 3.2.0.

## The bug

`prepareStep` attaches a `cachePoint` to the final message and returns that array
as its `messages` override. The SDK carries an override forward:

```js
// ai@7.0.48
const stepMessages = prepareStepResult?.messages ?? stepInputMessages;  // :5552
messagesForNextStep = [...stepMessages, ...stepResponseMessages];        // :5933
```

So the point placed on step one is still in the array on step two, which then
adds another at the new tail. Driving `prepareStep` exactly as the SDK does:

```
cachePoints in messages per step: [1, 2, 3, 4, 5]
(plus one always on the System message)
```

By step four a Bedrock request carries five checkpoints. Converse caps how many
a request may hold, so a long tool-using turn eventually exceeds it and the call
fails outright. Below that ceiling the stranded points still sit at positions the
conversation has moved past — the opposite of the "follows the end of the
conversation as it grows" the code claimed.

## The fix

Strip the previous step's point before attaching the new one, so exactly one
rides the tail however many steps a turn takes.

Both halves now manage only the `cachePoint` key and leave the rest of the
`amazonBedrock` namespace alone — attaching previously replaced the namespace
wholesale, dropping any other option on that message. The third test covers this.

## Why nothing caught it

Every existing `prepareStep` test drives a single step, where accumulation is not
yet observable. The new tests drive six, and assert both the count and the
position. All three fail without the fix.

Backend suite: 147 files, 2450 tests, green. `pnpm typecheck` clean.

## Note

The commit message says Converse caps checkpoints; I confirmed the accumulation
directly but did not verify the exact cap against AWS docs. The fix stands on
either reading — stranded mid-conversation points are wrong regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)