### PR TITLE
fix(frontend): make the composer mic button start dictation

### DIFF
--- a/apps/frontend/components/ai-elements/prompt-input.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.tsx
@@ -799,6 +799,7 @@ export const PromptInputSpeechButton = ({
   className,
   textareaRef,
   onTranscriptionChange,
+  onClick,
   ...props
 }: PromptInputSpeechButtonProps) => {
   const { isListening, isSupported, toggleListening } = useSpeechToText({
@@ -814,7 +815,15 @@ export const PromptInputSpeechButton = ({
         className,
       )}
       disabled={!isSupported}
-      onClick={toggleListening}
+      // `onClick` is taken out of the spread and composed here, the way
+      // PromptInputTextarea handles `onKeyDown` (issue #710). A caller rarely
+      // writes one by hand, but wrapping this button in a Radix trigger with
+      // `asChild` injects one, and left in the spread below it would replace
+      // the toggle outright — dictation then never starts (issue #752).
+      onClick={(event) => {
+        onClick?.(event);
+        toggleListening();
+      }}
       {...props}
     >
       <MicIcon className="size-4" />

--- a/apps/frontend/components/composer.test.tsx
+++ b/apps/frontend/components/composer.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useRef, useState } from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import type { Provider } from "@platypus/schemas";
 import { Composer } from "./composer";
+import { PromptInputSpeechButton } from "./ai-elements/prompt-input";
 
 /**
  * Issue #749: closing the model picker used to move focus twice — Radix
@@ -15,6 +16,31 @@ import { Composer } from "./composer";
  * without passing through the trigger. Confirming the keyboard itself needs a
  * physical device.
  */
+
+class FakeSpeechRecognition extends EventTarget {
+  continuous = false;
+  interimResults = false;
+  lang = "";
+  start = vi.fn(() => this.onstart?.(new Event("start")));
+  stop = vi.fn(() => this.onend?.(new Event("end")));
+  onstart: ((ev: Event) => void) | null = null;
+  onend: ((ev: Event) => void) | null = null;
+  onresult: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+}
+
+let lastRecognition: FakeSpeechRecognition | null = null;
+
+const registerRecognition = (instance: FakeSpeechRecognition) => {
+  lastRecognition = instance;
+};
+
+class TrackingSpeechRecognition extends FakeSpeechRecognition {
+  constructor() {
+    super();
+    registerRecognition(this);
+  }
+}
 
 const provider = {
   id: "provider-1",
@@ -63,6 +89,7 @@ const renderComposer = () => {
     onModelChange,
     textarea: screen.getByPlaceholderText("Ask anything"),
     trigger: screen.getByText("Select model").closest("button")!,
+    mic: screen.getByRole("button", { name: "Microphone" }),
   };
 };
 
@@ -92,6 +119,13 @@ beforeEach(() => {
     unobserve() {}
     disconnect() {}
   } as unknown as typeof ResizeObserver;
+  lastRecognition = null;
+  window.SpeechRecognition =
+    TrackingSpeechRecognition as unknown as Window["SpeechRecognition"];
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(window, "SpeechRecognition");
 });
 
 describe("Composer model picker focus", () => {
@@ -128,5 +162,49 @@ describe("Composer model picker focus", () => {
     // regression: on mobile it drops the keyboard before the textarea reopens it.
     expect(focused).toEqual([textarea]);
     expect(focused).not.toContain(trigger);
+  });
+});
+
+/**
+ * Issue #752: the mic button wrote its own `onClick` before spreading caller
+ * props, so the `onClick` that Radix's TooltipTrigger injects through `asChild`
+ * replaced it. The tap closed the tooltip and did nothing else, so dictation
+ * never started - on any platform, not just the Android one it was reported on.
+ *
+ * These drive the composer as a user meets it, mic inside its tooltip trigger,
+ * because that wrapper is the whole defect. Asserting on a transcript alone
+ * cannot catch it: recognition is constructed on mount, so a test that emits a
+ * result directly on it passes whether or not the click ever landed.
+ */
+describe("Composer dictation", () => {
+  it("starts recognition when the mic is clicked", () => {
+    const { mic } = renderComposer();
+
+    fireEvent.click(mic);
+
+    expect(lastRecognition?.start).toHaveBeenCalled();
+  });
+
+  it("stops recognition when the mic is clicked again", () => {
+    const { mic } = renderComposer();
+
+    fireEvent.click(mic);
+    fireEvent.click(mic);
+
+    expect(lastRecognition?.stop).toHaveBeenCalled();
+  });
+
+  it("still runs an onClick supplied by a wrapping trigger", () => {
+    const onClick = vi.fn();
+    render(
+      <PromptInputSpeechButton aria-label="Microphone" onClick={onClick} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Microphone" }));
+
+    // Both run: the wrapper keeps its behaviour - a tooltip still closes on
+    // tap - and the button keeps its own.
+    expect(onClick).toHaveBeenCalled();
+    expect(lastRecognition?.start).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #752.

## What was wrong

`PromptInputSpeechButton` wrote `onClick={toggleListening}` **before** spreading
the caller's props, so any incoming `onClick` silently replaced it.

The composer wraps that button in a Radix `TooltipTrigger` with `asChild`.
Radix's Slot composes an event handler only for keys that exist on the child
element — the mic button is written with no `onClick` of its own, so the merged
handler handed down was purely the tooltip's internal close handler. It arrived
in `props`, was spread last, and overwrote the toggle. Tapping the mic closed
the tooltip and did nothing else.

`recognition.start()` was never reached, which is why no permission prompt
appeared, the listening state never engaged, and no transcript arrived. Despite
the report being filed against Chrome for Android, **this was not
platform-specific** — dictation was dead on every browser. It reproduces in
jsdom.

This also rules out the two theories on the issue: the tap does reach the button
(Radix composes handlers, it never calls `preventDefault` on the click), and the
environment was a secure context all along. The tooltip flash on first tap is
ordinary touch behaviour — focus opens it, the click closes it — not the defect.

## The fix

Take `onClick` out of the spread and compose it, exactly as
`PromptInputTextarea` already handles `onKeyDown` (#710) and as
`SidebarTrigger` handles its own click. A wrapping trigger keeps its behaviour,
the button keeps its own.

## Why the existing test missed it

`message-editor.test.tsx` clicks the mic and then emits a result directly on the
recognition object. Recognition is constructed on mount, so that test passes
whether or not the click ever landed — it pins the transcript-to-textarea
wiring, not the button.

The three new tests drive the composer as a user meets it, mic inside its real
tooltip trigger: recognition starts on click, stops on a second click, and a
caller-supplied `onClick` still runs alongside the toggle. I checked they aren't
vacuous — with the fix reverted, all three fail.

## Scope

A sweep of every `.tsx` in the frontend for the same shape (a component writing
its own `on*` handler and then spreading caller props after it) found 18
matches. This mic button is the only live defect. Details are in a comment on
the issue; the dormant cases — `CodeBlockCopyButton`, `MessageBranchPrevious`,
`MessageBranchNext`, `SidebarRail`, and the carousel primitives, none of which
have call sites — are deliberately left alone.

No docs change is due: no env var, schema bound, plugin, or visible label
changes, and `building-with-platypus/chat.mdx` already documents voice input as
working.

## Verification

`pnpm test` (697 tests, 62 files), `pnpm typecheck`, and `pnpm lint` all pass.

Everything here is verified in jsdom. The prop-ordering defect is definitively
gone, but whether dictation then works end to end on Chrome for Android —
permission prompt, Google speech services, `continuous = true` — is untested and
needs a tap on a physical device.

Recognition errors still only reach `console.error`, which is what made this
invisible to diagnose on a phone in the first place. That is filed separately
rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
