### PR TITLE
chore(docs): drop implemented-by from three accepted ADRs

### DIFF
--- a/docs/adr/0020-the-system-prompt-prefix-is-stable-while-a-chat-is-active.md
+++ b/docs/adr/0020-the-system-prompt-prefix-is-stable-while-a-chat-is-active.md
@@ -1,6 +1,5 @@
 ---
 status: accepted
-implemented-by: "#623"
 ---
 
 # The system prompt is stable while a Chat is active, and volatile turn state cannot reach it by construction

--- a/docs/adr/0021-a-read-only-hint-is-trusted-for-retention-never-for-authority.md
+++ b/docs/adr/0021-a-read-only-hint-is-trusted-for-retention-never-for-authority.md
@@ -1,6 +1,5 @@
 ---
 status: accepted
-implemented-by: "#626"
 ---
 
 # A tool's read-only hint is trusted for retention, never for authority

--- a/docs/adr/0022-event-causation-is-ambient-run-context.md
+++ b/docs/adr/0022-event-causation-is-ambient-run-context.md
@@ -1,6 +1,5 @@
 ---
 status: accepted
-implemented-by: "#668"
 ---
 
 # Event causation is ambient run context, not a plugin-boundary parameter


### PR DESCRIPTION
Found by the ADR-status step of the pre-release check.

`docs/adr/README.md` pairs `implemented-by` with
`accepted-pending-implementation` — it names the issue or PR that *will* build
the decision, so a reader knows the ADR describes a target rather than the
current codebase. Flipping to `accepted` is meant to happen in the implementing
PR.

Three ADRs are at `accepted` but still carry the key, so each flip dropped the
status and left the pointer behind, aimed at work that is already done:

| ADR | Key | Implementation, verified in `main` |
| --- | --- | --- |
| 0020 | `#623` | `SystemPromptStableContext` — `apps/backend/src/system-prompt.ts:43` |
| 0021 | `#626` | `readOnlyToolNames` sidecar — `apps/backend/src/tools/tool-session.ts:117` |
| 0022 | `#668` | `apps/backend/src/event-causation.ts`, read by `services/event-dispatch.ts` |

I confirmed each decision is genuinely implemented before removing its key, so
no status downgrade is warranted in either direction.

## What is deliberately unchanged

The **"In the code" admonitions stay.** The README has an implementing PR remove
the admonition that says what the code does *today* — because that one exists to
tell a reader the decision is unbuilt. These three say the opposite: they
describe what shipped and cite real files, which is useful to keep.

No ADR text is rewritten. Three frontmatter lines are deleted; nothing else.