### PR TITLE
fix(backend): run the backend container as a non-root user

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -50,19 +50,39 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-# Don't run production as root
-RUN addgroup --system --gid 1001 nodejs && \
-    adduser --system --uid 1001 hono && \
-    mkdir -p /data/files && chown hono:nodejs /data/files
+# `su-exec` lets the entrypoint drop from root to `platypus` once it has
+# repaired the ownership of a bind-mounted /data.
+RUN apk add --no-cache su-exec
+
+# Don't run production as root. uid/gid 1001 is the part of this identity that
+# leaves the image — a bind-mounted /data has to match it — so it is fixed;
+# the account name is not, and both images use `platypus`.
+RUN addgroup --system --gid 1001 platypus && \
+    adduser --system --uid 1001 --ingroup platypus platypus && \
+    mkdir -p /data/files && chown -R platypus:platypus /data
+
+# WORKDIR created /app as root:root, and only the *contents* of the copies below
+# carry --chown. The STORAGE_DISK_PATH default resolves to /app/data/files, so
+# the directory itself has to be writable or the app cannot create it.
+RUN chown platypus:platypus /app
 
 # Copy prod dependencies (includes root node_modules and workspace node_modules)
-COPY --from=prod-deps /app .
+COPY --from=prod-deps --chown=platypus:platypus /app .
 
 # Copy source code
-COPY --from=builder /app/out/full/ .
+COPY --from=builder --chown=platypus:platypus /app/out/full/ .
+
+COPY --chown=platypus:platypus apps/backend/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Expose port
 EXPOSE 4000
+
+# The entrypoint fixes ownership of the bind-mounted /data and then drops to
+# `platypus`, so the server below never runs as root. Deployments that would
+# rather the container never start as root at all can set `--user 1001:1001`
+# and take on making /data writable by that uid themselves.
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 # Run migrations and start the server
 CMD ["sh", "-c", "node ./apps/backend/scripts/migrate.ts && node --env-file-if-exists=./apps/backend/.env ./apps/backend/index.ts"]

--- a/apps/backend/docker-entrypoint.sh
+++ b/apps/backend/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+# Platypus runs as `platypus` (uid 1001, gid 1001). Two directories have to be
+# writable by that account, and only one of them can be settled while the image
+# is being built:
+#
+#   - Everything under /app, including the STORAGE_DISK_PATH default of
+#     ./data/files. The Dockerfile owns this; nothing here needs to.
+#   - /data, which compose.yaml bind-mounts from the host. On Linux a bind mount
+#     keeps the host directory's ownership and masks whatever the build set, so
+#     an existing deployment whose ./data belongs to some other uid would hit
+#     EACCES on the first upload. It can only be repaired once the mount is in
+#     place, which is here.
+#
+# Started as root, we repair that ownership and then drop to `platypus`, so the
+# application itself never runs privileged. Started as an explicit non-root user
+# (`docker run --user`, Kubernetes `runAsUser`) we cannot chown anything, so we
+# leave the mount alone and exec as whoever we already are — that deployment has
+# taken ownership of the problem itself and the host directory must already be
+# writable by its uid.
+if [ "$(id -u)" = "0" ]; then
+  for dir in /data "${STORAGE_DISK_PATH:-}"; do
+    [ -n "$dir" ] || continue
+    [ -d "$dir" ] || mkdir -p "$dir"
+    # Recursing a large store on every restart is wasteful, and the common case
+    # is a directory this container already owns. Only walk it when the top of
+    # the tree says the owner is somebody else.
+    if [ "$(stat -c %u "$dir")" != "1001" ]; then
+      chown -R platypus:platypus "$dir"
+    fi
+  done
+  exec su-exec platypus "$@"
+fi
+
+exec "$@"

--- a/apps/docs/content/self-hosting/docker-compose.mdx
+++ b/apps/docs/content/self-hosting/docker-compose.mdx
@@ -98,6 +98,36 @@ a model server running on the host machine rather than in the stack — see
 - `./data` — a bind mount into the backend at `/data`, used by the default
   disk storage backend for uploaded files.
 
+#### File ownership on `./data`
+
+The backend serves requests as an unprivileged account, uid **1001**, rather
+than as root. Everything inside the image is already owned by it; a bind mount
+is the exception, because it keeps whatever ownership the directory has on the
+host.
+
+You do not normally have to do anything about this. The container starts as
+root, takes ownership of `/data` if it belongs to somebody else, and only then
+drops to uid 1001 — so an existing `./data` full of uploads keeps working across
+an upgrade, and a fresh one is created correctly.
+
+Two cases do need you:
+
+- **You pin the container to a user yourself** — a `user:` key in
+  `compose.yaml`, `docker run --user`, or a Kubernetes `runAsUser`. The
+  container can no longer change ownership of anything, so make the host
+  directory writable by the uid you pinned it to:
+
+  ```bash
+  sudo chown -R 1001:1001 ./data
+  ```
+
+- **`./data` sits on a filesystem that does not carry Unix ownership** — an NFS
+  export with root squash, or an SMB share. Ownership there is decided by the
+  mount, not by the container, so set it at mount time.
+
+Uploads failing with a permission error, on a stack that is otherwise healthy,
+is the symptom of both.
+
 ## First boot
 
 <Steps>

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -57,17 +57,18 @@ ENV NODE_ENV=production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 ENV NEXT_TELEMETRY_DISABLED=1
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+# uid/gid 1001 is fixed; the account name matches the backend image.
+RUN addgroup --system --gid 1001 platypus
+RUN adduser --system --uid 1001 --ingroup platypus platypus
 
 COPY --from=builder /app/apps/frontend/public ./apps/frontend/public
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/.next/static ./apps/frontend/.next/static
+COPY --from=builder --chown=platypus:platypus /app/apps/frontend/.next/standalone ./
+COPY --from=builder --chown=platypus:platypus /app/apps/frontend/.next/static ./apps/frontend/.next/static
 
-USER nextjs
+USER platypus
 
 EXPOSE 3000
 


### PR DESCRIPTION
Closes #722.

The backend image created a `hono` user but never switched to it, so the container ran as root. Both images also now use one account name, `platypus`, as agreed during triage.

## Why an entrypoint rather than a plain `USER`

Switching naively breaks file storage in two ways, both called out on the issue:

1. `WORKDIR /app` is created root-owned and only the *contents* of the copies carry `--chown`. `STORAGE_DISK_PATH` defaults to `./data/files` → `/app/data/files`, which the app then cannot create.
2. `compose.yaml` bind-mounts `./data:/data`. On Linux a bind mount keeps the host directory's ownership and masks the image's build-time `chown`, so an existing deployment whose `./data` belongs to another uid fails every upload with `EACCES` after an image bump.

(1) is fixed at build time by chowning `/app` itself. (2) cannot be — the mount does not exist until runtime. So the container starts as root, repairs `/data` if it belongs to someone else, and `su-exec`s down to `platypus` before the server starts. **The server process never runs privileged**; the image simply has no `USER` line, so `docker inspect` will show none.

The alternative — requiring operators to pre-chown `./data` to uid 1001 — would silently break every existing deployment on upgrade. This way the upgrade is a no-op for them. Deployments that would rather the container never start as root at all can pass `--user 1001:1001` and own the problem themselves; the entrypoint detects that, skips the chown, and execs as-is.

The chown is guarded by a `stat` on the top of the tree, so a store this container already owns is not walked recursively on every restart.

## Naming

Both images: user and group `platypus`, uid/gid **1001** unchanged. uid/gid is the only half of that identity that leaves the image — it is what a bind-mounted `./data` has to match — so it is fixed. Nothing in the repo referenced the old names: no `user:` in `compose.yaml`, no k8s or Helm manifests, nothing in the docs.

Both images also now pass `--ingroup`, without which the primary group was never actually set — `--chown=<user>:nodejs` read as group-based but wasn't. `id -gn` now returns `platypus` rather than falling through.

## Docs

`self-hosting/docker-compose.mdx` gains a "File ownership on `./data`" subsection under Volumes, written in terms of uid 1001 rather than the account name: the default (nothing to do), the pinned-`user:` case, and the NFS/SMB case where ownership is decided at mount time.

## Verification

Both images built; all four entrypoint branches exercised. A named volume pre-chowned to uid 4242 stands in for the foreign-owned bind mount — it drives the same entrypoint branch without Docker Desktop's virtiofs remapping the ownership out from under the test.

| Case | Result |
| --- | --- |
| `id -gn`, both images | `platypus` |
| Foreign-owned (4242) volume | repaired to 1001, dropped to `platypus`, wrote a new file, pre-existing file intact |
| `--user 1001:1001`, volume owned by 1001 | execs directly, writes fine |
| `--user 1001:1001`, foreign volume | no crash, write refused — the documented outcome |
| Frontend | HTTP 200, serving process uid 1001 |

Docs contract test passes.

**Still wants a Linux check before merge.** The named-volume proxy exercises the logic faithfully but is not a real bind mount, which is the `ready-for-human` gate on #722. Minimum bar from the issue: run `compose.yaml` on a Linux host with a pre-existing `./data` owned by a different uid, upload a file to a Chat, read it back.

## Noted, not fixed here

`STORAGE_DISK_PATH` defaults to `./data/files` → `/app/data/files`, but `compose.yaml` mounts `./data:/data`. Unless an operator sets `STORAGE_DISK_PATH=/data/files`, uploads land inside the container and die with it — the bind mount is inert. That is a pre-existing data-loss bug independent of this change, and changing the default would relocate existing installs' files, so it is filed separately as #767.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
