### PR TITLE
chore(frontend): clear the four standing ESLint warnings

### DIFF
--- a/apps/frontend/app/oauth/mcp/callback/oauth-callback-handler.tsx
+++ b/apps/frontend/app/oauth/mcp/callback/oauth-callback-handler.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useBackendUrl } from "@/app/client-context";
 import { joinUrl } from "@/lib/utils";
 import { writeAt } from "@/lib/api-write";
@@ -38,6 +39,7 @@ export const OAuthCallbackHandler = ({
     missingParams ? "Missing authorization code or state parameter." : null,
   );
   const [isProcessing, setIsProcessing] = useState(!missingParams);
+  const router = useRouter();
 
   useEffect(() => {
     if (!code || !state) {
@@ -106,7 +108,7 @@ export const OAuthCallbackHandler = ({
         <Button
           variant="outline"
           className="cursor-pointer"
-          onClick={() => (window.location.href = "/")}
+          onClick={() => router.push("/")}
         >
           Back to Home
         </Button>

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -136,6 +136,13 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
       mutate: globalMutate,
       onSuccess: () => {
         toast.success("Organization deleted");
+        // A full document load, deliberately, not `router.push`. The
+        // Organization this view is scoped to no longer exists, and a
+        // client-side transition keeps the app shell alive — the cached RSC
+        // payload and SWR entries for the deleted Org included, which the
+        // surrounding layout would go on rendering. Reloading rebuilds
+        // everything from a server that now agrees the Org is gone.
+        // eslint-disable-next-line @next/next/no-location-assign-relative-destination
         window.location.href = `/`;
       },
       onError: (message) => {

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -243,6 +243,11 @@ const WorkspaceForm = ({
       mutate: globalMutate,
       onSuccess: () => {
         toast.success("Workspace deleted");
+        // A full document load, deliberately — see the matching note in
+        // `organization-form.tsx`. The Workspace this view is scoped to is
+        // gone, and a client-side transition would keep the app shell (and its
+        // cached payload for the deleted Workspace) alive around it.
+        // eslint-disable-next-line @next/next/no-location-assign-relative-destination
         window.location.href = `/${orgId}`;
       },
       onError: (message) => {

--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -60,6 +60,11 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Vitest's coverage report. Generated JavaScript, and it carries its own
+    // `eslint-disable` headers that this config then reports as unused — so a
+    // developer who has run `test:coverage` lints a different set of warnings
+    // from CI, which has no such directory.
+    "coverage/**",
   ]),
 ]);
 


### PR DESCRIPTION
Spotted in the v3.2.0 release run's annotations. `pnpm lint` exits 0 on
`0 errors, N warnings`, so the lint job was green and nothing surfaced them.

All three `no-location-assign-relative-destination` warnings predate v3.1.1 —
`c258068` (2026-04-03) and `e172732` / #598 (2026-08-20) — so they were outside
the range the pre-release check reconciles and would not have been caught even
by a range-scoped sweep.

## `router.push` where the rule is right

`app/oauth/mcp/callback/oauth-callback-handler.tsx` — the **Back to Home**
button on the error screen. A plain escape hatch with no cached state riding on
it, so the rule's advice applies as written.

## A documented exception where it is not

`components/organization-form.tsx` and `components/workspace-form.tsx` both
navigate away *immediately after deleting the record the current view is scoped
to*:

```js
toast.success("Workspace deleted");
window.location.href = `/${orgId}`;
```

A client-side transition is exactly what you do not want here — it keeps the app
shell alive, cached RSC payload and SWR entries for the now-deleted Workspace
included, and the surrounding layout goes on rendering them. The full load
rebuilds from a server that agrees the record is gone.

So these keep the hard navigation and gain a comment plus a scoped
`eslint-disable-next-line`. The warning is right about the general case and
wrong about these two; the comment is what records the difference, instead of
the next reader rediscovering it.

**Flag if you disagree** — this is a judgement call about intended behaviour, and
if the reload was incidental rather than deliberate, the right change is
`router.push` + `router.refresh()` in both and I will make it.

## `coverage/**` added to the ignore list

`eslint.config.mjs`'s `globalIgnores` overrides `eslint-config-next`'s defaults
and did not carry `coverage/**`. Vitest's coverage output is generated
JavaScript that ships its own `eslint-disable` headers, which ESLint then reports
as unused directives — so a developer who had run `test:coverage` saw four
warnings locally where CI, with no such directory, saw three.

## Checks

`pnpm lint` now reports **zero warnings** across the workspace. Typecheck, the
full test suite (8/8 tasks, 3344 tests) and `pnpm build` all pass.

No user-visible label, field or nav item changes, so no docs update is due under
the CLAUDE.md table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)