### PR TITLE
chore(frontend): extract the shared form footer buttons

### DIFF
--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -20,18 +20,12 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { FormFooterButtons } from "@/components/form-footer-buttons";
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import Link from "next/link";
-import {
-  ChevronsUpDown,
-  Trash2,
-  ImageIcon,
-  Camera,
-  X,
-  Building,
-} from "lucide-react";
+import { ChevronsUpDown, ImageIcon, Camera, X, Building } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -1035,30 +1029,18 @@ const AgentForm = ({
         </Collapsible>
       </FieldSet>
 
-      <div className="flex gap-2">
-        <Button
-          className="cursor-pointer"
-          onClick={handleSubmit}
-          disabled={
-            isSubmitting ||
-            readOnly ||
-            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
-          }
-        >
-          {agentId ? "Update" : "Save"}
-        </Button>
-
-        {agentId && !isOrgScoped && (
-          <Button
-            className="cursor-pointer"
-            variant="outline"
-            onClick={() => setIsDeleteDialogOpen(true)}
-            disabled={isSubmitting}
-          >
-            <Trash2 /> Delete
-          </Button>
-        )}
-      </div>
+      <FormFooterButtons
+        submitText={agentId ? "Update" : "Save"}
+        onSubmit={handleSubmit}
+        submitDisabled={
+          isSubmitting ||
+          readOnly ||
+          !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+        }
+        deleteVisible={!!agentId && !isOrgScoped}
+        deleteDisabled={isSubmitting}
+        onDelete={() => setIsDeleteDialogOpen(true)}
+      />
 
       <ConfirmDialog
         open={isDeleteDialogOpen}

--- a/apps/frontend/components/blueprint-form.tsx
+++ b/apps/frontend/components/blueprint-form.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
-import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import {
@@ -21,10 +20,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { FormFooterButtons } from "@/components/form-footer-buttons";
 import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
-import { Bot, Plug, Sparkles, Trash2, Unplug } from "lucide-react";
+import { Bot, Plug, Sparkles, Unplug } from "lucide-react";
 import type {
   Blueprint,
   BlueprintItem,
@@ -559,28 +559,16 @@ const BlueprintForm = ({
 
       {formError && <FieldError className="mb-4">{formError}</FieldError>}
 
-      <div className="flex gap-2">
-        <Button
-          className="cursor-pointer"
-          onClick={handleSubmit}
-          disabled={
-            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
-          }
-        >
-          {blueprintId ? "Update" : "Save"}
-        </Button>
-
-        {blueprintId && (
-          <Button
-            className="cursor-pointer"
-            variant="outline"
-            onClick={() => setIsDeleteDialogOpen(true)}
-            disabled={isSubmitting}
-          >
-            <Trash2 /> Delete
-          </Button>
-        )}
-      </div>
+      <FormFooterButtons
+        submitText={blueprintId ? "Update" : "Save"}
+        onSubmit={handleSubmit}
+        submitDisabled={
+          isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+        }
+        deleteVisible={!!blueprintId}
+        deleteDisabled={isSubmitting}
+        onDelete={() => setIsDeleteDialogOpen(true)}
+      />
 
       <ConfirmDialog
         open={isDeleteDialogOpen}

--- a/apps/frontend/components/form-footer-buttons.test.tsx
+++ b/apps/frontend/components/form-footer-buttons.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FormFooterButtons } from "./form-footer-buttons";
+
+describe("FormFooterButtons", () => {
+  it("hides the delete button by default", () => {
+    render(<FormFooterButtons submitText="Save" />);
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Delete/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the delete button when deleteVisible is true", () => {
+    render(<FormFooterButtons submitText="Update" deleteVisible />);
+
+    expect(screen.getByRole("button", { name: /Delete/ })).toBeInTheDocument();
+  });
+
+  it("fires onSubmit on click when type is 'button'", () => {
+    const onSubmit = vi.fn();
+    render(<FormFooterButtons submitText="Save" onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not wire onClick when type is 'submit', leaving the form's onSubmit in control", () => {
+    const onSubmit = vi.fn();
+    render(
+      <FormFooterButtons
+        submitText="Create"
+        onSubmit={onSubmit}
+        type="submit"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Create" });
+    expect(button).toHaveAttribute("type", "submit");
+
+    fireEvent.click(button);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("fires onDelete when the delete button is clicked", () => {
+    const onDelete = vi.fn();
+    render(
+      <FormFooterButtons submitText="Save" deleteVisible onDelete={onDelete} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Delete/ }));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects submitDisabled and deleteDisabled", () => {
+    render(
+      <FormFooterButtons
+        submitText="Save"
+        submitDisabled
+        deleteVisible
+        deleteDisabled
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Delete/ })).toBeDisabled();
+  });
+});

--- a/apps/frontend/components/form-footer-buttons.tsx
+++ b/apps/frontend/components/form-footer-buttons.tsx
@@ -1,7 +1,7 @@
 import { Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-type FormFooterButtonsProps = {
+export type FormFooterButtonsProps = {
   submitText: string;
   onSubmit?: () => void;
   submitDisabled?: boolean;
@@ -13,7 +13,7 @@ type FormFooterButtonsProps = {
   type?: "button" | "submit";
 };
 
-const FormFooterButtons = ({
+export const FormFooterButtons = ({
   submitText,
   onSubmit,
   submitDisabled,
@@ -49,5 +49,3 @@ const FormFooterButtons = ({
     </div>
   );
 };
-
-export { FormFooterButtons };

--- a/apps/frontend/components/form-footer-buttons.tsx
+++ b/apps/frontend/components/form-footer-buttons.tsx
@@ -1,0 +1,53 @@
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type FormFooterButtonsProps = {
+  submitText: string;
+  onSubmit?: () => void;
+  submitDisabled?: boolean;
+  submitClassName?: string;
+  deleteVisible?: boolean;
+  deleteDisabled?: boolean;
+  deleteClassName?: string;
+  onDelete?: () => void;
+  type?: "button" | "submit";
+};
+
+const FormFooterButtons = ({
+  submitText,
+  onSubmit,
+  submitDisabled,
+  submitClassName = "cursor-pointer",
+  deleteVisible = false,
+  deleteDisabled,
+  deleteClassName = "cursor-pointer",
+  onDelete,
+  type = "button",
+}: FormFooterButtonsProps) => {
+  return (
+    <div className="flex gap-2">
+      <Button
+        type={type}
+        className={submitClassName}
+        onClick={type === "button" ? onSubmit : undefined}
+        disabled={submitDisabled}
+      >
+        {submitText}
+      </Button>
+
+      {deleteVisible && (
+        <Button
+          type="button"
+          variant="outline"
+          className={deleteClassName}
+          onClick={onDelete}
+          disabled={deleteDisabled}
+        >
+          <Trash2 /> Delete
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export { FormFooterButtons };

--- a/apps/frontend/components/kanban-board-form.tsx
+++ b/apps/frontend/components/kanban-board-form.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel, FieldError } from "@/components/ui/field";
+import { FormFooterButtons } from "@/components/form-footer-buttons";
 import { useBackendUrl } from "@/app/client-context";
 import { joinUrl } from "@/lib/utils";
 import { canSubmitForm, retractFieldError } from "@/lib/form-errors";
@@ -205,29 +206,21 @@ export function KanbanBoardForm({
         </Button>
       </div>
 
-      <div className="flex gap-2">
-        <Button
-          type="submit"
-          disabled={
-            isSubmitting ||
-            isDeleting ||
-            !name.trim() ||
-            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
-          }
-        >
-          {isEditing ? "Update" : "Create board"}
-        </Button>
-        {isEditing && onDelete && (
-          <Button
-            type="button"
-            variant="outline"
-            onClick={onDelete}
-            disabled={isSubmitting || isDeleting}
-          >
-            <Trash2 /> Delete
-          </Button>
-        )}
-      </div>
+      <FormFooterButtons
+        type="submit"
+        submitText={isEditing ? "Update" : "Create board"}
+        submitDisabled={
+          isSubmitting ||
+          isDeleting ||
+          !name.trim() ||
+          !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+        }
+        submitClassName=""
+        deleteVisible={isEditing && !!onDelete}
+        deleteDisabled={isSubmitting || isDeleting}
+        deleteClassName=""
+        onDelete={onDelete}
+      />
     </form>
   );
 }

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { FormFooterButtons } from "@/components/form-footer-buttons";
 import { useState, useEffect } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
@@ -879,30 +880,18 @@ const McpForm = ({
         </div>
       </FieldSet>
 
-      <div className="flex gap-2">
-        <Button
-          className="cursor-pointer"
-          onClick={handleSubmit}
-          disabled={
-            isSubmitting ||
-            isTesting ||
-            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
-          }
-        >
-          {mcpId ? "Update" : "Save"}
-        </Button>
-
-        {mcpId && (
-          <Button
-            className="cursor-pointer"
-            variant="outline"
-            onClick={() => setIsDeleteDialogOpen(true)}
-            disabled={isSubmitting || isTesting}
-          >
-            <Trash2 /> Delete
-          </Button>
-        )}
-      </div>
+      <FormFooterButtons
+        submitText={mcpId ? "Update" : "Save"}
+        onSubmit={handleSubmit}
+        submitDisabled={
+          isSubmitting ||
+          isTesting ||
+          !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+        }
+        deleteVisible={!!mcpId}
+        deleteDisabled={isSubmitting || isTesting}
+        onDelete={() => setIsDeleteDialogOpen(true)}
+      />
 
       <ConfirmDialog
         open={isDeleteDialogOpen}

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -10,8 +10,8 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
-import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { FormFooterButtons } from "@/components/form-footer-buttons";
 import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
@@ -25,7 +25,6 @@ import {
 } from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
-import { Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import useSWR, { useSWRConfig } from "swr";
 
@@ -200,26 +199,18 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
         </FieldGroup>
       </FieldSet>
 
-      <div className="flex gap-2">
-        <Button
-          onClick={handleSubmit}
-          disabled={
-            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
-          }
-        >
-          {orgId ? "Update" : "Save"}
-        </Button>
-
-        {orgId && (
-          <Button
-            variant="outline"
-            onClick={() => setIsDeleteDialogOpen(true)}
-            disabled={isSubmitting}
-          >
-            <Trash2 /> Delete
-          </Button>
-        )}
-      </div>
+      <FormFooterButtons
+        submitText={orgId ? "Update" : "Save"}
+        onSubmit={handleSubmit}
+        submitDisabled={
+          isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+        }
+        submitClassName=""
+        deleteVisible={!!orgId}
+        deleteDisabled={isSubmitting}
+        deleteClassName=""
+        onDelete={() => setIsDeleteDialogOpen(true)}
+      />
 
       <ConfirmDialog
         open={isDeleteDialogOpen}

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -42,6 +42,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { FormFooterButtons } from "@/components/form-footer-buttons";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
@@ -1372,38 +1373,26 @@ const ProviderForm = ({
       </FieldSet>
 
       {!isReadOnly && (
-        <div className="flex gap-2">
-          <Button
-            className="cursor-pointer"
-            onClick={handleSubmit}
-            disabled={
-              isSubmitting ||
-              !!headersError ||
-              !!extraBodyError ||
-              // RETRACTABLE_FIELDS is deliberately empty: several fields here
-              // (apiMode, organization, project) render only for certain
-              // provider types, so a `validationErrors` key can outlive the
-              // input that would retract it. Server-returned errors must
-              // never gate Save for that reason — re-submitting simply
-              // re-validates. The JSON errors above are different: they are
-              // computed here as the user types and always clear themselves.
-              !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
-            }
-          >
-            {providerId ? "Update" : "Save"}
-          </Button>
-
-          {providerId && (
-            <Button
-              className="cursor-pointer"
-              variant="outline"
-              onClick={() => setIsDeleteDialogOpen(true)}
-              disabled={isSubmitting}
-            >
-              <Trash2 /> Delete
-            </Button>
-          )}
-        </div>
+        <FormFooterButtons
+          submitText={providerId ? "Update" : "Save"}
+          onSubmit={handleSubmit}
+          submitDisabled={
+            isSubmitting ||
+            !!headersError ||
+            !!extraBodyError ||
+            // RETRACTABLE_FIELDS is deliberately empty: several fields here
+            // (apiMode, organization, project) render only for certain
+            // provider types, so a `validationErrors` key can outlive the
+            // input that would retract it. Server-returned errors must
+            // never gate Save for that reason — re-submitting simply
+            // re-validates. The JSON errors above are different: they are
+            // computed here as the user types and always clear themselves.
+            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+          }
+          deleteVisible={!!providerId}
+          deleteDisabled={isSubmitting}
+          onDelete={() => setIsDeleteDialogOpen(true)}
+        />
       )}
 
       <ConfirmDialog

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -10,14 +10,13 @@ import {
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
-import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { FormFooterButtons } from "@/components/form-footer-buttons";
 import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
-import { Trash2 } from "lucide-react";
 import { type Skill, type Agent } from "@platypus/schemas";
 import useSWR, { useSWRConfig } from "swr";
 import { fetcher, joinUrl } from "@/lib/utils";
@@ -293,28 +292,16 @@ const SkillForm = ({
         </Card>
       )}
 
-      <div className="flex gap-2">
-        <Button
-          className="cursor-pointer"
-          onClick={handleSubmit}
-          disabled={
-            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
-          }
-        >
-          {skillId ? "Update" : "Save"}
-        </Button>
-
-        {skillId && (
-          <Button
-            className="cursor-pointer"
-            variant="outline"
-            onClick={() => setIsDeleteDialogOpen(true)}
-            disabled={isSubmitting}
-          >
-            <Trash2 /> Delete
-          </Button>
-        )}
-      </div>
+      <FormFooterButtons
+        submitText={skillId ? "Update" : "Save"}
+        onSubmit={handleSubmit}
+        submitDisabled={
+          isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+        }
+        deleteVisible={!!skillId}
+        deleteDisabled={isSubmitting}
+        onDelete={() => setIsDeleteDialogOpen(true)}
+      />
 
       <ConfirmDialog
         open={isDeleteDialogOpen}

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -19,10 +19,11 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { FormFooterButtons } from "@/components/form-footer-buttons";
 import { useState, useMemo } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
-import { ChevronsUpDown, Trash2 } from "lucide-react";
+import { ChevronsUpDown } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -1260,31 +1261,19 @@ const TriggerForm = ({
         </FieldGroup>
       </FieldSet>
 
-      <div className="flex gap-2">
-        <Button
-          className="cursor-pointer"
-          onClick={handleSubmit}
-          disabled={
-            isSubmitting ||
-            !canSubmitForm(validationErrors, RETRACTABLE_FIELDS) ||
-            !isCronValid ||
-            (triggerType === "event" && selectedEvents.length === 0)
-          }
-        >
-          {triggerId ? "Update" : "Save"}
-        </Button>
-
-        {triggerId && (
-          <Button
-            className="cursor-pointer"
-            variant="outline"
-            onClick={() => setIsDeleteDialogOpen(true)}
-            disabled={isSubmitting}
-          >
-            <Trash2 /> Delete
-          </Button>
-        )}
-      </div>
+      <FormFooterButtons
+        submitText={triggerId ? "Update" : "Save"}
+        onSubmit={handleSubmit}
+        submitDisabled={
+          isSubmitting ||
+          !canSubmitForm(validationErrors, RETRACTABLE_FIELDS) ||
+          !isCronValid ||
+          (triggerType === "event" && selectedEvents.length === 0)
+        }
+        deleteVisible={!!triggerId}
+        deleteDisabled={isSubmitting}
+        onDelete={() => setIsDeleteDialogOpen(true)}
+      />
 
       <ConfirmDialog
         open={isDeleteDialogOpen}

--- a/apps/frontend/components/webhook-form.tsx
+++ b/apps/frontend/components/webhook-form.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { FormFooterButtons } from "@/components/form-footer-buttons";
 import { useCallback, useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
@@ -30,7 +31,7 @@ import {
 import { toast } from "sonner";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
-import { Trash2, Eye, EyeOff, Copy, RefreshCw, Plus, X } from "lucide-react";
+import { Eye, EyeOff, Copy, RefreshCw, Plus, X } from "lucide-react";
 
 interface Webhook {
   id: string;
@@ -502,28 +503,16 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
         </FieldGroup>
       </FieldSet>
 
-      <div className="flex gap-2">
-        <Button
-          className="cursor-pointer"
-          onClick={handleSubmit}
-          disabled={
-            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
-          }
-        >
-          {isEditMode ? "Update" : "Save"}
-        </Button>
-
-        {isEditMode && (
-          <Button
-            className="cursor-pointer"
-            variant="outline"
-            onClick={() => setIsDeleteDialogOpen(true)}
-            disabled={isSubmitting}
-          >
-            <Trash2 /> Delete
-          </Button>
-        )}
-      </div>
+      <FormFooterButtons
+        submitText={isEditMode ? "Update" : "Save"}
+        onSubmit={handleSubmit}
+        submitDisabled={
+          isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+        }
+        deleteVisible={isEditMode}
+        deleteDisabled={isSubmitting}
+        onDelete={() => setIsDeleteDialogOpen(true)}
+      />
 
       <ConfirmDialog
         open={isDeleteDialogOpen}

--- a/apps/frontend/components/workspace-context-form.tsx
+++ b/apps/frontend/components/workspace-context-form.tsx
@@ -29,7 +29,7 @@ import { writeAt } from "@/lib/api-write";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import useSWR from "swr";
-import { Trash2 } from "lucide-react";
+import { FormFooterButtons } from "@/components/form-footer-buttons";
 import type { Organization, Workspace, Context } from "@platypus/schemas";
 
 interface WorkspaceWithOrg extends Workspace {
@@ -268,22 +268,16 @@ export const WorkspaceContextForm = ({ contextId }: { contextId?: string }) => {
         </FieldGroup>
       </FieldSet>
 
-      <div className="flex gap-2">
-        <Button type="submit" disabled={isSubmitting}>
-          {contextId ? "Update" : "Create"}
-        </Button>
-        {contextId && (
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => setIsDeleteDialogOpen(true)}
-            disabled={isSubmitting}
-          >
-            <Trash2 className="w-4 h-4" />
-            Delete
-          </Button>
-        )}
-      </div>
+      <FormFooterButtons
+        type="submit"
+        submitText={contextId ? "Update" : "Create"}
+        submitDisabled={isSubmitting}
+        submitClassName=""
+        deleteVisible={!!contextId}
+        deleteDisabled={isSubmitting}
+        deleteClassName=""
+        onDelete={() => setIsDeleteDialogOpen(true)}
+      />
 
       {/* Delete Dialog */}
       <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -11,7 +11,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
-import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -20,6 +19,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { FormFooterButtons } from "@/components/form-footer-buttons";
 import { useState } from "react";
 import { useResetOnChange } from "@/hooks/use-reset-on-change";
 import { useRouter } from "next/navigation";
@@ -37,7 +37,6 @@ import {
   canListOrgMembers,
   canManageWorkspaceDelegation,
 } from "@/lib/authorization";
-import { Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import useSWR, { useSWRConfig } from "swr";
 
@@ -561,26 +560,18 @@ const WorkspaceForm = ({
         </FieldGroup>
       </FieldSet>
 
-      <div className="flex gap-2">
-        <Button
-          onClick={handleSubmit}
-          disabled={
-            isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
-          }
-        >
-          {workspaceId ? "Update" : "Save"}
-        </Button>
-
-        {workspaceId && (
-          <Button
-            variant="outline"
-            onClick={() => setIsDeleteDialogOpen(true)}
-            disabled={isSubmitting}
-          >
-            <Trash2 /> Delete
-          </Button>
-        )}
-      </div>
+      <FormFooterButtons
+        submitText={workspaceId ? "Update" : "Save"}
+        onSubmit={handleSubmit}
+        submitDisabled={
+          isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)
+        }
+        submitClassName=""
+        deleteVisible={!!workspaceId}
+        deleteDisabled={isSubmitting}
+        deleteClassName=""
+        onDelete={() => setIsDeleteDialogOpen(true)}
+      />
 
       <ConfirmDialog
         open={isDeleteDialogOpen}


### PR DESCRIPTION
## Summary
- Extracts a shared `FormFooterButtons` component (`apps/frontend/components/form-footer-buttons.tsx`) that owns the Save/Update + Delete button row, replacing 11 near-identical hand-rolled footers.
- Migrated: agent-form, mcp-form, provider-form, webhook-form, trigger-form, skill-form, blueprint-form, organization-form, workspace-form, kanban-board-form, workspace-context-form. Each form keeps its own disabled logic, delete-visibility gate, and delete confirmation dialog — the shared component renders only the button row.
- `sandbox-settings.tsx` is left out of scope: its footer has a third Cancel-button state (shown when no sandbox exists yet) that doesn't fit the two-button shape.
- Normalized the Trash2 icon to the bare `<Trash2 />` default — `button.tsx`'s global CSS already forces any icon without a `size-*` class to `size-4`, and Tailwind's `h-4 w-4` and `size-4` are both 1rem, so the previous split was source-level inconsistency, not an actual visual difference.
- No user-facing copy changes.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (755 tests, incl. 6 new tests for `FormFooterButtons`)
- [x] Two-axis code review (Standards + Spec) run; findings addressed (exported props type, added test coverage)

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)