### PR TITLE
chore(docs): mark ADR-0019 as pending implementation

### DIFF
--- a/docs/adr/0019-invitations-are-redeemable-into-accounts.md
+++ b/docs/adr/0019-invitations-are-redeemable-into-accounts.md
@@ -1,8 +1,19 @@
 ---
-status: accepted
+status: accepted-pending-implementation
+implemented-by: "#549, #550"
 ---
 
 # Invitations are redeemable into accounts
+
+> **In the code today.** None of this is built yet. An invitation carries no
+> token and there is no redemption link: the row is still matched to an
+> _existing_ account by email address, exactly as ADR-0008 and ADR-0009
+> describe, so the invitee must already hold an account before the invitation
+> is visible to them. Registration is open, and there is no Operator switch to
+> require an invitation. [#549](https://github.com/willdady/platypus/issues/549)
+> builds the token and the redeeming link;
+> [#550](https://github.com/willdady/platypus/issues/550) adds the Operator
+> switch. See `apps/backend/src/routes/invitation.ts`.
 
 Extends ADR-0008 and ADR-0009. Those ADRs treat an invitation as a row matched to an
 _existing_ account by email address, which makes the invitation useless as an admission


### PR DESCRIPTION
Found by `/pre-release-check` while reconciling `v3.2.0..main` for the 3.2.1 release.

ADR-0019 *Invitations are redeemable into accounts* carries `status: accepted`, which `docs/adr/README.md` defines as "decided, **and the code matches**". The code does not match — none of it is built:

- `invitation` has no `token` column (`apps/backend/src/db/schema.ts`).
- There is no redemption route; `apps/backend/src/routes/invitation.ts` and `user-invitation.ts` contain no redemption path.
- Neither `disableSignUp` nor `REQUIRE_INVITATION_TO_SIGN_UP` appears anywhere in `apps` or `packages`.
- Both implementing issues, #549 and #550, are still open.

Invitations are still matched to an existing account by email address, the ADR-0008 / ADR-0009 model that ADR-0019 says it replaces. #548 reinforced that model this cycle by lower-casing the stored address so the exact-equality predicate can match.

So the release would publish an ADR asserting its own decision is live code, and a reader would go looking for a token flow that does not exist — precisely what `accepted-pending-implementation` exists to prevent.

## What this changes

Status and the two keys that state requires, following the shape ADR-0022 used while it was pending:

- `status: accepted-pending-implementation`
- `implemented-by: "#549, #550"`
- an "In the code today" admonition under the title, saying what the code actually does

**The ADR's own text is untouched** — the repo's rule is that an ADR keeps its history.

Flipping back to `accepted` and dropping the admonition is now acceptance criteria on #549 / #550.

## Verification

- `pnpm format` leaves the file unchanged.
- `apps/docs/content/docs-contract.test.ts` passes (45/45) — internal links and heading anchors intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)