### PR TITLE
fix(backend): key the event debounce on alternate entity ids

### DIFF
--- a/apps/backend/src/services/event-dispatch.test.ts
+++ b/apps/backend/src/services/event-dispatch.test.ts
@@ -79,6 +79,32 @@ async function flushMicrotasks() {
   }
 }
 
+/**
+ * Dispatches two events of the same type back-to-back inside the debounce
+ * window and reports how many trigger runs came out the other side: 1 when
+ * the pair shared a debounce key, 2 when it keyed apart.
+ */
+async function runsForPair(
+  trigger: ReturnType<typeof makeEventTrigger>,
+  event: Parameters<typeof dispatchEvent>[2],
+  first: unknown,
+  second: unknown,
+): Promise<number> {
+  // Each dispatch runs its own webhook query (none) then trigger query.
+  mockDb.where
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([trigger])
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([trigger]);
+
+  dispatchEvent("org-1", "ws-1", event, first);
+  await vi.advanceTimersByTimeAsync(0);
+  dispatchEvent("org-1", "ws-1", event, second);
+  await flushMicrotasks();
+
+  return mockExecuteTrigger.mock.calls.length;
+}
+
 describe("event-dispatch", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -387,6 +413,78 @@ describe("event-dispatch", () => {
       // Both calls key onto the same trigger+card debounce entry, so they
       // coalesce into a single execution — same as card.updated does.
       expect(mockExecuteTrigger).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not coalesce card.deleted events for two different cards", async () => {
+      // card.deleted carries its id as `cardId`, not `id`. Two unrelated cards
+      // deleted inside the debounce window must key apart (#811).
+      const runs = await runsForPair(
+        makeEventTrigger({ config: { events: ["card.deleted"] } }),
+        "card.deleted",
+        { cardId: "c1", boardId: "board-1", columnId: "col-1" },
+        { cardId: "c2", boardId: "board-1", columnId: "col-1" },
+      );
+
+      expect(runs).toBe(2);
+    });
+
+    it("should still coalesce repeated card.deleted events for the same card", async () => {
+      const runs = await runsForPair(
+        makeEventTrigger({ config: { events: ["card.deleted"] } }),
+        "card.deleted",
+        { cardId: "c1", boardId: "board-1", columnId: "col-1" },
+        { cardId: "c1", boardId: "board-1", columnId: "col-1" },
+      );
+
+      expect(runs).toBe(1);
+    });
+
+    it("should not coalesce notification.dismissed events for two different notifications", async () => {
+      const runs = await runsForPair(
+        makeEventTrigger({ config: { events: ["notification.dismissed"] } }),
+        "notification.dismissed",
+        { notificationId: "n-1" },
+        { notificationId: "n-2" },
+      );
+
+      expect(runs).toBe(2);
+    });
+
+    it("should not coalesce single notification.read events for two different notifications", async () => {
+      const runs = await runsForPair(
+        makeEventTrigger({ config: { events: ["notification.read"] } }),
+        "notification.read",
+        { notificationId: "n-1", userId: "user-1" },
+        { notificationId: "n-2", userId: "user-1" },
+      );
+
+      expect(runs).toBe(2);
+    });
+
+    it("should coalesce bulk notification.read events, which name no single entity", async () => {
+      // A bulk mark-all-read is legitimately a multi-entity event, so it keeps
+      // sharing the per-trigger fallback bucket.
+      const runs = await runsForPair(
+        makeEventTrigger({ config: { events: ["notification.read"] } }),
+        "notification.read",
+        { notificationIds: ["n-1", "n-2"], userId: "user-1", bulk: true },
+        { notificationIds: ["n-3"], userId: "user-1", bulk: true },
+      );
+
+      expect(runs).toBe(1);
+    });
+
+    it("should prefer a top-level id over an alternate key when both are present", async () => {
+      // Row-spreading events carry `id`; a stray `cardId` naming a different
+      // entity must not split the bucket for one and the same card.
+      const runs = await runsForPair(
+        makeEventTrigger({ config: { events: ["card.updated"] } }),
+        "card.updated",
+        { id: "c1", cardId: "other-1" },
+        { id: "c1", cardId: "other-2" },
+      );
+
+      expect(runs).toBe(1);
     });
 
     it("should handle multiple webhooks and triggers", async () => {

--- a/apps/backend/src/services/event-dispatch.ts
+++ b/apps/backend/src/services/event-dispatch.ts
@@ -12,6 +12,26 @@ import { logger } from "../logger.ts";
 import { currentCausingAgents } from "../event-causation.ts";
 import type { WebhookEvent, EventTriggerConfig } from "@platypus/schemas";
 
+/**
+ * The debounce bucket an event with no single entity falls back to. Bulk
+ * `notification.read` lands here by design — it names a set of notifications,
+ * so coalescing two of them into one run is correct.
+ */
+const SHARED_BUCKET = "unknown";
+
+/** The entity id an event's data carries under `key`, or `undefined`. */
+const entityIdOf = (
+  eventData: unknown,
+  key: "id" | "cardId" | "notificationId",
+): string | number | undefined => {
+  const value = (eventData as Record<string, unknown> | null | undefined)?.[
+    key
+  ];
+  return typeof value === "string" || typeof value === "number"
+    ? value
+    : undefined;
+};
+
 export function dispatchEvent(
   orgId: string,
   workspaceId: string,
@@ -111,8 +131,19 @@ export function dispatchEvent(
           }
         }
 
-        // Debounce per trigger+entity to coalesce rapid events
-        const entityId = (data as { id?: string | number })?.id ?? "unknown";
+        // Debounce per trigger+entity to coalesce rapid events. Only the
+        // row-spreading events (`card.created`/`updated`/`moved`,
+        // `notification.created`/`updated`) carry a top-level `id`; the rest
+        // name their entity under an event-specific key, and reading `id`
+        // alone dropped all of them into SHARED_BUCKET per trigger, so two
+        // unrelated entities coalesced into a single run (#811). A new event
+        // naming its id under some further key would regress the same way —
+        // the chain below is structural, not enforced per event.
+        const entityId =
+          entityIdOf(data, "id") ??
+          entityIdOf(data, "cardId") ??
+          entityIdOf(data, "notificationId") ??
+          SHARED_BUCKET;
         const debounceKey = `${trigger.id}:${entityId}`;
 
         debounceTriggerExecution(


### PR DESCRIPTION
## Summary

`dispatchEvent` derived the debounce entity from `data.id` alone. Four of the eight Webhook events name their entity under a different key, so every one of them fell into a single shared bucket per Trigger — two unrelated Cards deleted inside the 5s window coalesced into one run and the second never fired, silently.

The derivation now reads `cardId` and `notificationId` alongside `id`. That leaves only bulk `notification.read` on the shared bucket, which names a set of notifications and is correct to coalesce.

Two departures from the issue's literal patch, both cosmetic:

- the `"unknown"` sentinel is now a named `SHARED_BUCKET` constant — it is load-bearing for bulk `notification.read`, not just an absence marker;
- the reads go through a small typed `entityIdOf` accessor rather than an inline cast, so a non-string/number value under one of those keys can't leak into the key.

## Tests

Six cases in `event-dispatch.test.ts`, which previously covered the self-actor guard only and never exercised key derivation. Written test-first: three go red on the old derivation (`card.deleted`, `notification.dismissed`, single `notification.read`, each coalescing two unrelated entities into one run) and green on the new one. The other three pin the behaviour that must not change — same entity still coalesces, bulk `notification.read` stays on the shared bucket, and `id` wins over an alternate key when both are present.

Confirmed the suite isn't vacuous by re-running it against the old one-key derivation: still 3 failures.

## Docs

No change. The docs table in `CLAUDE.md` doesn't intersect this diff — no `.env.example`, no user-facing schema bound, nothing under `plugins/**`, no frontend label — and nothing in `apps/docs/content` describes the debounce key.

## Notes for #670

Two pre-existing behaviours this PR does not change, worth knowing before the run-rate breaker keys on the same derivation:

- a Card id colliding with a Notification id would share a bucket on a Trigger subscribed to both event families;
- the key still omits the event type, so `card.moved` and `card.updated` for one Card coalesce.

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)