### PR TITLE
feat(backend): open an Agent's MCP tool sessions concurrently

### DIFF
--- a/apps/backend/src/tools/index.test.ts
+++ b/apps/backend/src/tools/index.test.ts
@@ -243,43 +243,6 @@ describe("composeToolSet", () => {
     expect(tools.acme__bare).toBe(bare);
   });
 
-  it("names both plugins when it takes a tool name an earlier tool set claimed", async () => {
-    // Keyed on the *namespaced* name, because that is the name the turn's map
-    // holds and the only name two Tool sets can now contest.
-    const claimed = new Map([
-      ["acme__search", { toolSetId: "other.set", plugin: "other" }],
-    ]);
-
-    const tools = await compose({
-      search: { execute: () => ({}) } as unknown as Tool,
-    }).buildTurnTools(ctx, claimed);
-
-    // The later one still wins — assignment order is the precedence order — but
-    // the swap is no longer silent.
-    expect(tools).toHaveProperty("acme__search");
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tool: "acme__search",
-        plugin: "acme",
-        shadowedToolSet: "other.set",
-        shadowedPlugin: "other",
-      }),
-      expect.stringContaining("same tool name"),
-    );
-  });
-
-  it("says nothing when no name is contested", async () => {
-    const claimed = new Map([
-      ["acme__listBoards", { toolSetId: "other.set", plugin: "other" }],
-    ]);
-
-    await compose({
-      search: { execute: () => ({}) } as unknown as Tool,
-    }).buildTurnTools(ctx, claimed);
-
-    expect(logger.warn).not.toHaveBeenCalled();
-  });
-
   it("binds the plugin's deploy-time config into the factory", async () => {
     const tools = vi.fn().mockResolvedValue({});
     const plugin = makePluginContext({ config: { region: "eu" } });
@@ -367,10 +330,7 @@ describe("composeToolSet tool-name namespacing", () => {
   it("namespaces on every turn, whether or not anything collides", async () => {
     // Nothing claimed, nothing contested — the name still changes, so it never
     // depends on the order an Agent's Tool sets happen to sit in.
-    const tools = await compose({ createIssue: stub("a") }).buildTurnTools(
-      ctx,
-      new Map(),
-    );
+    const tools = await compose({ createIssue: stub("a") }).buildTurnTools(ctx);
     expect(tools).toHaveProperty("acme__createIssue");
     expect(logger.warn).not.toHaveBeenCalled();
   });
@@ -395,18 +355,10 @@ describe("composeToolSet tool-name namespacing", () => {
 
   it("gives two plugins contributing one tool name distinct names, dropping neither", async () => {
     const first = await compose({ createIssue: stub("a") }).buildTurnTools(ctx);
-    // The turn's map as the second set is shown it — the first set's tools,
-    // already claimed.
-    const claimed = new Map(
-      Object.keys(first).map((name) => [
-        name,
-        { toolSetId: "acme.widgets", plugin: "acme" },
-      ]),
-    );
     const second = await compose(
       { createIssue: stub("b") },
       { pluginName: "globex" },
-    ).buildTurnTools(ctx, claimed);
+    ).buildTurnTools(ctx);
 
     expect(Object.keys(first)).toEqual(["acme__createIssue"]);
     expect(Object.keys(second)).toEqual(["globex__createIssue"]);

--- a/apps/backend/src/tools/index.ts
+++ b/apps/backend/src/tools/index.ts
@@ -75,14 +75,13 @@ export type ToolSetRegistration = {
    * and result-normalized. Never rejects: a Tool set that cannot serve this turn
    * contributes no tools instead of failing it.
    *
-   * `claimed` is the turn's accumulating tool map as it stands, so a name this
-   * Tool set is about to take from an earlier one is reported rather than
-   * silently swapped. Optional: a caller resolving a single Tool set in
-   * isolation has no turn map to compare against.
+   * Reads no turn state and mutates none of it, so a turn can resolve all of an
+   * Agent's Tool sets at once. Reporting a name this Tool set takes from an
+   * earlier one belongs to whoever merges the results in assignment order —
+   * `openToolSession` — because only there is the answer deterministic.
    */
   buildTurnTools: (
     context: CoreToolSetContext,
-    claimed?: ReadonlyMap<string, ToolOwner>,
   ) => Promise<Record<string, Tool>>;
   /**
    * The contribution's tools when it declared them as a static map, for the
@@ -347,7 +346,6 @@ export const composeToolSet = (
 
   const buildTurnTools = async (
     context: CoreToolSetContext,
-    claimed?: ReadonlyMap<string, ToolOwner>,
   ): Promise<Record<string, Tool>> => {
     let resolved: unknown = tools;
     if (typeof tools === "function") {
@@ -391,18 +389,13 @@ export const composeToolSet = (
       return {};
     }
 
-    // Namespaced after per-tool result normalization and before the tools are
-    // collision-reported and claimed, so ownership keying and collision
-    // reporting both see the final name — the only name the model, the
-    // Transcript, and a second Tool set can contest.
-    const turnTools = namespaceToolNames(
+    // Namespaced after per-tool result normalization, so the name that leaves
+    // here is the final one — the only name the model, the Transcript, and a
+    // second Tool set can contest, and so the one the merge phase keys
+    // ownership and collision reporting on.
+    return namespaceToolNames(
       normalizeToolResults(resolved as Record<string, Tool>),
     );
-    reportToolNameCollisions(turnTools, claimed, {
-      toolSetId: id,
-      plugin: pluginName,
-    });
-    return turnTools;
   };
 
   return {

--- a/apps/backend/src/tools/tool-session.test.ts
+++ b/apps/backend/src/tools/tool-session.test.ts
@@ -291,6 +291,204 @@ describe("openToolSession", () => {
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
+  describe("resolving concurrently (issue #776)", () => {
+    /**
+     * Serve `servers` MCP connections, counting how many were opening at once.
+     * Every server parks until all of them have been asked to open, or until a
+     * short real timeout — so a sequential resolve fails the assertion below
+     * with a peak of 1 rather than hanging the suite.
+     */
+    const instrumentConcurrentOpens = (servers: number) => {
+      const counts = { inFlight: 0, peak: 0 };
+      let markAllEntered: () => void = () => {};
+      const allEntered = new Promise<void>((r) => (markAllEntered = r));
+      const escapeHatch = new Promise<void>((r) => setTimeout(r, 100));
+
+      mockCreateMCPClient.mockImplementation(async () => {
+        counts.inFlight += 1;
+        counts.peak = Math.max(counts.peak, counts.inFlight);
+        if (counts.inFlight === servers) markAllEntered();
+        await Promise.race([allEntered, escapeHatch]);
+        counts.inFlight -= 1;
+        return {
+          listTools: vi.fn().mockResolvedValue({ tools: [{ name: "go" }] }),
+          toolsFromDefinitions: vi
+            .fn()
+            .mockReturnValue({ go: toolNamed("go") }),
+          close: vi.fn().mockResolvedValue(undefined),
+        };
+      });
+      return counts;
+    };
+
+    it("opens every attached MCP at once, so the slowest bounds the turn rather than the sum", async () => {
+      const counts = instrumentConcurrentOpens(3);
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("mcp-1", "mcp-2", "mcp-3"),
+        queriesFor([
+          mcpRow(),
+          mcpRow({ id: "mcp-2", name: "Two", slug: "two" }),
+          mcpRow({ id: "mcp-3", name: "Three", slug: "three" }),
+        ]),
+      );
+
+      expect(counts.peak).toBe(3);
+      expect(Object.keys(session.tools).sort()).toEqual([
+        "test_mcp__go",
+        "three__go",
+        "two__go",
+      ]);
+    });
+
+    it("merges in assignment order even when the later Tool set resolves first", async () => {
+      const finished: string[] = [];
+      let releaseSlow: () => void = () => {};
+      // Raced with a short real timeout so a resolve that never overlaps fails
+      // the order assertion below rather than hanging the suite.
+      const slow = Promise.race([
+        new Promise<void>((r) => (releaseSlow = r)),
+        new Promise<void>((r) => setTimeout(r, 100)),
+      ]);
+      register(
+        "set.slow",
+        async () => {
+          await slow;
+          finished.push("set.slow");
+          return { search: toolNamed("slow") };
+        },
+        { pluginName: "core-a" },
+      );
+      register(
+        "set.fast",
+        // Resolves before the set assigned ahead of it, and still loses the
+        // name: precedence is the Agent's assignment order, not the wire's.
+        () => {
+          releaseSlow();
+          finished.push("set.fast");
+          return Promise.resolve({ search: toolNamed("fast") });
+        },
+        { pluginName: "core-b" },
+      );
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("set.slow", "set.fast"),
+        noMcps(),
+      );
+
+      expect(finished).toEqual(["set.fast", "set.slow"]);
+      expect(session.tools.search).toEqual(toolNamed("fast"));
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tool: "search",
+          toolSet: "set.fast",
+          plugin: "core-b",
+          shadowedToolSet: "set.slow",
+          shadowedPlugin: "core-a",
+        }),
+        expect.stringContaining("same tool name"),
+      );
+    });
+
+    it("reports a name an MCP takes from a Tool set assigned before it", async () => {
+      register("set.native", { test_mcp__search: toolNamed("native") });
+      connected({ search: toolNamed("mcp") });
+
+      const session = await openToolSession(
+        scope,
+        grantedAgent("set.native", "mcp-1"),
+        queriesFor([mcpRow()]),
+      );
+
+      expect(session.tools["test_mcp__search"]).toEqual(toolNamed("mcp"));
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tool: "test_mcp__search",
+          toolSet: "mcp-1",
+          mcpSlug: "test_mcp",
+          shadowedToolSet: "set.native",
+        }),
+        expect.stringContaining("same tool name"),
+      );
+    });
+
+    it("costs a failing Tool set only its own tools when it resolves beside others", async () => {
+      register("set.fanout-broken", () => {
+        throw new Error("no API key");
+      });
+      register("set.fanout-fine", { fine: toolNamed("fine") });
+      // Connects, then cannot list — the failure that used to strand a socket.
+      // Keyed by URL rather than queued, so the assertion does not depend on
+      // which of the concurrent opens reached the mock first.
+      const stranded = vi.fn().mockResolvedValue(undefined);
+      mockCreateMCPClient.mockImplementation(
+        ({ transport }: { transport: { url: string } }) =>
+          Promise.resolve(
+            transport.url === "https://broken.example.com"
+              ? {
+                  listTools: vi.fn().mockRejectedValue(new Error("gone")),
+                  toolsFromDefinitions: vi.fn(),
+                  close: stranded,
+                }
+              : {
+                  listTools: vi
+                    .fn()
+                    .mockResolvedValue({ tools: [{ name: "ok" }] }),
+                  toolsFromDefinitions: vi
+                    .fn()
+                    .mockReturnValue({ ok: toolNamed("ok") }),
+                  close: vi.fn().mockResolvedValue(undefined),
+                },
+          ),
+      );
+
+      const session = await openToolSession(
+        scope,
+        // An unknown id, a throwing factory, an MCP with no URL, a listing
+        // failure and a healthy MCP — all resolving at once.
+        grantedAgent(
+          "nope",
+          "set.fanout-broken",
+          "mcp-3",
+          "mcp-1",
+          "mcp-2",
+          "set.fanout-fine",
+        ),
+        queriesFor([
+          mcpRow({ url: "https://broken.example.com" }),
+          mcpRow({ id: "mcp-2", name: "Two", slug: "two" }),
+          mcpRow({ id: "mcp-3", name: "Three", slug: "three", url: null }),
+        ]),
+      );
+
+      expect(Object.keys(session.tools).sort()).toEqual(["fine", "two__ok"]);
+      await session.dispose();
+      expect(stranded).toHaveBeenCalled();
+    });
+
+    // The DB lookup is the one thing in the resolve phase that can still reject.
+    // It surfaces to the caller as it always did, in assignment order, and only
+    // once every sibling has finished opening — so nothing is left connected.
+    it("closes a sibling's connection when a lookup rejects the turn", async () => {
+      const close = connected({ a: toolNamed("a") });
+      const queries = {
+        getMcp: vi.fn((id: string) =>
+          id === "mcp-1"
+            ? Promise.resolve(mcpRow())
+            : Promise.reject(new Error("database is down")),
+        ),
+      };
+
+      await expect(
+        openToolSession(scope, grantedAgent("mcp-1", "mcp-2"), queries),
+      ).rejects.toThrow("database is down");
+
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
   describe("the MCP branch", () => {
     it("serves an MCP server's tools, namespaced under its slug, for an id no Tool set claims, and closes it on dispose", async () => {
       const close = connected({ mcpTool: toolNamed("mcpTool") });
@@ -477,8 +675,13 @@ describe("openToolSession", () => {
       );
     });
 
-    it("fails the turn loudly when two attached MCPs resolve to the same slug", async () => {
-      connected({ a: toolNamed("a") });
+    // The throw escapes `openToolSession`, so the caller never receives a
+    // session it could dispose. Both servers have connected by the time the
+    // merge reaches the second — they resolve side by side — so closing them is
+    // this session's own job on the way out.
+    it("fails the turn loudly when two attached MCPs resolve to the same slug, closing both", async () => {
+      const first = connected({ a: toolNamed("a") });
+      const second = connected({ b: toolNamed("b") });
 
       await expect(
         openToolSession(
@@ -489,7 +692,12 @@ describe("openToolSession", () => {
             mcpRow({ id: "mcp-2", name: "Test MCP Again" }),
           ]),
         ),
-      ).rejects.toThrow(/same tool-namespace slug "test_mcp"/);
+      ).rejects.toThrow(
+        'Two attached MCPs resolve to the same tool-namespace slug "test_mcp": "Test MCP" (mcp-1) and "Test MCP Again" (mcp-2). Rename one of them.',
+      );
+
+      expect(first).toHaveBeenCalled();
+      expect(second).toHaveBeenCalled();
     });
 
     it("closes every connection even when one close throws", async () => {

--- a/apps/backend/src/tools/tool-session.ts
+++ b/apps/backend/src/tools/tool-session.ts
@@ -155,12 +155,12 @@ export const openToolSession = async (
   queries: ToolSessionQueries,
 ): Promise<ToolSession> => {
   const tools: Record<string, Tool> = {};
-  // Tool name -> where it came from. Handed to each Tool set as it resolves so
-  // it can report the names it is about to take, and the reason this is a Map
+  // Tool name -> where it came from. Read by the merge below to report the
+  // names an arriving Tool set is about to take, and the reason this is a Map
   // rather than the tool map alone.
   const owners = new Map<string, ToolOwner>();
   // Every name, among `tools`, whose MCP declared `readOnlyHint` (#626). Only
-  // ever added to from the MCP branch of `open` below.
+  // ever added to from the MCP case of `merge` below.
   const readOnlyToolNames = new Set<string>();
   const closers: Array<() => Promise<void>> = [];
   // Registered closers, by identity, and scoped to **this session** — so the
@@ -171,7 +171,7 @@ export const openToolSession = async (
   const registered = new Set<Closer>();
   let disposed = false;
   // MCP slug -> the MCP that already claimed it this turn (issue #467); see
-  // the collision check in `open` below for why this fails loudly.
+  // the collision check in `merge` below for why this fails loudly.
   const usedMcpSlugs = new Map<string, McpRow>();
 
   const registerCloser: CoreCloserRegistrar = (close, attribution) => {
@@ -198,29 +198,68 @@ export const openToolSession = async (
     closers.push(() => runCloser(close, attribution));
   };
 
+  /**
+   * Take `incoming`'s names for `owner`, reporting the ones taken from a Tool
+   * set that claimed them earlier this turn.
+   *
+   * Reporting lives here rather than at each call site because a claim that
+   * goes unreported is the bug issue #776 had to unpick: the check used to run
+   * in two different places depending on the kind of Tool set, and only one of
+   * them was at merge time.
+   */
   const claim = (incoming: Record<string, Tool>, owner: ToolOwner): void => {
+    reportToolNameCollisions(incoming, owners, owner);
     for (const [name, tool] of Object.entries(incoming)) {
       tools[name] = tool;
       owners.set(name, owner);
     }
   };
 
-  /** Resolve one assigned id — a registered Tool set, or else an MCP server. */
-  const open = async (
+  /**
+   * What resolving one assigned id produced, before any of it has touched the
+   * turn. Carries its own fault rather than rejecting: a resolve runs beside
+   * its siblings, and a rejection would settle the group while they are still
+   * opening connections — clients the session would then never see to close.
+   */
+  type Resolution =
+    | { kind: "none" }
+    | { kind: "failed"; error: unknown }
+    | { kind: "tools"; tools: Record<string, Tool>; owner: ToolOwner }
+    | {
+        kind: "mcp";
+        mcp: McpRow;
+        tools: Record<string, Tool>;
+        owner: ToolOwner;
+        readOnlyNames: readonly string[];
+      };
+
+  /**
+   * Resolve one assigned id — a registered Tool set, or else an MCP server.
+   *
+   * Everything that touches the network or the database, and nothing else: this
+   * reads none of the turn's shared state (`tools`, `owners`, `usedMcpSlugs`,
+   * `readOnlyToolNames`) and mutates none of it, which is what lets every
+   * assigned id resolve at once. `registerCloser` is the one exception, and
+   * deliberately so — a connection is registered for closing the moment it
+   * exists, so a server that opens beside one that fails is still torn down.
+   */
+  const resolve = async (
     toolSetId: string,
     context: CoreToolSetContext,
-  ): Promise<void> => {
+  ): Promise<Resolution> => {
     const registration = getToolSet(toolSetId);
     if (registration) {
-      const turnTools = await registration.buildTurnTools(context, owners);
-      claim(turnTools, {
-        toolSetId,
-        // A Tool set belonging to no loaded plugin is a core registration, and
-        // reads as one — the annotation the Tools catalog already uses. `null`
-        // is reserved for the MCP branch, where there is genuinely no plugin.
-        plugin: getToolSetPlugin(toolSetId) ?? CORE_BUILTIN_OWNER,
-      });
-      return;
+      return {
+        kind: "tools",
+        tools: await registration.buildTurnTools(context),
+        owner: {
+          toolSetId,
+          // A Tool set belonging to no loaded plugin is a core registration, and
+          // reads as one — the annotation the Tools catalog already uses. `null`
+          // is reserved for the MCP branch, where there is genuinely no plugin.
+          plugin: getToolSetPlugin(toolSetId) ?? CORE_BUILTIN_OWNER,
+        },
+      };
     }
 
     // Not a registered Tool set — the id names an MCP server, or nothing.
@@ -229,28 +268,12 @@ export const openToolSession = async (
       logger.warn(
         `Tool set with id '${toolSetId}' not found as static tool set or MCP`,
       );
-      return;
+      return { kind: "none" };
     }
     if (!mcp.url) {
       logger.warn(`MCP '${toolSetId}' has no URL configured`);
-      return;
+      return { kind: "none" };
     }
-
-    // Checked before connecting — a turn-time backstop for two attached MCPs
-    // resolving to the same tool-namespace slug (issue #467). The DB and the
-    // create/update routes prevent this going forward, but a row created
-    // before this fix (or backfilled with a collision the app-level check
-    // never saw) can still reach here, and silently picking a winner would
-    // reintroduce the exact shadowing this issue is about — just one level up,
-    // at the MCP rather than the tool. So this fails the turn loudly instead
-    // of warning and continuing, the way a plain tool-name collision does.
-    const incumbentMcp = usedMcpSlugs.get(mcp.slug);
-    if (incumbentMcp) {
-      throw new Error(
-        `Two attached MCPs resolve to the same tool-namespace slug "${mcp.slug}": "${incumbentMcp.name}" (${incumbentMcp.id}) and "${mcp.name}" (${mcp.id}). Rename one of them.`,
-      );
-    }
-    usedMcpSlugs.set(mcp.slug, mcp);
 
     const warnUnreachable = (error: unknown) => {
       logger.warn(
@@ -266,12 +289,14 @@ export const openToolSession = async (
       });
     } catch (error) {
       warnUnreachable(error);
-      return;
+      return { kind: "none" };
     }
 
     // Registered the moment the connection exists, and before anything else can
     // fail on it — a server that connects and then fails to list its tools used
-    // to leave the socket open for the life of the process.
+    // to leave the socket open for the life of the process. It is also why the
+    // slug check now belongs to the merge and not here: a connection this
+    // session can close is worth more than one never opened.
     registerCloser(() => client.close(), {
       mcpId: mcp.id,
       scope: mcp.organizationId ? "org" : "ws",
@@ -287,7 +312,7 @@ export const openToolSession = async (
       definitions = await client.listTools();
     } catch (error) {
       warnUnreachable(error);
-      return;
+      return { kind: "none" };
     }
     const mcpTools = client.toolsFromDefinitions(definitions);
 
@@ -310,6 +335,7 @@ export const openToolSession = async (
     // reintroduce this same bug for a server exposing both `pull` and
     // `github__pull`.
     const namespaced: Record<string, Tool> = {};
+    const readOnlyNames: string[] = [];
     for (const [rawName, tool] of Object.entries(mcpTools)) {
       const namespacedName = namespaceMcpToolName(mcp.slug, rawName);
       if (!TOOL_NAME_PATTERN.test(namespacedName)) {
@@ -330,31 +356,73 @@ export const openToolSession = async (
       // predating #467's namespacing degrades safely: an unrecognised name
       // reads as undeclared rather than being matched by accident.
       if (readOnlyHintByRawName.get(rawName)) {
-        readOnlyToolNames.add(namespacedName);
+        readOnlyNames.push(namespacedName);
       }
     }
 
-    const owner: ToolOwner = { toolSetId, plugin: null, mcpSlug: mcp.slug };
-    const normalized = normalizeToolResults(namespaced);
-    reportToolNameCollisions(normalized, owners, owner);
-    claim(normalized, owner);
+    return {
+      kind: "mcp",
+      mcp,
+      tools: normalizeToolResults(namespaced),
+      owner: { toolSetId, plugin: null, mcpSlug: mcp.slug },
+      readOnlyNames,
+    };
   };
 
-  if (agent) {
-    // What a Tool-set factory is handed: the turn's scope with this session's
-    // Agent on it, so a parent's and a delegate's differ by exactly the Agent.
-    // The registrar is this session's own — a delegate registers into itself and
-    // the parent closes the delegate, so lifetime nests without a shared list.
-    const context: CoreToolSetContext = {
-      ...scope,
-      agentId: agent.id,
-      registerCloser,
-    };
-    // Sequentially: each Tool set is shown the names the ones before it claimed.
-    for (const toolSetId of agent.toolSetIds ?? []) {
-      await open(toolSetId, context);
+  /** {@link resolve}, with its own fault carried back rather than thrown. */
+  const resolveSafely = async (
+    toolSetId: string,
+    context: CoreToolSetContext,
+  ): Promise<Resolution> => {
+    try {
+      return await resolve(toolSetId, context);
+    } catch (error) {
+      return { kind: "failed", error };
     }
-  }
+  };
+
+  /**
+   * Fold one resolution into the turn. The only phase that touches the turn's
+   * tool map, owner map, read-only names and claimed MCP slugs, and the only
+   * one that reports a collision (through {@link claim}) — walked in
+   * `toolSetIds` order, so the winner of a contested name and the warnings that
+   * name it are what they always were, whichever resolve finished first.
+   */
+  const merge = (resolution: Resolution): void => {
+    switch (resolution.kind) {
+      case "none":
+        return;
+      // Rethrown here rather than where it was raised, so it reaches the caller
+      // in assignment order and after every sibling has finished opening.
+      case "failed":
+        throw resolution.error;
+      case "tools":
+        claim(resolution.tools, resolution.owner);
+        return;
+      case "mcp": {
+        // A turn-time backstop for two attached MCPs resolving to the same
+        // tool-namespace slug (issue #467). The DB and the create/update routes
+        // prevent this going forward, but a row created before this fix (or
+        // backfilled with a collision the app-level check never saw) can still
+        // reach here, and silently picking a winner would reintroduce the exact
+        // shadowing this issue is about — just one level up, at the MCP rather
+        // than the tool. So this fails the turn loudly instead of warning and
+        // continuing, the way a plain tool-name collision does.
+        const incumbentMcp = usedMcpSlugs.get(resolution.mcp.slug);
+        if (incumbentMcp) {
+          throw new Error(
+            `Two attached MCPs resolve to the same tool-namespace slug "${resolution.mcp.slug}": "${incumbentMcp.name}" (${incumbentMcp.id}) and "${resolution.mcp.name}" (${resolution.mcp.id}). Rename one of them.`,
+          );
+        }
+        usedMcpSlugs.set(resolution.mcp.slug, resolution.mcp);
+        claim(resolution.tools, resolution.owner);
+        for (const name of resolution.readOnlyNames) {
+          readOnlyToolNames.add(name);
+        }
+        return;
+      }
+    }
+  };
 
   const dispose = async (): Promise<void> => {
     if (disposed) return;
@@ -376,6 +444,39 @@ export const openToolSession = async (
       }
     }
   };
+
+  if (agent) {
+    // What a Tool-set factory is handed: the turn's scope with this session's
+    // Agent on it, so a parent's and a delegate's differ by exactly the Agent.
+    // The registrar is this session's own — a delegate registers into itself and
+    // the parent closes the delegate, so lifetime nests without a shared list.
+    const context: CoreToolSetContext = {
+      ...scope,
+      agentId: agent.id,
+      registerCloser,
+    };
+    // Concurrently: N MCP servers cost roughly the slowest open rather than the
+    // sum of them, which is better than 99% of a turn's preparation once an
+    // Agent attaches a few (issue #776). Nothing a Tool set *builds* ever
+    // depended on what resolved before it — a factory is called
+    // `tools(context, plugin)` and is never shown the accumulated map — so only
+    // the merge below stays ordered.
+    const resolutions = await Promise.all(
+      (agent.toolSetIds ?? []).map((toolSetId) =>
+        resolveSafely(toolSetId, context),
+      ),
+    );
+    try {
+      for (const resolution of resolutions) merge(resolution);
+    } catch (error) {
+      // The merge is the one phase that can fail the turn (two MCPs on one
+      // slug), and it throws past the caller — which never receives the session
+      // and so could never dispose it. Everything the resolve phase opened is
+      // registered by now, so this is the only place it can be closed.
+      await dispose();
+      throw error;
+    }
+  }
 
   const nest: ToolSession["nest"] = async (nestedAgent) => {
     const child = await openToolSession(scope, nestedAgent, queries);


### PR DESCRIPTION
Closes #776.

Resolving an Agent's assigned Tool sets awaited each id before starting the next, so N attached MCP servers cost N × RTT before the first token. #557 measured three remote servers at 1582 ms of preparation against a 15 ms baseline — better than 99% of the phase, and additive.

## What changed

The work splits into two phases:

- **Resolve** — everything that touches the network or the database, run for every assigned id at once. It reads no shared turn state and mutates none of it, and carries its own fault back rather than rejecting: a rejection would settle the group while siblings were still opening connections, stranding their clients.
- **Merge** — walked in `toolSetIds` order, exactly as before. The only phase that touches the turn's tool map, owner map, read-only names and claimed MCP slugs, and the only one that reports a collision.

Collision reporting for a registered Tool set used to run inside `buildTurnTools` against the live owner map, so under a fan-out each Tool set would have inspected a half-filled map and the warnings would have gone nondeterministic. It now runs at merge time for both kinds, and `buildTurnTools` no longer takes `claimed`. This is internal to `apps/backend` — no SDK change, no API-version bump.

The slug-collision check moves into the merge, which also closes a pre-existing leak: it throws past `openToolSession`, so the caller never receives a session it could dispose. Every client the resolve phase opened is registered by then, and is now closed on the way out.

## Behaviour

Unchanged: the winner of a tool-name collision is still the later Tool set in assignment order, warnings are identical and deterministic, `readOnlyToolNames` resolves to the same namespaced names, two MCPs on one slug still fail the turn with the same message and the same incumbent/challenger pair, and delegate sessions opened through `nest` still close with the parent.

Two visible consequences of the design, both inherent to fanning out: two same-slug MCPs now each get a real outbound connection before the turn fails, and a fault on an early id no longer short-circuits the later ones. Neither is only wall clock — they show up in server-side logs.

## Tests

A new `resolving concurrently (issue #776)` block covers: peak in-flight opens across three MCP servers, merge order holding when the later Tool set resolves first, an MCP taking a name from an earlier Tool set, failure isolation under fan-out (unknown id + throwing factory + no-URL MCP + listing failure + healthy MCP together), and a lookup rejection still closing its sibling's connection. The slug-collision test now asserts both clients are closed.

The concurrency assertion is peak in-flight opens rather than a wall-clock bound — the same guarantee without a timing flake. Both concurrency tests were confirmed to fail against the sequential loop.

Two `index.test.ts` collision tests are deleted: that behaviour is no longer `buildTurnTools`'s, and it is covered in `tool-session.test.ts`.

No docs owed — the diff does not intersect the docs table in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
