### PR TITLE
feat(backend): expected-column precondition on card moves

### DIFF
--- a/apps/backend/src/routes/kanban.test.ts
+++ b/apps/backend/src/routes/kanban.test.ts
@@ -1040,6 +1040,36 @@ describe("Kanban Routes", () => {
       expect(res.status).toBe(200);
     });
 
+    // ADR-0010: a stale view of the board is a conflict, not a malformed
+    // request, so the UI can tell "re-sync" apart from "you sent nonsense".
+    it("should answer 409 when the card has left the expected column", async () => {
+      mockSession();
+      mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess
+      mockDb.limit.mockResolvedValueOnce([
+        { ownerId: "user-1", organizationId: "org-1" },
+      ]); // requireWorkspaceAccess
+
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "card-1", columnId: "col-2", boardId: "board-1" },
+      ]); // card guard — already moved on
+      mockDb.limit.mockResolvedValueOnce([{ id: "col-2", boardId: "board-1" }]); // target column guard
+
+      mockDb.orderBy.mockResolvedValueOnce([]);
+      mockDb.returning.mockResolvedValueOnce([]); // the predicate matched no row
+
+      const res = await app.request(`${baseUrl}/${boardId}/cards/card-1/move`, {
+        method: "POST",
+        body: JSON.stringify({
+          columnId: "col-2",
+          afterCardId: null,
+          expectedColumnId: "col-1",
+        }),
+        headers: { "Content-Type": "application/json" },
+      });
+
+      expect(res.status).toBe(409);
+    });
+
     it("should move card after another card", async () => {
       mockSession();
       mockDb.limit.mockResolvedValueOnce([{ role: "member" }]); // requireOrgAccess

--- a/apps/backend/src/services/kanban.test.ts
+++ b/apps/backend/src/services/kanban.test.ts
@@ -5,6 +5,11 @@ vi.mock("./event-dispatch.ts", () => ({
   dispatchEvent: vi.fn(),
 }));
 
+// Imported after `test-utils`, which is what installs the suite-wide
+// `drizzle-orm` mock — pulled in earlier, `eq` would be the real export and the
+// predicate assertions below would have nothing to read.
+import { eq } from "drizzle-orm";
+import { kanbanCard as kanbanCardTable } from "../db/schema.ts";
 import { ConflictError, NotFoundError, ValidationError } from "../errors.ts";
 import { dispatchEvent } from "./event-dispatch.ts";
 import {
@@ -502,6 +507,69 @@ describe("kanban module", () => {
       expect(result.card.columnId).toBe("col-new");
     });
 
+    // Without these two the suite is vacuous: every refusal test below fakes
+    // the outcome by stubbing zero rows, so an implementation that dropped the
+    // predicate and kept only the `if (!row) throw` would pass them all. The
+    // predicate itself is what has to be pinned.
+    //
+    // `drizzle-orm` is mocked suite-wide (see test-utils), so `eq()` returns
+    // undefined and the assembled clause is unreadable from the `where` args.
+    // Asserting on the `eq` mock's arguments is what remains observable. That
+    // proves the predicate is built and handed to the UPDATE; it cannot prove
+    // Postgres applies it, which no test here can without a real database.
+    it("constrains the update to the expected column", async () => {
+      vi.mocked(eq).mockClear();
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-old", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]);
+      db.orderBy.mockResolvedValue([]);
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-new", position: 1 },
+      ]);
+
+      await moveCard(asDb(db), ctx, {
+        cardId: "card-1",
+        columnId: "col-new",
+        afterCardId: null,
+        expectedColumnId: "col-old",
+      });
+
+      expect(vi.mocked(eq)).toHaveBeenCalledWith(
+        kanbanCardTable.columnId,
+        "col-old",
+      );
+    });
+
+    // The converse: with no expectation the update stays unconditional, or
+    // every existing caller silently acquires a precondition it never asked
+    // for. "col-old" is the card's current column, so a precondition applied
+    // unconditionally from the pre-read would show up here.
+    it("leaves the update unconditional when no column is expected", async () => {
+      vi.mocked(eq).mockClear();
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-old", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]);
+      db.orderBy.mockResolvedValue([]);
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-new", position: 1 },
+      ]);
+
+      await moveCard(asDb(db), ctx, {
+        cardId: "card-1",
+        columnId: "col-new",
+        afterCardId: null,
+      });
+
+      expect(vi.mocked(eq)).not.toHaveBeenCalledWith(
+        kanbanCardTable.columnId,
+        "col-old",
+      );
+    });
+
     // The expectation is a predicate on the UPDATE, so a card that has moved on
     // matches no rows. A comparison against the pre-transaction read would pass
     // here and let the stale write land.
@@ -559,13 +627,23 @@ describe("kanban module", () => {
     // the refusal has to leave the transaction by throwing — a value returned
     // from the callback would commit that renumbering alongside a move that
     // never happened.
+    //
+    // The target column below has a collapsed gap (1.0 to 1.0005, under the
+    // 0.001 threshold) and the card is dropped into it, so `placeCardInColumn`
+    // takes its rebalance branch and issues the renumbering UPDATEs — the
+    // writes the rollback has to discard. The mock has no rollback semantics,
+    // so what is asserted is the property that makes a real transaction roll
+    // back: the throw happens inside it.
     it("throws the refusal from inside the transaction so the rebalance rolls back", async () => {
       db.limit
         .mockResolvedValueOnce([
           { id: "card-1", columnId: "col-old", boardId: "board-1" },
         ])
         .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]);
-      db.orderBy.mockResolvedValue([]);
+      db.orderBy.mockResolvedValue([
+        { id: "card-2", position: 1.0 },
+        { id: "card-3", position: 1.0005 },
+      ]);
       db.returning.mockResolvedValue([]);
 
       let threwInsideTransaction = false;
@@ -582,11 +660,16 @@ describe("kanban module", () => {
         moveCard(asDb(db), ctx, {
           cardId: "card-1",
           columnId: "col-new",
-          afterCardId: null,
+          afterCardId: "card-2",
           expectedColumnId: "col-stale",
         }),
       ).rejects.toThrow(ConflictError);
 
+      // Guards the setup: without the rebalance actually firing there are no
+      // stray position writes to roll back, and this test would be asserting
+      // the throw against a case that never had the problem. One update is the
+      // move itself; the rebalance adds one per card it renumbers.
+      expect(db.update.mock.calls.length).toBeGreaterThan(1);
       expect(threwInsideTransaction).toBe(true);
     });
   });

--- a/apps/backend/src/services/kanban.test.ts
+++ b/apps/backend/src/services/kanban.test.ts
@@ -5,7 +5,7 @@ vi.mock("./event-dispatch.ts", () => ({
   dispatchEvent: vi.fn(),
 }));
 
-import { NotFoundError, ValidationError } from "../errors.ts";
+import { ConflictError, NotFoundError, ValidationError } from "../errors.ts";
 import { dispatchEvent } from "./event-dispatch.ts";
 import {
   applyBodyDiff,
@@ -479,6 +479,115 @@ describe("kanban module", () => {
           changedFields: [],
         }),
       );
+    });
+
+    it("moves the card when the expected column still matches", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-old", boardId: "board-1" },
+        ]) // requireCard
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]); // requireColumn
+      db.orderBy.mockResolvedValue([]); // placeCardInColumn
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-new", position: 1 },
+      ]);
+
+      const result = await moveCard(asDb(db), ctx, {
+        cardId: "card-1",
+        columnId: "col-new",
+        afterCardId: null,
+        expectedColumnId: "col-old",
+      });
+
+      expect(result.card.columnId).toBe("col-new");
+    });
+
+    // The expectation is a predicate on the UPDATE, so a card that has moved on
+    // matches no rows. A comparison against the pre-transaction read would pass
+    // here and let the stale write land.
+    it("refuses the move when the card has left the expected column", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-old", boardId: "board-1" },
+        ]) // requireCard
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]); // requireColumn
+      db.orderBy.mockResolvedValue([]); // placeCardInColumn
+      db.returning.mockResolvedValue([]); // the predicate matched no row
+
+      await expect(
+        moveCard(asDb(db), ctx, {
+          cardId: "card-1",
+          columnId: "col-new",
+          afterCardId: null,
+          expectedColumnId: "col-stale",
+        }),
+      ).rejects.toThrow(ConflictError);
+
+      expect(dispatchEvent).not.toHaveBeenCalled();
+    });
+
+    // The refusal sends the caller back to re-read the board rather than handing
+    // it the winning writer's state, which is what invites an immediate
+    // re-assertion of the losing move.
+    it("does not name the card's current column in the refusal", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-note-processing", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]);
+      db.orderBy.mockResolvedValue([]);
+      db.returning.mockResolvedValue([]);
+
+      let message = "";
+      try {
+        await moveCard(asDb(db), ctx, {
+          cardId: "card-1",
+          columnId: "col-new",
+          afterCardId: null,
+          expectedColumnId: "col-stale",
+        });
+      } catch (caught) {
+        message = (caught as Error).message;
+      }
+
+      // Asserted first so the check below can't pass by the move succeeding.
+      expect(message).toContain("expected column");
+      expect(message).not.toContain("col-note-processing");
+    });
+
+    // `placeCardInColumn` renumbers the target column before the update runs, so
+    // the refusal has to leave the transaction by throwing — a value returned
+    // from the callback would commit that renumbering alongside a move that
+    // never happened.
+    it("throws the refusal from inside the transaction so the rebalance rolls back", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-old", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]);
+      db.orderBy.mockResolvedValue([]);
+      db.returning.mockResolvedValue([]);
+
+      let threwInsideTransaction = false;
+      db.transaction.mockImplementation(async (cb: (tx: MockDb) => unknown) => {
+        try {
+          return await cb(db);
+        } catch (error) {
+          threwInsideTransaction = true;
+          throw error;
+        }
+      });
+
+      await expect(
+        moveCard(asDb(db), ctx, {
+          cardId: "card-1",
+          columnId: "col-new",
+          afterCardId: null,
+          expectedColumnId: "col-stale",
+        }),
+      ).rejects.toThrow(ConflictError);
+
+      expect(threwInsideTransaction).toBe(true);
     });
   });
 

--- a/apps/backend/src/services/kanban.ts
+++ b/apps/backend/src/services/kanban.ts
@@ -15,7 +15,7 @@ import {
   organizationMember as organizationMemberTable,
 } from "../db/schema.ts";
 import { user } from "../db/auth-schema.ts";
-import { NotFoundError, ValidationError } from "../errors.ts";
+import { ConflictError, NotFoundError, ValidationError } from "../errors.ts";
 import type { ScopeContext } from "../scope.ts";
 import { dispatchEvent } from "./event-dispatch.ts";
 import { listScopedByIds } from "./scoped-resource.ts";
@@ -725,11 +725,24 @@ export const updateCard = async (
  * Moves a card within or between columns. Both the card and the target column
  * must be in scope, so a move never carries a card off its board on the HTTP
  * surface or out of the Workspace on the Tool surface.
+ *
+ * `expectedColumnId` makes the move conditional: it applies only while the card
+ * is still in that column, so a caller working from a stale read cannot
+ * silently undo a move someone else made in the meantime. It is a predicate on
+ * the UPDATE rather than a check against `previous`, because `previous` is read
+ * before the transaction opens — comparing against it would catch a stale
+ * caller but still let two concurrent writers both pass and the later one win,
+ * which is the race worth closing.
  */
 export const moveCard = async (
   database: Database,
   ctx: KanbanContext,
-  input: { cardId: string; columnId: string; afterCardId: string | null },
+  input: {
+    cardId: string;
+    columnId: string;
+    afterCardId: string | null;
+    expectedColumnId?: string;
+  },
 ): Promise<CardResult> => {
   const previous = await requireCard(database, ctx, input.cardId);
   const column = await requireColumn(database, ctx, input.columnId);
@@ -749,10 +762,32 @@ export const moveCard = async (
         ...lastEditedBy(ctx.actor),
         updatedAt: new Date(),
       })
-      .where(eq(kanbanCardTable.id, input.cardId))
+      .where(
+        input.expectedColumnId === undefined
+          ? eq(kanbanCardTable.id, input.cardId)
+          : and(
+              eq(kanbanCardTable.id, input.cardId),
+              eq(kanbanCardTable.columnId, input.expectedColumnId),
+            ),
+      )
       .returning();
 
-    return rows[0];
+    const row = rows[0];
+    // Thrown rather than returned so the transaction rolls back:
+    // `placeCardInColumn` may already have renumbered the target column on its
+    // rebalance path, and committing that alongside a move that did not happen
+    // would reorder the board on a refused write.
+    //
+    // The message deliberately does not say where the card is now. Handing the
+    // winning writer's state back to the loser invites an immediate
+    // re-assertion of the stale move; making the caller re-read forces a fresh
+    // look at the board that changed underneath it.
+    if (!row) {
+      throw new ConflictError(
+        "Card is no longer in the expected column; re-read it before moving it",
+      );
+    }
+    return row;
   });
 
   // A move only ever touches columnId and position (bookkeeping, excluded),

--- a/apps/backend/src/tools/kanban.test.ts
+++ b/apps/backend/src/tools/kanban.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { z } from "zod";
-import { mockDb, resetMockDb } from "../test-utils.ts";
+import { callTool, mockDb, resetMockDb } from "../test-utils.ts";
 
 vi.mock("../services/event-dispatch.ts", () => ({
   dispatchEvent: vi.fn(),
@@ -391,6 +391,39 @@ describe("createKanbanTools", () => {
           ctx,
         ),
       ).toEqual({ error: "Card not found" });
+    });
+
+    // A refused precondition has to reach the model as a readable result. If it
+    // escaped `asToolResult` it would throw into the run instead, which is a
+    // failed run rather than an agent that re-reads and carries on.
+    it("reports a refused expected column back to the model", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-now", boardId: "board-1" },
+        ]) // requireCard
+        .mockResolvedValueOnce([{ id: "col-target", boardId: "board-1" }]); // requireColumn
+      mockDb.orderBy.mockResolvedValue([]); // placeCardInColumn
+      mockDb.returning.mockResolvedValue([]); // the predicate matched no row
+
+      // The message is asserted whole: it must name the problem without naming
+      // the column the card is now in. `col-now` above is the current column,
+      // and it does not appear here.
+      expect(
+        await callTool(
+          tools.moveCard,
+          {
+            cardId: "card-1",
+            columnId: "col-target",
+            afterCardId: null,
+            label: "test",
+            expectedColumnId: "col-stale",
+          },
+          ctx,
+        ),
+      ).toEqual({
+        error:
+          "Card is no longer in the expected column; re-read it before moving it",
+      });
     });
   });
 

--- a/apps/backend/src/tools/kanban.ts
+++ b/apps/backend/src/tools/kanban.ts
@@ -7,7 +7,7 @@ import {
   kanbanColumn as kanbanColumnTable,
   kanbanCard as kanbanCardTable,
 } from "../db/schema.ts";
-import { NotFoundError, ValidationError } from "../errors.ts";
+import { ConflictError, NotFoundError, ValidationError } from "../errors.ts";
 import {
   bulkUpdateCards,
   copyCard,
@@ -59,7 +59,11 @@ export function createKanbanTools(
     try {
       return await run();
     } catch (error) {
-      if (error instanceof NotFoundError || error instanceof ValidationError) {
+      if (
+        error instanceof NotFoundError ||
+        error instanceof ValidationError ||
+        error instanceof ConflictError
+      ) {
         return { error: error.message };
       }
       throw error;
@@ -294,10 +298,30 @@ export function createKanbanTools(
         .describe(
           "Place after this card ID, or null to place at the beginning",
         ),
+      // The wording carries the feature. An agent's useful expectation is the
+      // board it read at the start of the run, which may be minutes old by the
+      // time it moves anything; if the description invites a fresh lookup the
+      // check compares current state against current state and never fires.
+      expectedColumnId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional. The column this card was in when you last read it. The " +
+            "move is refused if someone else has moved the card since, so you " +
+            "cannot silently undo their change. Do not look the card up in " +
+            "order to fill this in — omit it if you do not already know.",
+        ),
     }),
-    execute: async ({ cardId, columnId, afterCardId }) =>
+    execute: async ({ cardId, columnId, afterCardId, expectedColumnId }) =>
       asToolResult(async () =>
-        withCardUrl(await moveCard(db, ctx, { cardId, columnId, afterCardId })),
+        withCardUrl(
+          await moveCard(db, ctx, {
+            cardId,
+            columnId,
+            afterCardId,
+            expectedColumnId,
+          }),
+        ),
       ),
   });
 

--- a/apps/docs/content/building-with-platypus/boards.mdx
+++ b/apps/docs/content/building-with-platypus/boards.mdx
@@ -87,27 +87,25 @@ set lets an Agent:
   labels first rather than inventing one.
 </Callout>
 
-### When two people move the same card
-
-An Agent run can take minutes, and a board can be open in someone's browser the
-whole time. So a card can move while a move is already on its way.
-
-Platypus refuses the second move rather than letting it through. If you drag a
-card an Agent has moved since your board last refreshed, the card snaps back and
-you are told it was moved by someone else; the board then reloads so you can see
-where it actually is. Nothing is lost — your drag simply did not apply, and you
-can repeat it against the board as it now stands.
-
-The same holds between two Agents working one board at once. An Agent that acts
-on a stale reading of the board is refused and told to look again, instead of
-quietly undoing the other's work. This is why a card occasionally does not go
-where you put it: something else got there first, and the board is telling you
-rather than hiding it.
-
 This is what makes boards a two-way surface: you arrange the work, and an Agent —
 in a Chat or on a schedule via a [Trigger](/building-with-platypus/triggers) — can
 keep it moving. Board activity (cards created, updated, or deleted) can in turn
 fire **Event** Triggers, so a change on a board can kick off another Agent run.
+
+### When two people move the same card
+
+An Agent run can take minutes, and a board can be open in someone's browser the
+whole time — so a card can move while another move is already on its way.
+Platypus refuses the later move rather than letting it silently overwrite the
+first. The same holds between two Agents working one board at once: an Agent
+acting on a stale reading of the board is refused and told to look again.
+
+<Callout type="warning">
+  If you drag a card an Agent has moved since your board last refreshed, the
+  card snaps back and the board reloads to show where it actually is. Your drag
+  did not apply — nothing else was lost, and you can repeat it against the board
+  as it now stands.
+</Callout>
 
 ## Where to next
 

--- a/apps/docs/content/building-with-platypus/boards.mdx
+++ b/apps/docs/content/building-with-platypus/boards.mdx
@@ -87,6 +87,23 @@ set lets an Agent:
   labels first rather than inventing one.
 </Callout>
 
+### When two people move the same card
+
+An Agent run can take minutes, and a board can be open in someone's browser the
+whole time. So a card can move while a move is already on its way.
+
+Platypus refuses the second move rather than letting it through. If you drag a
+card an Agent has moved since your board last refreshed, the card snaps back and
+you are told it was moved by someone else; the board then reloads so you can see
+where it actually is. Nothing is lost — your drag simply did not apply, and you
+can repeat it against the board as it now stands.
+
+The same holds between two Agents working one board at once. An Agent that acts
+on a stale reading of the board is refused and told to look again, instead of
+quietly undoing the other's work. This is why a card occasionally does not go
+where you put it: something else got there first, and the board is telling you
+rather than hiding it.
+
 This is what makes boards a two-way surface: you arrange the work, and an Agent —
 in a Chat or on a schedule via a [Trigger](/building-with-platypus/triggers) — can
 keep it moving. Board activity (cards created, updated, or deleted) can in turn

--- a/apps/frontend/components/kanban-board.test.tsx
+++ b/apps/frontend/components/kanban-board.test.tsx
@@ -46,6 +46,29 @@ vi.mock("swr", () => ({
   },
 }));
 
+// dnd-kit's pointer sensors don't survive jsdom, so a real drag can't be
+// simulated. This renders the genuine DndContext (so the sortable children
+// still get their provider) while keeping a handle on the drag callbacks the
+// board passes it, which is what lets a test drive a card drop.
+const dragHandlers: {
+  onDragStart?: (event: unknown) => void;
+  onDragEnd?: (event: unknown) => void;
+} = {};
+
+vi.mock("@dnd-kit/core", async () => {
+  const actual =
+    await vi.importActual<typeof import("@dnd-kit/core")>("@dnd-kit/core");
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    DndContext: (props: Record<string, unknown>) => {
+      dragHandlers.onDragStart = props.onDragStart as (e: unknown) => void;
+      dragHandlers.onDragEnd = props.onDragEnd as (e: unknown) => void;
+      return React.createElement(actual.DndContext, props);
+    },
+  };
+});
+
 import { KanbanBoard } from "./kanban-board";
 
 // --- Fixtures ----------------------------------------------------------------
@@ -449,6 +472,70 @@ describe("KanbanBoard transport", () => {
       expect(
         screen.getByRole("heading", { name: "Delete Column" }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("card drag", () => {
+    beforeEach(() => {
+      boardState = makeBoardState([
+        makeColumn({ id: "col-1", name: "In Progress" }, [
+          makeCard({ id: "card-1", columnId: "col-1" }),
+        ]),
+        makeColumn({ id: "col-2", name: "Done" }, []),
+      ]);
+    });
+
+    /** Drops card-1 onto col-2, going through the board's real drag handlers. */
+    function dropCardOnDoneColumn() {
+      const active = {
+        id: "card-1",
+        data: { current: { type: "card" } },
+        rect: { current: { translated: null, initial: null } },
+      };
+      dragHandlers.onDragStart?.({ active });
+      dragHandlers.onDragEnd?.({
+        active,
+        over: { id: "col-2", rect: { top: 0, height: 10 } },
+      });
+    }
+
+    it("sends the column the card was dragged from", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse(200, { id: "card-1" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      renderBoard();
+      dropCardOnDoneColumn();
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toContain("/cards/card-1/move");
+      expect(JSON.parse(init.body as string)).toMatchObject({
+        columnId: "col-2",
+        expectedColumnId: "col-1",
+      });
+    });
+
+    // The card is elsewhere, so reverting to the last poll would leave it in the
+    // wrong column until the next interval — hence the refetch.
+    it("explains a refused drag and re-syncs the board", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse(409, {
+          error: "Card is no longer in the expected column",
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      renderBoard();
+      dropCardOnDoneColumn();
+
+      await waitFor(() =>
+        expect(toastError).toHaveBeenCalledWith(
+          "This card was moved by someone else. Your change was not applied.",
+        ),
+      );
+      expect(mutateBoard).toHaveBeenCalled();
     });
   });
 

--- a/apps/frontend/components/kanban-board.tsx
+++ b/apps/frontend/components/kanban-board.tsx
@@ -531,10 +531,28 @@ export function KanbanBoard({
         joinUrl(baseUrl, `cards/${active.id}/move`),
         {
           method: "POST",
-          data: { columnId: targetColumn.id, afterCardId },
+          data: {
+            columnId: targetColumn.id,
+            afterCardId,
+            // The board polls, so the column this drag started from may already
+            // be out of date. Sending it makes the move conditional: an agent's
+            // move that landed mid-drag is reported rather than overwritten.
+            expectedColumnId: sourceColumn.id,
+          },
         },
       );
       if (outcome.outcome === "success") {
+        await mutate();
+      } else if (outcome.outcome === "conflict") {
+        // Not a failed write but a stale board, so the message says who moved
+        // it rather than surfacing wording aimed at an agent.
+        toast.error(
+          "This card was moved by someone else. Your change was not applied.",
+        );
+        // Dropping the optimistic copy falls back to the last poll — the very
+        // state that just lost the race — so this path re-fetches rather than
+        // leaving the card in the wrong column until the next interval.
+        setLocalColumns(null);
         await mutate();
       } else {
         toast.error(outcome.message);

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -2248,6 +2248,12 @@ export const kanbanCardUpdateSchema = kanbanCardSchema
 export const kanbanCardMoveSchema = z.object({
   columnId: z.string(),
   afterCardId: z.string().nullable(),
+  /**
+   * The column the card was in when the caller last read it. When given, the
+   * move applies only while the card is still there, so a caller working from
+   * a stale view cannot overwrite a move made in the meantime.
+   */
+  expectedColumnId: z.string().optional(),
 });
 
 // Kanban Card Comment


### PR DESCRIPTION
Closes #777.

## Why

`moveCard` moved unconditionally, so the last write won and said nothing about it. The case that motivates the change is overlapping Trigger runs: an Agent reads the board, reasons for minutes, then moves a card that another Agent has moved in the meantime. Its move lands anyway and silently undoes the other's.

An Agent's expectation is not a fresh reading — it comes from its context, which is the board it read at the start of the run. That staleness is exactly what makes the check worth having on the Tool surface, and it is why the Tool description tells an Agent not to look the card up in order to fill the field in. A re-read would compare current state against current state and never fire.

## What

`expectedColumnId`, optional, on the move schema, the service, the `moveCard` Tool, and the board's drag. Absent, behaviour is unchanged. Present, the move applies only while the card is still in that column.

Two implementation points that are load-bearing rather than incidental:

- **The expectation is a predicate on the `UPDATE`, not a comparison against the pre-read.** `moveCard` reads the card before opening its transaction. Checking against that read would catch a stale caller but would still let two concurrent writers both pass, with the later one winning — which is the race the feature exists to close.
- **The refusal throws from inside the transaction.** `placeCardInColumn` renumbers the target column before the update runs, but only on its rebalance path. Returning the refusal instead of throwing would commit that renumbering alongside a move that did not happen, reordering a board on a refused write — intermittently, since the rebalance is conditional.

Typed as `ConflictError` (409 under ADR-0010) and added to the kanban `asToolResult` catch, so an Agent reads the refusal as a result rather than the run failing on it. The message does not say where the card is now: making the caller re-read forces a fresh look at the board that changed underneath it, where handing back the winner's state invites an immediate re-assertion of the stale move.

In the browser, a refused drag reverts, says the card was moved by someone else, and re-fetches — the optimistic revert alone would restore the poll that just lost the race.

## Testing

Backend, Tool, and route coverage for both the applied and refused paths, plus the board's first card-drag tests (dnd-kit's sensors don't run under jsdom, so the test captures the drag callbacks while rendering the real provider).

The predicate tests were mutation-checked. Removing the predicate fails one test; moving the throw outside the transaction fails one test. This matters because `drizzle-orm` is mocked suite-wide and `eq()` returns `undefined`, so a conflict test that only stubs zero rows passes whether or not the predicate exists — asserting on the `eq` mock's arguments is what stays observable.

**What the tests cannot show:** there is no real database in the suite, so nothing here proves Postgres applies the predicate or that the transaction actually rolls back. What is proven is that the predicate is built and handed to the `UPDATE`, and that the refusal throws from inside the transaction — the property that makes a real transaction roll back.

## Out of scope

`bulkUpdateCards` remains an unguarded path that can change a card's column. Not an oversight: guarding it needs a decision about how a failed expectation interacts with its per-card outcome reporting, since it reports per-card success today rather than failing the batch. That is a separate design question.

## Docs

`boards.mdx` describes the behaviour rather than the field — nobody using the product ever supplies it, but they will see a drag get refused, and without the doc that reads as a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
