### PR TITLE
chore(frontend): extract FormTextField from the hand-wired Field+Input blocks

### DIFF
--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/create/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { mutate } from "swr";
 import { ResourcePage } from "@/components/resource-page";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { FormTextField } from "@/components/form-text-field";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { useBackendUrl } from "@/app/client-context";
@@ -67,16 +67,14 @@ const CreateDashboardPage = ({
       variant="create"
     >
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="space-y-2">
-          <Label htmlFor="name">Name</Label>
-          <Input
-            id="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="My Dashboard"
-            required
-          />
-        </div>
+        <FormTextField
+          label="Name"
+          name="name"
+          value={name}
+          onChange={setName}
+          placeholder="My Dashboard"
+          required
+        />
         <div className="space-y-2">
           <Label htmlFor="description">Description</Label>
           <Textarea

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -9,8 +9,8 @@ import {
   FieldDescription,
   FieldError,
 } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
+import { FormTextField } from "@/components/form-text-field";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -259,6 +259,13 @@ const AgentForm = ({
       [id]: value,
     }));
   };
+
+  // Adapts FormTextField's `onChange(value)` to handleChange's `onChange(e)`
+  // so the centralized clear-error-and-set-formData logic stays in one place.
+  const toFieldChange = (id: string) => (value: string) =>
+    handleChange({
+      target: { id, value },
+    } as React.ChangeEvent<HTMLInputElement>);
 
   const handleNumberChange = (id: string, value: string) => {
     clearValidationErrors(id);
@@ -576,21 +583,16 @@ const AgentForm = ({
         </div>
 
         <FieldGroup>
-          <Field data-invalid={!!validationErrors.name}>
-            <FieldLabel htmlFor="name">Name</FieldLabel>
-            <Input
-              id="name"
-              placeholder="Name"
-              value={formData.name}
-              onChange={handleChange}
-              disabled={isSubmitting || readOnly}
-              aria-invalid={!!validationErrors.name}
-              autoFocus
-            />
-            {validationErrors.name && (
-              <FieldError>{validationErrors.name}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Name"
+            name="name"
+            placeholder="Name"
+            value={formData.name}
+            onChange={toFieldChange("name")}
+            disabled={isSubmitting || readOnly}
+            error={validationErrors.name}
+            autoFocus
+          />
           <Field data-invalid={!!validationErrors.description}>
             <ExpandableTextarea
               id="description"
@@ -605,27 +607,17 @@ const AgentForm = ({
               error={validationErrors.description}
             />
           </Field>
-          <Field data-invalid={!!validationErrors.inputPlaceholder}>
-            <FieldLabel htmlFor="inputPlaceholder">
-              Input Placeholder
-            </FieldLabel>
-            <Input
-              id="inputPlaceholder"
-              placeholder="What would you like to know?"
-              value={formData.inputPlaceholder}
-              onChange={handleChange}
-              disabled={isSubmitting || readOnly}
-              maxLength={100}
-              aria-invalid={!!validationErrors.inputPlaceholder}
-            />
-            <FieldDescription>
-              Custom placeholder text shown in the chat input when this agent is
-              selected
-            </FieldDescription>
-            {validationErrors.inputPlaceholder && (
-              <FieldError>{validationErrors.inputPlaceholder}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Input Placeholder"
+            name="inputPlaceholder"
+            placeholder="What would you like to know?"
+            value={formData.inputPlaceholder}
+            onChange={toFieldChange("inputPlaceholder")}
+            disabled={isSubmitting || readOnly}
+            maxLength={100}
+            error={validationErrors.inputPlaceholder}
+            description="Custom placeholder text shown in the chat input when this agent is selected"
+          />
           <Field data-invalid={!!validationErrors.instructions}>
             <ExpandableTextarea
               id="instructions"
@@ -716,25 +708,18 @@ const AgentForm = ({
               </Field>
             );
           })()}
-          <Field className="w-1/2" data-invalid={!!validationErrors.maxSteps}>
-            <FieldLabel htmlFor="maxSteps">Max steps</FieldLabel>
-            <Input
-              id="maxSteps"
-              type="number"
-              min="1"
-              value={formData.maxSteps}
-              onChange={(e) => handleNumberChange("maxSteps", e.target.value)}
-              disabled={isSubmitting || readOnly}
-              aria-invalid={!!validationErrors.maxSteps}
-            />
-            <FieldDescription>
-              Controls when a tool-calling loop should stop based on the number
-              of steps executed
-            </FieldDescription>
-            {validationErrors.maxSteps && (
-              <FieldError>{validationErrors.maxSteps}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            className="w-1/2"
+            label="Max steps"
+            name="maxSteps"
+            type="number"
+            min="1"
+            value={String(formData.maxSteps)}
+            onChange={(value) => handleNumberChange("maxSteps", value)}
+            disabled={isSubmitting || readOnly}
+            error={validationErrors.maxSteps}
+            description="Controls when a tool-calling loop should stop based on the number of steps executed"
+          />
         </FieldGroup>
 
         {toolSets.length > 0 && (
@@ -918,112 +903,76 @@ const AgentForm = ({
           </CollapsibleTrigger>
           <CollapsibleContent className="mb-6">
             <FieldGroup className="grid grid-cols-2">
-              <Field data-invalid={!!validationErrors.temperature}>
-                <FieldLabel htmlFor="temperature">Temperature</FieldLabel>
-                <Input
-                  id="temperature"
-                  type="number"
-                  min="0"
-                  step="0.1"
-                  value={formData.temperature ?? ""}
-                  onChange={(e) =>
-                    handleFloatChange("temperature", e.target.value)
-                  }
-                  disabled={isSubmitting || readOnly}
-                  aria-invalid={!!validationErrors.temperature}
-                />
-                {validationErrors.temperature && (
-                  <FieldError>{validationErrors.temperature}</FieldError>
-                )}
-              </Field>
-              <Field data-invalid={!!validationErrors.seed}>
-                <FieldLabel htmlFor="seed">Seed</FieldLabel>
-                <Input
-                  id="seed"
-                  type="number"
-                  value={formData.seed ?? ""}
-                  onChange={(e) => handleNumberChange("seed", e.target.value)}
-                  disabled={isSubmitting || readOnly}
-                  aria-invalid={!!validationErrors.seed}
-                />
-                {validationErrors.seed && (
-                  <FieldError>{validationErrors.seed}</FieldError>
-                )}
-              </Field>
-              <Field data-invalid={!!validationErrors.topP}>
-                <FieldLabel htmlFor="topP">Top-p</FieldLabel>
-                <Input
-                  id="topP"
-                  type="number"
-                  min="0"
-                  max="1"
-                  step="0.1"
-                  value={formData.topP ?? ""}
-                  onChange={(e) => handleFloatChange("topP", e.target.value)}
-                  disabled={isSubmitting || readOnly}
-                  aria-invalid={!!validationErrors.topP}
-                />
-                {validationErrors.topP && (
-                  <FieldError>{validationErrors.topP}</FieldError>
-                )}
-              </Field>
-              <Field data-invalid={!!validationErrors.topK}>
-                <FieldLabel htmlFor="topK">Top-k</FieldLabel>
-                <Input
-                  id="topK"
-                  type="number"
-                  min="1"
-                  value={formData.topK ?? ""}
-                  onChange={(e) => handleNumberChange("topK", e.target.value)}
-                  disabled={isSubmitting || readOnly}
-                  aria-invalid={!!validationErrors.topK}
-                />
-                {validationErrors.topK && (
-                  <FieldError>{validationErrors.topK}</FieldError>
-                )}
-              </Field>
-              <Field data-invalid={!!validationErrors.presencePenalty}>
-                <FieldLabel htmlFor="presencePenalty">
-                  Presence Penalty
-                </FieldLabel>
-                <Input
-                  id="presencePenalty"
-                  type="number"
-                  min="-2"
-                  max="2"
-                  step="0.1"
-                  value={formData.presencePenalty ?? ""}
-                  onChange={(e) =>
-                    handleFloatChange("presencePenalty", e.target.value)
-                  }
-                  disabled={isSubmitting || readOnly}
-                  aria-invalid={!!validationErrors.presencePenalty}
-                />
-                {validationErrors.presencePenalty && (
-                  <FieldError>{validationErrors.presencePenalty}</FieldError>
-                )}
-              </Field>
-              <Field data-invalid={!!validationErrors.frequencyPenalty}>
-                <FieldLabel htmlFor="frequencyPenalty">
-                  Frequency Penalty
-                </FieldLabel>
-                <Input
-                  id="frequencyPenalty"
-                  type="number"
-                  min="-2"
-                  max="2"
-                  step="0.1"
-                  value={formData.frequencyPenalty ?? ""}
-                  onChange={(e) =>
-                    handleFloatChange("frequencyPenalty", e.target.value)
-                  }
-                  disabled={isSubmitting || readOnly}
-                  aria-invalid={!!validationErrors.frequencyPenalty}
-                />
-                {validationErrors.frequencyPenalty && (
-                  <FieldError>{validationErrors.frequencyPenalty}</FieldError>
-                )}
-              </Field>
+              <FormTextField
+                label="Temperature"
+                name="temperature"
+                type="number"
+                min="0"
+                step="0.1"
+                value={String(formData.temperature ?? "")}
+                onChange={(value) => handleFloatChange("temperature", value)}
+                disabled={isSubmitting || readOnly}
+                error={validationErrors.temperature}
+              />
+              <FormTextField
+                label="Seed"
+                name="seed"
+                type="number"
+                value={String(formData.seed ?? "")}
+                onChange={(value) => handleNumberChange("seed", value)}
+                disabled={isSubmitting || readOnly}
+                error={validationErrors.seed}
+              />
+              <FormTextField
+                label="Top-p"
+                name="topP"
+                type="number"
+                min="0"
+                max="1"
+                step="0.1"
+                value={String(formData.topP ?? "")}
+                onChange={(value) => handleFloatChange("topP", value)}
+                disabled={isSubmitting || readOnly}
+                error={validationErrors.topP}
+              />
+              <FormTextField
+                label="Top-k"
+                name="topK"
+                type="number"
+                min="1"
+                value={String(formData.topK ?? "")}
+                onChange={(value) => handleNumberChange("topK", value)}
+                disabled={isSubmitting || readOnly}
+                error={validationErrors.topK}
+              />
+              <FormTextField
+                label="Presence Penalty"
+                name="presencePenalty"
+                type="number"
+                min="-2"
+                max="2"
+                step="0.1"
+                value={String(formData.presencePenalty ?? "")}
+                onChange={(value) =>
+                  handleFloatChange("presencePenalty", value)
+                }
+                disabled={isSubmitting || readOnly}
+                error={validationErrors.presencePenalty}
+              />
+              <FormTextField
+                label="Frequency Penalty"
+                name="frequencyPenalty"
+                type="number"
+                min="-2"
+                max="2"
+                step="0.1"
+                value={String(formData.frequencyPenalty ?? "")}
+                onChange={(value) =>
+                  handleFloatChange("frequencyPenalty", value)
+                }
+                disabled={isSubmitting || readOnly}
+                error={validationErrors.frequencyPenalty}
+              />
             </FieldGroup>
           </CollapsibleContent>
         </Collapsible>

--- a/apps/frontend/components/blueprint-form.tsx
+++ b/apps/frontend/components/blueprint-form.tsx
@@ -8,7 +8,7 @@ import {
   FieldDescription,
   FieldError,
 } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
+import { FormTextField } from "@/components/form-text-field";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
 import { Switch } from "@/components/ui/switch";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -240,6 +240,13 @@ const BlueprintForm = ({
     setFormData((prev) => ({ ...prev, [id]: value }));
   };
 
+  // Adapts FormTextField's `onChange(value)` to handleChange's `onChange(e)`
+  // so the centralized clear-error-and-set-formData logic stays in one place.
+  const toFieldChange = (id: string) => (value: string) =>
+    handleChange({
+      target: { id, value },
+    } as React.ChangeEvent<HTMLInputElement>);
+
   const toggleItem = (
     type: AttachmentResourceType,
     id: string,
@@ -352,28 +359,21 @@ const BlueprintForm = ({
     <div className={classNames}>
       <FieldSet className="mb-6">
         <FieldGroup className="gap-4">
-          <Field data-invalid={!!validationErrors.name}>
-            <FieldLabel htmlFor="name">Name</FieldLabel>
-            <Input
-              id="name"
-              placeholder="Starter kit"
-              value={formData.name}
-              onChange={handleChange}
-              disabled={isSubmitting}
-              aria-invalid={!!validationErrors.name}
-              autoFocus
-            />
-            <div className="flex justify-between mt-1">
-              {validationErrors.name ? (
-                <FieldError>{validationErrors.name}</FieldError>
-              ) : (
-                <div />
-              )}
+          <FormTextField
+            label="Name"
+            name="name"
+            placeholder="Starter kit"
+            value={formData.name}
+            onChange={toFieldChange("name")}
+            disabled={isSubmitting}
+            error={validationErrors.name}
+            autoFocus
+            trailing={
               <p className="text-xs text-muted-foreground">
                 {formData.name.length}/100
               </p>
-            </div>
-          </Field>
+            }
+          />
           <Field data-invalid={!!validationErrors.description}>
             <ExpandableTextarea
               id="description"

--- a/apps/frontend/components/form-text-field.test.tsx
+++ b/apps/frontend/components/form-text-field.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FormTextField } from "./form-text-field";
+
+describe("FormTextField", () => {
+  it("pairs the label with the input via htmlFor/id", () => {
+    render(
+      <FormTextField label="Name" name="name" value="" onChange={vi.fn()} />,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Name" })).toBeInTheDocument();
+  });
+
+  it("calls onChange with the new value when typed into", async () => {
+    const onChange = vi.fn();
+    render(
+      <FormTextField label="Name" name="name" value="" onChange={onChange} />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Name" }), {
+      target: { value: "a" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("a");
+  });
+
+  it("renders the error and marks the field invalid", () => {
+    render(
+      <FormTextField
+        label="Name"
+        name="name"
+        value=""
+        onChange={vi.fn()}
+        error="Name is required"
+      />,
+    );
+
+    expect(screen.getByText("Name is required")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveAttribute(
+      "aria-invalid",
+      "true",
+    );
+  });
+
+  it("renders no error when none is given", () => {
+    render(
+      <FormTextField label="Name" name="name" value="" onChange={vi.fn()} />,
+    );
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveAttribute(
+      "aria-invalid",
+      "false",
+    );
+  });
+
+  it("renders the description", () => {
+    render(
+      <FormTextField
+        label="Name"
+        name="name"
+        value=""
+        onChange={vi.fn()}
+        description="Shown under the chat input"
+      />,
+    );
+
+    expect(screen.getByText("Shown under the chat input")).toBeInTheDocument();
+  });
+
+  it("renders trailing content alongside the error instead of after it", () => {
+    render(
+      <FormTextField
+        label="Name"
+        name="name"
+        value="abc"
+        onChange={vi.fn()}
+        error="Too long"
+        trailing={<p>3/64</p>}
+      />,
+    );
+
+    expect(screen.getByText("Too long")).toBeInTheDocument();
+    expect(screen.getByText("3/64")).toBeInTheDocument();
+  });
+
+  it("respects disabled and required", () => {
+    render(
+      <FormTextField
+        label="Name"
+        name="name"
+        value=""
+        onChange={vi.fn()}
+        disabled
+        required
+      />,
+    );
+
+    const input = screen.getByRole("textbox", { name: "Name" });
+    expect(input).toBeDisabled();
+    expect(input).toBeRequired();
+  });
+
+  it("respects autoFocus", () => {
+    render(
+      <FormTextField
+        label="Name"
+        name="name"
+        value=""
+        onChange={vi.fn()}
+        autoFocus
+      />,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveFocus();
+  });
+
+  it("passes through the type prop", () => {
+    render(
+      <FormTextField
+        label="Email"
+        name="email"
+        value=""
+        onChange={vi.fn()}
+        type="email"
+      />,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Email" })).toHaveAttribute(
+      "type",
+      "email",
+    );
+  });
+});

--- a/apps/frontend/components/form-text-field.tsx
+++ b/apps/frontend/components/form-text-field.tsx
@@ -1,0 +1,85 @@
+import { type ReactNode } from "react";
+import {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+
+export type FormTextFieldProps = {
+  label: string;
+  name: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string | null;
+  description?: ReactNode;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  autoFocus?: boolean;
+  type?: string;
+  trailing?: ReactNode;
+  className?: string;
+  inputClassName?: string;
+  min?: string | number;
+  max?: string | number;
+  step?: string | number;
+  maxLength?: number;
+};
+
+// Composes the ui/field + ui/input atoms so the six-line
+// Field/FieldLabel/Input/FieldError block doesn't have to be hand-wired at
+// every call site. `trailing` renders alongside the error (e.g. a character
+// counter) instead of after it, matching skill-form's layout.
+export const FormTextField = ({
+  label,
+  name,
+  value,
+  onChange,
+  error,
+  description,
+  placeholder,
+  disabled,
+  required,
+  autoFocus,
+  type = "text",
+  trailing,
+  className,
+  inputClassName,
+  min,
+  max,
+  step,
+  maxLength,
+}: FormTextFieldProps) => {
+  return (
+    <Field className={className} data-invalid={!!error}>
+      <FieldLabel htmlFor={name}>{label}</FieldLabel>
+      <Input
+        id={name}
+        type={type}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        required={required}
+        autoFocus={autoFocus}
+        aria-invalid={!!error}
+        className={inputClassName}
+        min={min}
+        max={max}
+        step={step}
+        maxLength={maxLength}
+      />
+      {description && <FieldDescription>{description}</FieldDescription>}
+      {trailing ? (
+        <div className="flex justify-between mt-1">
+          {error ? <FieldError>{error}</FieldError> : <div />}
+          {trailing}
+        </div>
+      ) : (
+        error && <FieldError>{error}</FieldError>
+      )}
+    </Field>
+  );
+};

--- a/apps/frontend/components/invitation-form.tsx
+++ b/apps/frontend/components/invitation-form.tsx
@@ -8,7 +8,7 @@ import {
   FieldError,
   FieldDescription,
 } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
+import { FormTextField } from "@/components/form-text-field";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { useState } from "react";
@@ -129,47 +129,36 @@ export function InvitationForm({ orgId, onSuccess }: InvitationFormProps) {
       <FieldSet>
         <FieldGroup className="gap-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <Field data-invalid={!!validationErrors.email}>
-              <FieldLabel htmlFor="email">Email</FieldLabel>
-              <Input
-                id="email"
-                type="email"
-                placeholder="user@example.com"
-                value={email}
-                onChange={(e) => {
-                  setEmail(e.target.value);
-                  setValidationErrors((prev) =>
-                    retractFieldError(prev, "email"),
-                  );
-                }}
-                disabled={isSubmitting}
-                autoFocus
-                required
-              />
-              {validationErrors.email && (
-                <FieldError>{validationErrors.email}</FieldError>
-              )}
-            </Field>
+            <FormTextField
+              label="Email"
+              name="email"
+              type="email"
+              placeholder="user@example.com"
+              value={email}
+              onChange={(value) => {
+                setEmail(value);
+                setValidationErrors((prev) => retractFieldError(prev, "email"));
+              }}
+              disabled={isSubmitting}
+              error={validationErrors.email}
+              autoFocus
+              required
+            />
 
-            <Field data-invalid={!!validationErrors.workspaceName}>
-              <FieldLabel htmlFor="workspaceName">Workspace name</FieldLabel>
-              <Input
-                id="workspaceName"
-                type="text"
-                placeholder="Defaults to the member's name"
-                value={workspaceName}
-                onChange={(e) => {
-                  setWorkspaceName(e.target.value);
-                  setValidationErrors((prev) =>
-                    retractFieldError(prev, "workspaceName"),
-                  );
-                }}
-                disabled={isSubmitting}
-              />
-              {validationErrors.workspaceName && (
-                <FieldError>{validationErrors.workspaceName}</FieldError>
-              )}
-            </Field>
+            <FormTextField
+              label="Workspace name"
+              name="workspaceName"
+              placeholder="Defaults to the member's name"
+              value={workspaceName}
+              onChange={(value) => {
+                setWorkspaceName(value);
+                setValidationErrors((prev) =>
+                  retractFieldError(prev, "workspaceName"),
+                );
+              }}
+              disabled={isSubmitting}
+              error={validationErrors.workspaceName}
+            />
           </div>
 
           {/* ADR-0009: the invitation carries an ordered set of blueprints,

--- a/apps/frontend/components/kanban-board-form.tsx
+++ b/apps/frontend/components/kanban-board-form.tsx
@@ -6,6 +6,7 @@ import { mutate } from "swr";
 import { nanoid } from "nanoid";
 import { Trash2, Plus } from "lucide-react";
 import { Input } from "@/components/ui/input";
+import { FormTextField } from "@/components/form-text-field";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
 import { Field, FieldLabel, FieldError } from "@/components/ui/field";
@@ -116,24 +117,20 @@ export function KanbanBoardForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      <Field data-invalid={!!validationErrors.name}>
-        <FieldLabel htmlFor="name">Name</FieldLabel>
-        <Input
-          id="name"
-          value={name}
-          onChange={(e) => {
-            setValidationErrors((prev) => retractFieldError(prev, "name"));
-            setName(e.target.value);
-          }}
-          placeholder="Board name"
-          disabled={isSubmitting}
-          required
-          autoFocus={!isEditing}
-        />
-        {validationErrors.name && (
-          <FieldError>{validationErrors.name}</FieldError>
-        )}
-      </Field>
+      <FormTextField
+        label="Name"
+        name="name"
+        value={name}
+        onChange={(value) => {
+          setValidationErrors((prev) => retractFieldError(prev, "name"));
+          setName(value);
+        }}
+        placeholder="Board name"
+        disabled={isSubmitting}
+        required
+        autoFocus={!isEditing}
+        error={validationErrors.name}
+      />
       <Field data-invalid={!!validationErrors.description}>
         <FieldLabel htmlFor="description">Description</FieldLabel>
         <Textarea

--- a/apps/frontend/components/mcp-form.tsx
+++ b/apps/frontend/components/mcp-form.tsx
@@ -9,6 +9,7 @@ import {
   FieldError,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { FormTextField } from "@/components/form-text-field";
 import { RevealableInput } from "@/components/ui/revealable-input";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
@@ -175,6 +176,13 @@ const McpForm = ({
     // Clear test result when form changes
     setTestResult(null);
   };
+
+  // Adapts FormTextField's `onChange(value)` to handleChange's `onChange(e)`
+  // so the centralized clear-error-and-set-formData logic stays in one place.
+  const toFieldChange = (id: string) => (value: string) =>
+    handleChange({
+      target: { id, value },
+    } as React.ChangeEvent<HTMLInputElement>);
 
   const handleSelectChange = (id: string, value: string) => {
     // Clear the error for this field, including any reported against a path
@@ -505,40 +513,28 @@ const McpForm = ({
     <div className={classNames}>
       <FieldSet className="mb-6">
         <FieldGroup>
-          <Field data-invalid={!!validationErrors.name}>
-            <FieldLabel htmlFor="name">Name</FieldLabel>
-            <Input
-              id="name"
-              placeholder="My MCP Server"
-              value={formData.name}
-              onChange={handleChange}
-              disabled={isSubmitting}
-              aria-invalid={!!validationErrors.name}
-              autoFocus
-            />
-            {validationErrors.name && (
-              <FieldError>{validationErrors.name}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Name"
+            name="name"
+            placeholder="My MCP Server"
+            value={formData.name}
+            onChange={toFieldChange("name")}
+            disabled={isSubmitting}
+            error={validationErrors.name}
+            autoFocus
+          />
 
-          <Field data-invalid={!!validationErrors.url}>
-            <FieldLabel htmlFor="url">URL</FieldLabel>
-            <Input
-              id="url"
-              type="url"
-              placeholder="https://example.com/mcp"
-              value={formData.url}
-              onChange={handleChange}
-              disabled={isSubmitting}
-              aria-invalid={!!validationErrors.url}
-            />
-            <FieldDescription>
-              The URL endpoint for the MCP integration.
-            </FieldDescription>
-            {validationErrors.url && (
-              <FieldError>{validationErrors.url}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="URL"
+            name="url"
+            type="url"
+            placeholder="https://example.com/mcp"
+            value={formData.url}
+            onChange={toFieldChange("url")}
+            disabled={isSubmitting}
+            error={validationErrors.url}
+            description="The URL endpoint for the MCP integration."
+          />
 
           <FieldGroup className="grid grid-cols-3 gap-4">
             <Field className="col-span-1">
@@ -587,20 +583,15 @@ const McpForm = ({
           {/* OAuth Client Credentials */}
           {formData.authType === "OAuth" && (
             <FieldGroup className="grid grid-cols-2 gap-4">
-              <Field data-invalid={!!validationErrors.oauthClientId}>
-                <FieldLabel htmlFor="oauthClientId">Client ID</FieldLabel>
-                <Input
-                  id="oauthClientId"
-                  placeholder="OAuth Client ID"
-                  value={formData.oauthClientId}
-                  onChange={handleChange}
-                  disabled={isSubmitting}
-                  aria-invalid={!!validationErrors.oauthClientId}
-                />
-                {validationErrors.oauthClientId && (
-                  <FieldError>{validationErrors.oauthClientId}</FieldError>
-                )}
-              </Field>
+              <FormTextField
+                label="Client ID"
+                name="oauthClientId"
+                placeholder="OAuth Client ID"
+                value={formData.oauthClientId ?? ""}
+                onChange={toFieldChange("oauthClientId")}
+                disabled={isSubmitting}
+                error={validationErrors.oauthClientId}
+              />
 
               <Field data-invalid={!!validationErrors.oauthClientSecret}>
                 <FieldLabel htmlFor="oauthClientSecret">
@@ -627,32 +618,17 @@ const McpForm = ({
                 Leave blank if the server supports dynamic client registration.
               </FieldDescription>
 
-              <Field
+              <FormTextField
                 className="col-span-2"
-                data-invalid={!!validationErrors.oauthRequestedScope}
-              >
-                <FieldLabel htmlFor="oauthRequestedScope">
-                  OAuth Scopes
-                </FieldLabel>
-                <Input
-                  id="oauthRequestedScope"
-                  placeholder="e.g. https://www.googleapis.com/auth/calendar"
-                  value={formData.oauthRequestedScope || ""}
-                  onChange={handleChange}
-                  disabled={isSubmitting}
-                  aria-invalid={!!validationErrors.oauthRequestedScope}
-                />
-                <FieldDescription>
-                  Space-separated list of OAuth scopes to request. Required by
-                  some providers (e.g. Google) that reject authorize requests
-                  without an explicit scope parameter.
-                </FieldDescription>
-                {validationErrors.oauthRequestedScope && (
-                  <FieldError>
-                    {validationErrors.oauthRequestedScope}
-                  </FieldError>
-                )}
-              </Field>
+                label="OAuth Scopes"
+                name="oauthRequestedScope"
+                placeholder="e.g. https://www.googleapis.com/auth/calendar"
+                value={formData.oauthRequestedScope || ""}
+                onChange={toFieldChange("oauthRequestedScope")}
+                disabled={isSubmitting}
+                error={validationErrors.oauthRequestedScope}
+                description="Space-separated list of OAuth scopes to request. Required by some providers (e.g. Google) that reject authorize requests without an explicit scope parameter."
+              />
             </FieldGroup>
           )}
 

--- a/apps/frontend/components/provider-form.tsx
+++ b/apps/frontend/components/provider-form.tsx
@@ -11,6 +11,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
+import { FormTextField } from "@/components/form-text-field";
 import { RevealableInput } from "@/components/ui/revealable-input";
 import { Button } from "@/components/ui/button";
 import {
@@ -679,6 +680,13 @@ const ProviderForm = ({
     }
   };
 
+  // Adapts FormTextField's `onChange(value)` to handleChange's `onChange(e)`
+  // so the centralized clear-error-and-set-formData logic stays in one place.
+  const toFieldChange = (id: string) => (value: string) =>
+    handleChange({
+      target: { id, value },
+    } as React.ChangeEvent<HTMLInputElement>);
+
   const handleSelectChange = (id: string, value: string) => {
     // Clear validation error for this field
     setValidationErrors((prev) => retractFieldError(prev, id));
@@ -939,21 +947,16 @@ const ProviderForm = ({
             </Select>
           </Field>
 
-          <Field data-invalid={!!validationErrors.name}>
-            <FieldLabel htmlFor="name">Name</FieldLabel>
-            <Input
-              id="name"
-              placeholder="Name"
-              value={formData.name}
-              onChange={handleChange}
-              disabled={isSubmitting || isReadOnly}
-              aria-invalid={!!validationErrors.name}
-              autoFocus
-            />
-            {validationErrors.name && (
-              <FieldError>{validationErrors.name}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Name"
+            name="name"
+            placeholder="Name"
+            value={formData.name}
+            onChange={toFieldChange("name")}
+            disabled={isSubmitting || isReadOnly}
+            error={validationErrors.name}
+            autoFocus
+          />
 
           <Field data-invalid={!!validationErrors.apiKey}>
             <FieldLabel htmlFor="apiKey">API Key</FieldLabel>
@@ -972,43 +975,29 @@ const ProviderForm = ({
           </Field>
 
           {formData.providerType === "Bedrock" && (
-            <Field data-invalid={!!validationErrors.region}>
-              <FieldLabel htmlFor="region">Region</FieldLabel>
-              <Input
-                id="region"
-                placeholder="us-east-1"
-                value={formData.region}
-                onChange={handleChange}
-                disabled={isSubmitting || isReadOnly}
-                aria-invalid={!!validationErrors.region}
-              />
-              <FieldDescription>
-                AWS region identifier (e.g., us-east-1, eu-west-1).
-              </FieldDescription>
-              {validationErrors.region && (
-                <FieldError>{validationErrors.region}</FieldError>
-              )}
-            </Field>
+            <FormTextField
+              label="Region"
+              name="region"
+              placeholder="us-east-1"
+              value={formData.region ?? ""}
+              onChange={toFieldChange("region")}
+              disabled={isSubmitting || isReadOnly}
+              error={validationErrors.region}
+              description="AWS region identifier (e.g., us-east-1, eu-west-1)."
+            />
           )}
 
-          <Field data-invalid={!!validationErrors.baseUrl}>
-            <FieldLabel htmlFor="baseUrl">Base URL</FieldLabel>
-            <Input
-              id="baseUrl"
-              type="url"
-              placeholder="https://api.example.com/"
-              value={formData.baseUrl}
-              onChange={handleChange}
-              disabled={isSubmitting || isReadOnly}
-              aria-invalid={!!validationErrors.baseUrl}
-            />
-            <FieldDescription>
-              Optional base URL for the provider.
-            </FieldDescription>
-            {validationErrors.baseUrl && (
-              <FieldError>{validationErrors.baseUrl}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Base URL"
+            name="baseUrl"
+            type="url"
+            placeholder="https://api.example.com/"
+            value={formData.baseUrl ?? ""}
+            onChange={toFieldChange("baseUrl")}
+            disabled={isSubmitting || isReadOnly}
+            error={validationErrors.baseUrl}
+            description="Optional base URL for the provider."
+          />
 
           {/* Invalid only for an error against the list itself: `data-invalid`
               reddens every descendant, which on a row error would paint the
@@ -1053,88 +1042,51 @@ const ProviderForm = ({
             {modelIdsError && <FieldError>{modelIdsError}</FieldError>}
           </Field>
 
-          <Field data-invalid={!!validationErrors.taskModelId}>
-            <FieldLabel htmlFor="taskModelId">Task Model ID</FieldLabel>
-            <Input
-              id="taskModelId"
-              placeholder="gpt-4"
-              value={formData.taskModelId}
-              onChange={handleChange}
-              disabled={isSubmitting || isReadOnly}
-              aria-invalid={!!validationErrors.taskModelId}
-            />
-            <FieldDescription>
-              Model to use for chat metadata generation.
-            </FieldDescription>
-            {validationErrors.taskModelId && (
-              <FieldError>{validationErrors.taskModelId}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Task Model ID"
+            name="taskModelId"
+            placeholder="gpt-4"
+            value={formData.taskModelId}
+            onChange={toFieldChange("taskModelId")}
+            disabled={isSubmitting || isReadOnly}
+            error={validationErrors.taskModelId}
+            description="Model to use for chat metadata generation."
+          />
 
-          <Field data-invalid={!!validationErrors.memoryExtractionModelId}>
-            <FieldLabel htmlFor="memoryExtractionModelId">
-              Memory Extraction Model ID
-            </FieldLabel>
-            <Input
-              id="memoryExtractionModelId"
-              placeholder="gpt-4"
-              value={formData.memoryExtractionModelId}
-              onChange={handleChange}
-              disabled={isSubmitting || isReadOnly}
-              aria-invalid={!!validationErrors.memoryExtractionModelId}
-            />
-            <FieldDescription>
-              Model to use for extracting memories from conversations.
-            </FieldDescription>
-            {validationErrors.memoryExtractionModelId && (
-              <FieldError>
-                {validationErrors.memoryExtractionModelId}
-              </FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Memory Extraction Model ID"
+            name="memoryExtractionModelId"
+            placeholder="gpt-4"
+            value={formData.memoryExtractionModelId}
+            onChange={toFieldChange("memoryExtractionModelId")}
+            disabled={isSubmitting || isReadOnly}
+            error={validationErrors.memoryExtractionModelId}
+            description="Model to use for extracting memories from conversations."
+          />
 
-          <Field data-invalid={!!validationErrors.embeddingModelId}>
-            <FieldLabel htmlFor="embeddingModelId">
-              Embedding Model ID
-            </FieldLabel>
-            <Input
-              id="embeddingModelId"
-              placeholder="text-embedding-3-small"
-              value={formData.embeddingModelId || ""}
-              onChange={handleChange}
-              disabled={isSubmitting || isReadOnly}
-              aria-invalid={!!validationErrors.embeddingModelId}
-            />
-            <FieldDescription>
-              Model to use for generating memory embeddings. Required for
-              semantic memory search.
-            </FieldDescription>
-            {validationErrors.embeddingModelId && (
-              <FieldError>{validationErrors.embeddingModelId}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Embedding Model ID"
+            name="embeddingModelId"
+            placeholder="text-embedding-3-small"
+            value={formData.embeddingModelId || ""}
+            onChange={toFieldChange("embeddingModelId")}
+            disabled={isSubmitting || isReadOnly}
+            error={validationErrors.embeddingModelId}
+            description="Model to use for generating memory embeddings. Required for semantic memory search."
+          />
 
           {formData.embeddingModelId && (
-            <Field data-invalid={!!validationErrors.embeddingDimensions}>
-              <FieldLabel htmlFor="embeddingDimensions">
-                Embedding Dimensions
-              </FieldLabel>
-              <Input
-                id="embeddingDimensions"
-                type="number"
-                placeholder="1536"
-                value={formData.embeddingDimensions}
-                onChange={handleChange}
-                disabled={isSubmitting || isReadOnly}
-                aria-invalid={!!validationErrors.embeddingDimensions}
-              />
-              <FieldDescription>
-                Number of dimensions for the embedding model output (256-4096).
-              </FieldDescription>
-              {validationErrors.embeddingDimensions && (
-                <FieldError>{validationErrors.embeddingDimensions}</FieldError>
-              )}
-            </Field>
+            <FormTextField
+              label="Embedding Dimensions"
+              name="embeddingDimensions"
+              type="number"
+              placeholder="1536"
+              value={formData.embeddingDimensions}
+              onChange={toFieldChange("embeddingDimensions")}
+              disabled={isSubmitting || isReadOnly}
+              error={validationErrors.embeddingDimensions}
+              description="Number of dimensions for the embedding model output (256-4096)."
+            />
           )}
         </FieldGroup>
 
@@ -1188,37 +1140,27 @@ const ProviderForm = ({
                     )}
                   </Field>
 
-                  <Field data-invalid={!!validationErrors.organization}>
-                    <FieldLabel htmlFor="organization">Organization</FieldLabel>
-                    <Input
-                      id="organization"
-                      placeholder="org-..."
-                      value={formData.organization}
-                      onChange={handleChange}
-                      disabled={isSubmitting || isReadOnly}
-                      aria-invalid={!!validationErrors.organization}
-                    />
-                    <FieldDescription>OpenAI organization ID.</FieldDescription>
-                    {validationErrors.organization && (
-                      <FieldError>{validationErrors.organization}</FieldError>
-                    )}
-                  </Field>
+                  <FormTextField
+                    label="Organization"
+                    name="organization"
+                    placeholder="org-..."
+                    value={formData.organization ?? ""}
+                    onChange={toFieldChange("organization")}
+                    disabled={isSubmitting || isReadOnly}
+                    error={validationErrors.organization}
+                    description="OpenAI organization ID."
+                  />
 
-                  <Field data-invalid={!!validationErrors.project}>
-                    <FieldLabel htmlFor="project">Project</FieldLabel>
-                    <Input
-                      id="project"
-                      placeholder="proj_..."
-                      value={formData.project}
-                      onChange={handleChange}
-                      disabled={isSubmitting || isReadOnly}
-                      aria-invalid={!!validationErrors.project}
-                    />
-                    <FieldDescription>OpenAI project ID.</FieldDescription>
-                    {validationErrors.project && (
-                      <FieldError>{validationErrors.project}</FieldError>
-                    )}
-                  </Field>
+                  <FormTextField
+                    label="Project"
+                    name="project"
+                    placeholder="proj_..."
+                    value={formData.project ?? ""}
+                    onChange={toFieldChange("project")}
+                    disabled={isSubmitting || isReadOnly}
+                    error={validationErrors.project}
+                    description="OpenAI project ID."
+                  />
                 </>
               )}
 

--- a/apps/frontend/components/skill-form.tsx
+++ b/apps/frontend/components/skill-form.tsx
@@ -6,9 +6,8 @@ import {
   FieldGroup,
   FieldSet,
   FieldDescription,
-  FieldError,
 } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
+import { FormTextField } from "@/components/form-text-field";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
 import { Switch } from "@/components/ui/switch";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
@@ -136,6 +135,13 @@ const SkillForm = ({
     }));
   };
 
+  // Adapts FormTextField's `onChange(value)` to handleChange's `onChange(e)`
+  // so the centralized clear-error-and-set-formData logic stays in one place.
+  const toFieldChange = (id: string) => (value: string) =>
+    handleChange({
+      target: { id, value },
+    } as React.ChangeEvent<HTMLInputElement>);
+
   const handleSubmit = async () => {
     setIsSubmitting(true);
     setValidationErrors({});
@@ -197,28 +203,21 @@ const SkillForm = ({
     <div className={classNames}>
       <FieldSet className="mb-6">
         <FieldGroup className="gap-4">
-          <Field data-invalid={!!validationErrors.name}>
-            <FieldLabel htmlFor="name">Name</FieldLabel>
-            <Input
-              id="name"
-              placeholder="skill-name"
-              value={formData.name}
-              onChange={handleChange}
-              disabled={isSubmitting}
-              aria-invalid={!!validationErrors.name}
-              autoFocus
-            />
-            <div className="flex justify-between mt-1">
-              {validationErrors.name ? (
-                <FieldError>{validationErrors.name}</FieldError>
-              ) : (
-                <div />
-              )}
+          <FormTextField
+            label="Name"
+            name="name"
+            placeholder="skill-name"
+            value={formData.name}
+            onChange={toFieldChange("name")}
+            disabled={isSubmitting}
+            error={validationErrors.name}
+            autoFocus
+            trailing={
               <p className="text-xs text-muted-foreground">
                 {formData.name.length}/64
               </p>
-            </div>
-          </Field>
+            }
+          />
           <Field data-invalid={!!validationErrors.description}>
             <ExpandableTextarea
               id="description"

--- a/apps/frontend/components/trigger-form.tsx
+++ b/apps/frontend/components/trigger-form.tsx
@@ -8,8 +8,8 @@ import {
   FieldDescription,
   FieldError,
 } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
+import { FormTextField } from "@/components/form-text-field";
 import { AgentAvatar } from "@/components/agent-avatar";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
@@ -523,6 +523,13 @@ const TriggerForm = ({
     }));
   };
 
+  // Adapts FormTextField's `onChange(value)` to handleChange's `onChange(e)`
+  // so the centralized clear-error-and-set-formData logic stays in one place.
+  const toFieldChange = (id: string) => (value: string) =>
+    handleChange({
+      target: { id, value },
+    } as React.ChangeEvent<HTMLInputElement>);
+
   const handleNumberChange = (id: string, value: string) => {
     setFormData((prevData) => ({
       ...prevData,
@@ -668,36 +675,26 @@ const TriggerForm = ({
             </Select>
           </Field>
 
-          <Field data-invalid={!!validationErrors.name}>
-            <FieldLabel htmlFor="name">Name</FieldLabel>
-            <Input
-              id="name"
-              placeholder="Daily report generation"
-              value={formData.name}
-              onChange={handleChange}
-              disabled={isSubmitting}
-              aria-invalid={!!validationErrors.name}
-              autoFocus
-            />
-            {validationErrors.name && (
-              <FieldError>{validationErrors.name}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Name"
+            name="name"
+            placeholder="Daily report generation"
+            value={formData.name}
+            onChange={toFieldChange("name")}
+            disabled={isSubmitting}
+            error={validationErrors.name}
+            autoFocus
+          />
 
-          <Field data-invalid={!!validationErrors.description}>
-            <FieldLabel htmlFor="description">Description</FieldLabel>
-            <Input
-              id="description"
-              placeholder="Optional description..."
-              value={formData.description}
-              onChange={handleChange}
-              disabled={isSubmitting}
-              aria-invalid={!!validationErrors.description}
-            />
-            {validationErrors.description && (
-              <FieldError>{validationErrors.description}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Description"
+            name="description"
+            placeholder="Optional description..."
+            value={formData.description}
+            onChange={toFieldChange("description")}
+            disabled={isSubmitting}
+            error={validationErrors.description}
+          />
 
           <Field data-invalid={!!validationErrors.agentId}>
             <FieldLabel>Agent</FieldLabel>
@@ -956,30 +953,25 @@ const TriggerForm = ({
 
               {/* Advanced Mode */}
               {scheduleMode === "advanced" && (
-                <Field data-invalid={!!validationErrors.cronExpression}>
-                  <FieldLabel htmlFor="cronExpression">
-                    Cron Expression
-                  </FieldLabel>
-                  <Input
-                    id="cronExpression"
-                    placeholder="0 9 * * *"
-                    value={formData.cronExpression}
-                    onChange={handleChange}
-                    disabled={isSubmitting}
-                    aria-invalid={!!validationErrors.cronExpression}
-                    className={!isCronValid ? "border-destructive" : ""}
-                  />
-                  <FieldDescription>
-                    Format: minute hour day-of-month month day-of-week. Example:
-                    &quot;0 9 * * *&quot; runs daily at 9:00 AM.
-                  </FieldDescription>
-                  {validationErrors.cronExpression && (
-                    <FieldError>{validationErrors.cronExpression}</FieldError>
-                  )}
-                  {!isCronValid && !validationErrors.cronExpression && (
-                    <FieldError>Invalid cron expression</FieldError>
-                  )}
-                </Field>
+                <FormTextField
+                  label="Cron Expression"
+                  name="cronExpression"
+                  placeholder="0 9 * * *"
+                  value={formData.cronExpression}
+                  onChange={toFieldChange("cronExpression")}
+                  disabled={isSubmitting}
+                  inputClassName={!isCronValid ? "border-destructive" : ""}
+                  error={
+                    validationErrors.cronExpression ||
+                    (!isCronValid ? "Invalid cron expression" : undefined)
+                  }
+                  description={
+                    <>
+                      Format: minute hour day-of-month month day-of-week.
+                      Example: &quot;0 9 * * *&quot; runs daily at 9:00 AM.
+                    </>
+                  }
+                />
               )}
 
               <Field data-invalid={!!validationErrors.timezone}>
@@ -1158,23 +1150,18 @@ const TriggerForm = ({
               </Field>
             )}
 
-          <Field className="w-1/2">
-            <FieldLabel htmlFor="maxRunsToKeep">Max Runs to Keep</FieldLabel>
-            <Input
-              id="maxRunsToKeep"
-              type="number"
-              min="1"
-              max="1000"
-              value={formData.maxRunsToKeep}
-              onChange={(e) =>
-                handleNumberChange("maxRunsToKeep", e.target.value)
-              }
-              disabled={isSubmitting}
-            />
-            <FieldDescription>
-              Maximum number of run records to keep (oldest will be deleted)
-            </FieldDescription>
-          </Field>
+          <FormTextField
+            className="w-1/2"
+            label="Max Runs to Keep"
+            name="maxRunsToKeep"
+            type="number"
+            min="1"
+            max="1000"
+            value={String(formData.maxRunsToKeep)}
+            onChange={(value) => handleNumberChange("maxRunsToKeep", value)}
+            disabled={isSubmitting}
+            description="Maximum number of run records to keep (oldest will be deleted)"
+          />
 
           <Field orientation="horizontal">
             <Switch

--- a/apps/frontend/components/webhook-form.tsx
+++ b/apps/frontend/components/webhook-form.tsx
@@ -9,6 +9,7 @@ import {
   FieldError,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { FormTextField } from "@/components/form-text-field";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { ConfirmDialog } from "@/components/confirm-dialog";
@@ -301,47 +302,34 @@ const WebhookForm = ({ orgId, workspaceId, webhookId }: WebhookFormProps) => {
     <div>
       <FieldSet className="mb-6">
         <FieldGroup>
-          <Field data-invalid={!!validationErrors.name}>
-            <FieldLabel htmlFor="name">Name</FieldLabel>
-            <Input
-              id="name"
-              type="text"
-              placeholder="My Webhook"
-              value={name}
-              onChange={(e) => {
-                clearValidationErrors("name");
-                setName(e.target.value);
-              }}
-              disabled={isSubmitting}
-              aria-invalid={!!validationErrors.name}
-              autoFocus
-            />
-            {validationErrors.name && (
-              <FieldError>{validationErrors.name}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Name"
+            name="name"
+            placeholder="My Webhook"
+            value={name}
+            onChange={(value) => {
+              clearValidationErrors("name");
+              setName(value);
+            }}
+            disabled={isSubmitting}
+            error={validationErrors.name}
+            autoFocus
+          />
 
-          <Field data-invalid={!!validationErrors.url}>
-            <FieldLabel htmlFor="url">URL</FieldLabel>
-            <Input
-              id="url"
-              type="url"
-              placeholder="https://example.com/webhook"
-              value={url}
-              onChange={(e) => {
-                clearValidationErrors("url");
-                setUrl(e.target.value);
-              }}
-              disabled={isSubmitting}
-              aria-invalid={!!validationErrors.url}
-            />
-            <FieldDescription>
-              The URL that will receive webhook POST requests.
-            </FieldDescription>
-            {validationErrors.url && (
-              <FieldError>{validationErrors.url}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="URL"
+            name="url"
+            type="url"
+            placeholder="https://example.com/webhook"
+            value={url}
+            onChange={(value) => {
+              clearValidationErrors("url");
+              setUrl(value);
+            }}
+            disabled={isSubmitting}
+            error={validationErrors.url}
+            description="The URL that will receive webhook POST requests."
+          />
 
           <Field data-invalid={!!validationErrors.enabled}>
             <div className="flex items-center gap-3">

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -8,7 +8,7 @@ import {
   FieldError,
   FieldDescription,
 } from "@/components/ui/field";
-import { Input } from "@/components/ui/input";
+import { FormTextField } from "@/components/form-text-field";
 import { Switch } from "@/components/ui/switch";
 import { ExpandableTextarea } from "@/components/expandable-textarea";
 import {
@@ -180,6 +180,13 @@ const WorkspaceForm = ({
     }));
   };
 
+  // Adapts FormTextField's `onChange(value)` to handleChange's `onChange(e)`
+  // so the centralized clear-error-and-set-formData logic stays in one place.
+  const toFieldChange = (id: string) => (value: string) =>
+    handleChange({
+      target: { id, value },
+    } as React.ChangeEvent<HTMLInputElement>);
+
   const handleSubmit = async () => {
     setIsSubmitting(true);
     setValidationErrors({});
@@ -261,21 +268,16 @@ const WorkspaceForm = ({
     <div className={classNames}>
       <FieldSet className="mb-6">
         <FieldGroup>
-          <Field data-invalid={!!validationErrors.name}>
-            <FieldLabel htmlFor="name">Name</FieldLabel>
-            <Input
-              id="name"
-              placeholder="Workspace name"
-              value={formData.name}
-              onChange={handleChange}
-              disabled={isSubmitting}
-              aria-invalid={!!validationErrors.name}
-              autoFocus
-            />
-            {validationErrors.name && (
-              <FieldError>{validationErrors.name}</FieldError>
-            )}
-          </Field>
+          <FormTextField
+            label="Name"
+            name="name"
+            placeholder="Workspace name"
+            value={formData.name}
+            onChange={toFieldChange("name")}
+            disabled={isSubmitting}
+            error={validationErrors.name}
+            autoFocus
+          />
 
           {/* ADR-0008: on creation an admin assigns the workspace owner. */}
           {!workspaceId && (
@@ -466,36 +468,26 @@ const WorkspaceForm = ({
           )}
 
           {workspaceId && (
-            <Field data-invalid={!!validationErrors.maxDailySummaries}>
-              <FieldLabel htmlFor="maxDailySummaries">
-                Memory Summary Retention
-              </FieldLabel>
-              <Input
-                id="maxDailySummaries"
-                type="number"
-                min={7}
-                max={365}
-                value={formData.maxDailySummaries}
-                onChange={(e) => {
-                  setValidationErrors((prev) =>
-                    retractFieldError(prev, "maxDailySummaries"),
-                  );
-                  setFormData((prevData) => ({
-                    ...prevData,
-                    maxDailySummaries: parseInt(e.target.value) || 90,
-                  }));
-                }}
-                disabled={isSubmitting}
-                aria-invalid={!!validationErrors.maxDailySummaries}
-              />
-              <FieldDescription>
-                Maximum number of daily memory summaries to retain (7-365,
-                default 90 days).
-              </FieldDescription>
-              {validationErrors.maxDailySummaries && (
-                <FieldError>{validationErrors.maxDailySummaries}</FieldError>
-              )}
-            </Field>
+            <FormTextField
+              label="Memory Summary Retention"
+              name="maxDailySummaries"
+              type="number"
+              min={7}
+              max={365}
+              value={String(formData.maxDailySummaries)}
+              onChange={(value) => {
+                setValidationErrors((prev) =>
+                  retractFieldError(prev, "maxDailySummaries"),
+                );
+                setFormData((prevData) => ({
+                  ...prevData,
+                  maxDailySummaries: parseInt(value) || 90,
+                }));
+              }}
+              disabled={isSubmitting}
+              error={validationErrors.maxDailySummaries}
+              description="Maximum number of daily memory summaries to retain (7-365, default 90 days)."
+            />
           )}
 
           {/* Delegation flags (ADR-0006) — admin-only. When off, only org


### PR DESCRIPTION
## Summary

- New `FormTextField` (`apps/frontend/components/form-text-field.tsx`) composes the existing `ui/field` + `ui/input` atoms — no new primitive, no copied field classes — replacing the hand-wired `Field`/`FieldLabel`/`Input`/`FieldError` six-line block.
- Migrates **35 call sites** across 10 forms (provider 9, agent 9, trigger 4, mcp 4, workspace 2, webhook 2, invitation 2, blueprint 1, skill 1, kanban-board 1) plus the dashboards/create page's Name field.
- `error` drives `data-invalid`, `aria-invalid`, and the rendered `FieldError` in one place; `trailing` covers skill-form/blueprint-form's char-counter row; invitation-form's two-column grid stays at the callsite, with only the inner field swapped in; per-form error-clearing strategies (`clearValidationErrors`, `retractFieldError`, centralized `handleChange`) are preserved as-is.
- Added a small `toFieldChange(id)` adapter helper in the 7 forms that share a centralized `handleChange(e)`, so `FormTextField`'s `onChange(value)` doesn't require repeating a synthetic-event cast at every call site.

## Deferred / left as-is

- `app/settings/page.tsx`'s Name field is **not migrated** — it has no error state, a bespoke inline Save/Cancel button row next to the input, and an `onFocus` select-all-text behavior that doesn't fit `FormTextField`'s shape. Left alone per the issue's escape hatch.
- Out of scope, untouched: `Select` fields, `ExpandableTextarea`-backed fields, `RevealableInput`/secret fields, and the dynamic header key/value rows in mcp-form/webhook-form (no `Field`/label wrapper to begin with).

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (769 frontend / 2475 backend tests, all green)
- [x] Existing form tests unmodified — they assert behavior, not markup
- [x] New `form-text-field.test.tsx` covers label/id pairing, onChange, error rendering + aria-invalid, description, trailing slot, disabled/required/autoFocus, and the `type` prop

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)