### PR TITLE
fix: sort sidebar chats by updatedAt instead of createdAt (#750)

### DIFF
--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -116,7 +116,7 @@ chat.get(
       })
       .from(chatTable)
       .where(whereClause)
-      .orderBy(desc(chatTable.isPinned), desc(chatTable.createdAt))
+      .orderBy(desc(chatTable.isPinned), desc(chatTable.updatedAt))
       .limit(limit)
       .offset(offset);
 

--- a/apps/frontend/components/app-sidebar.tsx
+++ b/apps/frontend/components/app-sidebar.tsx
@@ -151,10 +151,10 @@ export function AppSidebar() {
   const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
 
   const last7Days = regularChats.filter(
-    (chat) => new Date(chat.createdAt) >= sevenDaysAgo,
+    (chat) => new Date(chat.updatedAt) >= sevenDaysAgo,
   );
   const other = regularChats.filter(
-    (chat) => new Date(chat.createdAt) < sevenDaysAgo,
+    (chat) => new Date(chat.updatedAt) < sevenDaysAgo,
   );
 
   const hasRecent = last7Days.length > 0;


### PR DESCRIPTION
## The bug

Today both the backend list query (`GET /api/chat`) and the sidebar's "Last 7 days" grouping use `createdAt`. Returning to an older chat (or renaming/pinning it) never moves it up the sidebar list, even when it has recent activity.

## The fix

- In `apps/backend/src/routes/chat.ts`, sort by `desc(chatTable.updatedAt)` rather than `desc(chatTable.createdAt)`.
- In `apps/frontend/components/app-sidebar.tsx`, compute the `last7Days` / `other` split from `chat.updatedAt` instead of `chat.createdAt`.
- Preserves the primary `isPinned` sort order so pinned chats remain on top.

Closes #750