### PR TITLE
chore: require English commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,10 @@ This project follows [Conventional Commits](https://www.conventionalcommits.org/
 
 **Format:** `<type>[optional scope]: <description>`
 
+**Write commit messages in English.** The subject and body must both be in
+English, so that every reviewer and maintainer can read the history without
+translation.
+
 **Examples:**
 
 ```
@@ -132,7 +136,7 @@ chore(tests): add missing test coverage
 > so the fix still lands as your work.
 
 1. Ensure your code passes all tests (`pnpm test`) and is formatted (`pnpm format`).
-2. Write clear, descriptive commit messages following the conventions above.
+2. Write clear, descriptive commit messages in English, following the conventions above.
 3. Update the docs in `apps/docs/content` in the same PR, not a follow-up one.
    If you changed an `.env.example`, a user-facing limit or enum in
    `packages/schemas`, anything under `apps/backend/src/plugins`, or a visible


### PR DESCRIPTION
## Summary

- state in `CONTRIBUTING.md` that commit subjects and bodies must be written in English
- repeat the requirement in the pull request checklist item that already points at the commit conventions

## Why

The **Commit Messages** section pinned the allowed Conventional Commit types but never named a language. A contributor could follow every documented rule and still land history that reviewers and maintainers cannot read — which is exactly what happened on #755, where all four subjects and bodies are in Chinese. The rule was real but unwritten, so the gap is ours.

No behaviour or code changes; documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)