### PR TITLE
fix(schemas): correlate widget type and data

### DIFF
--- a/packages/schemas/index.test.ts
+++ b/packages/schemas/index.test.ts
@@ -46,11 +46,20 @@ import {
   findModelEntry,
   triggerRunStatsSchema,
   iframeWidgetDataSchema,
+  widgetSchema,
   widgetTypeSchema,
   widgetUpdateDataSchema,
 } from "./index";
 
 describe("iframe widget schemas", () => {
+  const widgetEnvelope = {
+    id: "widget-1",
+    dashboardId: "dashboard-1",
+    title: "Status",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
   it("accepts an HTTPS URL and registers iframe as a widget type", () => {
     expect(
       iframeWidgetDataSchema.safeParse({
@@ -86,6 +95,56 @@ describe("iframe widget schemas", () => {
       }).success,
     ).toBe(true);
   });
+
+  it("rejects a non-HTTPS URL when parsing a complete iframe widget", () => {
+    expect(
+      widgetSchema.safeParse({
+        ...widgetEnvelope,
+        type: "iframe",
+        data: { url: "http://status.example.com/embed" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts complete iframe and image widgets under their own data contracts", () => {
+    expect(
+      widgetSchema.safeParse({
+        ...widgetEnvelope,
+        type: "iframe",
+        data: { url: "https://status.example.com/embed" },
+      }).success,
+    ).toBe(true);
+    expect(
+      widgetSchema.safeParse({
+        ...widgetEnvelope,
+        type: "image",
+        data: { url: "http://cdn.example.com/status.png" },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects data that belongs to a different widget type", () => {
+    expect(
+      widgetSchema.safeParse({
+        ...widgetEnvelope,
+        type: "text",
+        data: { url: "https://example.com/not-text" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it.each(widgetTypeSchema.options)(
+    "keeps null data valid for a %s widget",
+    (type) => {
+      expect(
+        widgetSchema.safeParse({
+          ...widgetEnvelope,
+          type,
+          data: null,
+        }).success,
+      ).toBe(true);
+    },
+  );
 });
 
 describe("Organization Schema", () => {

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -2512,26 +2512,50 @@ export const widgetDataSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("bar-chart"), data: barChartWidgetDataSchema }),
 ]);
 
-export const widgetSchema = z.object({
+const widgetBaseSchema = z.object({
   id: z.string(),
   dashboardId: z.string(),
-  type: widgetTypeSchema,
   title: z.string(),
-  data: z
-    .union([
-      metricWidgetDataSchema,
-      textWidgetDataSchema,
-      imageWidgetDataSchema,
-      iframeWidgetDataSchema,
-      weatherWidgetDataSchema,
-      lineChartWidgetDataSchema,
-      pieChartWidgetDataSchema,
-      barChartWidgetDataSchema,
-    ])
-    .nullable(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });
+
+// Keep each persisted widget type paired with its own data contract. A plain
+// data union can let a permissive schema shadow a stricter schema with the same shape.
+export const widgetSchema = z.discriminatedUnion("type", [
+  widgetBaseSchema.extend({
+    type: z.literal("metric"),
+    data: metricWidgetDataSchema.nullable(),
+  }),
+  widgetBaseSchema.extend({
+    type: z.literal("text"),
+    data: textWidgetDataSchema.nullable(),
+  }),
+  widgetBaseSchema.extend({
+    type: z.literal("image"),
+    data: imageWidgetDataSchema.nullable(),
+  }),
+  widgetBaseSchema.extend({
+    type: z.literal("iframe"),
+    data: iframeWidgetDataSchema.nullable(),
+  }),
+  widgetBaseSchema.extend({
+    type: z.literal("weather"),
+    data: weatherWidgetDataSchema.nullable(),
+  }),
+  widgetBaseSchema.extend({
+    type: z.literal("line-chart"),
+    data: lineChartWidgetDataSchema.nullable(),
+  }),
+  widgetBaseSchema.extend({
+    type: z.literal("pie-chart"),
+    data: pieChartWidgetDataSchema.nullable(),
+  }),
+  widgetBaseSchema.extend({
+    type: z.literal("bar-chart"),
+    data: barChartWidgetDataSchema.nullable(),
+  }),
+]);
 
 export type Widget = z.infer<typeof widgetSchema>;
 


### PR DESCRIPTION
## What

- Parse persisted widgets with a discriminated union so each `type` uses its own data schema.
- Preserve nullable data for all eight widget types.
- Add regression coverage for iframe HTTPS validation, image URLs, cross-type data mismatches, and null data.

## Why

The previous plain `data` union allowed the permissive image schema to match iframe payloads before the iframe HTTPS refinement ran. Pairing `type` and `data` structurally closes that read-schema gap without changing the write contract.

Closes #780

## Validation

- `pnpm --filter @platypus/schemas test -- --run index.test.ts` (172 passed)
- `pnpm --filter @platypus/schemas typecheck`
- `pnpm typecheck` (8 tasks)
- `pnpm test` (8 tasks; schemas 172, backend 2475, frontend 749, plus docs/plugin packages)
- `pnpm lint`
- `pnpm format`

All commands passed. They were run with Node.js v22.23.2, so pnpm emitted the repository's expected `node >=24` engine warning.

## Checklist

- [x] The **PR title** is a Conventional Commit subject (`feat:`, `fix:` or `chore:`, optional scope).
- [x] **The change is covered by tests.**
- [x] Docs in `apps/docs/content` are updated when required. This change does not alter a user-facing limit or enum.
- [x] `pnpm test`, `pnpm typecheck` and `pnpm format` pass locally.
