### PR TITLE
fix(backend): store uploaded files at /data/files in the image

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -50,6 +50,15 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
+# Where this image keeps uploaded files. `DiskStorage`'s own default is
+# relative, so it resolves under WORKDIR and lands in the container's writable
+# layer — gone on the next container recreate, which an image upgrade and a
+# Kubernetes rollout both perform. Declaring it here reaches every way the image
+# is deployed rather than Compose alone: mount a volume over /data and uploads
+# persist with nothing else to configure. A deployment that sets the variable
+# itself still overrides this.
+ENV STORAGE_DISK_PATH=/data/files
+
 # `su-exec` lets the entrypoint drop from root to `platypus` once it has
 # repaired the ownership of a bind-mounted /data.
 RUN apk add --no-cache su-exec
@@ -62,8 +71,8 @@ RUN addgroup --system --gid 1001 platypus && \
     mkdir -p /data/files && chown -R platypus:platypus /data
 
 # WORKDIR created /app as root:root, and only the *contents* of the copies below
-# carry --chown. The STORAGE_DISK_PATH default resolves to /app/data/files, so
-# the directory itself has to be writable or the app cannot create it.
+# carry --chown, leaving the directory itself owned by root. The application
+# runs from here as `platypus`, so hand it over.
 RUN chown platypus:platypus /app
 
 # Copy prod dependencies (includes root node_modules and workspace node_modules)

--- a/apps/backend/docker-entrypoint.sh
+++ b/apps/backend/docker-entrypoint.sh
@@ -5,13 +5,15 @@ set -e
 # writable by that account, and only one of them can be settled while the image
 # is being built:
 #
-#   - Everything under /app, including the STORAGE_DISK_PATH default of
-#     ./data/files. The Dockerfile owns this; nothing here needs to.
-#   - /data, which compose.yaml bind-mounts from the host. On Linux a bind mount
-#     keeps the host directory's ownership and masks whatever the build set, so
-#     an existing deployment whose ./data belongs to some other uid would hit
-#     EACCES on the first upload. It can only be repaired once the mount is in
-#     place, which is here.
+#   - Everything under /app, the application's own working directory. The
+#     Dockerfile owns this; nothing here needs to.
+#   - /data, which holds the store the image points STORAGE_DISK_PATH at, and
+#     which a deployment mounts its own volume over — a compose.yaml bind mount,
+#     a Kubernetes PersistentVolumeClaim. On Linux a mount keeps the host
+#     directory's ownership and masks whatever the build set, so an existing
+#     deployment whose directory belongs to some other uid would hit EACCES on
+#     the first write. It can only be repaired once the mount is in place, which
+#     is here.
 #
 # Started as root, we repair that ownership and then drop to `platypus`, so the
 # application itself never runs privileged. Started as an explicit non-root user

--- a/apps/docs/content/docs-contract.test.ts
+++ b/apps/docs/content/docs-contract.test.ts
@@ -417,6 +417,166 @@ describe("environment variables", () => {
   });
 });
 
+// --- where the self-hosting pages say uploaded files land -------------------
+
+const COMPOSE_FILE = "compose.yaml";
+const COMPOSE_YAML = readRepoFile(COMPOSE_FILE);
+
+const BACKEND_DOCKERFILE = "apps/backend/Dockerfile";
+const DOCKERFILE = readRepoFile(BACKEND_DOCKERFILE);
+
+/** Leading-whitespace width, used to walk `compose.yaml` by indentation. */
+const indentWidth = (line: string): number =>
+  line.length - line.trimStart().length;
+
+type ComposeLine = { text: string; line: number };
+
+/**
+ * The lines of one nested block of `compose.yaml`, addressed by key path.
+ *
+ * No YAML parser is a dependency of this package, and this file already
+ * hand-reads Markdown tables and `.env` assignments. The compose file is short,
+ * hand-maintained and three levels deep, so a key path plus indentation reads
+ * it. An extractor that quietly stops matching would turn the assertions below
+ * green, so the first test in the block checks that it found anything at all.
+ */
+const composeBlock = (keyPath: string[]): ComposeLine[] => {
+  let lines: ComposeLine[] = COMPOSE_YAML.split("\n").map((text, index) => ({
+    text,
+    line: index + 1,
+  }));
+  let indent = 0;
+  for (const key of keyPath) {
+    const start = lines.findIndex(
+      ({ text }) =>
+        indentWidth(text) === indent && text.trim().startsWith(`${key}:`),
+    );
+    if (start === -1) return [];
+    const body: ComposeLine[] = [];
+    for (const entry of lines.slice(start + 1)) {
+      if (entry.text.trim() === "") continue;
+      if (indentWidth(entry.text) <= indent) break;
+      body.push(entry);
+    }
+    if (body.length === 0) return [];
+    lines = body;
+    indent = indentWidth(body[0].text);
+  }
+  return lines;
+};
+
+type BindMount = { host: string; container: string; line: number };
+
+/** The `host:container` bind mounts of a service's `volumes:` block. */
+const composeBindMounts = (service: string): BindMount[] =>
+  composeBlock(["services", service, "volumes"]).flatMap(({ text, line }) => {
+    const match = text.trim().match(/^-\s*(\.\S*?):(\/\S+?)(?::[a-z,]+)?$/);
+    return match ? [{ host: match[1], container: match[2], line }] : [];
+  });
+
+/** An `ENV KEY=value` declaration in the backend Dockerfile. */
+const dockerfileEnv = (
+  name: string,
+): { value: string; line: number } | undefined => {
+  const lines = DOCKERFILE.split("\n");
+  for (const [index, text] of lines.entries()) {
+    const match = text.match(new RegExp(`^ENV ${name}=(\\S+)\\s*$`));
+    if (match) return { value: match[1], line: index + 1 };
+  }
+  return undefined;
+};
+
+/**
+ * Where the self-hosting pages tell an Operator their uploaded files are.
+ *
+ * Two pages make that claim and both are load-bearing: the Compose page names
+ * `./data` as the directory uploads are written to, and the production page
+ * sends the Operator there to back them up — a Chat File part is the one thing
+ * a database dump does not contain, so a wrong directory there is silent data
+ * loss discovered at restore time.
+ *
+ * Neither claim is true on its own. `STORAGE_DISK_PATH` is resolved relative to
+ * the working directory, so left at its library default the backend writes
+ * uploads into the container's own layer and any mount receives nothing. The
+ * backend image is what settles this, because it is what every deployment has
+ * in common — Compose, Kubernetes, Swarm, a bare `docker run`. The pages that
+ * promise the mount sit in a third place again, which is what this pins.
+ */
+describe("the uploaded-files location the self-hosting pages promise", () => {
+  const imagePath = dockerfileEnv("STORAGE_DISK_PATH");
+  const bindMounts = composeBindMounts("backend");
+  const claimedBy = "apps/docs/content/self-hosting/docker-compose.mdx";
+
+  it("parsed the image and the compose file", () => {
+    expect(
+      dockerfileEnv("NODE_ENV")?.value,
+      `read no \`ENV NODE_ENV\` out of ${BACKEND_DOCKERFILE}, so the extractor ` +
+        `below cannot be trusted to find STORAGE_DISK_PATH either`,
+    ).toBeDefined();
+    expect(
+      bindMounts.map((mount) => `${mount.host}:${mount.container}`),
+      `parsed no host bind mount out of the backend service in ${COMPOSE_FILE}`,
+    ).not.toHaveLength(0);
+  });
+
+  it("has the image store uploads where a volume can be mounted", () => {
+    expect(
+      imagePath?.value,
+      `${BACKEND_DOCKERFILE} declares no \`ENV STORAGE_DISK_PATH\`, so the backend ` +
+        `falls back to DiskStorage's relative default. That resolves under ` +
+        `WORKDIR, inside the container's own layer, and every deployment that ` +
+        `does not set the variable itself loses uploaded files on the next ` +
+        `container recreate — an image upgrade, or a Kubernetes rollout.\n` +
+        `${claimedBy} promises an Operator those files are on the host.`,
+    ).toBeDefined();
+
+    expect(
+      imagePath?.value.startsWith("/"),
+      `${BACKEND_DOCKERFILE}:${imagePath?.line} sets STORAGE_DISK_PATH to ` +
+        `\`${imagePath?.value}\`. A relative path resolves under WORKDIR, which ` +
+        `is inside the image; it has to be absolute to name a mount point.`,
+    ).toBe(true);
+  });
+
+  it("mounts the compose stack's host directory over that location", () => {
+    const mount = bindMounts.find(
+      (candidate) =>
+        imagePath?.value === candidate.container ||
+        imagePath?.value.startsWith(`${candidate.container}/`),
+    );
+    expect(
+      mount?.host,
+      `The backend image stores uploads at \`${imagePath?.value}\` ` +
+        `(${BACKEND_DOCKERFILE}:${imagePath?.line}), which is not under any bind ` +
+        `mount the backend service declares in ${COMPOSE_FILE} ` +
+        `(${bindMounts.map((m) => `${m.container} at line ${m.line}`).join(", ") || "none"}).\n` +
+        `The Compose stack would write uploads into the container layer and lose ` +
+        `them on recreate, while ${claimedBy} goes on promising they are on the ` +
+        `host under that bind mount.`,
+    ).toBeDefined();
+  });
+
+  it("names that mount on both pages that send an Operator to it", () => {
+    const violations: string[] = [];
+    for (const page of [
+      "self-hosting/docker-compose.mdx",
+      "self-hosting/production.mdx",
+    ]) {
+      const content = readDoc(page);
+      if (bindMounts.some((mount) => content.includes(`\`${mount.host}\``)))
+        continue;
+      violations.push(
+        `apps/docs/content/${page} names none of the host directories the ` +
+          `backend service bind-mounts ` +
+          `(${bindMounts.map((m) => `\`${m.host}\` at ${COMPOSE_FILE}:${m.line}`).join(", ")}).\n` +
+          `That page tells an Operator where their uploads are and what to back ` +
+          `up, so it has to name the directory Compose actually mounts.`,
+      );
+    }
+    expectNoViolations(violations);
+  });
+});
+
 // --- webhook events ----------------------------------------------------------
 
 describe("webhook events", () => {

--- a/apps/docs/content/reference/backend-configuration.mdx
+++ b/apps/docs/content/reference/backend-configuration.mdx
@@ -170,13 +170,25 @@ is the production option.
 | Variable                       | Purpose                                                                                                       | Default        | Required                  |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------- | -------------- | ------------------------- |
 | `STORAGE_BACKEND`              | Storage backend: `disk` or `s3`.                                                                              | `disk`         | No                        |
-| `STORAGE_DISK_PATH`            | Filesystem path for stored files (when `STORAGE_BACKEND=disk`).                                               | `./data/files` | No                        |
+| `STORAGE_DISK_PATH`            | Filesystem path for stored files (when `STORAGE_BACKEND=disk`), resolved relative to the working directory.   | `./data/files` | No                        |
 | `STORAGE_PUBLIC_URL`           | Optional public URL for direct file access, bypassing the `/files` proxy endpoint (e.g. a CDN or bucket URL). | _(unset)_      | No                        |
 | `STORAGE_S3_BUCKET`            | S3 bucket name.                                                                                               | _(unset)_      | When `STORAGE_BACKEND=s3` |
 | `STORAGE_S3_REGION`            | S3 region.                                                                                                    | `us-east-1`    | No                        |
 | `STORAGE_S3_ENDPOINT`          | S3 endpoint URL. Only needed for S3-compatible services (MinIO, R2, Spaces); leave unset for AWS S3.          | _(unset)_      | No                        |
 | `STORAGE_S3_ACCESS_KEY_ID`     | S3 access key ID.                                                                                             | _(unset)_      | When `STORAGE_BACKEND=s3` |
 | `STORAGE_S3_SECRET_ACCESS_KEY` | S3 secret access key.                                                                                         | _(unset)_      | When `STORAGE_BACKEND=s3` |
+
+The backend image sets `STORAGE_DISK_PATH` to `/data/files` and creates that
+directory, so mounting any volume over `/data` persists uploaded files — the
+Compose stack does it with the `./data` bind mount, and a Kubernetes deployment
+does it with a `PersistentVolumeClaim`. Your own value overrides the image's.
+
+<Callout type="warning">
+  If you set `STORAGE_DISK_PATH` yourself, point it inside a volume you actually
+  mount. A path that exists only in the container survives a restart but not a
+  container recreate, which both an image upgrade and a Kubernetes rollout
+  perform.
+</Callout>
 
 ## Sandbox
 

--- a/apps/docs/content/self-hosting/docker-compose.mdx
+++ b/apps/docs/content/self-hosting/docker-compose.mdx
@@ -95,8 +95,11 @@ a model server running on the host machine rather than in the stack — see
 
 - `postgres_data` — a named volume holding the database. Your data lives here;
   don't delete it unless you mean to start over.
-- `./data` — a bind mount into the backend at `/data`, used by the default
-  disk storage backend for uploaded files.
+- `./data` — a bind mount into the backend at `/data`. The backend image stores
+  uploaded files at `/data/files`, so they arrive here on the host, under
+  `./data/files`. Override
+  [`STORAGE_DISK_PATH`](/reference/backend-configuration#storage) and your
+  uploads follow it out of this mount.
 
 #### File ownership on `./data`
 

--- a/apps/docs/turbo.json
+++ b/apps/docs/turbo.json
@@ -6,6 +6,8 @@
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/.env.example",
+        "$TURBO_ROOT$/compose.yaml",
+        "$TURBO_ROOT$/apps/backend/Dockerfile",
         "$TURBO_ROOT$/apps/backend/.env.example",
         "$TURBO_ROOT$/apps/frontend/.env.example",
         "$TURBO_ROOT$/apps/backend/src/plugins/builtin.ts",


### PR DESCRIPTION
## The problem

`DiskStorage` resolves `STORAGE_DISK_PATH` relative to the working directory, which is `/app` in the backend image. Its `./data/files` default therefore wrote uploads to `/app/data/files` — the container's own writable layer, discarded whenever the container is recreated.

The image separately creates `/data/files`, and the Compose stack bind-mounts `./data` over `/data`. The storage root and the mount point were two different directories, and nothing connected them.

## The scope is not what the issue says

#767's brief claims every default Compose deployment loses its files. That is wrong, and the brief says why in its own verification note: the triage agent was permission-blocked from reading `.env.example` and guessed at it. The root `.env.example` already ships `STORAGE_DISK_PATH=/data/files`, so an Operator following the documented `cp .env.example .env` was never affected.

The real gap is every deployment that is not "Compose with the shipped `.env`":

- **Kubernetes**, which recreates the container on *every rollout* — far more often than an upgrade
- bare `docker run`, Swarm, Nomad
- a hand-written or trimmed `.env` — our own quick-start invites one by naming four variables to set "at minimum"

## The fix

`apps/backend/Dockerfile` now declares:

```dockerfile
ENV STORAGE_DISK_PATH=/data/files
```

The image already created and chowned that directory; the application simply never agreed with it. Fixing it here reaches every deployment mechanism at once, which a `compose.yaml`-level fix would not have — that was the issue's recommended approach, and it would have left Kubernetes broken.

`DiskStorage`'s relative default is deliberately untouched: it is correct for local development, where the process runs from the backend directory rather than `/app`. `compose.yaml` is unchanged, since a second copy of the same path would only be something to keep in sync.

## Verification

Built from this branch and exercised against real containers:

| Case | Result |
| --- | --- |
| `docker run -v vol:/data`, no env set (the Kubernetes shape) | `/data/files` — files land on the volume |
| New container over the same volume (a rollout) | Chat File part and Agent avatar both read back |
| `-e STORAGE_DISK_PATH=/data/custom` | override wins over the image `ENV` |
| Compose, trimmed `.env`, `compose.yaml` setting nothing | `/data/files` — files land on the host |
| Compose, `.env` sets `/data/elsewhere` | Operator's value still wins |

## Migration

Files already at `/app/data/files` do not move. Only a deployment that mounted a volume there has any to lose; without one, every container recreate has been discarding them already.

## Docs and regression guard

The configuration reference and the Docker Compose page now describe the image as the thing that sets the path. The docs contract pins the image's storage root inside the directory Compose mounts, so the Dockerfile, `compose.yaml` and those pages cannot drift apart again.

## Known limitation, not addressed here

A bare `STORAGE_DISK_PATH=` (an empty value in `.env`, or an empty Kubernetes ConfigMap key) overrides the image `ENV` with an empty string, and `process.env.STORAGE_DISK_PATH || "./data/files"` then falls back to the relative path. This is pre-existing behaviour, unchanged by this PR, and no image-level default can defend against it — once a deployment sets the variable to `""` the image default is gone. Failing loudly at startup would be the remedy, as a separate change.

Closes #767