### PR TITLE
fix(backend): recover Chats stuck in `running` after a restart

### DIFF
--- a/apps/backend/index.ts
+++ b/apps/backend/index.ts
@@ -10,7 +10,7 @@ import {
   type AdminSignUp,
 } from "./src/db/seed.ts";
 import { startMemoryScheduler } from "./src/jobs/memory-scheduler.ts";
-import { startTriggerScheduler } from "./src/jobs/trigger-scheduler.ts";
+import { startScheduler } from "./src/jobs/scheduler.ts";
 import { loadPlugins } from "./src/plugins/loader.ts";
 import { setLoadedPlugins } from "./src/plugins/registry.ts";
 import { installProviderWarningLogger } from "./src/provider-warnings.ts";
@@ -88,7 +88,7 @@ const main = async () => {
 
   // Start background jobs (safe for horizontal scaling)
   startMemoryScheduler();
-  startTriggerScheduler();
+  startScheduler();
 };
 
 const exponentialBackoff = async <T>(

--- a/apps/backend/src/jobs/scheduler.test.ts
+++ b/apps/backend/src/jobs/scheduler.test.ts
@@ -79,21 +79,6 @@ describe("stuckChatCutoff", () => {
     // 60 min per-run timeout + 5 min buffer = 65 min.
     expect(stuckChatCutoff().toISOString()).toBe("2026-08-30T10:55:00.000Z");
   });
-
-  it("excludes a turn younger than the cutoff and includes an older one", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-08-30T12:00:00.000Z"));
-    const cutoff = stuckChatCutoff();
-
-    // The comparison the sweep asks Postgres to make, either side of the
-    // boundary by a millisecond. `<` is strict, so the cutoff itself stays.
-    const justStale = new Date(cutoff.getTime() - 1);
-    const justLive = new Date(cutoff.getTime() + 1);
-
-    expect(justStale < cutoff).toBe(true);
-    expect(cutoff < cutoff).toBe(false);
-    expect(justLive < cutoff).toBe(false);
-  });
 });
 
 describe("recoverStuckChats", () => {
@@ -109,19 +94,30 @@ describe("recoverStuckChats", () => {
     vi.useRealTimers();
   });
 
-  it("fails only `running` Chats older than the cutoff", async () => {
+  it("fails `running` Chats whose turn started before the cutoff", async () => {
     const captured = captureUpdate([{ id: "chat-1" }]);
 
     await recoverStuckChats();
 
     expect(captured.set).toMatchObject({ status: "failed" });
 
+    // The whole predicate, pinned exactly. Asserting the rendered string
+    // rather than fragments of it is what makes this a real test: it fails
+    // if the comparison flips direction (a `>` would sweep every live turn
+    // and spare every dead one), if the anchor moves to `updated_at`, or if
+    // the `running` guard is dropped.
     const { sql: text, params } = render(captured.where);
-    expect(text).toContain(`"status" = `);
-    expect(params).toContain("running");
+    expect(text).toBe(
+      `("chat"."status" = $1 and ("chat"."last_turn_at" < $2 or ` +
+        `("chat"."last_turn_at" is null and "chat"."updated_at" < $3)))`,
+    );
     // 12:00 − (30 min + 5 min buffer): the peer-safety window, bound as a
     // UTC `timestamp` parameter exactly as the Trigger sweep binds its own.
-    expect(params).toContain("2026-08-30T11:25:00.000Z");
+    expect(params).toEqual([
+      "running",
+      "2026-08-30T11:25:00.000Z",
+      "2026-08-30T11:25:00.000Z",
+    ]);
   });
 
   it("falls back to `updatedAt` for rows with no `lastTurnAt`", async () => {
@@ -129,13 +125,14 @@ describe("recoverStuckChats", () => {
 
     await recoverStuckChats();
 
-    const { sql: text, params } = render(captured.where);
-    expect(text).toContain(`"last_turn_at"`);
-    expect(text).toContain(`"updated_at"`);
-    expect(text).toContain(`"last_turn_at" is null`);
-    // Both branches compare against the same cutoff.
-    expect(params.filter((p) => p === "2026-08-30T11:25:00.000Z")).toHaveLength(
-      2,
+    // The fallback is a second disjunct rather than a COALESCE so both
+    // comparisons stay on real columns and drizzle binds the cutoff through
+    // each column's own encoder. It is reached only when `last_turn_at` is
+    // NULL, so a row that has a turn timestamp is never judged on the
+    // timestamp auto-titling and memory extraction bump.
+    const { sql: text } = render(captured.where);
+    expect(text).toContain(
+      `("chat"."last_turn_at" is null and "chat"."updated_at" < $3)`,
     );
   });
 

--- a/apps/backend/src/jobs/scheduler.test.ts
+++ b/apps/backend/src/jobs/scheduler.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { SQL } from "drizzle-orm";
+
+/**
+ * Unlike most backend tests, this file does NOT import `../test-utils.ts`:
+ * that module mocks `drizzle-orm` itself, which would replace `and`/`isNull`
+ * with spies and leave nothing to render. The stuck-Chat sweep's whole
+ * behaviour lives in the predicate it hands Postgres, so the test keeps
+ * drizzle real and renders the query instead.
+ */
+
+const { mockDb, mockLogger } = vi.hoisted(() => ({
+  mockDb: {
+    update: vi.fn(),
+  },
+  mockLogger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../index.ts", () => ({ db: mockDb }));
+vi.mock("../logger.ts", () => ({ logger: mockLogger }));
+
+import { recoverStuckChats, stuckChatCutoff } from "./scheduler.ts";
+import { chat as chatTable } from "../db/schema.ts";
+
+const dialect = new PgDialect();
+
+/** Records the `.set()` payload and `.where()` predicate of one update chain. */
+const captureUpdate = (returning: unknown[]) => {
+  const captured: { set?: Record<string, unknown>; where?: SQL } = {};
+  mockDb.update.mockReturnValue({
+    set: (values: Record<string, unknown>) => {
+      captured.set = values;
+      return {
+        where: (predicate: SQL) => {
+          captured.where = predicate;
+          return { returning: () => Promise.resolve(returning) };
+        },
+      };
+    },
+  });
+  return captured;
+};
+
+/** The rendered SQL + bound parameters of a where clause. */
+const render = (predicate: SQL | undefined) => {
+  if (!predicate) throw new Error("No where clause was captured");
+  return dialect.sqlToQuery(predicate);
+};
+
+describe("stuckChatCutoff", () => {
+  beforeEach(() => {
+    delete process.env.CHAT_PER_RUN_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    delete process.env.CHAT_PER_RUN_TIMEOUT_MS;
+    vi.useRealTimers();
+  });
+
+  it("sits one stale buffer past the default Chat per-run timeout", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-30T12:00:00.000Z"));
+
+    // 30 min per-run timeout + 5 min buffer = 35 min.
+    expect(stuckChatCutoff().toISOString()).toBe("2026-08-30T11:25:00.000Z");
+  });
+
+  it("tracks CHAT_PER_RUN_TIMEOUT_MS, not the Trigger per-run timeout", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-30T12:00:00.000Z"));
+    process.env.CHAT_PER_RUN_TIMEOUT_MS = String(60 * 60 * 1000);
+
+    // 60 min per-run timeout + 5 min buffer = 65 min.
+    expect(stuckChatCutoff().toISOString()).toBe("2026-08-30T10:55:00.000Z");
+  });
+
+  it("excludes a turn younger than the cutoff and includes an older one", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-30T12:00:00.000Z"));
+    const cutoff = stuckChatCutoff();
+
+    // The comparison the sweep asks Postgres to make, either side of the
+    // boundary by a millisecond. `<` is strict, so the cutoff itself stays.
+    const justStale = new Date(cutoff.getTime() - 1);
+    const justLive = new Date(cutoff.getTime() + 1);
+
+    expect(justStale < cutoff).toBe(true);
+    expect(cutoff < cutoff).toBe(false);
+    expect(justLive < cutoff).toBe(false);
+  });
+});
+
+describe("recoverStuckChats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CHAT_PER_RUN_TIMEOUT_MS;
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-30T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    delete process.env.CHAT_PER_RUN_TIMEOUT_MS;
+    vi.useRealTimers();
+  });
+
+  it("fails only `running` Chats older than the cutoff", async () => {
+    const captured = captureUpdate([{ id: "chat-1" }]);
+
+    await recoverStuckChats();
+
+    expect(captured.set).toMatchObject({ status: "failed" });
+
+    const { sql: text, params } = render(captured.where);
+    expect(text).toContain(`"status" = `);
+    expect(params).toContain("running");
+    // 12:00 − (30 min + 5 min buffer): the peer-safety window, bound as a
+    // UTC `timestamp` parameter exactly as the Trigger sweep binds its own.
+    expect(params).toContain("2026-08-30T11:25:00.000Z");
+  });
+
+  it("falls back to `updatedAt` for rows with no `lastTurnAt`", async () => {
+    const captured = captureUpdate([{ id: "chat-1" }]);
+
+    await recoverStuckChats();
+
+    const { sql: text, params } = render(captured.where);
+    expect(text).toContain(`"last_turn_at"`);
+    expect(text).toContain(`"updated_at"`);
+    expect(text).toContain(`"last_turn_at" is null`);
+    // Both branches compare against the same cutoff.
+    expect(params.filter((p) => p === "2026-08-30T11:25:00.000Z")).toHaveLength(
+      2,
+    );
+  });
+
+  it("logs the sweep at warn with the row count and cutoff", async () => {
+    captureUpdate([{ id: "chat-1" }, { id: "chat-2" }]);
+
+    await recoverStuckChats();
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        count: 2,
+        cutoff: "2026-08-30T11:25:00.000Z",
+      }),
+      expect.stringContaining("Chat"),
+    );
+  });
+
+  it("stays quiet when nothing is stuck", async () => {
+    captureUpdate([]);
+
+    await recoverStuckChats();
+
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("targets the chat table", async () => {
+    captureUpdate([]);
+
+    await recoverStuckChats();
+
+    expect(mockDb.update).toHaveBeenCalledWith(chatTable);
+  });
+});

--- a/apps/backend/src/jobs/scheduler.ts
+++ b/apps/backend/src/jobs/scheduler.ts
@@ -242,6 +242,16 @@ async function processDueTriggers(): Promise<void> {
 const RECOVERY_STALE_BUFFER_MS = 5 * 60 * 1000;
 
 /**
+ * The moment before which a `running` row of any kind has no live owner:
+ * the run's own per-run timeout ago, plus the buffer above. Both sweeps go
+ * through here, so the one thing that makes them safe against a peer's live
+ * work is stated once.
+ */
+function staleCutoff(perRunTimeoutMs: number): Date {
+  return new Date(Date.now() - (perRunTimeoutMs + RECOVERY_STALE_BUFFER_MS));
+}
+
+/**
  * Periodic recovery for state left behind by a server crash mid-execution.
  *
  * Two failure modes both manifest as "trigger never runs again":
@@ -268,9 +278,7 @@ const RECOVERY_STALE_BUFFER_MS = 5 * 60 * 1000;
  * the staleness threshold, a peer is currently executing — leave it alone.
  */
 async function recoverStuckTriggers(): Promise<void> {
-  const staleThresholdMs =
-    DEFAULT_PER_RUN_TIMEOUT_MS + RECOVERY_STALE_BUFFER_MS;
-  const cutoff = new Date(Date.now() - staleThresholdMs);
+  const cutoff = staleCutoff(DEFAULT_PER_RUN_TIMEOUT_MS);
 
   // Mark abandoned running runs as failed. The age cutoff guarantees no
   // live peer is still working on them.
@@ -364,9 +372,7 @@ async function recoverStuckTriggers(): Promise<void> {
  * earlier cutoff and could fail a peer's live turn.
  */
 export function stuckChatCutoff(): Date {
-  return new Date(
-    Date.now() - (chatPerRunTimeoutMs() + RECOVERY_STALE_BUFFER_MS),
-  );
+  return staleCutoff(chatPerRunTimeoutMs());
 }
 
 /**

--- a/apps/backend/src/jobs/scheduler.ts
+++ b/apps/backend/src/jobs/scheduler.ts
@@ -1,6 +1,7 @@
-import { sql, and, eq, isNull, lt, lte, inArray } from "drizzle-orm";
+import { sql, and, eq, isNull, lt, lte, or, inArray } from "drizzle-orm";
 import { db } from "../index.ts";
 import {
+  chat as chatTable,
   trigger as triggerTable,
   triggerRun as triggerRunTable,
 } from "../db/schema.ts";
@@ -10,14 +11,17 @@ import {
 } from "../services/trigger-execution.ts";
 import { logger } from "../logger.ts";
 import { DEFAULT_PER_RUN_TIMEOUT_MS } from "../runs/run-registry.ts";
+import { chatPerRunTimeoutMs } from "../runs/chat-timeouts.ts";
 import { validateCronExpression } from "../utils/cron.ts";
 import type { CronTriggerConfig } from "@platypus/schemas";
 
-// Advisory lock ID for trigger scheduler (same as old schedule scheduler)
-const TRIGGER_SCHEDULER_LOCK_ID = 987654321;
+// Advisory lock ID for the background scheduler. The numeric value is load
+// bearing across deploys: an old and a new instance must contend for the same
+// lock during a rolling restart, so never change it when renaming things here.
+const SCHEDULER_LOCK_ID = 987654321;
 
 // Check interval: 60 seconds (1 minute)
-const TRIGGER_SCHEDULER_INTERVAL_MS = parseInt(
+const SCHEDULER_INTERVAL_MS = parseInt(
   process.env.SCHEDULE_SCHEDULER_INTERVAL_MS || "60000",
 );
 
@@ -50,19 +54,19 @@ async function withConcurrencyLimit<T>(
 
 /**
  * Attempts to acquire an advisory lock and runs the given function if successful.
- * This ensures only one backend instance processes triggers at a time.
+ * This ensures only one backend instance runs the scheduled work at a time.
  */
 async function runWithLock(fn: () => Promise<void>): Promise<void> {
   // Try to acquire advisory lock (non-blocking)
   const lockResult = await db.execute(
-    sql`SELECT pg_try_advisory_lock(${TRIGGER_SCHEDULER_LOCK_ID}) as acquired`,
+    sql`SELECT pg_try_advisory_lock(${SCHEDULER_LOCK_ID}) as acquired`,
   );
 
   const acquired = lockResult.rows[0]?.acquired;
 
   if (!acquired) {
     logger.debug(
-      "Another backend instance is processing triggers, skipping this run",
+      "Another backend instance is running the scheduler, skipping this tick",
     );
     return;
   }
@@ -71,9 +75,7 @@ async function runWithLock(fn: () => Promise<void>): Promise<void> {
     await fn();
   } finally {
     // Always release lock, even if processing fails
-    await db.execute(
-      sql`SELECT pg_advisory_unlock(${TRIGGER_SCHEDULER_LOCK_ID})`,
-    );
+    await db.execute(sql`SELECT pg_advisory_unlock(${SCHEDULER_LOCK_ID})`);
   }
 }
 
@@ -230,11 +232,12 @@ async function processDueTriggers(): Promise<void> {
 }
 
 /**
- * Buffer added on top of the per-run timeout before we consider a `running`
- * `trigger_run` row abandoned. Any live instance would have aborted the run
- * by `started_at + DEFAULT_PER_RUN_TIMEOUT_MS`, so anything older than that
- * plus this buffer is definitely orphaned. Five extra minutes gives the
- * normal per-run timeout path a chance to write the failure first.
+ * Buffer added on top of a run's own per-run timeout before we consider a
+ * `running` row abandoned — shared by both sweeps below, each of which adds it
+ * to the timeout its own kind of run is bounded by. Any live instance would
+ * have aborted the run by `started + <its per-run timeout>`, so anything older
+ * than that plus this buffer is definitely orphaned. Five extra minutes gives
+ * the normal per-run timeout path a chance to write the failure first.
  */
 const RECOVERY_STALE_BUFFER_MS = 5 * 60 * 1000;
 
@@ -347,26 +350,101 @@ async function recoverStuckTriggers(): Promise<void> {
 }
 
 /**
- * Starts the trigger scheduler.
+ * The moment before which a `running` Chat is considered abandoned.
+ *
+ * Derived from `CHAT_PER_RUN_TIMEOUT_MS` — the ceiling a Chat turn actually
+ * runs under (`runs/chat-timeouts.ts`) — and NOT from the Trigger's
+ * `DEFAULT_PER_RUN_TIMEOUT_MS`, which is three times shorter and would fail
+ * live turns. A live instance aborts any turn older than its own per-run
+ * timeout, so a row past this cutoff has no live owner on any instance.
+ *
+ * Horizontal scaling: this env var is read per process, unlike the Trigger
+ * timeout which is a code constant. Instances sharing a database must be
+ * configured with the same value; one given a shorter value computes an
+ * earlier cutoff and could fail a peer's live turn.
+ */
+export function stuckChatCutoff(): Date {
+  return new Date(
+    Date.now() - (chatPerRunTimeoutMs() + RECOVERY_STALE_BUFFER_MS),
+  );
+}
+
+/**
+ * Periodic recovery for Chats left `running` by a server crash mid-turn.
+ *
+ * `ChatSink.onStart` sets the Chat's status to `running`, and the sink is the
+ * only writer of a terminal status. The per-run and per-step timeouts that
+ * would otherwise end the turn are `setTimeout` handles in the in-memory run
+ * registry, so a crash takes them with it and the row stays `running` for
+ * ever: a sidebar spinner that never stops, a composer the frontend keeps
+ * disabled, and (since #761) a Chat-list poll every 3s for as long as a tab
+ * is open. Issue #762.
+ *
+ * Age is measured on `lastTurnAt`, the run sink's own turn-boundary signal,
+ * never on `updatedAt` — auto-titling and memory extraction bump `updatedAt`
+ * at their own cadence, so a background write on a dead Chat would keep the
+ * row looking recent and the sweep would never fire (see `db/schema.ts`).
+ * Rows predating the column fall back to `updatedAt`.
+ *
+ * Same horizontal-scaling reasoning as `recoverStuckTriggers`: the age cutoff
+ * is what makes this safe against a peer's live work; the advisory lock only
+ * serializes concurrent sweeps.
+ *
+ * The status written is `failed`, not `cancelled` — nobody requested a
+ * cancellation, and reporting one would misdescribe the event.
+ */
+export async function recoverStuckChats(): Promise<void> {
+  const cutoff = stuckChatCutoff();
+
+  const orphaned = await db
+    .update(chatTable)
+    .set({ status: "failed", updatedAt: new Date() })
+    .where(
+      and(
+        eq(chatTable.status, "running"),
+        or(
+          lt(chatTable.lastTurnAt, cutoff),
+          and(isNull(chatTable.lastTurnAt), lt(chatTable.updatedAt, cutoff)),
+        ),
+      ),
+    )
+    .returning({ id: chatTable.id });
+
+  if (orphaned.length === 0) return;
+
+  logger.warn(
+    { count: orphaned.length, cutoff: cutoff.toISOString() },
+    "Marked orphaned Chats as failed (older than the Chat per-run timeout)",
+  );
+}
+
+/**
+ * Starts the background scheduler.
  * This should be called after the database is initialized.
  */
-export function startTriggerScheduler(): void {
+export function startScheduler(): void {
   logger.info(
-    `Starting trigger scheduler (interval: ${TRIGGER_SCHEDULER_INTERVAL_MS}ms, wall-clock aligned)`,
+    `Starting scheduler (interval: ${SCHEDULER_INTERVAL_MS}ms, wall-clock aligned)`,
   );
 
-  // Schedule at wall-clock-aligned intervals with advisory lock. Recovery
-  // and due-trigger processing share the same lock so they don't race each
-  // other or peer instances. Recovery runs every tick (cheap when there's
+  // Schedule at wall-clock-aligned intervals with advisory lock. Both recovery
+  // sweeps and due-trigger processing share the same lock so they don't race
+  // each other or peer instances. Recovery runs every tick (cheap when there's
   // nothing to do) so a crash self-heals without requiring a restart, and
   // multiple booting instances can't all sweep concurrently — the first to
-  // grab the lock does it.
-  scheduleAligned(TRIGGER_SCHEDULER_INTERVAL_MS, async () => {
+  // grab the lock does it. Each sweep is wrapped independently so one failing
+  // doesn't skip the others.
+  scheduleAligned(SCHEDULER_INTERVAL_MS, async () => {
     await runWithLock(async () => {
       try {
         await recoverStuckTriggers();
       } catch (error) {
         logger.error({ error }, "Trigger recovery sweep failed");
+      }
+      try {
+        await recoverStuckChats();
+      } catch (error) {
+        logger.error({ error }, "Chat recovery sweep failed");
       }
       await processDueTriggers();
     });

--- a/apps/backend/src/routes/chat.ts
+++ b/apps/backend/src/routes/chat.ts
@@ -32,36 +32,7 @@ import {
   resolveMemoryPin,
   retrieveRecentSummaries,
 } from "../services/memory-retrieval.ts";
-
-/**
- * The bounds an interactive Chat run is given.
- *
- * Chat used to take the registry's own defaults, which are deliberately tight
- * because they are what an unbounded caller falls back to. That gave a watched
- * conversation a 10-minute ceiling — shorter than a long agentic turn — and no
- * way for an Operator to raise it (issue #552).
- *
- * The per-step bound is an idle timeout: time with no streamed chunk at all,
- * not time spent on one step. Two minutes of complete silence from a provider
- * is a stall worth acting on; a long answer is not, and no longer trips it.
- *
- * Override via env:
- *  - `CHAT_PER_STEP_TIMEOUT_MS` (default 2 min)
- *  - `CHAT_PER_RUN_TIMEOUT_MS` (default 30 min)
- */
-const DEFAULT_CHAT_PER_STEP_TIMEOUT_MS = 2 * 60 * 1000;
-const DEFAULT_CHAT_PER_RUN_TIMEOUT_MS = 30 * 60 * 1000;
-
-const chatTimeouts = () => ({
-  perStepTimeoutMs: parseInt(
-    process.env.CHAT_PER_STEP_TIMEOUT_MS ??
-      String(DEFAULT_CHAT_PER_STEP_TIMEOUT_MS),
-  ),
-  perRunTimeoutMs: parseInt(
-    process.env.CHAT_PER_RUN_TIMEOUT_MS ??
-      String(DEFAULT_CHAT_PER_RUN_TIMEOUT_MS),
-  ),
-});
+import { chatTimeouts } from "../runs/chat-timeouts.ts";
 
 // --- Routes ---
 

--- a/apps/backend/src/runs/chat-timeouts.ts
+++ b/apps/backend/src/runs/chat-timeouts.ts
@@ -1,0 +1,40 @@
+/**
+ * The bounds an interactive Chat run is given.
+ *
+ * Chat used to take the registry's own defaults, which are deliberately tight
+ * because they are what an unbounded caller falls back to. That gave a watched
+ * conversation a 10-minute ceiling — shorter than a long agentic turn — and no
+ * way for an Operator to raise it (issue #552).
+ *
+ * The per-step bound is an idle timeout: time with no streamed chunk at all,
+ * not time spent on one step. Two minutes of complete silence from a provider
+ * is a stall worth acting on; a long answer is not, and no longer trips it.
+ *
+ * Override via env:
+ *  - `CHAT_PER_STEP_TIMEOUT_MS` (default 2 min)
+ *  - `CHAT_PER_RUN_TIMEOUT_MS` (default 30 min)
+ *
+ * Horizontal scaling: `CHAT_PER_RUN_TIMEOUT_MS` is read per process, and the
+ * scheduler's stuck-Chat sweep derives its staleness cutoff from it (see
+ * `jobs/scheduler.ts`). Every instance sharing a database MUST be given the
+ * same value — an instance configured with a shorter one computes an earlier
+ * cutoff and could fail a turn a peer is still running.
+ */
+export const DEFAULT_CHAT_PER_STEP_TIMEOUT_MS = 2 * 60 * 1000;
+export const DEFAULT_CHAT_PER_RUN_TIMEOUT_MS = 30 * 60 * 1000;
+
+/** The configured wall-clock ceiling for a whole Chat turn. */
+export const chatPerRunTimeoutMs = (): number =>
+  parseInt(
+    process.env.CHAT_PER_RUN_TIMEOUT_MS ??
+      String(DEFAULT_CHAT_PER_RUN_TIMEOUT_MS),
+  );
+
+/** The per-step and per-run bounds handed to the run registry for a Chat turn. */
+export const chatTimeouts = () => ({
+  perStepTimeoutMs: parseInt(
+    process.env.CHAT_PER_STEP_TIMEOUT_MS ??
+      String(DEFAULT_CHAT_PER_STEP_TIMEOUT_MS),
+  ),
+  perRunTimeoutMs: chatPerRunTimeoutMs(),
+});

--- a/apps/docs/content/reference/backend-configuration.mdx
+++ b/apps/docs/content/reference/backend-configuration.mdx
@@ -131,17 +131,21 @@ When either bound stops a turn, the reason is shown in the chat rather than the
 answer simply ending.
 
 If the backend is killed mid-turn, neither bound gets the chance to run, so the
-chat would otherwise stay marked as running for ever — the sidebar keeps
-spinning and the composer stays disabled. A background sweep now marks those
-chats failed once they are older than `CHAT_PER_RUN_TIMEOUT_MS` plus a
-five-minute grace period, and it runs once a minute, so a chat abandoned by a
-crash frees itself roughly 35 minutes later on the defaults.
+Chat would otherwise stay marked as running for ever — the sidebar keeps
+spinning and the composer stays disabled. A background sweep marks those Chats
+failed once they are older than `CHAT_PER_RUN_TIMEOUT_MS` plus a five-minute
+grace period, and it runs once a minute, so a Chat abandoned by a crash frees
+itself roughly 35 minutes later on the defaults.
 
-If you run more than one backend against the same database, give every instance
-the same `CHAT_PER_RUN_TIMEOUT_MS`. The sweep uses it to work out which chats
-are old enough to have no live owner; an instance configured with a shorter
-value would decide too early and could mark another instance's live turn as
-failed.
+<Callout type="warning">
+  Running several backends against one database looks like it needs no
+  co-ordination, because each turn belongs to the instance serving it. The
+  sweep is the exception: it decides which Chats are old enough to have no
+  live owner, and it decides that from its own
+  `CHAT_PER_RUN_TIMEOUT_MS`. Give an instance a shorter value than its peers
+  and it will mark their live turns as failed mid-answer. Set the same value
+  on every instance.
+</Callout>
 
 ## Tools
 

--- a/apps/docs/content/reference/backend-configuration.mdx
+++ b/apps/docs/content/reference/backend-configuration.mdx
@@ -130,6 +130,19 @@ through.
 When either bound stops a turn, the reason is shown in the chat rather than the
 answer simply ending.
 
+If the backend is killed mid-turn, neither bound gets the chance to run, so the
+chat would otherwise stay marked as running for ever — the sidebar keeps
+spinning and the composer stays disabled. A background sweep now marks those
+chats failed once they are older than `CHAT_PER_RUN_TIMEOUT_MS` plus a
+five-minute grace period, and it runs once a minute, so a chat abandoned by a
+crash frees itself roughly 35 minutes later on the defaults.
+
+If you run more than one backend against the same database, give every instance
+the same `CHAT_PER_RUN_TIMEOUT_MS`. The sweep uses it to work out which chats
+are old enough to have no live owner; an instance configured with a shorter
+value would decide too early and could mark another instance's live turn as
+failed.
+
 ## Tools
 
 | Variable                        | Purpose                                                                                                                                   | Default                 | Required |

--- a/apps/docs/content/reference/backend-configuration.mdx
+++ b/apps/docs/content/reference/backend-configuration.mdx
@@ -97,8 +97,8 @@ for the seeding rule and the recovery path.
 | Variable                         | Purpose                                                               | Default              | Required |
 | -------------------------------- | --------------------------------------------------------------------- | -------------------- | -------- |
 | `MEMORY_EXTRACTION_INTERVAL_MS`  | How often the memory-extraction worker runs, in milliseconds.         | `300000` (5 minutes) | No       |
-| `SCHEDULE_SCHEDULER_INTERVAL_MS` | How often the schedule scheduler polls for due runs, in milliseconds. | `60000` (1 minute)   | No       |
-| `SCHEDULE_MAX_CONCURRENT`        | Maximum parallel schedule executions.                                 | `5`                  | No       |
+| `SCHEDULE_SCHEDULER_INTERVAL_MS` | How often the scheduler runs, in milliseconds. Each pass starts due Triggers and recovers runs and Chats abandoned by a crash. | `60000` (1 minute)   | No       |
+| `SCHEDULE_MAX_CONCURRENT`        | Maximum parallel Trigger executions.                                  | `5`                  | No       |
 
 ## Triggers
 


### PR DESCRIPTION
Closes #762

A Chat whose row is `running` when the backend process dies stays that way for ever. The per-run and per-step timeouts that would end the turn are `setTimeout` handles in the in-memory run registry, so a crash takes them with it, and the run sink — the only writer of a terminal status — never gets to run. Nothing else in the deployment moves the row: startup doesn't query it, `POST /chat/:chatId/cancel` is a pass-through to the same in-memory registry, and `status` isn't writable through the API.

One row, three user-visible faults: a sidebar spinner that never stops, a composer the frontend keeps disabled, and — since #761 — a Chat-list poll every 3s for as long as the tab is open. Today the only escape is deleting the Chat or running a manual `UPDATE`.

## What this does

Adds `recoverStuckChats()` to the scheduler's existing per-minute tick, under the advisory lock already held there. It marks `running` Chats `failed` once they are older than `CHAT_PER_RUN_TIMEOUT_MS` plus a five-minute buffer — roughly 35 minutes on the defaults, where today there is no bound at all — and logs the sweep at `warn` with the row count and cutoff. `failed`, not `cancelled`: nobody requested a cancellation.

Three details decide whether it is correct:

- **Age is anchored on `lastTurnAt`**, the run sink's own turn-boundary signal, never on `updatedAt` — auto-titling and memory extraction bump `updatedAt` at their own cadence, so a background write on a dead Chat would keep the row looking recent and the sweep would never fire. Rows predating the column fall back to `updatedAt`. Written as two disjuncts rather than a `COALESCE` so both comparisons stay on real columns and drizzle binds the cutoff through each column's own encoder, exactly as the Trigger sweep does.
- **The cutoff derives from the Chat timeout, not the Trigger one.** `DEFAULT_PER_RUN_TIMEOUT_MS` is three times shorter and would fail live turns.
- **Safety against a peer instance is the age cutoff, not the lock.** A live instance would have aborted anything older than its own per-run timeout, so a row past the cutoff has no live owner. The lock only serializes concurrent sweeps.

One risk the Trigger sweep does not carry: `CHAT_PER_RUN_TIMEOUT_MS` is an environment variable read per process, where the Trigger timeout is a code constant. An instance given a shorter value than its peers computes an earlier cutoff and could fail their live turns. That requirement is called out in `runs/chat-timeouts.ts`, on `stuckChatCutoff()`, and as a warning callout in the configuration reference.

## Also here

- The Chat timeouts move from `routes/chat.ts` to `runs/chat-timeouts.ts`, so the scheduler can read the per-run bound without importing the route tree.
- `jobs/trigger-scheduler.ts` → `jobs/scheduler.ts`, `startTriggerScheduler` → `startScheduler`, `TRIGGER_SCHEDULER_LOCK_ID` → `SCHEDULER_LOCK_ID`. **The lock's numeric value `987654321` is unchanged** — changing it would let an old and a new instance sweep simultaneously during a rolling deploy. `memory-scheduler.ts` is untouched.
- `SCHEDULE_SCHEDULER_INTERVAL_MS` was documented as polling "for due runs", which this change invalidates: the tick now also drives both recovery sweeps. Description corrected; the variable names are deliberately unchanged, since renaming them would break existing deployments' configuration.

## Testing

`pnpm typecheck`, `pnpm lint`, and the full suite pass (2462 backend, 691 frontend, docs contract 45/45).

The unit tests pin the sweep's predicate exactly — the rendered SQL and its bound parameters — which fails if the comparison flips direction, the anchor moves off `lastTurnAt`, or the `running` guard is dropped. Confirmed by mutating `lt` to `gt` and watching it fail.

**One acceptance criterion is only partially met, and reviewers should know it.** The issue asks for coverage of the cutoff boundary with a row either side of it. That comparison executes in Postgres, and this repo's test suite has no database, so no unit test actually runs a row through it — what is here pins the query's shape, not its execution. Closing the gap properly means adding an in-process database to the test suite (`@electric-sql/pglite` would do it), which is a new dependency and a new testing pattern for the repo, so it is left as a separate decision rather than smuggled into a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
