### PR TITLE
fix(backend): keep event payload text out of the trigger run-start log line

### DIFF
--- a/apps/backend/src/services/trigger-execution.test.ts
+++ b/apps/backend/src/services/trigger-execution.test.ts
@@ -156,6 +156,28 @@ describe("trigger-execution", () => {
       });
     });
 
+    it("logs identifiers only — never the event payload's user content", async () => {
+      // The instruction an event Trigger runs opens with the serialised
+      // payload, so a prefix of it is a prefix of the Card (#812).
+      mockDb.limit.mockResolvedValueOnce([mockScopeRow]);
+      mockGenerate.mockResolvedValueOnce({ text: "ok", stats: {} });
+
+      await executeTrigger(baseTrigger, {
+        eventType: "card.updated",
+        eventData: {
+          id: "c1",
+          title: "Board the quarterly acquisition",
+          body: "Confidential body text",
+        },
+      });
+
+      const logged = JSON.stringify(mockLogger.info.mock.calls);
+      expect(logged).not.toContain("Board the quarterly acquisition");
+      expect(logged).not.toContain("Confidential body text");
+      expect(logged).not.toContain("Do something");
+      expect(startLine()).toMatchObject({ eventType: "card.updated" });
+    });
+
     it("establishes itself as the originating Trigger for everything the run writes", async () => {
       mockDb.limit.mockResolvedValueOnce([mockScopeRow]);
       let seen: { trigger?: string; agents?: readonly string[] } = {};

--- a/apps/backend/src/services/trigger-execution.ts
+++ b/apps/backend/src/services/trigger-execution.ts
@@ -146,15 +146,19 @@ export const executeTrigger = async (
   // next cause. On a cron both are empty; on an event Trigger they are the
   // ambient context of the write that dispatched it, which is the one thing a
   // Trigger loop leaves no other record of (#812).
+  //
+  // Identifiers only. The instruction is deliberately absent: on an event
+  // Trigger it opens with the serialised event payload, so even a short prefix
+  // put Card titles and body text on this line (#812).
   logger.info(
     {
       triggerId: id,
       runId,
       agentId,
       type: trigger.type,
+      eventType: eventContext?.eventType,
       causingAgents: currentCausingAgents(),
       originatingTriggerId: currentOriginatingTrigger(),
-      instruction: effectiveInstruction.substring(0, 100) + "...",
     },
     "Starting trigger execution",
   );


### PR DESCRIPTION
## Summary

- The "Starting trigger execution" log line included `instruction.substring(0, 100)`. For event Triggers the instruction begins with `Event Data:` plus the serialised payload, so Card ids, titles and body text prefixes reached the backend logs.
- #812 set an identifiers-only rule for dispatch decision lines, and the Triggers docs (added in #815) promise the lines "name identifiers only, never Card titles or body text". This line broke that promise.
- Drops the `instruction` field, adds `eventType` in its place, and pins the redaction with a test mirroring the one in `event-dispatch.test.ts`.

Found by the pre-release code review for 3.5.0.

Refs #812

## Test plan

- [x] `vitest run src/services/trigger-execution.test.ts` — 18 passed, including the new redaction test
- [x] `pnpm --filter @platypus/backend typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)