### PR TITLE
fix(frontend): stop dictation repeating on Android and surface its failures

### DIFF
--- a/apps/docs/content/building-with-platypus/chat.mdx
+++ b/apps/docs/content/building-with-platypus/chat.mdx
@@ -115,6 +115,20 @@ The same button is in the box you get when [rewriting a
 message](#rewriting-a-message), and it writes into that message rather than into
 the one below.
 
+Transcription is the browser's own speech recognition, so which browsers offer
+it varies. Where it can't run, the button still answers a press — an unsupported
+browser, a blocked microphone, a device with no speech service — instead of
+going quiet.
+
+<Callout type="warning">
+  **A browser only grants a microphone over a secure connection.** Reach your
+  instance at a plain `http://` address — a LAN IP such as
+  `http://192.168.1.20:3000` — and the microphone is refused before a word is
+  heard, whatever permission you granted. Everything else on the page keeps
+  working, which is what makes it look like a broken button. Serve the frontend
+  over HTTPS, or open it at `http://localhost`, which browsers treat as secure.
+</Callout>
+
 ## How long a Tool took
 
 When a reply uses a Tool, the Tool appears in the conversation as a collapsible

--- a/apps/frontend/components/ai-elements/prompt-input.tsx
+++ b/apps/frontend/components/ai-elements/prompt-input.tsx
@@ -19,7 +19,10 @@ import {
   InputGroupTextarea,
 } from "@/components/ui/input-group";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { useSpeechToText } from "@/hooks/use-speech-to-text";
+import {
+  useSpeechToText,
+  type SpeechToTextFaultCode,
+} from "@/hooks/use-speech-to-text";
 import { isImageAttachment } from "@/lib/message-parts";
 import { cn } from "@/lib/utils";
 import type { ChatStatus, FileUIPart } from "ai";
@@ -34,6 +37,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { nanoid } from "nanoid";
+import { toast } from "sonner";
 import {
   Children,
   type ClipboardEventHandler,
@@ -795,6 +799,27 @@ export type PromptInputSpeechButtonProps = ComponentProps<
   onTranscriptionChange?: (text: string) => void;
 };
 
+/**
+ * What each way dictation can fail means to the person it happened to, and
+ * what they can do about it (issue #768). Permission denial and "not available
+ * here" read differently on purpose: retrying gets you nowhere in one case and
+ * is the whole remedy in the other.
+ */
+const SPEECH_FAULT_MESSAGES: Record<SpeechToTextFaultCode, string> = {
+  unsupported: "Voice input isn't supported in this browser.",
+  "insecure-context":
+    "Voice input needs a secure connection. Open this page over HTTPS or on localhost.",
+  "not-allowed":
+    "Microphone access is blocked. Allow the microphone for this site in your browser settings.",
+  "service-not-allowed":
+    "This device's speech service isn't available, so voice input can't run here.",
+  network: "Voice input couldn't reach the speech service. Check your network.",
+  "audio-capture": "No microphone was found.",
+  "language-not-supported": "Voice input doesn't support this language.",
+  "bad-grammar": "Voice input couldn't read its recognition grammar.",
+  unknown: "Voice input stopped unexpectedly.",
+};
+
 export const PromptInputSpeechButton = ({
   className,
   textareaRef,
@@ -802,10 +827,18 @@ export const PromptInputSpeechButton = ({
   onClick,
   ...props
 }: PromptInputSpeechButtonProps) => {
-  const { isListening, isSupported, toggleListening } = useSpeechToText({
+  const { isListening, fault, toggleListening } = useSpeechToText({
     textareaRef,
     onTranscriptionChange,
   });
+
+  // Every failure the hook reports is a fresh object, so a second identical
+  // failure is a second toast rather than a silent no-op.
+  useEffect(() => {
+    if (fault) {
+      toast.error(SPEECH_FAULT_MESSAGES[fault.code]);
+    }
+  }, [fault]);
 
   return (
     <PromptInputButton
@@ -814,7 +847,10 @@ export const PromptInputSpeechButton = ({
         isListening && "animate-pulse bg-accent text-accent-foreground",
         className,
       )}
-      disabled={!isSupported}
+      // The button stays enabled even where dictation cannot run. A disabled
+      // one takes no pointer events, so its tooltip never opens and the reason
+      // never reaches anyone — the silent failure of issue #768. Pressing it
+      // answers with the reason instead.
       // `onClick` is taken out of the spread and composed here, the way
       // PromptInputTextarea handles `onKeyDown` (issue #710). A caller rarely
       // writes one by hand, but wrapping this button in a Radix trigger with

--- a/apps/frontend/components/composer.test.tsx
+++ b/apps/frontend/components/composer.test.tsx
@@ -1,9 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useRef, useState } from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import type { Provider } from "@platypus/schemas";
 import { Composer } from "./composer";
 import { PromptInputSpeechButton } from "./ai-elements/prompt-input";
+import { toast } from "sonner";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
 
 /**
  * Issue #749: switching models dropped the Android on-screen keyboard and
@@ -108,6 +119,13 @@ const openPicker = (trigger: HTMLElement) => {
   return screen.getByText("gpt-4o");
 };
 
+const setSecureContext = (value: boolean) => {
+  Object.defineProperty(window, "isSecureContext", {
+    value,
+    configurable: true,
+  });
+};
+
 /** Records every element that takes focus from this point on, in order. */
 const recordFocus = () => {
   const targets: EventTarget[] = [];
@@ -116,6 +134,7 @@ const recordFocus = () => {
 };
 
 beforeEach(() => {
+  vi.clearAllMocks();
   // jsdom has no matchMedia; PromptInputTextarea subscribes to it.
   window.matchMedia = vi.fn().mockReturnValue({
     matches: false,
@@ -130,6 +149,7 @@ beforeEach(() => {
     disconnect() {}
   } as unknown as typeof ResizeObserver;
   lastRecognition = null;
+  setSecureContext(true);
   window.SpeechRecognition =
     TrackingSpeechRecognition as unknown as Window["SpeechRecognition"];
 });
@@ -250,5 +270,63 @@ describe("Composer dictation", () => {
     // tap - and the button keeps its own.
     expect(onClick).toHaveBeenCalled();
     expect(lastRecognition?.start).toHaveBeenCalled();
+  });
+});
+
+/**
+ * Issue #768: a recognition failure only reached `console.error`. On a phone
+ * there is no console short of `chrome://inspect` over USB, so permission
+ * denial, an unavailable speech service and a tap that never landed all
+ * presented the same way - as nothing happening.
+ */
+describe("Composer dictation failures", () => {
+  it("says why voice input cannot run outside a secure context", () => {
+    // A LAN address over plain http: the constructor is still on `window`, so
+    // the API looks available, but no browser grants a microphone here.
+    setSecureContext(false);
+
+    const { mic } = renderComposer();
+    fireEvent.click(mic);
+
+    expect(lastRecognition).toBeNull();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Voice input needs a secure connection. Open this page over HTTPS or on localhost.",
+    );
+  });
+
+  it("tells the user when the microphone is blocked", () => {
+    const { mic } = renderComposer();
+    fireEvent.click(mic);
+
+    act(() => lastRecognition?.onerror?.({ error: "not-allowed" }));
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Microphone access is blocked. Allow the microphone for this site in your browser settings.",
+    );
+  });
+
+  it("says nothing when the microphone simply heard nothing", () => {
+    const { mic } = renderComposer();
+    fireEvent.click(mic);
+
+    act(() => lastRecognition?.onerror?.({ error: "no-speech" }));
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps the mic pressable where dictation is unavailable, so it can explain", () => {
+    Reflect.deleteProperty(window, "SpeechRecognition");
+
+    const { mic } = renderComposer();
+
+    // A disabled button takes no pointer events, so its tooltip never opens
+    // and the reason never reaches anyone.
+    expect(mic).not.toBeDisabled();
+
+    fireEvent.click(mic);
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Voice input isn't supported in this browser.",
+    );
   });
 });

--- a/apps/frontend/hooks/use-speech-to-text.test.tsx
+++ b/apps/frontend/hooks/use-speech-to-text.test.tsx
@@ -42,6 +42,10 @@ class FakeSpeechRecognition extends EventTarget {
     });
     this.onresult?.({ resultIndex, results });
   }
+
+  emitError(error: string) {
+    this.onerror?.({ error });
+  }
 }
 
 describe("useSpeechToText", () => {
@@ -57,8 +61,16 @@ describe("useSpeechToText", () => {
     }
   }
 
+  const setSecureContext = (value: boolean) => {
+    Object.defineProperty(window, "isSecureContext", {
+      value,
+      configurable: true,
+    });
+  };
+
   beforeEach(() => {
     lastInstance = null;
+    setSecureContext(true);
     window.SpeechRecognition =
       TrackingSpeechRecognition as unknown as Window["SpeechRecognition"];
   });
@@ -108,7 +120,50 @@ describe("useSpeechToText", () => {
     expect(result.current.transcript).toBe("hello world");
   });
 
-  it("ignores results already appended when the engine replays them", () => {
+  it("writes each phrase once when the engine restates the whole utterance", () => {
+    const textarea = document.createElement("textarea");
+    const textareaRef = { current: textarea };
+    const onTranscriptionChange = vi.fn();
+
+    const { result } = renderHook(() =>
+      useSpeechToText({ textareaRef, onTranscriptionChange }),
+    );
+
+    act(() => result.current.toggleListening());
+
+    // The stream Chrome for Android produces for "hello world" then "how are
+    // you": one more `isFinal` entry per partial update, each carrying the
+    // whole utterance so far. Concatenating the list writes every word again
+    // for every entry it appears in (issue #752).
+    const stream = [
+      "hello",
+      "hello world",
+      "hello world",
+      "hello world",
+      "hello world",
+      "hello world how",
+      "hello world how are",
+      "hello world how are you",
+      "hello world how are you",
+    ];
+
+    stream.forEach((_, index) => {
+      act(() =>
+        lastInstance?.emitResults(
+          stream
+            .slice(0, index + 1)
+            .map((transcript) => ({ transcript, isFinal: true })),
+        ),
+      );
+    });
+
+    expect(textarea.value).toBe("hello world how are you");
+    expect(onTranscriptionChange).toHaveBeenLastCalledWith(
+      "hello world how are you",
+    );
+  });
+
+  it("keeps separate phrases when the results are segments rather than restatements", () => {
     const textarea = document.createElement("textarea");
     const textareaRef = { current: textarea };
     const onTranscriptionChange = vi.fn();
@@ -124,7 +179,7 @@ describe("useSpeechToText", () => {
     );
     expect(textarea.value).toBe("one");
 
-    // Android re-sends the finalised "one" alongside the new " two".
+    // The engine re-sends the finalised "one" alongside the new " two".
     act(() =>
       lastInstance?.emitResults([
         { transcript: "one", isFinal: true },
@@ -132,8 +187,30 @@ describe("useSpeechToText", () => {
       ]),
     );
 
-    expect(textarea.value).toBe("one  two");
-    expect(onTranscriptionChange).toHaveBeenLastCalledWith("one  two");
+    expect(textarea.value).toBe("one two");
+    expect(onTranscriptionChange).toHaveBeenLastCalledWith("one two");
+  });
+
+  it("keeps the rest of the session when one result restates another", () => {
+    const textarea = document.createElement("textarea");
+    const textareaRef = { current: textarea };
+
+    const { result } = renderHook(() => useSpeechToText({ textareaRef }));
+
+    act(() => result.current.toggleListening());
+
+    // "yes" opening "yes please" reads as a restatement, so that phrase is
+    // spoken once. Judging each entry against its neighbour keeps the mistake
+    // to the pair - the unrelated segment after it still lands.
+    act(() =>
+      lastInstance?.emitResults([
+        { transcript: "yes", isFinal: true },
+        { transcript: "yes please", isFinal: true },
+        { transcript: "send it", isFinal: true },
+      ]),
+    );
+
+    expect(textarea.value).toBe("yes please send it");
   });
 
   it("does not re-append a final result promoted from an interim one", () => {
@@ -163,7 +240,7 @@ describe("useSpeechToText", () => {
     expect(textarea.value).toBe("hello");
   });
 
-  it("starts a fresh count when a new session replaces the result list", () => {
+  it("keeps earlier speech when a new session replaces the result list", () => {
     const textarea = document.createElement("textarea");
     const textareaRef = { current: textarea };
 
@@ -187,6 +264,75 @@ describe("useSpeechToText", () => {
     );
 
     expect(textarea.value).toBe("one two three");
+  });
+
+  it("reports a recognition failure to the caller", () => {
+    const { result } = renderHook(() => useSpeechToText());
+
+    act(() => result.current.toggleListening());
+    expect(result.current.fault).toBeNull();
+
+    act(() => lastInstance?.emitError("not-allowed"));
+
+    expect(result.current.fault).toEqual({ code: "not-allowed" });
+    expect(result.current.isListening).toBe(false);
+  });
+
+  it("reports a failure again when the same one happens twice", () => {
+    const { result } = renderHook(() => useSpeechToText());
+
+    act(() => result.current.toggleListening());
+    act(() => lastInstance?.emitError("network"));
+    const first = result.current.fault;
+
+    act(() => result.current.toggleListening());
+    act(() => lastInstance?.emitError("network"));
+
+    expect(result.current.fault).toEqual({ code: "network" });
+    expect(result.current.fault).not.toBe(first);
+  });
+
+  it("calls an unrecognised error code unknown", () => {
+    const { result } = renderHook(() => useSpeechToText());
+
+    act(() => result.current.toggleListening());
+    act(() => lastInstance?.emitError("something-new"));
+
+    expect(result.current.fault).toEqual({ code: "unknown" });
+  });
+
+  it.each(["no-speech", "aborted"])("ends quietly on %s", (error) => {
+    const { result } = renderHook(() => useSpeechToText());
+
+    act(() => result.current.toggleListening());
+    act(() => lastInstance?.emitError(error));
+
+    expect(result.current.fault).toBeNull();
+    expect(result.current.isListening).toBe(false);
+  });
+
+  it("refuses to run outside a secure context and says why", () => {
+    setSecureContext(false);
+
+    const { result } = renderHook(() => useSpeechToText());
+
+    expect(result.current.isSupported).toBe(false);
+    // No recognition object is built at all, so nothing can be started.
+    expect(lastInstance).toBeNull();
+
+    act(() => result.current.toggleListening());
+
+    expect(result.current.fault).toEqual({ code: "insecure-context" });
+  });
+
+  it("says why when the browser has no Web Speech API", () => {
+    Reflect.deleteProperty(window, "SpeechRecognition");
+
+    const { result } = renderHook(() => useSpeechToText());
+
+    act(() => result.current.toggleListening());
+
+    expect(result.current.fault).toEqual({ code: "unsupported" });
   });
 
   it("stops recognition on unmount", () => {

--- a/apps/frontend/hooks/use-speech-to-text.ts
+++ b/apps/frontend/hooks/use-speech-to-text.ts
@@ -60,6 +60,96 @@ declare global {
   }
 }
 
+/**
+ * Why dictation is not working, as a code the caller turns into words
+ * (issue #768). `unsupported` and `insecure-context` are standing conditions
+ * of the page; the rest are the `error` values `SpeechRecognitionErrorEvent`
+ * defines for an attempt that failed.
+ */
+export type SpeechToTextFaultCode =
+  | "unsupported"
+  | "insecure-context"
+  | "not-allowed"
+  | "service-not-allowed"
+  | "network"
+  | "audio-capture"
+  | "language-not-supported"
+  | "bad-grammar"
+  | "unknown";
+
+/**
+ * A failure worth telling the user about. A fresh object each time, so a
+ * caller watching it sees a second identical failure as a second event rather
+ * than as no change.
+ */
+export type SpeechToTextFault = { code: SpeechToTextFaultCode };
+
+/**
+ * Failures the user caused or already knows about: silence, and stopping
+ * dictation yourself. Ending quietly is the honest response to both.
+ */
+const QUIET_ERRORS = new Set(["no-speech", "aborted"]);
+
+const RECOGNITION_FAULT_CODES = new Set<string>([
+  "not-allowed",
+  "service-not-allowed",
+  "network",
+  "audio-capture",
+  "language-not-supported",
+  "bad-grammar",
+]);
+
+/**
+ * Runs two pieces of speech together with exactly one gap between them.
+ * Engines differ on whether a result carries its own leading space, so both
+ * gluing the words and doubling the space are possible without this.
+ */
+const joinSpoken = (left: string, right: string) => {
+  if (!left || !right) {
+    return left + right;
+  }
+  return /\s$/.test(left) || /^\s/.test(right)
+    ? left + right
+    : `${left} ${right}`;
+};
+
+/**
+ * The transcript the result list describes, whichever way the engine chose to
+ * fill it in.
+ *
+ * By the spec each result is its own segment of speech, so the session's
+ * transcript is every final result run together. Chrome for Android instead
+ * grows the list by one `isFinal` entry per partial update, and each entry
+ * carries the whole utterance so far, so running them together repeats every
+ * word once for each entry it appears in (issue #752).
+ *
+ * One rule covers both: an entry that the next one begins with was restated by
+ * it and only the later one counts. Segments of genuinely different speech are
+ * not prefixes of one another, so they all survive. Judging each entry against
+ * its neighbour rather than the list as a whole keeps a coincidence — one
+ * phrase that happens to open the next — down to that pair.
+ */
+const readTranscript = (results: SpeechRecognitionResultList) => {
+  const finals: string[] = [];
+
+  for (let i = 0; i < results.length; i++) {
+    const result = results[i];
+    // Only the tail of the list can still be interim, so stop at the first one
+    // and pick those indices up once they are final.
+    if (!result?.isFinal) {
+      break;
+    }
+    finals.push(result[0]?.transcript ?? "");
+  }
+
+  return finals
+    .filter((transcript, index) => {
+      const next = finals[index + 1];
+      return next === undefined || !next.startsWith(transcript);
+    })
+    .reduce(joinSpoken, "");
+};
+
 export type UseSpeechToTextOptions = {
   textareaRef?: RefObject<HTMLTextAreaElement | null>;
   onTranscriptionChange?: (text: string) => void;
@@ -75,20 +165,37 @@ export function useSpeechToText({
   onTranscriptionChange,
 }: UseSpeechToTextOptions = {}) {
   const [isListening, setIsListening] = useState(false);
-  const [isSupported, setIsSupported] = useState(false);
+  const [availability, setAvailability] = useState<
+    "unknown" | "ready" | "unsupported" | "insecure-context"
+  >("unknown");
+  const [fault, setFault] = useState<SpeechToTextFault | null>(null);
   const [transcript, setTranscript] = useState("");
   const recognitionRef = useRef<SpeechRecognition | null>(null);
-  // How many entries of the current session's result list have already been
-  // appended. Chrome on Android re-delivers results that were finalised
-  // earlier in the session with `resultIndex` back at 0, so `resultIndex`
-  // alone cannot tell new speech from a replay and the text doubles up.
-  const consumedResultsRef = useRef(0);
+  // The part of this session's transcript already written into the textarea.
+  // Every result event carries the session's transcript from the top, so what
+  // is new is whatever this does not already cover — which is what makes a
+  // replayed or restated result a no-op instead of a repeat.
+  const writtenRef = useRef("");
 
   useEffect(() => {
-    if (
-      typeof window === "undefined" ||
-      !("SpeechRecognition" in window || "webkitSpeechRecognition" in window)
-    ) {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (!(
+      "SpeechRecognition" in window || "webkitSpeechRecognition" in window
+    )) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setAvailability("unsupported");
+      return;
+    }
+
+    // The constructor is on `window` on insecure origins too, so the API looks
+    // available right up until `start()` fails with `not-allowed` — a browser
+    // will not grant the microphone outside a secure context. Saying so up
+    // front beats a mic button that claims to work and doesn't (issue #768).
+    if (window.isSecureContext === false) {
+      setAvailability("insecure-context");
       return;
     }
 
@@ -101,7 +208,7 @@ export function useSpeechToText({
     recognition.lang = "en-US";
 
     recognition.onstart = () => {
-      consumedResultsRef.current = 0;
+      writtenRef.current = "";
       setIsListening(true);
     };
 
@@ -110,49 +217,55 @@ export function useSpeechToText({
     };
 
     recognition.onresult = (event) => {
-      // A shorter list than we have already consumed means the engine started
-      // a fresh list mid-session; the old indices no longer refer to anything.
-      if (event.results.length < consumedResultsRef.current) {
-        consumedResultsRef.current = 0;
+      const textarea = textareaRef?.current;
+      if (!textarea) {
+        return;
       }
 
-      let finalTranscript = "";
+      const spoken = readTranscript(event.results);
+      const written = writtenRef.current;
+      // A transcript that carries on the one already written extends it; one
+      // that doesn't belongs to a result list the engine started afresh, and
+      // is new speech in its own right.
+      const continues = written !== "" && spoken.startsWith(written);
+      const addition = continues ? spoken.slice(written.length) : spoken;
 
-      for (let i = consumedResultsRef.current; i < event.results.length; i++) {
-        const result = event.results[i];
-        // Finalised results arrive in order and only the tail can still be
-        // interim, so stop here and pick this index up once it is final.
-        if (!result?.isFinal) {
-          break;
-        }
-        finalTranscript += result[0]?.transcript ?? "";
-        consumedResultsRef.current = i + 1;
+      if (!addition) {
+        return;
       }
+      writtenRef.current = spoken;
 
-      if (finalTranscript && textareaRef?.current) {
-        const textarea = textareaRef.current;
-        const currentValue = textarea.value;
-        const newValue =
-          currentValue + (currentValue ? " " : "") + finalTranscript;
+      const currentValue = textarea.value;
+      // An extension is an exact continuation of what is in the box, down to
+      // whether it starts mid-word, so it goes on verbatim. Anything else
+      // begins a new run of speech and needs a gap from what is there.
+      const newValue = continues
+        ? currentValue + addition
+        : joinSpoken(currentValue, addition);
 
-        textarea.value = newValue;
-        textarea.dispatchEvent(new Event("input", { bubbles: true }));
-        setTranscript(newValue);
-        onTranscriptionChange?.(newValue);
-      }
+      textarea.value = newValue;
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      setTranscript(newValue);
+      onTranscriptionChange?.(newValue);
     };
 
     recognition.onerror = (event) => {
-      console.error("Speech recognition error:", event.error);
       setIsListening(false);
+      if (QUIET_ERRORS.has(event.error)) {
+        return;
+      }
+      setFault({
+        code: RECOGNITION_FAULT_CODES.has(event.error)
+          ? (event.error as SpeechToTextFaultCode)
+          : "unknown",
+      });
     };
 
     recognitionRef.current = recognition;
-    // Expose support for the Web Speech API (only knowable after mount) to
-    // render so the mic button can enable; this setState is part of
+    // Whether dictation can run here is only knowable after mount, and it is
+    // what the mic button answers a press with; this setState is part of
     // initialising that external system.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setIsSupported(true);
+    setAvailability("ready");
 
     return () => {
       recognition.stop();
@@ -161,16 +274,30 @@ export function useSpeechToText({
 
   const toggleListening = useCallback(() => {
     const recognition = recognitionRef.current;
-    if (!recognition) {
+    if (availability !== "ready" || !recognition) {
+      // Nothing to toggle, so answer the tap with the reason instead of
+      // leaving it looking like a missed press.
+      setFault({
+        code:
+          availability === "insecure-context" ? availability : "unsupported",
+      });
       return;
     }
+
+    setFault(null);
 
     if (isListening) {
       recognition.stop();
     } else {
       recognition.start();
     }
-  }, [isListening]);
+  }, [availability, isListening]);
 
-  return { isListening, isSupported, toggleListening, transcript };
+  return {
+    isListening,
+    isSupported: availability === "ready",
+    fault,
+    toggleListening,
+    transcript,
+  };
 }


### PR DESCRIPTION
Fixes #768, and finishes the dictation work started in #752.

## Repeating transcripts

v3.2.2 shipped f3829c4 for this and it did not hold. The reported text says why:

```
hello hello world hello world hello world hello world hello world how
hello world how are hello world how are you hello world how are you
```

That is `"hello world"` then `"how are you"`, dictated on Chrome for Android.
Split it and every chunk is the whole utterance up to that moment. Chrome for
Android grows `event.results` by one `isFinal` entry per partial update, and
each entry carries everything said so far — the list is a chain of restatements,
not a sequence of segments. Running it together writes every word once for each
entry it appears in.

f3829c4 tracked how many entries had been consumed. That defeats a list the
engine *replays*, but not this: each entry genuinely is new, it just
re-contains its predecessors.

One rule now covers both engines: **an entry the next one begins with was
restated by it, so only the later one counts.** Segments of genuinely different
speech are not prefixes of one another, so a spec-correct desktop stream is
untouched. Entries are judged against their neighbour rather than the list as a
whole, which bounds the cost of a coincidence — one phrase that happens to open
the next collapses that pair and nothing else, and there is a test pinning that.

The write into the textarea is now a content diff rather than an append, so a
replay, a restatement or a redelivered list adds nothing at all.

## Failures the user could not see

`onerror` reached `console.error` and nowhere else. On a phone there is no
console short of `chrome://inspect` over USB, so permission denial, an
unavailable speech service and a tap that never landed all presented
identically — as nothing happening. That is what made #752 take a full triage
round.

The hook now reports a fault code and the button turns it into a message.
`no-speech` and `aborted` stay quiet: ending without comment is the honest
answer to silence, and to the user stopping dictation themselves.

Two gaps in the same vein close with it:

- **Insecure origins.** The Web Speech constructor is exposed on them, so
  `isSupported` came back `true`, the mic rendered enabled, and pressing it
  failed with `not-allowed`. No browser grants a microphone outside a secure
  context, so that is now checked before recognition is built and the button
  says so.
- **The disabled button.** It no longer renders `disabled` where dictation is
  unavailable. A disabled button takes no pointer events, so its tooltip never
  opens and the reason never reaches anyone — a quieter version of the same
  silence.

## Where this came from

All of it is inherited from the vendored AI Elements speech button, and all of
it was unreachable until #752 made the mic clickable. Upstream still ships the
`resultIndex` loop — correct per spec, correct on desktop, wrong on Android —
along with the `console.error`-only handler and the `disabled` button. Worth
knowing that `prompt-input.tsx` is a registry copy, not a dependency: a future
`shadcn add prompt-input` would reintroduce all of this.

## Verification

- A test replays the Android stream and reproduces the string above
  character-for-character against the previous implementation; it passes after
  the change. Nine hook tests and four component tests are new.
- Both failure paths were driven in a real Chrome against a running instance:
  an insecure origin reports the secure-connection message, and a blocked
  microphone reports the permission message. No speech `console.error` remains.
- `pnpm test` (2462 backend, 716 frontend, 49 docs), `pnpm typecheck` and
  `pnpm lint` are clean.

The Android fix itself could not be exercised on an Android device from here —
Chrome's recogniser ignores the fake-audio flag and the quirk does not exist off
Android. What it rests on is the reported stream, reproduced as a regression
test.

## Docs

`building-with-platypus/chat.mdx` gains the secure-connection trap under **Voice
input**. It bites self-hosters reaching an instance on a plain `http://` LAN
address, and presents as a mic button that does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
