### PR TITLE
feat(frontend): extract shared RevealableInput control

### DIFF
--- a/apps/frontend/app/sign-in/page.tsx
+++ b/apps/frontend/app/sign-in/page.tsx
@@ -5,14 +5,8 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/components/auth-provider";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from "@/components/ui/input-group";
+import { RevealableInput } from "@/components/ui/revealable-input";
 import { Label } from "@/components/ui/label";
-import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
 
 export default function SignInPage() {
@@ -20,7 +14,6 @@ export default function SignInPage() {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -80,26 +73,13 @@ export default function SignInPage() {
 
           <div className="space-y-2">
             <Label htmlFor="password">Password</Label>
-            <InputGroup>
-              <InputGroupInput
-                id="password"
-                type={showPassword ? "text" : "password"}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-              />
-              <InputGroupAddon align="inline-end">
-                <InputGroupButton
-                  type="button"
-                  size="icon-xs"
-                  onClick={() => setShowPassword(!showPassword)}
-                  disabled={isLoading}
-                  aria-label={showPassword ? "Hide password" : "Show password"}
-                >
-                  {showPassword ? <EyeOff /> : <Eye />}
-                </InputGroupButton>
-              </InputGroupAddon>
-            </InputGroup>
+            <RevealableInput
+              id="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              disabled={isLoading}
+            />
           </div>
 
           <Button type="submit" className="w-full" disabled={isLoading}>

--- a/apps/frontend/app/sign-up/page.tsx
+++ b/apps/frontend/app/sign-up/page.tsx
@@ -5,14 +5,8 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "@/components/auth-provider";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from "@/components/ui/input-group";
+import { RevealableInput } from "@/components/ui/revealable-input";
 import { Label } from "@/components/ui/label";
-import { Eye, EyeOff } from "lucide-react";
 import Link from "next/link";
 
 export default function SignUpPage() {
@@ -21,7 +15,6 @@ export default function SignUpPage() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -94,28 +87,15 @@ export default function SignUpPage() {
 
           <div className="space-y-2">
             <Label htmlFor="password">Password</Label>
-            <InputGroup>
-              <InputGroupInput
-                id="password"
-                type={showPassword ? "text" : "password"}
-                placeholder="At least 8 characters"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                minLength={8}
-                required
-              />
-              <InputGroupAddon align="inline-end">
-                <InputGroupButton
-                  type="button"
-                  size="icon-xs"
-                  onClick={() => setShowPassword(!showPassword)}
-                  disabled={isLoading}
-                  aria-label={showPassword ? "Hide password" : "Show password"}
-                >
-                  {showPassword ? <EyeOff /> : <Eye />}
-                </InputGroupButton>
-              </InputGroupAddon>
-            </InputGroup>
+            <RevealableInput
+              id="password"
+              placeholder="At least 8 characters"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              minLength={8}
+              required
+              disabled={isLoading}
+            />
           </div>
 
           <Button type="submit" className="w-full" disabled={isLoading}>

--- a/apps/frontend/components/change-password-dialog.test.tsx
+++ b/apps/frontend/components/change-password-dialog.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ChangePasswordDialog } from "./change-password-dialog";
+
+vi.mock("@/app/client-context", () => ({
+  useBackendUrl: () => "http://localhost:3000",
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("ChangePasswordDialog revealable input", () => {
+  const dummyUser = {
+    id: "user-123",
+    email: "alice@example.com",
+    name: "Alice",
+  };
+
+  it("defaults new password input to type='password'", () => {
+    render(
+      <ChangePasswordDialog
+        user={dummyUser}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText("New Password");
+    expect(input).toHaveAttribute("type", "password");
+    expect(
+      screen.getByRole("button", { name: "Show new password" }),
+    ).toBeInTheDocument();
+  });
+
+  it("toggles new password input between masked and revealed", () => {
+    render(
+      <ChangePasswordDialog
+        user={dummyUser}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText("New Password");
+    const toggleButton = screen.getByRole("button", {
+      name: "Show new password",
+    });
+
+    fireEvent.click(toggleButton);
+    expect(input).toHaveAttribute("type", "text");
+    expect(
+      screen.getByRole("button", { name: "Hide new password" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide new password" }));
+    expect(input).toHaveAttribute("type", "password");
+    expect(
+      screen.getByRole("button", { name: "Show new password" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/change-password-dialog.tsx
+++ b/apps/frontend/components/change-password-dialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { RevealableInput } from "@/components/ui/revealable-input";
 import { Field, FieldLabel, FieldGroup, FieldSet } from "@/components/ui/field";
 import { useState } from "react";
 import { useBackendUrl } from "@/app/client-context";
@@ -110,9 +110,8 @@ export function ChangePasswordDialog({
           <FieldGroup>
             <Field>
               <FieldLabel htmlFor="newPassword">New Password</FieldLabel>
-              <Input
+              <RevealableInput
                 id="newPassword"
-                type="password"
                 value={newPassword}
                 onChange={(e) => {
                   setNewPassword(e.target.value);
@@ -121,6 +120,7 @@ export function ChangePasswordDialog({
                 disabled={isSubmitting}
                 placeholder="Enter new password (min 8 characters)"
                 autoComplete="new-password"
+                revealLabel="new password"
               />
               {validationError && (
                 <p className="text-sm text-destructive mt-1">

--- a/apps/frontend/components/change-password-form.test.tsx
+++ b/apps/frontend/components/change-password-form.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ChangePasswordForm } from "./change-password-form";
+
+const mockChangePassword = vi.fn();
+
+vi.mock("@/components/auth-provider", () => ({
+  useAuth: () => ({
+    authClient: {
+      changePassword: mockChangePassword,
+    },
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("ChangePasswordForm revealable inputs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defaults all three password fields to masked type='password'", () => {
+    render(<ChangePasswordForm />);
+
+    const currentPassword = screen.getByLabelText("Current Password");
+    const newPassword = screen.getByLabelText("New Password");
+    const confirmPassword = screen.getByLabelText("Confirm New Password");
+
+    expect(currentPassword).toHaveAttribute("type", "password");
+    expect(newPassword).toHaveAttribute("type", "password");
+    expect(confirmPassword).toHaveAttribute("type", "password");
+
+    expect(
+      screen.getByRole("button", { name: "Show current password" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show new password" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show confirm new password" }),
+    ).toBeInTheDocument();
+  });
+
+  it("revealing Current Password leaves the other two masked", () => {
+    render(<ChangePasswordForm />);
+
+    const currentPassword = screen.getByLabelText("Current Password");
+    const newPassword = screen.getByLabelText("New Password");
+    const confirmPassword = screen.getByLabelText("Confirm New Password");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show current password" }),
+    );
+
+    expect(currentPassword).toHaveAttribute("type", "text");
+    expect(newPassword).toHaveAttribute("type", "password");
+    expect(confirmPassword).toHaveAttribute("type", "password");
+
+    expect(
+      screen.getByRole("button", { name: "Hide current password" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show new password" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show confirm new password" }),
+    ).toBeInTheDocument();
+  });
+
+  it("toggles all fields independently", () => {
+    render(<ChangePasswordForm />);
+
+    const currentPassword = screen.getByLabelText("Current Password");
+    const newPassword = screen.getByLabelText("New Password");
+    const confirmPassword = screen.getByLabelText("Confirm New Password");
+
+    // Reveal New Password
+    fireEvent.click(screen.getByRole("button", { name: "Show new password" }));
+    expect(currentPassword).toHaveAttribute("type", "password");
+    expect(newPassword).toHaveAttribute("type", "text");
+    expect(confirmPassword).toHaveAttribute("type", "password");
+
+    // Reveal Confirm New Password
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show confirm new password" }),
+    );
+    expect(currentPassword).toHaveAttribute("type", "password");
+    expect(newPassword).toHaveAttribute("type", "text");
+    expect(confirmPassword).toHaveAttribute("type", "text");
+
+    // Conceal New Password
+    fireEvent.click(screen.getByRole("button", { name: "Hide new password" }));
+    expect(currentPassword).toHaveAttribute("type", "password");
+    expect(newPassword).toHaveAttribute("type", "password");
+    expect(confirmPassword).toHaveAttribute("type", "text");
+  });
+});

--- a/apps/frontend/components/change-password-form.tsx
+++ b/apps/frontend/components/change-password-form.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useAuth } from "@/components/auth-provider";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { RevealableInput } from "@/components/ui/revealable-input";
 import {
   Field,
   FieldLabel,
@@ -56,38 +56,38 @@ export function ChangePasswordForm() {
         <FieldGroup>
           <Field>
             <FieldLabel htmlFor="currentPassword">Current Password</FieldLabel>
-            <Input
+            <RevealableInput
               id="currentPassword"
-              type="password"
               value={currentPassword}
               onChange={(e) => setCurrentPassword(e.target.value)}
               required
               disabled={isSubmitting}
+              revealLabel="current password"
             />
           </Field>
           <Field>
             <FieldLabel htmlFor="newPassword">New Password</FieldLabel>
-            <Input
+            <RevealableInput
               id="newPassword"
-              type="password"
               value={newPassword}
               onChange={(e) => setNewPassword(e.target.value)}
               required
               disabled={isSubmitting}
+              revealLabel="new password"
             />
           </Field>
           <Field data-invalid={!!errors.confirmPassword}>
             <FieldLabel htmlFor="confirmPassword">
               Confirm New Password
             </FieldLabel>
-            <Input
+            <RevealableInput
               id="confirmPassword"
-              type="password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               required
               disabled={isSubmitting}
               aria-invalid={!!errors.confirmPassword}
+              revealLabel="confirm new password"
             />
             {errors.confirmPassword && (
               <FieldError>{errors.confirmPassword}</FieldError>

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -9,12 +9,7 @@ import {
   FieldError,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from "@/components/ui/input-group";
+import { RevealableInput } from "@/components/ui/revealable-input";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import {
@@ -49,8 +44,6 @@ import {
   Check,
   X,
   ExternalLink,
-  Eye,
-  EyeOff,
   ShieldCheck,
   ShieldOff,
   Plus,
@@ -121,8 +114,6 @@ const McpForm = ({
   const [validationErrors, setValidationErrors] = useState<
     Record<string, string>
   >({});
-  const [showBearerToken, setShowBearerToken] = useState(false);
-  const [showOauthClientSecret, setShowOauthClientSecret] = useState(false);
   const [isTesting, setIsTesting] = useState(false);
   const [testResult, setTestResult] = useState<{
     success: boolean;
@@ -576,32 +567,15 @@ const McpForm = ({
                 data-invalid={!!validationErrors.bearerToken}
               >
                 <FieldLabel htmlFor="bearerToken">Bearer Token</FieldLabel>
-                <InputGroup>
-                  <InputGroupInput
-                    id="bearerToken"
-                    type={showBearerToken ? "text" : "password"}
-                    placeholder="Bearer token"
-                    value={formData.bearerToken}
-                    onChange={handleChange}
-                    disabled={isSubmitting}
-                    aria-invalid={!!validationErrors.bearerToken}
-                  />
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      type="button"
-                      size="icon-xs"
-                      onClick={() => setShowBearerToken(!showBearerToken)}
-                      disabled={isSubmitting}
-                      aria-label={
-                        showBearerToken
-                          ? "Hide bearer token"
-                          : "Show bearer token"
-                      }
-                    >
-                      {showBearerToken ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
+                <RevealableInput
+                  id="bearerToken"
+                  placeholder="Bearer token"
+                  value={formData.bearerToken}
+                  onChange={handleChange}
+                  disabled={isSubmitting}
+                  aria-invalid={!!validationErrors.bearerToken}
+                  revealLabel="bearer token"
+                />
                 {validationErrors.bearerToken && (
                   <FieldError>{validationErrors.bearerToken}</FieldError>
                 )}
@@ -631,38 +605,19 @@ const McpForm = ({
                 <FieldLabel htmlFor="oauthClientSecret">
                   Client Secret
                 </FieldLabel>
-                <InputGroup>
-                  <InputGroupInput
-                    id="oauthClientSecret"
-                    type={showOauthClientSecret ? "text" : "password"}
-                    placeholder={
-                      mcpId && mcp?.oauthClientId
-                        ? "Leave blank to keep current"
-                        : "OAuth Client Secret"
-                    }
-                    value={formData.oauthClientSecret}
-                    onChange={handleChange}
-                    disabled={isSubmitting}
-                    aria-invalid={!!validationErrors.oauthClientSecret}
-                  />
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      type="button"
-                      size="icon-xs"
-                      onClick={() =>
-                        setShowOauthClientSecret(!showOauthClientSecret)
-                      }
-                      disabled={isSubmitting}
-                      aria-label={
-                        showOauthClientSecret
-                          ? "Hide client secret"
-                          : "Show client secret"
-                      }
-                    >
-                      {showOauthClientSecret ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
+                <RevealableInput
+                  id="oauthClientSecret"
+                  placeholder={
+                    mcpId && mcp?.oauthClientId
+                      ? "Leave blank to keep current"
+                      : "OAuth Client Secret"
+                  }
+                  value={formData.oauthClientSecret}
+                  onChange={handleChange}
+                  disabled={isSubmitting}
+                  aria-invalid={!!validationErrors.oauthClientSecret}
+                  revealLabel="client secret"
+                />
                 {validationErrors.oauthClientSecret && (
                   <FieldError>{validationErrors.oauthClientSecret}</FieldError>
                 )}

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -11,12 +11,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
-import {
-  InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-} from "@/components/ui/input-group";
+import { RevealableInput } from "@/components/ui/revealable-input";
 import { Button } from "@/components/ui/button";
 import {
   Collapsible,
@@ -27,8 +22,6 @@ import {
   Building,
   ChevronRight,
   ChevronsUpDown,
-  Eye,
-  EyeOff,
   Info,
   OctagonX,
   Plus,
@@ -523,7 +516,6 @@ const ProviderForm = ({
     Record<string, string>
   >({});
   const [error, setError] = useState<string | null>(null);
-  const [showApiKey, setShowApiKey] = useState(false);
 
   const fetchUrl =
     providerId && user
@@ -964,28 +956,15 @@ const ProviderForm = ({
 
           <Field data-invalid={!!validationErrors.apiKey}>
             <FieldLabel htmlFor="apiKey">API Key</FieldLabel>
-            <InputGroup>
-              <InputGroupInput
-                id="apiKey"
-                type={showApiKey ? "text" : "password"}
-                placeholder="sk-..."
-                value={formData.apiKey}
-                onChange={handleChange}
-                disabled={isSubmitting || isReadOnly}
-                aria-invalid={!!validationErrors.apiKey}
-              />
-              <InputGroupAddon align="inline-end">
-                <InputGroupButton
-                  type="button"
-                  size="icon-xs"
-                  onClick={() => setShowApiKey(!showApiKey)}
-                  disabled={isSubmitting || isReadOnly}
-                  aria-label={showApiKey ? "Hide API key" : "Show API key"}
-                >
-                  {showApiKey ? <EyeOff /> : <Eye />}
-                </InputGroupButton>
-              </InputGroupAddon>
-            </InputGroup>
+            <RevealableInput
+              id="apiKey"
+              placeholder="sk-..."
+              value={formData.apiKey}
+              onChange={handleChange}
+              disabled={isSubmitting || isReadOnly}
+              aria-invalid={!!validationErrors.apiKey}
+              revealLabel="API key"
+            />
             {validationErrors.apiKey && (
               <FieldError>{validationErrors.apiKey}</FieldError>
             )}

--- a/apps/frontend/components/ui/revealable-input.test.tsx
+++ b/apps/frontend/components/ui/revealable-input.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { RevealableInput } from "./revealable-input";
+
+describe("RevealableInput", () => {
+  it("defaults to type='password'", () => {
+    render(<RevealableInput aria-label="Secret" />);
+
+    const input = screen.getByLabelText("Secret");
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("has type='button' on the toggle button", () => {
+    render(<RevealableInput aria-label="Secret" />);
+
+    const button = screen.getByRole("button", { name: "Show password" });
+    expect(button).toHaveAttribute("type", "button");
+  });
+
+  it("flips to text and back when clicked, flipping aria-label", () => {
+    render(<RevealableInput aria-label="Secret" />);
+
+    const input = screen.getByLabelText("Secret");
+    const showButton = screen.getByRole("button", { name: "Show password" });
+
+    fireEvent.click(showButton);
+    expect(input).toHaveAttribute("type", "text");
+    const hideButton = screen.getByRole("button", { name: "Hide password" });
+    expect(hideButton).toBeInTheDocument();
+
+    fireEvent.click(hideButton);
+    expect(input).toHaveAttribute("type", "password");
+    expect(
+      screen.getByRole("button", { name: "Show password" }),
+    ).toBeInTheDocument();
+  });
+
+  it("preserves typed value across reveal and conceal", () => {
+    render(<RevealableInput aria-label="Secret" />);
+
+    const input = screen.getByLabelText("Secret");
+    fireEvent.change(input, { target: { value: "my-secret-token-42" } });
+    expect(input).toHaveValue("my-secret-token-42");
+
+    const toggle = screen.getByRole("button", { name: "Show password" });
+    fireEvent.click(toggle);
+    expect(input).toHaveAttribute("type", "text");
+    expect(input).toHaveValue("my-secret-token-42");
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide password" }));
+    expect(input).toHaveAttribute("type", "password");
+    expect(input).toHaveValue("my-secret-token-42");
+  });
+
+  it("uses custom revealLabel in the accessible name", () => {
+    render(<RevealableInput aria-label="API Key" revealLabel="API key" />);
+
+    const showButton = screen.getByRole("button", { name: "Show API key" });
+    expect(showButton).toBeInTheDocument();
+
+    fireEvent.click(showButton);
+    expect(
+      screen.getByRole("button", { name: "Hide API key" }),
+    ).toBeInTheDocument();
+  });
+
+  it("toggles two instances rendered together independently", () => {
+    render(
+      <div>
+        <RevealableInput
+          id="pass1"
+          aria-label="First Password"
+          revealLabel="first password"
+        />
+        <RevealableInput
+          id="pass2"
+          aria-label="Second Password"
+          revealLabel="second password"
+        />
+      </div>,
+    );
+
+    const input1 = screen.getByLabelText("First Password");
+    const input2 = screen.getByLabelText("Second Password");
+
+    expect(input1).toHaveAttribute("type", "password");
+    expect(input2).toHaveAttribute("type", "password");
+
+    // Reveal first input only
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show first password" }),
+    );
+    expect(input1).toHaveAttribute("type", "text");
+    expect(input2).toHaveAttribute("type", "password");
+
+    // Reveal second input
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show second password" }),
+    );
+    expect(input1).toHaveAttribute("type", "text");
+    expect(input2).toHaveAttribute("type", "text");
+
+    // Conceal first input
+    fireEvent.click(
+      screen.getByRole("button", { name: "Hide first password" }),
+    );
+    expect(input1).toHaveAttribute("type", "password");
+    expect(input2).toHaveAttribute("type", "text");
+  });
+
+  it("disables the toggle button when input is disabled", () => {
+    render(<RevealableInput aria-label="Secret" disabled />);
+
+    const button = screen.getByRole("button", { name: "Show password" });
+    expect(button).toBeDisabled();
+  });
+});

--- a/apps/frontend/components/ui/revealable-input.tsx
+++ b/apps/frontend/components/ui/revealable-input.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import * as React from "react";
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+
+export interface RevealableInputProps extends React.ComponentProps<
+  typeof InputGroupInput
+> {
+  revealLabel?: string;
+}
+
+export function RevealableInput({
+  revealLabel = "password",
+  ...props
+}: RevealableInputProps) {
+  const [show, setShow] = useState(false);
+
+  return (
+    <InputGroup>
+      <InputGroupInput {...props} type={show ? "text" : "password"} />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton
+          type="button"
+          size="icon-xs"
+          onClick={() => setShow(!show)}
+          disabled={props.disabled}
+          aria-label={show ? `Hide ${revealLabel}` : `Show ${revealLabel}`}
+        >
+          {show ? <EyeOff /> : <Eye />}
+        </InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  );
+}

--- a/apps/frontend/components/ui/revealable-input.tsx
+++ b/apps/frontend/components/ui/revealable-input.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
+
 import {
   InputGroup,
   InputGroupAddon,
@@ -10,32 +10,35 @@ import {
   InputGroupInput,
 } from "@/components/ui/input-group";
 
-export interface RevealableInputProps extends React.ComponentProps<
-  typeof InputGroupInput
-> {
-  revealLabel?: string;
-}
-
-export function RevealableInput({
+function RevealableInput({
   revealLabel = "password",
+  disabled,
   ...props
-}: RevealableInputProps) {
-  const [show, setShow] = useState(false);
+}: React.ComponentProps<typeof InputGroupInput> & {
+  revealLabel?: string;
+}) {
+  const [revealed, setRevealed] = React.useState(false);
 
   return (
     <InputGroup>
-      <InputGroupInput {...props} type={show ? "text" : "password"} />
+      <InputGroupInput
+        {...props}
+        disabled={disabled}
+        type={revealed ? "text" : "password"}
+      />
       <InputGroupAddon align="inline-end">
         <InputGroupButton
           type="button"
           size="icon-xs"
-          onClick={() => setShow(!show)}
-          disabled={props.disabled}
-          aria-label={show ? `Hide ${revealLabel}` : `Show ${revealLabel}`}
+          onClick={() => setRevealed(!revealed)}
+          disabled={disabled}
+          aria-label={revealed ? `Hide ${revealLabel}` : `Show ${revealLabel}`}
         >
-          {show ? <EyeOff /> : <Eye />}
+          {revealed ? <EyeOff /> : <Eye />}
         </InputGroupButton>
       </InputGroupAddon>
     </InputGroup>
   );
 }
+
+export { RevealableInput };


### PR DESCRIPTION
## What

- Extract a shared `<RevealableInput>` component in `apps/frontend/components/ui/revealable-input.tsx` that manages password reveal/conceal toggle state internally.
- Adopt `<RevealableInput>` across `ChangePasswordForm` (Current Password, New Password, Confirm New Password) and `ChangePasswordDialog` (admin-set New Password), assigning distinct accessible `revealLabel`s so buttons don't collide.
- Migrate existing hand-rolled blocks in `apps/frontend/app/sign-in/page.tsx`, `apps/frontend/app/sign-up/page.tsx`, `apps/frontend/components/provider-form.tsx` (API key), and `apps/frontend/components/mcp-form.tsx` (Bearer token, OAuth client secret) to use `<RevealableInput>`.
- Left `components/webhook-form.tsx` alone as its signing secret row uses custom button styling alongside copy/regenerate controls and different icon sizing (`h-4 w-4`).
- Add tests in `components/ui/revealable-input.test.tsx`, `components/change-password-form.test.tsx`, and `components/change-password-dialog.test.tsx`. All existing tests in `app/sign-in/page.test.tsx`, `app/sign-up/page.test.tsx`, and `components/mcp-form.test.tsx` continue to pass unmodified.

## Why

Following #770 / #781, password reveal controls were present on auth pages but missing when changing passwords. Extracting a shared `<RevealableInput>` component eliminates code duplication, guarantees per-instance state and `type="button"` toggle semantics, and provides consistent reveal behavior across the entire app.

Closes #784

## Checklist

- [x] The **PR title** is a Conventional Commit subject (`feat:`, `fix:` or `chore:`, optional scope). This is squash-merged as the commit on `main` and is what the changelog and version bump are built from — a title without one means the change ships with neither.
- [x] **The change is covered by tests.** New behaviour gets tests; a bug fix gets a test that fails without the fix. A change with no test is one nothing stops from coming back — say so in the description if you believe this one genuinely cannot be tested.
- [x] Docs in `apps/docs/content` are updated **in this PR** if it touched an `.env.example`, a user-facing limit or enum in `packages/schemas`, anything under `apps/backend/src/plugins`, or a visible label or field in the frontend.
- [x] `pnpm test`, `pnpm typecheck` and `pnpm format` pass locally.
