### PR TITLE
fix(frontend): align form submit-button labels to the form-conventions rule

### DIFF
--- a/apps/docs/content/self-hosting/sandbox.mdx
+++ b/apps/docs/content/self-hosting/sandbox.mdx
@@ -107,7 +107,7 @@ container already exists for the Workspace — starting it if it is stopped — 
 only reads `networks` and `extraHosts` when it creates a new one. So saving a
 changed allowlist has **no effect on a running sandbox**, and there is no
 "Recreate now" button or "pending" badge in the app to tell you so. On an
-existing Sandbox the screen offers **Update** and **Delete**, nothing else.
+existing Sandbox the screen offers **Save** and **Delete**, nothing else.
 
 Two ways to make a change take:
 

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/[dashboardId]/settings/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/[dashboardId]/settings/page.tsx
@@ -137,7 +137,7 @@ const DashboardSettingsPage = ({
             type="submit"
             disabled={saving || deleting || !displayName.trim()}
           >
-            Update
+            Save
           </Button>
           <Button
             type="button"

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/dashboards/create/page.tsx
@@ -86,7 +86,7 @@ const CreateDashboardPage = ({
         </div>
         {error && <p className="text-sm text-destructive">{error}</p>}
         <Button type="submit" disabled={loading || !name.trim()}>
-          {loading ? "Creating..." : "Create dashboard"}
+          {loading ? "Saving..." : "Save"}
         </Button>
       </form>
     </ResourcePage>

--- a/apps/frontend/components/app-sidebar.tsx
+++ b/apps/frontend/components/app-sidebar.tsx
@@ -585,7 +585,7 @@ export function AppSidebar() {
               disabled={isRenaming || !renameTitle.trim()}
               className="cursor-pointer"
             >
-              Save changes
+              Save
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/frontend/components/kanban-board-form.tsx
+++ b/apps/frontend/components/kanban-board-form.tsx
@@ -205,7 +205,7 @@ export function KanbanBoardForm({
 
       <FormFooterButtons
         type="submit"
-        submitText={isEditing ? "Update" : "Create board"}
+        submitText="Save"
         submitDisabled={
           isSubmitting ||
           isDeleting ||

--- a/apps/frontend/components/member-edit-dialog.tsx
+++ b/apps/frontend/components/member-edit-dialog.tsx
@@ -105,7 +105,7 @@ export function MemberEditDialog({
             disabled={isSubmitting || role === member.role}
             className={isSubmitting ? "opacity-50" : ""}
           >
-            {isSubmitting ? "Saving..." : "Save changes"}
+            {isSubmitting ? "Saving..." : "Save"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/frontend/components/organization-form.tsx
+++ b/apps/frontend/components/organization-form.tsx
@@ -200,7 +200,7 @@ const OrganizationForm = ({ classNames, orgId }: OrganizationFormProps) => {
       </FieldSet>
 
       <FormFooterButtons
-        submitText={orgId ? "Update" : "Save"}
+        submitText="Save"
         onSubmit={handleSubmit}
         submitDisabled={
           isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)

--- a/apps/frontend/components/sandbox-settings.tsx
+++ b/apps/frontend/components/sandbox-settings.tsx
@@ -980,7 +980,7 @@ const SandboxSettings = ({
           onClick={handleSave}
           disabled={isSubmitting}
         >
-          {hasSandbox ? "Update" : "Save"}
+          Save
         </Button>
 
         {hasSandbox ? (

--- a/apps/frontend/components/workspace-context-form.tsx
+++ b/apps/frontend/components/workspace-context-form.tsx
@@ -262,7 +262,7 @@ export const WorkspaceContextForm = ({ contextId }: { contextId?: string }) => {
 
       <FormFooterButtons
         type="submit"
-        submitText={contextId ? "Update" : "Create"}
+        submitText={contextId ? "Update" : "Save"}
         submitDisabled={isSubmitting}
         submitClassName=""
         deleteVisible={!!contextId}

--- a/apps/frontend/components/workspace-form.tsx
+++ b/apps/frontend/components/workspace-form.tsx
@@ -553,7 +553,7 @@ const WorkspaceForm = ({
       </FieldSet>
 
       <FormFooterButtons
-        submitText={workspaceId ? "Update" : "Save"}
+        submitText="Save"
         onSubmit={handleSubmit}
         submitDisabled={
           isSubmitting || !canSubmitForm(validationErrors, RETRACTABLE_FIELDS)


### PR DESCRIPTION
## Summary
- In-place edits (Sandbox, Organization, Workspace, Kanban board, Dashboard settings) now read `Save` instead of `Update`.
- Dialog edits (member role, chat rename) drop `Save changes` for the bare `Save`.
- Page-level creates (Dashboard, Kanban board) drop the named-entity verb (`Create dashboard`, `Create board`) for `Save`.
- Collection-member forms (e.g. Workspace Context) keep `Update` on edit and `Save` on create.
- Docs: `self-hosting/sandbox.mdx` updated — the Sandbox screen now offers **Save** and **Delete**, not Update.

Implements the rule in `.claude/skills/form-conventions/SKILL.md` per the agent brief on #793.

## Test plan
- [x] `pnpm typecheck` passes across the monorepo
- [x] `pnpm test` passes across the monorepo (769 frontend tests, docs-contract tests)
- [x] `/code-review` (Standards + Spec axes) run — no findings on either axis

Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)