### PR TITLE
fix(dashboard): rename the persisted Embed widget type from iframe to embed

### DIFF
--- a/apps/docs/content/self-hosting/upgrading.mdx
+++ b/apps/docs/content/self-hosting/upgrading.mdx
@@ -43,6 +43,25 @@ Two more things worth doing every time:
 - **Bump both images together.** The backend and frontend are released as a pair
   and are only tested against each other.
 
+## Coming from 3.4
+
+The Embed widget added in 3.4.0 was stored under the type name `iframe`. From
+3.5.0 it is stored as `embed`, matching what the Dashboard UI has always called
+it. A migration rewrites existing rows when the backend starts, so a production
+upgrade needs nothing from you.
+
+Two cases do:
+
+- **You create Widgets through the REST API.** Send `"type": "embed"`; the
+  backend no longer accepts `iframe`.
+- **You run a development database with `drizzle-kit push`.** Push applies
+  schema changes only and skips migration files, so Embed widgets created before
+  this release keep the old name and stop rendering. Rewrite them by hand:
+
+  ```sql
+  UPDATE "widget" SET "type" = 'embed' WHERE "type" = 'iframe';
+  ```
+
 ## Coming from 2.x
 
 Nothing beyond the section above. Configuration is stable across 2.x, and the

--- a/docs/adr/0023-run-timelines-record-shape-and-duration.md
+++ b/docs/adr/0023-run-timelines-record-shape-and-duration.md
@@ -15,7 +15,7 @@ seconds?" has no answer, and a run that fans out to Sub-Agents records nothing
 about the delegates at all. #647 adds a durable, timestamped **Run timeline**
 and renders it as a waterfall on a run detail page.
 
-The decision is what that timeline is *for*, because the obvious next step from
+The decision is what that timeline is _for_, because the obvious next step from
 "record what happened" is to keep recording more of it until the feature is a
 second-rate observability platform. **A Run timeline answers where a single
 run's time went — and only that.** Each **Run event** records a type, a start,
@@ -40,7 +40,7 @@ all of it moot rather than merely handled.
 
 The consequences worth naming. The timeline can say a Tool ran for 5.9 seconds
 and failed; it cannot say what it was called with, so some debugging still ends
-at "reproduce it in a Chat". Error *strings* are the deliberate exception —
+at "reproduce it in a Chat". Error _strings_ are the deliberate exception —
 captured, capped, and explicitly marked when truncated — because a timeline
 that cannot explain a failure answers half the question it exists for; they may
 echo fragments of a failed request, and that is a known and accepted limit


### PR DESCRIPTION
## Summary

Two pre-release-check findings for 3.5.0, one commit each:

- **`chore(docs): format ADR-0023`** — `pnpm format` dirtied `docs/adr/0023-run-timelines-record-shape-and-duration.md` (two `*emphasis*` spans → `_emphasis_`). Formatting is not checked in CI, so it drifted on `main`.
- **`fix(dashboard): rename the persisted Embed widget type from iframe to embed`** — #814 renamed the persisted widget type, added migration 0062 and changed the widget-create API enum, all under a `chore` subject that release-please does not record. This commit gives the change its changelog line and documents it for upgraders on the Upgrading page: production needs nothing, REST clients must send `embed`, and `drizzle-kit push` dev databases need the `UPDATE` by hand.

Refs #760, #814

## Test plan

- [x] `vitest run content/docs-contract.test.ts` — 49 passed
- [x] `pnpm format` leaves the tree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)