### PR TITLE
fix(frontend): stop dictation repeating finalized transcripts

### DIFF
--- a/apps/frontend/hooks/use-speech-to-text.test.tsx
+++ b/apps/frontend/hooks/use-speech-to-text.test.tsx
@@ -18,17 +18,29 @@ class FakeSpeechRecognition extends EventTarget {
   onerror: ((ev: unknown) => void) | null = null;
 
   emitFinalResult(transcript: string) {
-    this.onresult?.({
-      resultIndex: 0,
-      results: {
+    this.emitResults([{ transcript, isFinal: true }]);
+  }
+
+  /**
+   * Emits one `onresult` carrying the whole result list, the way Chrome on
+   * Android does: every result seen so far in the session, `resultIndex`
+   * back at 0.
+   */
+  emitResults(
+    entries: { transcript: string; isFinal: boolean }[],
+    resultIndex = 0,
+  ) {
+    const results: Record<string | number, unknown> = {
+      length: entries.length,
+    };
+    entries.forEach((entry, index) => {
+      results[index] = {
+        isFinal: entry.isFinal,
         length: 1,
-        0: {
-          isFinal: true,
-          length: 1,
-          0: { transcript, confidence: 1 },
-        },
-      },
+        0: { transcript: entry.transcript, confidence: 1 },
+      };
     });
+    this.onresult?.({ resultIndex, results });
   }
 }
 
@@ -94,6 +106,87 @@ describe("useSpeechToText", () => {
     expect(inputHandler).toHaveBeenCalledTimes(1);
     expect(onTranscriptionChange).toHaveBeenCalledWith("hello world");
     expect(result.current.transcript).toBe("hello world");
+  });
+
+  it("ignores results already appended when the engine replays them", () => {
+    const textarea = document.createElement("textarea");
+    const textareaRef = { current: textarea };
+    const onTranscriptionChange = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSpeechToText({ textareaRef, onTranscriptionChange }),
+    );
+
+    act(() => result.current.toggleListening());
+
+    act(() =>
+      lastInstance?.emitResults([{ transcript: "one", isFinal: true }]),
+    );
+    expect(textarea.value).toBe("one");
+
+    // Android re-sends the finalised "one" alongside the new " two".
+    act(() =>
+      lastInstance?.emitResults([
+        { transcript: "one", isFinal: true },
+        { transcript: " two", isFinal: true },
+      ]),
+    );
+
+    expect(textarea.value).toBe("one  two");
+    expect(onTranscriptionChange).toHaveBeenLastCalledWith("one  two");
+  });
+
+  it("does not re-append a final result promoted from an interim one", () => {
+    const textarea = document.createElement("textarea");
+    const textareaRef = { current: textarea };
+
+    const { result } = renderHook(() => useSpeechToText({ textareaRef }));
+
+    act(() => result.current.toggleListening());
+
+    act(() =>
+      lastInstance?.emitResults([{ transcript: "hello", isFinal: false }]),
+    );
+    expect(textarea.value).toBe("");
+
+    act(() =>
+      lastInstance?.emitResults([{ transcript: "hello", isFinal: true }]),
+    );
+    expect(textarea.value).toBe("hello");
+
+    act(() =>
+      lastInstance?.emitResults([
+        { transcript: "hello", isFinal: true },
+        { transcript: "there", isFinal: false },
+      ]),
+    );
+    expect(textarea.value).toBe("hello");
+  });
+
+  it("starts a fresh count when a new session replaces the result list", () => {
+    const textarea = document.createElement("textarea");
+    const textareaRef = { current: textarea };
+
+    const { result } = renderHook(() => useSpeechToText({ textareaRef }));
+
+    act(() => result.current.toggleListening());
+    act(() =>
+      lastInstance?.emitResults([
+        { transcript: "one", isFinal: true },
+        { transcript: " two", isFinal: true },
+      ]),
+    );
+    expect(textarea.value).toBe("one two");
+
+    // Android drops `continuous` and ends the session after an utterance; the
+    // next one starts a result list of its own.
+    act(() => result.current.toggleListening());
+    act(() => result.current.toggleListening());
+    act(() =>
+      lastInstance?.emitResults([{ transcript: "three", isFinal: true }]),
+    );
+
+    expect(textarea.value).toBe("one two three");
   });
 
   it("stops recognition on unmount", () => {

--- a/apps/frontend/hooks/use-speech-to-text.ts
+++ b/apps/frontend/hooks/use-speech-to-text.ts
@@ -78,6 +78,11 @@ export function useSpeechToText({
   const [isSupported, setIsSupported] = useState(false);
   const [transcript, setTranscript] = useState("");
   const recognitionRef = useRef<SpeechRecognition | null>(null);
+  // How many entries of the current session's result list have already been
+  // appended. Chrome on Android re-delivers results that were finalised
+  // earlier in the session with `resultIndex` back at 0, so `resultIndex`
+  // alone cannot tell new speech from a replay and the text doubles up.
+  const consumedResultsRef = useRef(0);
 
   useEffect(() => {
     if (
@@ -96,6 +101,7 @@ export function useSpeechToText({
     recognition.lang = "en-US";
 
     recognition.onstart = () => {
+      consumedResultsRef.current = 0;
       setIsListening(true);
     };
 
@@ -104,13 +110,23 @@ export function useSpeechToText({
     };
 
     recognition.onresult = (event) => {
+      // A shorter list than we have already consumed means the engine started
+      // a fresh list mid-session; the old indices no longer refer to anything.
+      if (event.results.length < consumedResultsRef.current) {
+        consumedResultsRef.current = 0;
+      }
+
       let finalTranscript = "";
 
-      for (let i = event.resultIndex; i < event.results.length; i++) {
+      for (let i = consumedResultsRef.current; i < event.results.length; i++) {
         const result = event.results[i];
-        if (result.isFinal) {
-          finalTranscript += result[0]?.transcript ?? "";
+        // Finalised results arrive in order and only the tail can still be
+        // interim, so stop here and pick this index up once it is final.
+        if (!result?.isFinal) {
+          break;
         }
+        finalTranscript += result[0]?.transcript ?? "";
+        consumedResultsRef.current = i + 1;
       }
 
       if (finalTranscript && textareaRef?.current) {


### PR DESCRIPTION
## What

Dictation on Android entered each phrase more than once. Speaking two phrases produced the first one twice.

## Why

`useSpeechToText`'s `onresult` walked `event.resultIndex` to the end of the result list and appended every final result it found. Chrome on Android re-delivers results that were finalized earlier in the same session with `resultIndex` back at 0, so every event re-appended everything before it. Desktop Chrome advances `resultIndex` as the spec describes, which is why this surfaced only on Android — and only now that #752 made the mic button reachable.

## How

Track how many entries of the session's result list have already been appended, rather than trusting `resultIndex`:

- the loop starts at that count and stops at the first non-final result (only the tail can still be interim), so an interim that is later finalized is appended exactly once;
- the count resets in `onstart`, and also when a shorter list arrives — Android ignores `continuous` and ends the session after each utterance, so the next one starts a result list of its own.

## Tests

The fake recognition object can now emit a whole result list the way Android does. Three new cases cover replayed finals, an interim promoted to final, and a new session replacing the list; the first two fail without this change.

Verified against those tests rather than on hardware, so it is worth a pass on a real Android device before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)