### PR TITLE
feat(frontend): animate context meter entrance

### DIFF
--- a/apps/frontend/components/chat.tsx
+++ b/apps/frontend/components/chat.tsx
@@ -13,6 +13,7 @@ import {
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { GlobeIcon, Info, Settings2 } from "lucide-react";
+import { AnimatePresence } from "motion/react";
 import { useRef, useEffect, useState, useCallback, useMemo } from "react";
 import {
   Chat as ChatType,
@@ -42,7 +43,7 @@ import { useSearchToggle } from "@/hooks/use-search-toggle";
 import { useModelSelection } from "@/hooks/use-model-selection";
 import { resolveModel } from "@/lib/resolve-model";
 import { clearedToolCallIds } from "@/lib/tool-result-clearing";
-import { ContextMeter } from "./context-meter";
+import { ContextMeter, ContextMeterEntrance } from "./context-meter";
 import { useMessageEditing } from "@/hooks/use-message-editing";
 import { ATTACHMENTS_ONLY_TEXT } from "@/lib/message-parts";
 import { useChatTitlePoll } from "@/hooks/use-chat-title-poll";
@@ -726,11 +727,21 @@ export const Chat = ({
                   // space, which reads as the last item of the tool row rather
                   // than drifting into the middle the way `justify-between`
                   // alone would leave it.
-                  <ContextMeter
-                    className="order-last -mx-3 -mb-3 mt-1.5 w-[calc(100%+1.5rem)] justify-center rounded-b-md bg-foreground/5 px-3 py-1.5 sm:order-none sm:mx-0 sm:mt-0 sm:mb-0 sm:w-auto sm:justify-start sm:rounded-none sm:bg-transparent sm:p-0 sm:mr-auto"
-                    occupancy={projectedOccupancy}
-                    contextWindow={resolvedModel?.contextWindow}
-                  />
+                  <AnimatePresence initial={false}>
+                    {projectedOccupancy != null &&
+                      resolvedModel?.contextWindow != null && (
+                        <ContextMeterEntrance
+                          key="context-meter"
+                          className="order-last -mx-3 w-[calc(100%+1.5rem)] sm:order-none sm:mx-0 sm:mr-auto sm:w-auto"
+                        >
+                          <ContextMeter
+                            className="mt-1.5 justify-center rounded-b-md bg-foreground/5 px-3 py-1.5 sm:mt-0 sm:justify-start sm:rounded-none sm:bg-transparent sm:p-0"
+                            occupancy={projectedOccupancy}
+                            contextWindow={resolvedModel.contextWindow}
+                          />
+                        </ContextMeterEntrance>
+                      )}
+                  </AnimatePresence>
                 }
                 submit={<PromptInputSubmit status={effectiveStatus} />}
               />

--- a/apps/frontend/components/context-meter.test.tsx
+++ b/apps/frontend/components/context-meter.test.tsx
@@ -1,7 +1,112 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { AnimatePresence } from "motion/react";
 
-import { ContextMeter } from "./context-meter";
+import { ContextMeter, ContextMeterEntrance } from "./context-meter";
+
+const motionPreference = vi.hoisted(() => ({
+  isMobile: true,
+  reducedMotion: false,
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => motionPreference.isMobile,
+}));
+
+vi.mock("motion/react", async (importOriginal) => {
+  const motion = await importOriginal<typeof import("motion/react")>();
+  return {
+    ...motion,
+    useReducedMotion: () => motionPreference.reducedMotion,
+  };
+});
+
+afterEach(() => {
+  motionPreference.isMobile = true;
+  motionPreference.reducedMotion = false;
+});
+
+describe("ContextMeterEntrance", () => {
+  const renderPresence = (visible: boolean, label = "meter") =>
+    render(
+      <AnimatePresence initial={false}>
+        {visible && (
+          <ContextMeterEntrance key="context-meter">
+            <span>{label}</span>
+          </ContextMeterEntrance>
+        )}
+      </AnimatePresence>,
+    );
+
+  const entranceFor = (label: string) =>
+    screen.getByText(label).parentElement?.parentElement;
+
+  it("shows a meter present on the first render at its natural height", () => {
+    renderPresence(true);
+
+    const entrance = entranceFor("meter");
+    expect(entrance).toHaveStyle({ height: "auto", opacity: "1" });
+    expect(entrance).toHaveClass("shrink-0", "overflow-hidden");
+    expect(screen.getByText("meter").parentElement).toHaveClass(
+      "-mb-3",
+      "sm:mb-0",
+    );
+  });
+
+  it("animates a mobile meter that becomes available without restarting on rerender", async () => {
+    const view = renderPresence(false);
+
+    view.rerender(
+      <AnimatePresence initial={false}>
+        <ContextMeterEntrance key="context-meter">
+          <span>meter</span>
+        </ContextMeterEntrance>
+      </AnimatePresence>,
+    );
+
+    const entrance = entranceFor("meter");
+    expect(entrance).toHaveStyle({ height: "0px", opacity: "0" });
+
+    await waitFor(
+      () => expect(entrance).toHaveStyle({ height: "auto", opacity: "1" }),
+      { timeout: 1_500 },
+    );
+
+    view.rerender(
+      <AnimatePresence initial={false}>
+        <ContextMeterEntrance key="context-meter">
+          <span>updated meter</span>
+        </ContextMeterEntrance>
+      </AnimatePresence>,
+    );
+    expect(entranceFor("updated meter")).toHaveStyle({
+      height: "auto",
+      opacity: "1",
+    });
+  });
+
+  it.each([
+    { name: "desktop", isMobile: false, reducedMotion: false },
+    { name: "reduced motion", isMobile: true, reducedMotion: true },
+  ])("shows a newly available meter immediately on $name", (preference) => {
+    motionPreference.isMobile = preference.isMobile;
+    motionPreference.reducedMotion = preference.reducedMotion;
+    const view = renderPresence(false);
+
+    view.rerender(
+      <AnimatePresence initial={false}>
+        <ContextMeterEntrance key="context-meter">
+          <span>meter</span>
+        </ContextMeterEntrance>
+      </AnimatePresence>,
+    );
+
+    expect(entranceFor("meter")).toHaveStyle({
+      height: "auto",
+      opacity: "1",
+    });
+  });
+});
 
 describe("ContextMeter", () => {
   it("renders nothing when no Context window is declared", () => {

--- a/apps/frontend/components/context-meter.test.tsx
+++ b/apps/frontend/components/context-meter.test.tsx
@@ -38,16 +38,16 @@ describe("ContextMeterEntrance", () => {
       </AnimatePresence>,
     );
 
-  const entranceFor = (label: string) =>
-    screen.getByText(label).parentElement?.parentElement;
+  const entranceFor = (label: string) => screen.getByText(label).closest("div");
 
   it("shows a meter present on the first render at its natural height", () => {
     renderPresence(true);
 
     const entrance = entranceFor("meter");
     expect(entrance).toHaveStyle({ height: "auto", opacity: "1" });
-    expect(entrance).toHaveClass("shrink-0", "overflow-hidden");
-    expect(screen.getByText("meter").parentElement).toHaveClass(
+    expect(entrance).toHaveClass(
+      "shrink-0",
+      "overflow-hidden",
       "-mb-3",
       "sm:mb-0",
     );
@@ -65,7 +65,9 @@ describe("ContextMeterEntrance", () => {
     );
 
     const entrance = entranceFor("meter");
-    expect(entrance).toHaveStyle({ height: "0px", opacity: "0" });
+    // The collapsed row starts at the height of its own `-mb-3` bleed, so the
+    // two cancel and it occupies nothing without pulling the toolbar upward.
+    expect(entrance).toHaveStyle({ height: "0.75rem", opacity: "0" });
 
     await waitFor(
       () => expect(entrance).toHaveStyle({ height: "auto", opacity: "1" }),

--- a/apps/frontend/components/context-meter.tsx
+++ b/apps/frontend/components/context-meter.tsx
@@ -1,7 +1,43 @@
 "use client";
 
+import { motion, useReducedMotion } from "motion/react";
+import type { ReactNode } from "react";
+
+import { useIsMobile } from "@/hooks/use-mobile";
 import { formatTokens } from "@/lib/context-window";
 import { cn } from "@/lib/utils";
+
+/**
+ * Reveals a context meter that becomes available after mount on mobile.
+ * The caller's `AnimatePresence initial={false}` keeps an initially available
+ * meter at its natural height, while desktop and reduced-motion layouts use an
+ * immediate transition.
+ */
+export const ContextMeterEntrance = ({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) => {
+  const isMobile = useIsMobile();
+  const prefersReducedMotion = useReducedMotion();
+  const shouldAnimate = isMobile && !prefersReducedMotion;
+  const visible = { height: "auto", opacity: 1 } as const;
+
+  return (
+    <motion.div
+      initial={shouldAnimate ? { height: 0, opacity: 0 } : visible}
+      animate={visible}
+      transition={{ duration: shouldAnimate ? 0.5 : 0, ease: "easeOut" }}
+      className={cn("shrink-0 overflow-hidden", className)}
+    >
+      {/* Keep the mobile footer bleed inside the clipped content so a collapsed
+          entrance has no negative margin that can pull the toolbar upward. */}
+      <div className="-mb-3 sm:mb-0">{children}</div>
+    </motion.div>
+  );
+};
 
 /**
  * How full the model's context will be on the next call (ADR-0018).
@@ -19,11 +55,9 @@ import { cn } from "@/lib/utils";
  * projection, and taking the declared window off the resolved model all belong
  * to the composing component.
  *
- * Renders nothing unless BOTH numbers are known — one hidden state with two
- * causes (no window declared, or the Provider reported no usage). A numerator
- * with no denominator would be a third display mode answering none of the
- * questions a meter exists for: a bare "42,000 tokens" cannot say whether that
- * is roomy or nearly fatal.
+ * Composing callers normally gate on BOTH numbers before mounting this meter,
+ * because a numerator with no denominator cannot say whether a value is roomy
+ * or nearly fatal. The internal guard remains for safe standalone reuse.
  */
 export const ContextMeter = ({
   occupancy,

--- a/apps/frontend/components/context-meter.tsx
+++ b/apps/frontend/components/context-meter.tsx
@@ -8,10 +8,23 @@ import { formatTokens } from "@/lib/context-window";
 import { cn } from "@/lib/utils";
 
 /**
+ * How far the mobile row bleeds down over the footer's own padding, matching
+ * the `-mb-3` below. The collapsed entrance starts at exactly this height so
+ * that height and negative margin cancel: the row occupies nothing, yet the
+ * margin never pulls the toolbar up by 12px on its own.
+ */
+const FOOTER_BLEED = "0.75rem";
+
+/**
  * Reveals a context meter that becomes available after mount on mobile.
  * The caller's `AnimatePresence initial={false}` keeps an initially available
  * meter at its natural height, while desktop and reduced-motion layouts use an
  * immediate transition.
+ *
+ * The bleed stays in CSS on the clipping box rather than on its content, so the
+ * `sm:` breakpoint still governs the resting layout and the tinted band sits
+ * inside the box being clipped — a negative margin on the content would shorten
+ * the box by 12px and cut the bottom of the band off.
  */
 export const ContextMeterEntrance = ({
   children,
@@ -27,14 +40,12 @@ export const ContextMeterEntrance = ({
 
   return (
     <motion.div
-      initial={shouldAnimate ? { height: 0, opacity: 0 } : visible}
+      initial={shouldAnimate ? { height: FOOTER_BLEED, opacity: 0 } : visible}
       animate={visible}
       transition={{ duration: shouldAnimate ? 0.5 : 0, ease: "easeOut" }}
-      className={cn("shrink-0 overflow-hidden", className)}
+      className={cn("shrink-0 overflow-hidden -mb-3 sm:mb-0", className)}
     >
-      {/* Keep the mobile footer bleed inside the clipped content so a collapsed
-          entrance has no negative margin that can pull the toolbar upward. */}
-      <div className="-mb-3 sm:mb-0">{children}</div>
+      {children}
     </motion.div>
   );
 };


### PR DESCRIPTION
## What

- animate the mobile context-meter row only when occupancy becomes available after the initial render
- use the existing Motion animation stack with `AnimatePresence initial={false}`
- keep desktop and reduced-motion layouts immediate
- preserve the desktop toolbar width and prevent the collapsed mobile row from pulling the toolbar upward
- cover initial presence, later mobile appearance, rerender stability, desktop, and reduced-motion behavior

## Why

The meter can become available after an assistant response supplies occupancy data. Its first mid-chat appearance should be smooth on mobile, while a meter already present during initial render must remain stable.

Closes #751.

## Checklist

- [x] The **PR title** is a Conventional Commit subject.
- [x] **The change is covered by tests.**
- [x] No documentation update is needed because no visible label, field, limit, enum, or configuration changed.
- [x] `pnpm test` passes: 8/8 Turbo tasks (schemas 155, docs 49, backend 2,462, frontend 707, plugin SDK 15, example tool set 5).
- [x] `pnpm typecheck` passes: 8/8 Turbo tasks.
- [x] `pnpm lint` passes: 4/4 Turbo tasks.
- [x] `pnpm build` passes: 5/5 Turbo tasks.
- [x] Prettier and `git diff --check` pass.

Local verification used Node 22.23.2, so pnpm printed the Node >=24 engine warning; all commands above completed successfully. CI will provide the supported Node 24 run.

AI assistance was used to implement and verify this change; I reviewed the diff and take responsibility for it.