### PR TITLE
chore(frontend): extract a shared resource create/edit page shell

### DIFF
--- a/apps/frontend/app/[orgId]/create/page.tsx
+++ b/apps/frontend/app/[orgId]/create/page.tsx
@@ -1,5 +1,5 @@
 import { WorkspaceForm } from "@/components/workspace-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 import { ProtectedRoute } from "@/components/protected-route";
 
 const WorkspaceCreatePage = async ({
@@ -11,13 +11,13 @@ const WorkspaceCreatePage = async ({
 
   return (
     <ProtectedRoute requireOrgAccess={true} requiredOrgRole="admin">
-      <div className="flex justify-center w-full p-4">
-        <div className="w-lg">
-          <BackButton fallbackHref={`/${orgId}`} />
-          <h1 className="text-2xl mb-4 font-bold">Create Workspace</h1>
-          <WorkspaceForm orgId={orgId} />
-        </div>
-      </div>
+      <ResourcePage
+        backFallbackHref={`/${orgId}`}
+        title="Create Workspace"
+        variant="wide"
+      >
+        <WorkspaceForm orgId={orgId} />
+      </ResourcePage>
     </ProtectedRoute>
   );
 };

--- a/apps/frontend/app/[orgId]/settings/agents/[agentId]/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/agents/[agentId]/page.tsx
@@ -1,6 +1,6 @@
 import { AgentForm } from "@/components/agent-form";
 import { headers } from "next/headers";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 import { type ToolSet } from "@platypus/schemas";
 import { joinUrl } from "@/lib/utils";
 
@@ -31,16 +31,17 @@ const OrgAgentEditPage = async ({
   const toolSets: ToolSet[] = toolSetsData.results;
 
   return (
-    <div>
-      <BackButton fallbackHref={`/${orgId}/settings/agents`} />
-      <h1 className="text-2xl mb-4 font-bold">Edit Shared Agent</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/settings/agents`}
+      title="Edit Shared Agent"
+    >
       <AgentForm
         orgId={orgId}
         agentId={agentId}
         toolSets={toolSets}
         orgScoped
       />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/settings/blueprints/[blueprintId]/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/blueprints/[blueprintId]/page.tsx
@@ -1,5 +1,5 @@
 import { BlueprintForm } from "@/components/blueprint-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const EditBlueprintPage = async ({
   params,
@@ -9,11 +9,12 @@ const EditBlueprintPage = async ({
   const { orgId, blueprintId } = await params;
 
   return (
-    <div>
-      <BackButton fallbackHref={`/${orgId}/settings/blueprints`} />
-      <h1 className="text-2xl font-bold mb-4">Edit Blueprint</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/settings/blueprints`}
+      title="Edit Blueprint"
+    >
       <BlueprintForm orgId={orgId} blueprintId={blueprintId} />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/settings/blueprints/create/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/blueprints/create/page.tsx
@@ -1,5 +1,5 @@
 import { BlueprintForm } from "@/components/blueprint-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const CreateBlueprintPage = async ({
   params,
@@ -9,11 +9,12 @@ const CreateBlueprintPage = async ({
   const { orgId } = await params;
 
   return (
-    <div>
-      <BackButton fallbackHref={`/${orgId}/settings/blueprints`} />
-      <h1 className="text-2xl font-bold mb-4">Create Blueprint</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/settings/blueprints`}
+      title="Create Blueprint"
+    >
       <BlueprintForm orgId={orgId} />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/settings/mcp/[mcpId]/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/mcp/[mcpId]/page.tsx
@@ -1,5 +1,5 @@
 import { McpForm } from "@/components/mcp-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const EditOrgMcpPage = async ({
   params,
@@ -9,11 +9,12 @@ const EditOrgMcpPage = async ({
   const { orgId, mcpId } = await params;
 
   return (
-    <div>
-      <BackButton fallbackHref={`/${orgId}/settings/mcp`} />
-      <h1 className="text-2xl font-bold mb-4">Edit Organization MCP</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/settings/mcp`}
+      title="Edit Organization MCP"
+    >
       <McpForm orgId={orgId} mcpId={mcpId} />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/settings/mcp/create/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/mcp/create/page.tsx
@@ -1,5 +1,5 @@
 import { McpForm } from "@/components/mcp-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const CreateOrgMcpPage = async ({
   params,
@@ -9,11 +9,12 @@ const CreateOrgMcpPage = async ({
   const { orgId } = await params;
 
   return (
-    <div>
-      <BackButton fallbackHref={`/${orgId}/settings/mcp`} />
-      <h1 className="text-2xl font-bold mb-4">Add Organization MCP</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/settings/mcp`}
+      title="Add Organization MCP"
+    >
       <McpForm orgId={orgId} />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/settings/skills/[skillId]/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/skills/[skillId]/page.tsx
@@ -1,5 +1,5 @@
 import { SkillForm } from "@/components/skill-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const EditOrgSkillPage = async ({
   params,
@@ -9,11 +9,12 @@ const EditOrgSkillPage = async ({
   const { orgId, skillId } = await params;
 
   return (
-    <div>
-      <BackButton fallbackHref={`/${orgId}/settings/skills`} />
-      <h1 className="text-2xl font-bold mb-4">Edit Organization Skill</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/settings/skills`}
+      title="Edit Organization Skill"
+    >
       <SkillForm orgId={orgId} skillId={skillId} />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/settings/skills/create/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/skills/create/page.tsx
@@ -1,5 +1,5 @@
 import { SkillForm } from "@/components/skill-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const CreateOrgSkillPage = async ({
   params,
@@ -9,11 +9,12 @@ const CreateOrgSkillPage = async ({
   const { orgId } = await params;
 
   return (
-    <div>
-      <BackButton fallbackHref={`/${orgId}/settings/skills`} />
-      <h1 className="text-2xl font-bold mb-4">Create Organization Skill</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/settings/skills`}
+      title="Create Organization Skill"
+    >
       <SkillForm orgId={orgId} />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/[agentId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/[agentId]/page.tsx
@@ -1,6 +1,6 @@
 import { AgentForm } from "@/components/agent-form";
 import { headers } from "next/headers";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 import { type ToolSet } from "@platypus/schemas";
 import { joinUrl } from "@/lib/utils";
 
@@ -35,18 +35,18 @@ const AgentEditPage = async ({
   const toolSets: ToolSet[] = toolSetsData.results;
 
   return (
-    <div className="flex justify-center pb-8">
-      <div className="w-full px-4 md:px-0 md:w-4/5 xl:w-2/5">
-        <BackButton fallbackHref={`/${orgId}/workspace/${workspaceId}`} />
-        <h1 className="text-2xl mb-4 font-bold">Edit Agent</h1>
-        <AgentForm
-          orgId={orgId}
-          workspaceId={workspaceId}
-          agentId={agentId}
-          toolSets={toolSets}
-        />
-      </div>
-    </div>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}`}
+      title="Edit Agent"
+      variant="create"
+    >
+      <AgentForm
+        orgId={orgId}
+        workspaceId={workspaceId}
+        agentId={agentId}
+        toolSets={toolSets}
+      />
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/create/page.tsx
@@ -1,6 +1,6 @@
 import { AgentForm } from "@/components/agent-form";
 import { headers } from "next/headers";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 import { type ToolSet } from "@platypus/schemas";
 import { joinUrl } from "@/lib/utils";
 
@@ -35,17 +35,13 @@ const AgentCreatePage = async ({
   const toolSets: ToolSet[] = toolSetsData.results;
 
   return (
-    <div className="flex justify-center pb-8">
-      <div className="w-full px-4 md:px-0 md:w-4/5 xl:w-2/5">
-        <BackButton fallbackHref={`/${orgId}/workspace/${workspaceId}`} />
-        <h1 className="text-2xl mb-4 font-bold">Create Agent</h1>
-        <AgentForm
-          orgId={orgId}
-          workspaceId={workspaceId}
-          toolSets={toolSets}
-        />
-      </div>
-    </div>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}`}
+      title="Create Agent"
+      variant="create"
+    >
+      <AgentForm orgId={orgId} workspaceId={workspaceId} toolSets={toolSets} />
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/boards/[boardId]/settings/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/boards/[boardId]/settings/page.tsx
@@ -9,7 +9,7 @@ import { writeEntity } from "@/lib/api-write";
 import { applyDeleteOutcome } from "@/lib/apply-write-outcome";
 import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 import { KanbanBoardForm } from "@/components/kanban-board-form";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { toast } from "sonner";
@@ -67,27 +67,24 @@ const BoardSettingsPage = ({
   }
 
   return (
-    <div className="flex justify-center pb-8">
-      <div className="w-full px-4 md:px-0 md:w-4/5 xl:w-2/5 space-y-8">
-        <BackButton
-          fallbackHref={`/${orgId}/workspace/${workspaceId}/boards/${boardId}`}
-        />
-        <h1 className="text-2xl font-bold">Board Settings</h1>
-
-        <KanbanBoardForm
-          orgId={orgId}
-          workspaceId={workspaceId}
-          board={{
-            id: data.board.id,
-            name: data.board.name,
-            description: data.board.description,
-            labels: data.board.labels,
-          }}
-          onDelete={() => setIsDeleteDialogOpen(true)}
-          isDeleting={isDeleting}
-          onSuccess={() => mutate()}
-        />
-      </div>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}/boards/${boardId}`}
+      title="Board Settings"
+      variant="settings"
+    >
+      <KanbanBoardForm
+        orgId={orgId}
+        workspaceId={workspaceId}
+        board={{
+          id: data.board.id,
+          name: data.board.name,
+          description: data.board.description,
+          labels: data.board.labels,
+        }}
+        onDelete={() => setIsDeleteDialogOpen(true)}
+        isDeleting={isDeleting}
+        onSuccess={() => mutate()}
+      />
 
       <ConfirmDialog
         open={isDeleteDialogOpen}
@@ -107,7 +104,7 @@ const BoardSettingsPage = ({
         onConfirm={handleDeleteConfirm}
         loading={isDeleting}
       />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/boards/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/boards/create/page.tsx
@@ -2,7 +2,7 @@
 
 import { use } from "react";
 import { KanbanBoardForm } from "@/components/kanban-board-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const CreateBoardPage = ({
   params,
@@ -12,15 +12,13 @@ const CreateBoardPage = ({
   const { orgId, workspaceId } = use(params);
 
   return (
-    <div className="flex justify-center pb-8">
-      <div className="w-full px-4 md:px-0 md:w-4/5 xl:w-2/5">
-        <BackButton
-          fallbackHref={`/${orgId}/workspace/${workspaceId}/boards`}
-        />
-        <h1 className="text-2xl mb-4 font-bold">New Board</h1>
-        <KanbanBoardForm orgId={orgId} workspaceId={workspaceId} />
-      </div>
-    </div>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}/boards`}
+      title="New Board"
+      variant="create"
+    >
+      <KanbanBoardForm orgId={orgId} workspaceId={workspaceId} />
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/[dashboardId]/settings/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/[dashboardId]/settings/page.tsx
@@ -4,7 +4,7 @@ import { use, useState } from "react";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import { Trash2 } from "lucide-react";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -106,52 +106,49 @@ const DashboardSettingsPage = ({
   }
 
   return (
-    <div className="flex justify-center pb-8">
-      <div className="w-full px-4 md:px-0 md:w-4/5 xl:w-2/5 space-y-8">
-        <BackButton
-          fallbackHref={`/${orgId}/workspace/${workspaceId}/dashboards/${dashboardId}`}
-        />
-        <h1 className="text-2xl font-bold">Dashboard Settings</h1>
-
-        <form onSubmit={handleSave} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="name">Name</Label>
-            <Input
-              id="name"
-              value={displayName}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="My Dashboard"
-              required
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="description">Description</Label>
-            <Textarea
-              id="description"
-              value={displayDescription}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Optional description"
-            />
-          </div>
-          {saveError && <p className="text-sm text-destructive">{saveError}</p>}
-          <div className="flex gap-2">
-            <Button
-              type="submit"
-              disabled={saving || deleting || !displayName.trim()}
-            >
-              Update
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setDeleteOpen(true)}
-              disabled={saving || deleting}
-            >
-              <Trash2 /> Delete
-            </Button>
-          </div>
-        </form>
-      </div>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}/dashboards/${dashboardId}`}
+      title="Dashboard Settings"
+      variant="settings"
+    >
+      <form onSubmit={handleSave} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="name">Name</Label>
+          <Input
+            id="name"
+            value={displayName}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My Dashboard"
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="description">Description</Label>
+          <Textarea
+            id="description"
+            value={displayDescription}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Optional description"
+          />
+        </div>
+        {saveError && <p className="text-sm text-destructive">{saveError}</p>}
+        <div className="flex gap-2">
+          <Button
+            type="submit"
+            disabled={saving || deleting || !displayName.trim()}
+          >
+            Update
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setDeleteOpen(true)}
+            disabled={saving || deleting}
+          >
+            <Trash2 /> Delete
+          </Button>
+        </div>
+      </form>
 
       <ConfirmDialog
         open={deleteOpen}
@@ -171,7 +168,7 @@ const DashboardSettingsPage = ({
         onConfirm={handleDelete}
         loading={deleting}
       />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/create/page.tsx
@@ -3,7 +3,7 @@
 import { use, useState } from "react";
 import { useRouter } from "next/navigation";
 import { mutate } from "swr";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -61,37 +61,37 @@ const CreateDashboardPage = ({
   };
 
   return (
-    <div className="flex justify-center pb-8">
-      <div className="w-full px-4 md:px-0 md:w-4/5 xl:w-2/5">
-        <BackButton fallbackHref={`/${orgId}/workspace/${workspaceId}`} />
-        <h1 className="text-2xl mb-4 font-bold">New Dashboard</h1>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="name">Name</Label>
-            <Input
-              id="name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="My Dashboard"
-              required
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="description">Description</Label>
-            <Textarea
-              id="description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="Optional description"
-            />
-          </div>
-          {error && <p className="text-sm text-destructive">{error}</p>}
-          <Button type="submit" disabled={loading || !name.trim()}>
-            {loading ? "Creating..." : "Create dashboard"}
-          </Button>
-        </form>
-      </div>
-    </div>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}`}
+      title="New Dashboard"
+      variant="create"
+    >
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="name">Name</Label>
+          <Input
+            id="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="My Dashboard"
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="description">Description</Label>
+          <Textarea
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Optional description"
+          />
+        </div>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <Button type="submit" disabled={loading || !name.trim()}>
+          {loading ? "Creating..." : "Create dashboard"}
+        </Button>
+      </form>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/mcp/[mcpId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/mcp/[mcpId]/page.tsx
@@ -1,5 +1,5 @@
 import { McpForm } from "@/components/mcp-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const McpEditPage = async ({
   params,
@@ -9,13 +9,12 @@ const McpEditPage = async ({
   const { orgId, workspaceId, mcpId } = await params;
 
   return (
-    <div>
-      <BackButton
-        fallbackHref={`/${orgId}/workspace/${workspaceId}/settings/mcp`}
-      />
-      <h1 className="text-2xl mb-4 font-bold">Edit MCP</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}/settings/mcp`}
+      title="Edit MCP"
+    >
       <McpForm orgId={orgId} workspaceId={workspaceId} mcpId={mcpId} />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/mcp/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/mcp/create/page.tsx
@@ -1,5 +1,5 @@
 import { McpForm } from "@/components/mcp-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const McpCreatePage = async ({
   params,
@@ -9,13 +9,12 @@ const McpCreatePage = async ({
   const { orgId, workspaceId } = await params;
 
   return (
-    <div>
-      <BackButton
-        fallbackHref={`/${orgId}/workspace/${workspaceId}/settings/mcp`}
-      />
-      <h1 className="text-2xl mb-4 font-bold">Create MCP</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}/settings/mcp`}
+      title="Create MCP"
+    >
       <McpForm orgId={orgId} workspaceId={workspaceId} />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/providers/[providerId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/providers/[providerId]/page.tsx
@@ -1,5 +1,5 @@
 import { ProviderForm } from "@/components/provider-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const ProviderEditPage = async ({
   params,
@@ -9,17 +9,16 @@ const ProviderEditPage = async ({
   const { orgId, workspaceId, providerId } = await params;
 
   return (
-    <div>
-      <BackButton
-        fallbackHref={`/${orgId}/workspace/${workspaceId}/settings/providers`}
-      />
-      <h1 className="text-2xl mb-4 font-bold">Edit Provider</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}/settings/providers`}
+      title="Edit Provider"
+    >
       <ProviderForm
         orgId={orgId}
         workspaceId={workspaceId}
         providerId={providerId}
       />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/providers/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/providers/create/page.tsx
@@ -1,5 +1,5 @@
 import { ProviderForm } from "@/components/provider-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const ProviderCreatePage = async ({
   params,
@@ -9,13 +9,12 @@ const ProviderCreatePage = async ({
   const { orgId, workspaceId } = await params;
 
   return (
-    <div>
-      <BackButton
-        fallbackHref={`/${orgId}/workspace/${workspaceId}/settings/providers`}
-      />
-      <h1 className="text-2xl mb-4 font-bold">Create Provider</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}/settings/providers`}
+      title="Create Provider"
+    >
       <ProviderForm orgId={orgId} workspaceId={workspaceId} />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/webhooks/[webhookId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/webhooks/[webhookId]/page.tsx
@@ -1,5 +1,5 @@
 import { WebhookForm } from "@/components/webhook-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const WebhookEditPage = async ({
   params,
@@ -9,17 +9,16 @@ const WebhookEditPage = async ({
   const { orgId, workspaceId, webhookId } = await params;
 
   return (
-    <div>
-      <BackButton
-        fallbackHref={`/${orgId}/workspace/${workspaceId}/settings/webhooks`}
-      />
-      <h1 className="text-2xl mb-4 font-bold">Edit Webhook</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}/settings/webhooks`}
+      title="Edit Webhook"
+    >
       <WebhookForm
         orgId={orgId}
         workspaceId={workspaceId}
         webhookId={webhookId}
       />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/webhooks/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/settings/webhooks/create/page.tsx
@@ -1,5 +1,5 @@
 import { WebhookForm } from "@/components/webhook-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const WebhookCreatePage = async ({
   params,
@@ -9,13 +9,12 @@ const WebhookCreatePage = async ({
   const { orgId, workspaceId } = await params;
 
   return (
-    <div>
-      <BackButton
-        fallbackHref={`/${orgId}/workspace/${workspaceId}/settings/webhooks`}
-      />
-      <h1 className="text-2xl mb-4 font-bold">Create Webhook</h1>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}/settings/webhooks`}
+      title="Create Webhook"
+    >
       <WebhookForm orgId={orgId} workspaceId={workspaceId} />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/skills/[skillId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/skills/[skillId]/page.tsx
@@ -1,5 +1,5 @@
 import { SkillForm } from "@/components/skill-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const SkillEditPage = async ({
   params,
@@ -9,13 +9,13 @@ const SkillEditPage = async ({
   const { orgId, workspaceId, skillId } = await params;
 
   return (
-    <div className="flex justify-center pb-8">
-      <div className="w-full px-4 md:px-0 md:w-4/5 xl:w-2/5">
-        <BackButton fallbackHref={`/${orgId}/workspace/${workspaceId}`} />
-        <h1 className="text-2xl mb-4 font-bold">Edit Skill</h1>
-        <SkillForm orgId={orgId} workspaceId={workspaceId} skillId={skillId} />
-      </div>
-    </div>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}`}
+      title="Edit Skill"
+      variant="create"
+    >
+      <SkillForm orgId={orgId} workspaceId={workspaceId} skillId={skillId} />
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/skills/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/skills/create/page.tsx
@@ -1,5 +1,5 @@
 import { SkillForm } from "@/components/skill-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const SkillCreatePage = async ({
   params,
@@ -9,13 +9,13 @@ const SkillCreatePage = async ({
   const { orgId, workspaceId } = await params;
 
   return (
-    <div className="flex justify-center pb-8">
-      <div className="w-full px-4 md:px-0 md:w-4/5 xl:w-2/5">
-        <BackButton fallbackHref={`/${orgId}/workspace/${workspaceId}`} />
-        <h1 className="text-2xl mb-4 font-bold">Create Skill</h1>
-        <SkillForm orgId={orgId} workspaceId={workspaceId} />
-      </div>
-    </div>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}`}
+      title="Create Skill"
+      variant="create"
+    >
+      <SkillForm orgId={orgId} workspaceId={workspaceId} />
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/[triggerId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use } from "react";
 import { TriggerForm } from "@/components/trigger-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const EditTriggerPage = ({
   params,
@@ -12,17 +12,17 @@ const EditTriggerPage = ({
   const { orgId, workspaceId, triggerId } = use(params);
 
   return (
-    <div className="flex justify-center pb-8">
-      <div className="w-full px-4 md:px-0 md:w-4/5 xl:w-2/5">
-        <BackButton fallbackHref={`/${orgId}/workspace/${workspaceId}`} />
-        <h1 className="text-2xl mb-4 font-bold">Edit Trigger</h1>
-        <TriggerForm
-          orgId={orgId}
-          workspaceId={workspaceId}
-          triggerId={triggerId}
-        />
-      </div>
-    </div>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}`}
+      title="Edit Trigger"
+      variant="create"
+    >
+      <TriggerForm
+        orgId={orgId}
+        workspaceId={workspaceId}
+        triggerId={triggerId}
+      />
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/triggers/create/page.tsx
@@ -2,7 +2,7 @@
 
 import { use } from "react";
 import { TriggerForm } from "@/components/trigger-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const CreateTriggerPage = ({
   params,
@@ -12,13 +12,13 @@ const CreateTriggerPage = ({
   const { orgId, workspaceId } = use(params);
 
   return (
-    <div className="flex justify-center pb-8">
-      <div className="w-full px-4 md:px-0 md:w-4/5 xl:w-2/5">
-        <BackButton fallbackHref={`/${orgId}/workspace/${workspaceId}`} />
-        <h1 className="text-2xl mb-4 font-bold">New Trigger</h1>
-        <TriggerForm orgId={orgId} workspaceId={workspaceId} />
-      </div>
-    </div>
+    <ResourcePage
+      backFallbackHref={`/${orgId}/workspace/${workspaceId}`}
+      title="New Trigger"
+      variant="create"
+    >
+      <TriggerForm orgId={orgId} workspaceId={workspaceId} />
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/create/page.tsx
+++ b/apps/frontend/app/create/page.tsx
@@ -1,17 +1,17 @@
 import { OrganizationForm } from "@/components/organization-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 import { ProtectedRoute } from "@/components/protected-route";
 
 const OrganizationCreatePage = () => {
   return (
     <ProtectedRoute requireSuperAdmin={true}>
-      <div className="flex justify-center w-full p-4">
-        <div className="w-lg">
-          <BackButton fallbackHref="/" />
-          <h1 className="text-2xl mb-4 font-bold">Create Organization</h1>
-          <OrganizationForm />
-        </div>
-      </div>
+      <ResourcePage
+        backFallbackHref="/"
+        title="Create Organization"
+        variant="wide"
+      >
+        <OrganizationForm />
+      </ResourcePage>
     </ProtectedRoute>
   );
 };

--- a/apps/frontend/app/settings/contexts/[contextId]/page.tsx
+++ b/apps/frontend/app/settings/contexts/[contextId]/page.tsx
@@ -1,5 +1,5 @@
 import { WorkspaceContextForm } from "@/components/workspace-context-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const WorkspaceContextEditPage = async ({
   params,
@@ -9,11 +9,12 @@ const WorkspaceContextEditPage = async ({
   const { contextId } = await params;
 
   return (
-    <div>
-      <BackButton fallbackHref="/settings/contexts" />
-      <h1 className="text-2xl mb-4 font-bold">Edit Workspace Context</h1>
+    <ResourcePage
+      backFallbackHref="/settings/contexts"
+      title="Edit Workspace Context"
+    >
       <WorkspaceContextForm contextId={contextId} />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/app/settings/contexts/create/page.tsx
+++ b/apps/frontend/app/settings/contexts/create/page.tsx
@@ -1,13 +1,14 @@
 import { WorkspaceContextForm } from "@/components/workspace-context-form";
-import { BackButton } from "@/components/back-button";
+import { ResourcePage } from "@/components/resource-page";
 
 const WorkspaceContextCreatePage = () => {
   return (
-    <div>
-      <BackButton fallbackHref="/settings/contexts" />
-      <h1 className="text-2xl mb-4 font-bold">Create Workspace Context</h1>
+    <ResourcePage
+      backFallbackHref="/settings/contexts"
+      title="Create Workspace Context"
+    >
       <WorkspaceContextForm />
-    </div>
+    </ResourcePage>
   );
 };
 

--- a/apps/frontend/components/resource-page.test.tsx
+++ b/apps/frontend/components/resource-page.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ResourcePage } from "./resource-page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+}));
+
+describe("ResourcePage", () => {
+  it("renders the back button, title, and children", () => {
+    render(
+      <ResourcePage backFallbackHref="/somewhere" title="Create Thing">
+        <div>form goes here</div>
+      </ResourcePage>,
+    );
+
+    expect(screen.getByRole("button", { name: /Back/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Create Thing" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("form goes here")).toBeInTheDocument();
+  });
+
+  it("defaults to the plain variant with no outer centering wrapper", () => {
+    const { container } = render(
+      <ResourcePage backFallbackHref="/somewhere" title="Title">
+        <div>content</div>
+      </ResourcePage>,
+    );
+
+    expect(container.firstChild).not.toHaveClass("flex");
+  });
+
+  it("applies the create variant's centered column and mb-4 title spacing", () => {
+    render(
+      <ResourcePage
+        backFallbackHref="/somewhere"
+        title="Create Thing"
+        variant="create"
+      >
+        <div>content</div>
+      </ResourcePage>,
+    );
+
+    const heading = screen.getByRole("heading", { name: "Create Thing" });
+    expect(heading).toHaveClass("mb-4");
+  });
+
+  it("applies the settings variant's spacing without a title mb-4", () => {
+    render(
+      <ResourcePage
+        backFallbackHref="/somewhere"
+        title="Settings"
+        variant="settings"
+      >
+        <div>content</div>
+      </ResourcePage>,
+    );
+
+    const heading = screen.getByRole("heading", { name: "Settings" });
+    expect(heading).not.toHaveClass("mb-4");
+  });
+
+  it("applies the wide variant's w-lg column", () => {
+    const { container } = render(
+      <ResourcePage backFallbackHref="/somewhere" title="Title" variant="wide">
+        <div>content</div>
+      </ResourcePage>,
+    );
+
+    expect(container.querySelector(".w-lg")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/resource-page.tsx
+++ b/apps/frontend/components/resource-page.tsx
@@ -1,0 +1,59 @@
+import { type ReactNode } from "react";
+import { BackButton } from "@/components/back-button";
+
+export type ResourcePageVariant = "plain" | "create" | "settings" | "wide";
+
+export type ResourcePageProps = {
+  backFallbackHref: string;
+  title: string;
+  children: ReactNode;
+  variant?: ResourcePageVariant;
+};
+
+const narrowTitleClass = "text-2xl mb-4 font-bold";
+const narrowColumnClass = "w-full px-4 md:px-0 md:w-4/5 xl:w-2/5";
+
+const layoutByVariant: Record<
+  ResourcePageVariant,
+  { outer?: string; inner: string; title: string }
+> = {
+  plain: { inner: "", title: narrowTitleClass },
+  create: {
+    outer: "flex justify-center pb-8",
+    inner: narrowColumnClass,
+    title: narrowTitleClass,
+  },
+  settings: {
+    outer: "flex justify-center pb-8",
+    inner: `${narrowColumnClass} space-y-8`,
+    title: "text-2xl font-bold",
+  },
+  wide: {
+    outer: "flex justify-center w-full p-4",
+    inner: "w-lg",
+    title: narrowTitleClass,
+  },
+};
+
+export const ResourcePage = ({
+  backFallbackHref,
+  title,
+  children,
+  variant = "plain",
+}: ResourcePageProps) => {
+  const layout = layoutByVariant[variant];
+
+  const inner = (
+    <div className={layout.inner}>
+      <BackButton fallbackHref={backFallbackHref} />
+      <h1 className={layout.title}>{title}</h1>
+      {children}
+    </div>
+  );
+
+  if (!layout.outer) {
+    return inner;
+  }
+
+  return <div className={layout.outer}>{inner}</div>;
+};


### PR DESCRIPTION
## Summary
- Adds `ResourcePage` (`apps/frontend/components/resource-page.tsx`), a shared BackButton + title + centered-column shell with `plain`/`create`/`settings`/`wide` variants covering the three drifted scaffold variants (A/B/D) plus the plain-block pages (C).
- Migrates all 27 create/edit pages identified in the audit to use it. `trigger-runs/page.tsx` is left as-is, per the issue's own carve-out (distinct layout, not in scope).
- No behavior or copy changes — same column widths, spacing, and BackButton fallback routing preserved per page.

Closes #788

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm --filter frontend test` (760 tests, including new `resource-page.test.tsx`)
- [x] Verified only `trigger-runs/page.tsx` still imports `BackButton` directly (`grep -rl BackButton apps/frontend/app`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)