### PR TITLE
fix(frontend): keep the on-screen keyboard up when switching models

### DIFF
--- a/apps/frontend/components/composer.test.tsx
+++ b/apps/frontend/components/composer.test.tsx
@@ -6,14 +6,24 @@ import { Composer } from "./composer";
 import { PromptInputSpeechButton } from "./ai-elements/prompt-input";
 
 /**
- * Issue #749: closing the model picker used to move focus twice — Radix
- * returned it to the trigger button, then a 250ms timer moved it on to the
- * textarea. On mobile the intermediate stop on a button dismissed the
- * on-screen keyboard, and the timer reopened it about half a second later.
+ * Issue #749: switching models dropped the Android on-screen keyboard and
+ * brought it back a moment later. Chrome shows the keyboard while an editable
+ * element has focus, so anything that parks focus elsewhere in between is a
+ * flap, and the picker did it twice.
  *
- * jsdom has no virtual keyboard, so what these tests pin is the mechanism
- * underneath it: focus ends on the textarea, and it gets there in one move
- * without passing through the trigger. Confirming the keyboard itself needs a
+ * The first pass fixed the tail: Radix returned focus to the trigger button on
+ * close and a 250ms timer then moved it to the textarea, so the picker now
+ * takes over the close and focuses the textarea itself. That alone was not
+ * enough — a press inside the picker focuses the nearest focusable ancestor
+ * first, which is the trigger button on the way in and cmdk's scrolling list on
+ * the way out, and the list held focus for the dialog's whole exit animation.
+ * The picker suppresses the browser's focus-on-press for both.
+ *
+ * jsdom has no virtual keyboard and does not move focus on a press, so it
+ * cannot show either symptom. These tests pin what the fix rests on instead:
+ * the press is default-prevented, focus lands on the textarea in a single move,
+ * and neither opening nor selecting broke. The focus timeline it produces in a
+ * real browser was measured under mobile emulation; the keyboard itself needs a
  * physical device.
  */
 
@@ -162,6 +172,40 @@ describe("Composer model picker focus", () => {
     // regression: on mobile it drops the keyboard before the textarea reopens it.
     expect(focused).toEqual([textarea]);
     expect(focused).not.toContain(trigger);
+  });
+
+  // A press that is default-prevented never moves focus, so the textarea keeps
+  // it while the picker opens and the search box keeps it while the picker
+  // closes. `fireEvent` returns false for exactly that.
+  it("does not let a press on the trigger take focus off the composer", () => {
+    const { trigger } = renderComposer();
+
+    expect(fireEvent.mouseDown(trigger)).toBe(false);
+  });
+
+  it("does not let a press on a model take focus off the search box", () => {
+    const { trigger } = renderComposer();
+    const item = openPicker(trigger).closest("[cmdk-item]")!;
+
+    expect(fireEvent.mouseDown(item)).toBe(false);
+  });
+
+  it("still opens and switches model when the picker is pressed, not just clicked", async () => {
+    const { textarea, trigger, onModelChange } = renderComposer();
+
+    // Selection runs off `click`, which a prevented `mousedown` does not stop —
+    // press both the trigger and the model the way a real tap does.
+    fireEvent.mouseDown(trigger);
+    fireEvent.mouseUp(trigger);
+    fireEvent.click(trigger);
+
+    const item = screen.getByText("gpt-4o");
+    fireEvent.mouseDown(item);
+    fireEvent.mouseUp(item);
+    fireEvent.click(item);
+
+    expect(onModelChange).toHaveBeenCalled();
+    await waitFor(() => expect(document.activeElement).toBe(textarea));
   });
 });
 

--- a/apps/frontend/components/model-selector-dialog.tsx
+++ b/apps/frontend/components/model-selector-dialog.tsx
@@ -1,3 +1,4 @@
+import type { MouseEvent } from "react";
 import { Agent, Provider } from "@platypus/schemas";
 import {
   ModelSelector,
@@ -27,6 +28,24 @@ const filterByKeywords = (
   const haystack = (keywords ?? []).join(" ").toLowerCase();
   return haystack.includes(search.toLowerCase()) ? 1 : 0;
 };
+
+/**
+ * Stops a press from moving focus, which is what keeps the on-screen keyboard
+ * up across a model switch (issue #749).
+ *
+ * A press inside the picker otherwise focuses the nearest focusable ancestor:
+ * the trigger button on the way in, and — because a model row is not itself
+ * focusable — cmdk's scrolling list, which carries `tabindex="-1"`, on the way
+ * out. Neither is editable, and Chrome on Android drops the keyboard the moment
+ * focus leaves an editable element, so it falls away and then reappears once
+ * focus reaches the textarea. Suppressed, focus stays on the composer textarea
+ * while the picker opens and on the search box while it closes, moving only
+ * between editable elements, and the keyboard never leaves.
+ *
+ * Opening and selecting both run off `click`, so neither is affected, and Tab
+ * still reaches these elements for anyone using a hardware keyboard.
+ */
+const keepFocus = (event: MouseEvent) => event.preventDefault();
 
 interface ModelSelectorDialogProps {
   agents: Agent[];
@@ -81,6 +100,7 @@ export const ModelSelectorDialog = ({
       variant="outline"
       size="sm"
       className="max-w-40 overflow-hidden sm:max-w-none"
+      onMouseDown={keepFocus}
     >
       {selectedAgent && (
         <AgentAvatar agent={selectedAgent} className="size-4" />
@@ -123,6 +143,7 @@ export const ModelSelectorDialog = ({
                   value={encodeAgentSelection(agent.id)}
                   keywords={[agent.name]}
                   className="cursor-pointer"
+                  onMouseDown={keepFocus}
                   onSelect={() => {
                     onModelChange(encodeAgentSelection(agent.id));
                     onOpenChange(false);
@@ -144,6 +165,7 @@ export const ModelSelectorDialog = ({
                   className="cursor-pointer"
                   value={encodeProviderSelection(provider.id, model.value)}
                   keywords={[model.label, provider.name]}
+                  onMouseDown={keepFocus}
                   onSelect={() => {
                     onModelChange(
                       encodeProviderSelection(provider.id, model.value),


### PR DESCRIPTION
Fixes #749. #763 fixed a real defect, but not the one causing the reported flap — on an Android device the behaviour was unchanged.

## Why #763 missed it

#763 removed the tail of the sequence: Radix returned focus to the trigger button on close, and a 250ms timer then moved it on to the textarea. Collapsing that into `onCloseAutoFocus` shortened the keyboard's downtime from ~250ms to ~200ms, which is imperceptible.

The blur that actually drops the keyboard happens at **tap time**, long before `onCloseAutoFocus` runs, so taking over the close could never reach it.

## The cause

Chrome shows the on-screen keyboard only while an editable element holds focus, so any intermediate stop on a non-editable one drops it. Recording the focus timeline during a model switch under mobile emulation:

```
 855ms  focusout  [edit] input[command-input]     <- keyboard-holding element
 855ms  focusin   [    ] div[command-list]        <- not editable, keyboard hides
1071ms  focusout  [    ] div[command-list]        <- 195ms later, the exit animation
1073ms  focusin   [edit] textarea                 <- keyboard reopens
```

A press focuses the nearest focusable ancestor. A model row is not focusable, so focus lands on cmdk's scrolling list — it carries `tabindex="-1"` — and stays there for the dialog's whole 200ms exit animation. There is a second, shorter stop on the way in: the trigger button holds focus for ~30ms between the textarea and the picker's search box.

## The fix

Suppress the browser's focus-on-press for the trigger and the model rows, so focus stays on the composer textarea while the picker opens and on the search box while it closes — only ever moving between editable elements.

`mousedown` rather than `pointerdown`: it is the event that drives focus on desktop, and it stays clear of touch panning. Both were checked against a synthesized touch scroll starting on a model row and neither breaks the list scrolling, but `mousedown` is the narrower instrument.

Opening and selecting both run off `click`, which a prevented `mousedown` does not stop, and Tab still reaches both elements. Because the change is in the shared picker, the chat input and the message editor both get it.

## Verification

Measured in Chromium under mobile emulation against the running app: 3/3 runs red before the change (~186–195ms parked on the list), 3/3 green after — `textarea` -> `command-input` -> `textarea`, every stop editable, with selection and dismissal unaffected.

Two new tests assert the press is default-prevented on the trigger and on a model row; both were checked against the unfixed component and fail there. A third presses (`mousedown`/`mouseup`/`click`) rather than clicking, so suppression breaking the interaction would be caught.

Lint, typecheck and the full frontend suite (700 tests) pass.

## Still outstanding

jsdom and desktop Chromium have no virtual keyboard, so none of this proves the keyboard itself stops flapping — only that the focus sequence causing it is gone. Confirming the symptom still needs a physical Android device. Unlike #763 there is at least a measured red-to-green change to confirm against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
