### PR TITLE
fix(frontend): clear the sidebar spinner when a run finishes

### DIFF
--- a/apps/frontend/components/app-sidebar.tsx
+++ b/apps/frontend/components/app-sidebar.tsx
@@ -65,6 +65,9 @@ import { useBackendUrl } from "@/app/client-context";
 import { TagInput } from "@/components/tag-input";
 import { useIsMobile } from "@/hooks/use-mobile";
 
+/** How often to re-read the chat list while at least one chat is running. */
+const RUNNING_CHAT_POLL_INTERVAL_MS = 3000;
+
 export function AppSidebar() {
   const { orgId, workspaceId } = useParams<{
     orgId: string;
@@ -129,6 +132,17 @@ export function AppSidebar() {
         )
       : null,
     fetcher,
+    {
+      // The per-chat spinner below is rendered straight off this cached list,
+      // and nothing else revalidates it when a run finishes — including runs in
+      // chats the user isn't currently viewing, where the client has no stream
+      // to hang a terminal event off. Poll while any listed chat is running;
+      // the condition clears itself once the backend reports a terminal status.
+      refreshInterval: (latest) =>
+        latest?.results.some((chat) => chat.status === "running")
+          ? RUNNING_CHAT_POLL_INTERVAL_MS
+          : 0,
+    },
   );
 
   const { data: orgData } = useSWR<Organization>(


### PR DESCRIPTION
Closes #748.

## The problem

The sidebar's per-chat progress spinner is rendered directly from `chat.status === "running"` on the cached chat-list payload (`app-sidebar.tsx`). That list is only revalidated by the local `revalidateChatList()` helper — called from rename, delete and pin — and by `use-chat-title-poll.ts`, which fires only on the `Untitled` → titled transition.

Nothing revalidated it when a run reached a terminal state, so the list kept serving the snapshot it fetched while the run was still `running`. The spinner stayed until something else forced a refetch. The backend status was correct throughout; the client just never re-read it.

Because the list `useSWR` call took no options, `revalidateOnFocus` was on by default — which is why the spinner cleared on tab refocus but persisted for anyone sitting in the tab, and why reloading worked.

## The fix

Poll the chat list while any listed chat reports `running`, using SWR's function form of `refreshInterval` so the predicate reads the freshest payload rather than a captured render's:

```ts
refreshInterval: (latest) =>
  latest?.results.some((chat) => chat.status === "running")
    ? RUNNING_CHAT_POLL_INTERVAL_MS
    : 0,
```

The stop condition is the data itself, so there is no attempt budget and nothing to reset — polling starts when a run starts and stops within one interval of it finishing. Cadence is 3s, matching `use-chat-title-poll.ts`.

This deliberately does not hang off the open chat's stream end. If chat A is running while you are viewing chat B, the client has no signal that A finished, so a stream-end hook would clear the spinner only for the chat currently on screen — the exact case in the report. Polling the list covers both.

## Verification

`pnpm --filter frontend typecheck` and `pnpm --filter frontend lint` both pass.

**Browser verification did not happen.** It needs a look before merge: confirm the spinner clears within a few seconds of a run finishing without touching the tab, both for the open chat and for one running in the background.

## Note on #750

Scoped to the spinner. #750 (chats not reordering live after new activity) shares this stale list and will likely improve as a side effect, but it is not verified here and stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
