### PR TITLE
chore: record the Run timeline scope boundary as ADR-0023

### DIFF
--- a/docs/adr/0023-run-timelines-record-shape-and-duration.md
+++ b/docs/adr/0023-run-timelines-record-shape-and-duration.md
@@ -1,0 +1,52 @@
+---
+status: accepted-pending-implementation
+implemented-by: "#647"
+---
+
+# A Run timeline records shape and duration, never payloads
+
+> **In the code today.** A **Trigger run** persists one row of aggregates — a
+> `stats` blob of step and tool-call counts plus token usage — and nothing
+> per-step. There are no Run events, no run detail page, and a delegated run
+> leaves no trace at all. See `apps/backend/src/runs/sinks/trigger-sink.ts`.
+
+A **Trigger run** reduces to one row of aggregates, so "why did this take 90
+seconds?" has no answer, and a run that fans out to Sub-Agents records nothing
+about the delegates at all. #647 adds a durable, timestamped **Run timeline**
+and renders it as a waterfall on a run detail page.
+
+The decision is what that timeline is *for*, because the obvious next step from
+"record what happened" is to keep recording more of it until the feature is a
+second-rate observability platform. **A Run timeline answers where a single
+run's time went — and only that.** Each **Run event** records a type, a start,
+a duration and a terminal status. It does not record tool inputs, tool outputs,
+reasoning content, or model messages. Where a question needs more than the
+shape and duration of one run — cross-run percentiles, failure clustering,
+flame graphs over many runs of the same Trigger — the answer is to export to
+OpenTelemetry, not to grow this.
+
+The rejected alternative was the one #647 originally proposed: capture tool
+inputs and outputs from the start, with byte caps and a redaction layer to keep
+secrets out. It was rejected because the caps and the redaction are the tell.
+Tool payloads are unbounded and arbitrary, so capturing them means inventing a
+truncation policy, and they carry whatever the Tool touched, so it means
+inventing a redaction policy — and a redaction policy over arbitrary content is
+a promise that cannot be kept, since the one secret shape nobody anticipated is
+the one that leaks. Worse, `trigger_run` is readable by any Workspace member
+while the credentials those payloads would contain are redacted from Providers
+and MCPs unless the Organization delegated them (ADR-0006), so payload capture
+would have made Run events a way around that rule. Recording no payloads makes
+all of it moot rather than merely handled.
+
+The consequences worth naming. The timeline can say a Tool ran for 5.9 seconds
+and failed; it cannot say what it was called with, so some debugging still ends
+at "reproduce it in a Chat". Error *strings* are the deliberate exception —
+captured, capped, and explicitly marked when truncated — because a timeline
+that cannot explain a failure answers half the question it exists for; they may
+echo fragments of a failed request, and that is a known and accepted limit
+rather than something the redaction argument above pretends away. The final
+assistant text is the other exception, kept because "what did it conclude" is
+the first thing anyone asks of a headless run and it is exactly one value per
+run rather than a stream. Both exceptions are bounded and named; anything
+further is the OTEL boundary, and this ADR is what a future reader should be
+pointed at before widening it.


### PR DESCRIPTION
Records the scope boundary settled while triaging #647, ahead of the implementation.

A **Run timeline** answers where a single run's time went, and only that. A **Run event** records a type, a start, a duration and a terminal status — no tool inputs, no tool outputs, no reasoning or message content. Where a question needs more than one run's shape and duration (cross-run percentiles, failure clustering, flame graphs over many runs), the answer is to export to OpenTelemetry rather than widen this.

The ADR exists mainly for the rejected alternative, which is what #647 originally proposed: capture tool payloads from the start, with byte caps and a redaction layer. The caps and the redaction are the tell — tool payloads are unbounded and arbitrary, so a redaction policy over them is a promise that can't be kept. It also would have made Run events a way around ADR-0006: `trigger_run` is readable by any Workspace member, while the credentials those payloads would carry are redacted from Providers and MCPs unless the Organization delegated them.

Two exceptions are named and bounded: error strings (capped, explicitly marked when truncated) and the final assistant text.

Status is `accepted-pending-implementation` with `implemented-by: #647`, so it carries the "in the code today" admonition the ADR README requires. #647 builds the change and flips it to `accepted` as part of that PR.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)