### PR TITLE
chore: record why Agents cannot write an Embed URL

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -134,7 +134,7 @@ A Workspace-scoped grid of **Widgets** with separate desktop and mobile layouts,
 _Avoid_: report, page, view.
 
 **Widget**:
-A typed tile on a **Dashboard** — metric, text/markdown, image, Embed, weather, or chart. An Agent may bring a Widget's data current but can never change its type, placement, size, or presence; updating requires matching the declared type, so a chart cannot be overwritten into a metric. An Embed is the one exception to data currency: it renders a human-provided HTTPS page, and its URL is set only through the Dashboard UI — no Agent can write it.
+A typed tile on a **Dashboard** — metric, text/markdown, image, Embed, weather, or chart. An Agent may bring a Widget's data current but can never change its type, placement, size, or presence; updating requires matching the declared type, so a chart cannot be overwritten into a metric. An Embed is the one exception to data currency: it renders a human-provided HTTPS page, and its URL is set only through the Dashboard UI — no Agent can write it. The exception costs nothing, because an Embed's URL is a pointer rather than content: the page behind it is already self-updating, so an Agent write would buy no currency while moving configuration — which Users own — into Agent hands.
 _Avoid_: tile, panel, component.
 
 **Trigger**:


### PR DESCRIPTION
## Summary

`CONTEXT.md` recorded the conclusion that an Embed's URL is set only through the Dashboard UI, with none of the reasoning behind it. The rule was a deliberate security decision in #346, but the glossary kept only the outcome — so during triage of #760 the justification could not be reconstructed from the record, and the constraint looked arbitrary.

This adds the reasoning to the **Widget** entry:

> The exception costs nothing, because an Embed's URL is a pointer rather than content: the page behind it is already self-updating, so an Agent write would buy no currency while moving configuration — which Users own — into Agent hands.

The distinction matters beyond this one rule. For every other widget type, `data` is content that goes stale, which is what the Agent's data-currency role exists to fix. An Embed's URL is not content, so excluding it from Agent writes costs no currency at all — it only keeps configuration on the User side of the ownership split the **Dashboard** entry already draws.

## Context

- #346 made the call, on the grounds that iframes render third-party content inside the authenticated app.
- #759 (open) depends on this premise: its risk assessment rests on the URL being human-typed. If Agent-written Embed URLs are ever revisited, #759 needs reopening at the same time.
- #760 now carries an agent brief that enforces the rule structurally.

## Testing

Documentation only — one line of `CONTEXT.md`, no code, no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)