### PR TITLE
fix(frontend): focus the composer once when the model picker closes

### DIFF
--- a/apps/frontend/components/composer.test.tsx
+++ b/apps/frontend/components/composer.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useRef, useState } from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import type { Provider } from "@platypus/schemas";
+import { Composer } from "./composer";
+
+/**
+ * Issue #749: closing the model picker used to move focus twice — Radix
+ * returned it to the trigger button, then a 250ms timer moved it on to the
+ * textarea. On mobile the intermediate stop on a button dismissed the
+ * on-screen keyboard, and the timer reopened it about half a second later.
+ *
+ * jsdom has no virtual keyboard, so what these tests pin is the mechanism
+ * underneath it: focus ends on the textarea, and it gets there in one move
+ * without passing through the trigger. Confirming the keyboard itself needs a
+ * physical device.
+ */
+
+const provider = {
+  id: "provider-1",
+  name: "OpenAI",
+  modelIds: ["gpt-4o"],
+} as unknown as Provider;
+
+const renderComposer = () => {
+  const onModelChange = vi.fn();
+
+  const Harness = () => {
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const [value, setValue] = useState("");
+    const [modelId, setModelId] = useState("");
+
+    return (
+      <Composer
+        onSubmit={vi.fn()}
+        passthroughFileTypes={[]}
+        modelSelection={{
+          agents: [],
+          providers: [provider],
+          agentId: "",
+          modelId,
+          providerId: modelId ? provider.id : "",
+          onModelChange: (v) => {
+            onModelChange(v);
+            setModelId("gpt-4o");
+          },
+        }}
+        textarea={{
+          ref: textareaRef,
+          value,
+          onChange: (e) => setValue(e.target.value),
+          placeholder: "Ask anything",
+        }}
+        onTranscriptionChange={vi.fn()}
+        submit={<button type="submit">Send</button>}
+      />
+    );
+  };
+
+  render(<Harness />);
+
+  return {
+    onModelChange,
+    textarea: screen.getByPlaceholderText("Ask anything"),
+    trigger: screen.getByText("Select model").closest("button")!,
+  };
+};
+
+const openPicker = (trigger: HTMLElement) => {
+  fireEvent.click(trigger);
+  return screen.getByText("gpt-4o");
+};
+
+/** Records every element that takes focus from this point on, in order. */
+const recordFocus = () => {
+  const targets: EventTarget[] = [];
+  document.addEventListener("focusin", (e) => targets.push(e.target!));
+  return targets;
+};
+
+beforeEach(() => {
+  // jsdom has no matchMedia; PromptInputTextarea subscribes to it.
+  window.matchMedia = vi.fn().mockReturnValue({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }) as unknown as typeof window.matchMedia;
+  // cmdk scrolls the active item into view and observes its list.
+  Element.prototype.scrollIntoView = vi.fn();
+  window.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+describe("Composer model picker focus", () => {
+  it("returns focus to the textarea when a model is selected", async () => {
+    const { textarea, trigger, onModelChange } = renderComposer();
+
+    fireEvent.click(openPicker(trigger));
+
+    expect(onModelChange).toHaveBeenCalled();
+    await waitFor(() => expect(document.activeElement).toBe(textarea));
+  });
+
+  it("returns focus to the textarea when the picker is dismissed without a selection", async () => {
+    const { textarea, trigger, onModelChange } = renderComposer();
+
+    openPicker(trigger);
+    fireEvent.keyDown(document.activeElement!, { key: "Escape" });
+
+    expect(onModelChange).not.toHaveBeenCalled();
+    await waitFor(() => expect(document.activeElement).toBe(textarea));
+  });
+
+  it("does not pass focus through the trigger button on the way back", async () => {
+    const { textarea, trigger } = renderComposer();
+
+    const item = openPicker(trigger);
+    // Only the close is under test; opening the picker legitimately moves
+    // focus into it.
+    const focused = recordFocus();
+    fireEvent.click(item);
+    await waitFor(() => expect(document.activeElement).toBe(textarea));
+
+    // One move, straight to the textarea. Landing on the trigger first is the
+    // regression: on mobile it drops the keyboard before the textarea reopens it.
+    expect(focused).toEqual([textarea]);
+    expect(focused).not.toContain(trigger);
+  });
+});

--- a/apps/frontend/components/composer.tsx
+++ b/apps/frontend/components/composer.tsx
@@ -140,11 +140,16 @@ export const Composer = ({
             modelId={modelSelection.modelId}
             providerId={modelSelection.providerId}
             isOpen={isModelSelectorOpen}
-            onOpenChange={(open) => {
-              setIsModelSelectorOpen(open);
-              if (!open) {
-                setTimeout(() => textareaRef.current?.focus(), 250);
-              }
+            onOpenChange={setIsModelSelectorOpen}
+            // Closing the picker returns to the textarea, so a model switch
+            // doesn't interrupt typing. Radix would first hand focus back to
+            // the trigger button; letting it do so and then moving focus on
+            // again is two focus changes, which on mobile dismisses the
+            // on-screen keyboard and reopens it a moment later (issue #749).
+            // Taking over the close focus keeps it to a single move.
+            onCloseAutoFocus={(event) => {
+              event.preventDefault();
+              textareaRef.current?.focus();
             }}
             onModelChange={modelSelection.onModelChange}
             maxOutputTokens={modelSelection.maxOutputTokens}

--- a/apps/frontend/components/model-selector-dialog.tsx
+++ b/apps/frontend/components/model-selector-dialog.tsx
@@ -43,6 +43,13 @@ interface ModelSelectorDialogProps {
    * declaration is visible before a reply is cut short, not only after.
    */
   maxOutputTokens?: number;
+  /**
+   * Runs in place of the dialog's default close behaviour, which returns focus
+   * to the trigger button. Callers that want focus somewhere else — the
+   * composer wants its textarea (issue #749) — call `preventDefault()` on the
+   * event and focus their own target, so the close is a single focus move.
+   */
+  onCloseAutoFocus?: (event: Event) => void;
 }
 
 export const ModelSelectorDialog = ({
@@ -55,6 +62,7 @@ export const ModelSelectorDialog = ({
   onOpenChange,
   onModelChange,
   maxOutputTokens,
+  onCloseAutoFocus,
 }: ModelSelectorDialogProps) => {
   const selectedAgent = agentId ? agents.find((a) => a.id === agentId) : null;
 
@@ -99,7 +107,10 @@ export const ModelSelectorDialog = ({
       ) : (
         <ModelSelectorTrigger asChild>{trigger}</ModelSelectorTrigger>
       )}
-      <ModelSelectorContent filter={filterByKeywords}>
+      <ModelSelectorContent
+        filter={filterByKeywords}
+        onCloseAutoFocus={onCloseAutoFocus}
+      >
         <ModelSelectorInput placeholder="Search agents and models..." />
         <ModelSelectorList>
           <ModelSelectorEmpty>No results found.</ModelSelectorEmpty>


### PR DESCRIPTION
Fixes #749.

## The problem

Closing the composer's model picker moved focus **twice**:

1. The picker is a Radix modal `Dialog`, opened from a real `DialogTrigger`. Nothing overrode `onCloseAutoFocus`, so on close Radix returned focus to the trigger button — after the ~200ms exit animation.
2. The composer separately ran `setTimeout(() => textareaRef.current?.focus(), 250)` from the picker's `onOpenChange`.

On desktop the double handoff is invisible. On mobile the intermediate stop on a `<button>` dismisses the on-screen keyboard, and the timer reopens it — the ~450ms combined delay matching the "closes, then reopens about half a second later" in the report.

## The fix

Take over the dialog's close focus rather than racing it:

```tsx
onOpenChange={setIsModelSelectorOpen}
onCloseAutoFocus={(event) => {
  event.preventDefault();
  textareaRef.current?.focus();
}}
```

`preventDefault()` stops the focus return to the trigger; focusing in the same handler makes it a single move with no timer. `ModelSelectorDialog` gained an optional `onCloseAutoFocus` pass-through so the picker stays generic rather than learning about textareas.

This **preserves** the behaviour `c72bc9a` added deliberately — the textarea is ready to type in straight after a model switch — and extends it to dismissing the picker with Escape or the overlay. Because the change lives in the shared `Composer`, both the chat input and the message editor get it.

## Verification

Lint, typecheck and the full frontend suite (694 tests) pass.

The new tests were checked against the unfixed code: the targeted one fails there, recording the focus sequence as `[trigger, textarea]` — the double handoff itself. With the fix it is `[textarea]`.

Two notes for review:

- `onCloseAutoFocus` fires **asynchronously**, once React flushes the unmount effect, so the assertions use `waitFor`. A synchronous assertion fails misleadingly here.
- There is no test pinning "does not use a `setTimeout`" directly. Doing so with fake timers is brittle, because React's own scheduler uses timers to flush the effect that fires the handler. The single-focus-move assertion covers the user-visible consequence.

## Still outstanding

jsdom has no virtual keyboard, so **none of this proves the keyboard stops flapping** — only that the focus sequence causing it is fixed. Confirming the symptom needs a physical Android device running Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
