### PR TITLE
fix(frontend): survive a failed tool sets read on the Agent form

### DIFF
--- a/apps/docs/content/building-with-platypus/agents.mdx
+++ b/apps/docs/content/building-with-platypus/agents.mdx
@@ -133,6 +133,17 @@ An Agent that can only talk is limited. Give it the ability to _act_:
   show them.
 </Callout>
 
+<Callout type="warning">
+  A missing **Tools** card means your Workspace has no tool sets. It does not
+  mean the Agent lost the ones it already had. If the app couldn't read them at
+  all you get **Tools couldn't be loaded** in the card's place instead — read
+  that as "couldn't ask", not "there are none". Save the Agent anyway and its
+  tool sets stay as they were; the notice only means you can't change them on
+  this visit. When it names authentication, sign in again — and if it comes
+  back, your Operator has `BACKEND_URL`, `BETTER_AUTH_URL`, `FRONTEND_URL` and
+  `ALLOWED_ORIGINS` disagreeing with each other.
+</Callout>
+
 ## Compose Sub-Agents
 
 A **Sub-Agent** is just another Agent that this one can hand work to. In the

--- a/apps/frontend/app/[orgId]/settings/agents/[agentId]/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/agents/[agentId]/page.tsx
@@ -1,8 +1,7 @@
 import { AgentForm } from "@/components/agent-form";
 import { headers } from "next/headers";
 import { ResourcePage } from "@/components/resource-page";
-import { type ToolSet } from "@platypus/schemas";
-import { joinUrl } from "@/lib/utils";
+import { fetchToolSets } from "@/lib/tool-sets-request";
 
 const OrgAgentEditPage = async ({
   params,
@@ -11,24 +10,14 @@ const OrgAgentEditPage = async ({
 }) => {
   const { orgId, agentId } = await params;
 
-  // Use internal URL for SSR, fallback to BACKEND_URL for local dev
-  const backendUrl =
-    process.env.INTERNAL_BACKEND_URL || process.env.BACKEND_URL;
-
   // Org-scoped tool sets: static sets + org MCPs (the only ones a Shared agent
-  // may reference under the no-cascade rule).
+  // may reference under the no-cascade rule). A failed read is reported to the
+  // form rather than thrown, so the page still renders (issue #818).
   const headersList = await headers();
-  const toolSetsResponse = await fetch(
-    joinUrl(backendUrl || "", `/organizations/${orgId}/tools`),
-    {
-      headers: {
-        cookie: headersList.get("cookie") || "",
-      },
-    },
+  const toolSetsResult = await fetchToolSets(
+    `/organizations/${orgId}/tools`,
+    headersList.get("cookie") || "",
   );
-
-  const toolSetsData = await toolSetsResponse.json();
-  const toolSets: ToolSet[] = toolSetsData.results;
 
   return (
     <ResourcePage
@@ -38,7 +27,8 @@ const OrgAgentEditPage = async ({
       <AgentForm
         orgId={orgId}
         agentId={agentId}
-        toolSets={toolSets}
+        toolSets={toolSetsResult.ok ? toolSetsResult.toolSets : []}
+        toolSetsError={toolSetsResult.ok ? undefined : toolSetsResult.reason}
         orgScoped
       />
     </ResourcePage>

--- a/apps/frontend/app/[orgId]/settings/agents/[agentId]/page.tsx
+++ b/apps/frontend/app/[orgId]/settings/agents/[agentId]/page.tsx
@@ -1,7 +1,7 @@
 import { AgentForm } from "@/components/agent-form";
 import { headers } from "next/headers";
 import { ResourcePage } from "@/components/resource-page";
-import { fetchToolSets } from "@/lib/tool-sets-request";
+import { fetchToolSets, toolSetFormProps } from "@/lib/tool-sets-request";
 
 const OrgAgentEditPage = async ({
   params,
@@ -27,8 +27,7 @@ const OrgAgentEditPage = async ({
       <AgentForm
         orgId={orgId}
         agentId={agentId}
-        toolSets={toolSetsResult.ok ? toolSetsResult.toolSets : []}
-        toolSetsError={toolSetsResult.ok ? undefined : toolSetsResult.reason}
+        {...toolSetFormProps(toolSetsResult)}
         orgScoped
       />
     </ResourcePage>

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/[agentId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/[agentId]/page.tsx
@@ -1,8 +1,7 @@
 import { AgentForm } from "@/components/agent-form";
 import { headers } from "next/headers";
 import { ResourcePage } from "@/components/resource-page";
-import { type ToolSet } from "@platypus/schemas";
-import { joinUrl } from "@/lib/utils";
+import { fetchToolSets } from "@/lib/tool-sets-request";
 
 const AgentEditPage = async ({
   params,
@@ -11,28 +10,13 @@ const AgentEditPage = async ({
 }) => {
   const { orgId, workspaceId, agentId } = await params;
 
-  // Use internal URL for SSR, fallback to BACKEND_URL for local dev
-  const backendUrl =
-    process.env.INTERNAL_BACKEND_URL || process.env.BACKEND_URL;
-
-  // Fetch tool sets from the server
+  // Fetch tool sets from the server. A failed read is reported to the form
+  // rather than thrown, so the page still renders (issue #818).
   const headersList = await headers();
-  const [toolSetsResponse] = await Promise.all([
-    fetch(
-      joinUrl(
-        backendUrl || "",
-        `/organizations/${orgId}/workspaces/${workspaceId}/tools`,
-      ),
-      {
-        headers: {
-          cookie: headersList.get("cookie") || "",
-        },
-      },
-    ),
-  ]);
-
-  const toolSetsData = await toolSetsResponse.json();
-  const toolSets: ToolSet[] = toolSetsData.results;
+  const toolSetsResult = await fetchToolSets(
+    `/organizations/${orgId}/workspaces/${workspaceId}/tools`,
+    headersList.get("cookie") || "",
+  );
 
   return (
     <ResourcePage
@@ -44,7 +28,8 @@ const AgentEditPage = async ({
         orgId={orgId}
         workspaceId={workspaceId}
         agentId={agentId}
-        toolSets={toolSets}
+        toolSets={toolSetsResult.ok ? toolSetsResult.toolSets : []}
+        toolSetsError={toolSetsResult.ok ? undefined : toolSetsResult.reason}
       />
     </ResourcePage>
   );

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/[agentId]/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/[agentId]/page.tsx
@@ -1,7 +1,7 @@
 import { AgentForm } from "@/components/agent-form";
 import { headers } from "next/headers";
 import { ResourcePage } from "@/components/resource-page";
-import { fetchToolSets } from "@/lib/tool-sets-request";
+import { fetchToolSets, toolSetFormProps } from "@/lib/tool-sets-request";
 
 const AgentEditPage = async ({
   params,
@@ -28,8 +28,7 @@ const AgentEditPage = async ({
         orgId={orgId}
         workspaceId={workspaceId}
         agentId={agentId}
-        toolSets={toolSetsResult.ok ? toolSetsResult.toolSets : []}
-        toolSetsError={toolSetsResult.ok ? undefined : toolSetsResult.reason}
+        {...toolSetFormProps(toolSetsResult)}
       />
     </ResourcePage>
   );

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/create/page.tsx
@@ -1,7 +1,7 @@
 import { AgentForm } from "@/components/agent-form";
 import { headers } from "next/headers";
 import { ResourcePage } from "@/components/resource-page";
-import { fetchToolSets } from "@/lib/tool-sets-request";
+import { fetchToolSets, toolSetFormProps } from "@/lib/tool-sets-request";
 
 const AgentCreatePage = async ({
   params,
@@ -27,8 +27,7 @@ const AgentCreatePage = async ({
       <AgentForm
         orgId={orgId}
         workspaceId={workspaceId}
-        toolSets={toolSetsResult.ok ? toolSetsResult.toolSets : []}
-        toolSetsError={toolSetsResult.ok ? undefined : toolSetsResult.reason}
+        {...toolSetFormProps(toolSetsResult)}
       />
     </ResourcePage>
   );

--- a/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/create/page.tsx
+++ b/apps/frontend/app/[orgId]/workspace/[workspaceId]/agents/create/page.tsx
@@ -1,8 +1,7 @@
 import { AgentForm } from "@/components/agent-form";
 import { headers } from "next/headers";
 import { ResourcePage } from "@/components/resource-page";
-import { type ToolSet } from "@platypus/schemas";
-import { joinUrl } from "@/lib/utils";
+import { fetchToolSets } from "@/lib/tool-sets-request";
 
 const AgentCreatePage = async ({
   params,
@@ -11,28 +10,13 @@ const AgentCreatePage = async ({
 }) => {
   const { orgId, workspaceId } = await params;
 
-  // Use internal URL for SSR, fallback to BACKEND_URL for local dev
-  const backendUrl =
-    process.env.INTERNAL_BACKEND_URL || process.env.BACKEND_URL;
-
-  // Fetch tool sets from the server
+  // Fetch tool sets from the server. A failed read is reported to the form
+  // rather than thrown, so the page still renders (issue #818).
   const headersList = await headers();
-  const [toolSetsResponse] = await Promise.all([
-    fetch(
-      joinUrl(
-        backendUrl || "",
-        `/organizations/${orgId}/workspaces/${workspaceId}/tools`,
-      ),
-      {
-        headers: {
-          cookie: headersList.get("cookie") || "",
-        },
-      },
-    ),
-  ]);
-
-  const toolSetsData = await toolSetsResponse.json();
-  const toolSets: ToolSet[] = toolSetsData.results;
+  const toolSetsResult = await fetchToolSets(
+    `/organizations/${orgId}/workspaces/${workspaceId}/tools`,
+    headersList.get("cookie") || "",
+  );
 
   return (
     <ResourcePage
@@ -40,7 +24,12 @@ const AgentCreatePage = async ({
       title="Create Agent"
       variant="create"
     >
-      <AgentForm orgId={orgId} workspaceId={workspaceId} toolSets={toolSets} />
+      <AgentForm
+        orgId={orgId}
+        workspaceId={workspaceId}
+        toolSets={toolSetsResult.ok ? toolSetsResult.toolSets : []}
+        toolSetsError={toolSetsResult.ok ? undefined : toolSetsResult.reason}
+      />
     </ResourcePage>
   );
 };

--- a/apps/frontend/app/agent-pages-tool-sets.test.tsx
+++ b/apps/frontend/app/agent-pages-tool-sets.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+
+// The Agent form itself is exercised in components/agent-form.test.tsx. Here it
+// stands in as a prop recorder so these tests stay about what the *pages* hand
+// it after reading the tool sets.
+const { formProps } = vi.hoisted(() => ({
+  formProps: { current: null as Record<string, unknown> | null },
+}));
+
+vi.mock("@/components/agent-form", () => ({
+  AgentForm: (props: Record<string, unknown>) => {
+    formProps.current = props;
+    return null;
+  },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: async () => new Headers({ cookie: "better-auth.session_token=abc" }),
+}));
+
+// The page shell renders a back button, which needs a router.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+}));
+
+import AgentCreatePage from "./[orgId]/workspace/[workspaceId]/agents/create/page";
+import AgentEditPage from "./[orgId]/workspace/[workspaceId]/agents/[agentId]/page";
+import OrgAgentEditPage from "./[orgId]/settings/agents/[agentId]/page";
+
+function stubFetch(body: unknown, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { "content-type": "application/json" },
+        }),
+    ),
+  );
+}
+
+/** Runs a page the way Next does: resolve it, then render what it returned. */
+async function renderPage(page: (typeof pages)[number]) {
+  const element = await page.render();
+  render(element);
+  return element;
+}
+
+// Each page under test, with the params it takes.
+const pages = [
+  {
+    name: "workspace Agent create",
+    render: () =>
+      AgentCreatePage({
+        params: Promise.resolve({ orgId: "org1", workspaceId: "ws1" }),
+      }),
+  },
+  {
+    name: "workspace Agent edit",
+    render: () =>
+      AgentEditPage({
+        params: Promise.resolve({
+          orgId: "org1",
+          workspaceId: "ws1",
+          agentId: "a1",
+        }),
+      }),
+  },
+  {
+    name: "org-scoped Shared Agent edit",
+    render: () =>
+      OrgAgentEditPage({
+        params: Promise.resolve({ orgId: "org1", agentId: "a1" }),
+      }),
+  },
+];
+
+describe("Agent pages tool set loading", () => {
+  beforeEach(() => {
+    process.env.INTERNAL_BACKEND_URL = "http://backend:4000";
+    formProps.current = null;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.INTERNAL_BACKEND_URL;
+  });
+
+  for (const page of pages) {
+    describe(page.name, () => {
+      it("renders instead of throwing when the tool sets request is rejected as unauthorized", async () => {
+        stubFetch({ error: "Unauthorized" }, 401);
+
+        await expect(renderPage(page)).resolves.toBeTruthy();
+
+        expect(formProps.current).toMatchObject({
+          toolSets: [],
+          toolSetsError: "unauthorized",
+        });
+      });
+
+      it("renders instead of throwing when the backend is unreachable", async () => {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async () => {
+            throw new Error("ECONNREFUSED");
+          }),
+        );
+
+        await expect(renderPage(page)).resolves.toBeTruthy();
+
+        expect(formProps.current).toMatchObject({
+          toolSets: [],
+          toolSetsError: "unavailable",
+        });
+      });
+
+      it("passes the tool sets through with no error when the request succeeds", async () => {
+        stubFetch({ results: [{ id: "ts1", name: "Web" }] });
+
+        await expect(renderPage(page)).resolves.toBeTruthy();
+
+        expect(formProps.current).toMatchObject({
+          toolSets: [{ id: "ts1", name: "Web" }],
+          toolSetsError: undefined,
+        });
+      });
+
+      it("reports an empty catalogue as success, not as a failure", async () => {
+        stubFetch({ results: [] });
+
+        await renderPage(page);
+
+        expect(formProps.current).toMatchObject({
+          toolSets: [],
+          toolSetsError: undefined,
+        });
+      });
+    });
+  }
+
+  it("reads the org tool sets for a Shared Agent and the workspace tool sets otherwise", async () => {
+    stubFetch({ results: [] });
+    await OrgAgentEditPage({
+      params: Promise.resolve({ orgId: "org1", agentId: "a1" }),
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "http://backend:4000/organizations/org1/tools",
+      expect.anything(),
+    );
+
+    stubFetch({ results: [] });
+    await AgentCreatePage({
+      params: Promise.resolve({ orgId: "org1", workspaceId: "ws1" }),
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "http://backend:4000/organizations/org1/workspaces/ws1/tools",
+      expect.anything(),
+    );
+  });
+});

--- a/apps/frontend/components/agent-form.test.tsx
+++ b/apps/frontend/components/agent-form.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import type { Provider } from "@platypus/schemas";
+import type { Provider, ToolSet } from "@platypus/schemas";
 import {
   navigationMock,
   configMock,
@@ -210,5 +210,128 @@ describe("AgentForm avatar write partial-success handling", () => {
     );
     expect(toastError).toHaveBeenCalledWith("Avatar storage locked");
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("AgentForm tool set load failure", () => {
+  const toolSet = {
+    id: "ts1",
+    name: "Web Search",
+    category: "Built-in",
+  } as unknown as ToolSet;
+
+  beforeEach(() => {
+    resetFormHarness();
+    registerSwrData();
+    setDataFor("/agents/a1", undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the form instead of crashing when the tool sets could not be loaded", () => {
+    render(
+      <AgentForm
+        orgId="org1"
+        workspaceId="ws1"
+        toolSets={[]}
+        agents={[]}
+        toolSetsError="unauthorized"
+      />,
+    );
+
+    // The rest of the form is still usable.
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
+  it("names authentication as the cause when the tool sets request was rejected as unauthorized", () => {
+    render(
+      <AgentForm
+        orgId="org1"
+        workspaceId="ws1"
+        toolSets={[]}
+        agents={[]}
+        toolSetsError="unauthorized"
+      />,
+    );
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/tools couldn't be loaded/i);
+    expect(alert).toHaveTextContent(/sign(ed)? in|authenticat/i);
+  });
+
+  it("does not blame authentication when the tool sets request failed for another reason", () => {
+    render(
+      <AgentForm
+        orgId="org1"
+        workspaceId="ws1"
+        toolSets={[]}
+        agents={[]}
+        toolSetsError="unavailable"
+      />,
+    );
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/tools couldn't be loaded/i);
+    expect(alert).not.toHaveTextContent(/authenticat/i);
+  });
+
+  it("shows no error and no Tools card when the workspace genuinely has no tool sets", () => {
+    render(
+      <AgentForm orgId="org1" workspaceId="ws1" toolSets={[]} agents={[]} />,
+    );
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tools")).not.toBeInTheDocument();
+  });
+
+  it("renders the Tools card as usual when the tool sets loaded", () => {
+    render(
+      <AgentForm
+        orgId="org1"
+        workspaceId="ws1"
+        toolSets={[toolSet]}
+        agents={[]}
+      />,
+    );
+
+    expect(screen.getByText("Tools")).toBeInTheDocument();
+    expect(screen.getByText("Web Search")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("preserves an existing agent's tool set selections when the tool sets could not be loaded", async () => {
+    setDataFor("/agents/a1", {
+      id: "a1",
+      name: "Bot",
+      description: "A helpful bot",
+      instructions: "Be helpful",
+      providerId: "p1",
+      modelId: "gpt-4o",
+      maxSteps: 5,
+      toolSetIds: ["ts1", "ts2"],
+    });
+    const fetchMock = stubSaveSequence({ status: 200, body: { id: "a1" } });
+
+    render(
+      <AgentForm
+        orgId="org1"
+        workspaceId="ws1"
+        toolSets={[]}
+        agents={[]}
+        agentId="a1"
+        toolSetsError="unauthorized"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByDisplayValue("Bot")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Update" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.toolSetIds).toEqual(["ts1", "ts2"]);
   });
 });

--- a/apps/frontend/components/agent-form.test.tsx
+++ b/apps/frontend/components/agent-form.test.tsx
@@ -301,6 +301,65 @@ describe("AgentForm tool set load failure", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
+  it("still groups tool sets by category, keeping Uncategorized last", () => {
+    const uncategorised = {
+      id: "ts2",
+      name: "Loose Tool",
+    } as unknown as ToolSet;
+    const mcp = {
+      id: "ts3",
+      name: "Some MCP",
+      category: "MCP",
+    } as unknown as ToolSet;
+
+    render(
+      <AgentForm
+        orgId="org1"
+        workspaceId="ws1"
+        toolSets={[uncategorised, mcp, toolSet]}
+        agents={[]}
+      />,
+    );
+
+    const headings = screen
+      .getAllByText(/^(Built-in|MCP|Uncategorized)$/)
+      .map((el) => el.textContent);
+    expect(headings).toEqual(["Built-in", "MCP", "Uncategorized"]);
+  });
+
+  it("names the Organization, not a Workspace, on a Shared Agent", () => {
+    render(
+      <AgentForm
+        orgId="org1"
+        agentId="a1"
+        toolSets={[]}
+        agents={[]}
+        toolSetsError="unauthorized"
+        orgScoped
+      />,
+    );
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/Organization/);
+    expect(alert).not.toHaveTextContent(/Workspace/);
+  });
+
+  it("does not promise to preserve selections when creating a new Agent", () => {
+    render(
+      <AgentForm
+        orgId="org1"
+        workspaceId="ws1"
+        toolSets={[]}
+        agents={[]}
+        toolSetsError="unauthorized"
+      />,
+    );
+
+    expect(screen.getByRole("alert")).not.toHaveTextContent(
+      /existing tool selections/i,
+    );
+  });
+
   it("preserves an existing agent's tool set selections when the tool sets could not be loaded", async () => {
     setDataFor("/agents/a1", {
       id: "a1",

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -63,6 +63,8 @@ import { useBackendUrl } from "@/app/client-context";
 import { useAuth } from "@/components/auth-provider";
 import { AgentAvatar } from "@/components/agent-avatar";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ToolSetsUnavailableNotice } from "@/components/tool-sets-unavailable-notice";
+import { type ToolSetsFailureReason } from "@/lib/tool-sets-request";
 
 // toolSetIds, skillIds, and subAgentIds are deliberately excluded: this form
 // has no field that retracts an error keyed to them, so including them here
@@ -89,6 +91,7 @@ const AgentForm = ({
   workspaceId,
   agentId,
   toolSets,
+  toolSetsError,
   agents: propAgents,
   orgScoped = false,
 }: {
@@ -97,6 +100,9 @@ const AgentForm = ({
   workspaceId?: string;
   agentId?: string;
   toolSets: ToolSet[];
+  // Set when the tool sets couldn't be read, so the form can say so instead of
+  // presenting a failed read as an empty catalogue (issue #818).
+  toolSetsError?: ToolSetsFailureReason;
   agents?: Agent[];
   // When true the form edits an org-scoped (Shared) Agent on the Organization
   // surface, pulling its references from org-scoped lists and writing via the
@@ -722,7 +728,9 @@ const AgentForm = ({
           />
         </FieldGroup>
 
-        {toolSets.length > 0 && (
+        {toolSetsError && <ToolSetsUnavailableNotice reason={toolSetsError} />}
+
+        {!toolSetsError && toolSets.length > 0 && (
           <Card>
             <CardHeader>
               <CardTitle>Tools</CardTitle>

--- a/apps/frontend/components/agent-form.tsx
+++ b/apps/frontend/components/agent-form.tsx
@@ -728,7 +728,13 @@ const AgentForm = ({
           />
         </FieldGroup>
 
-        {toolSetsError && <ToolSetsUnavailableNotice reason={toolSetsError} />}
+        {toolSetsError && (
+          <ToolSetsUnavailableNotice
+            reason={toolSetsError}
+            scope={orgScoped ? "organization" : "workspace"}
+            hasExistingSelections={Boolean(agentId)}
+          />
+        )}
 
         {!toolSetsError && toolSets.length > 0 && (
           <Card>

--- a/apps/frontend/components/tool-sets-unavailable-notice.tsx
+++ b/apps/frontend/components/tool-sets-unavailable-notice.tsx
@@ -5,35 +5,46 @@ import { type ToolSetsFailureReason } from "@/lib/tool-sets-request";
 /**
  * Shown in place of the Tools card when the tool sets couldn't be read.
  *
- * Deliberately distinct from the "this workspace has no tool sets" case, which
+ * Deliberately distinct from the "this Workspace has no tool sets" case, which
  * renders nothing: substituting an empty list for a failed read hides the
  * misconfiguration that caused it (issue #818).
  */
 export const ToolSetsUnavailableNotice = ({
   reason,
+  scope,
+  hasExistingSelections,
 }: {
   reason: ToolSetsFailureReason;
-}) => (
-  <Alert variant="destructive">
-    <TriangleAlert />
-    <AlertTitle>Tools couldn&apos;t be loaded</AlertTitle>
-    <AlertDescription>
-      {reason === "unauthorized" ? (
+  /** Which catalogue was being read — a Shared Agent reads the org's. */
+  scope: "organization" | "workspace";
+  /** Only an existing Agent has selections worth reassuring the reader about. */
+  hasExistingSelections: boolean;
+}) => {
+  const owner = scope === "organization" ? "Organization" : "Workspace";
+
+  return (
+    <Alert variant="destructive">
+      <TriangleAlert />
+      <AlertTitle>Tools couldn&apos;t be loaded</AlertTitle>
+      <AlertDescription>
+        {reason === "unauthorized" ? (
+          <span>
+            The request for this {owner}&apos;s tools wasn&apos;t authenticated.
+            Try signing in again — if it keeps happening, the deployment&apos;s
+            backend and frontend URLs are likely misconfigured.
+          </span>
+        ) : (
+          <span>
+            The tools for this {owner} are temporarily unreachable. Reload the
+            page to try again.
+          </span>
+        )}
         <span>
-          The request for this workspace&apos;s tools wasn&apos;t authenticated.
-          Try signing in again — if it keeps happening, the deployment&apos;s
-          backend and frontend URLs are likely misconfigured.
+          {hasExistingSelections
+            ? "You can still edit and save this Agent; its existing tool selections are left unchanged."
+            : "You can still create this Agent, then grant it tools once they load."}
         </span>
-      ) : (
-        <span>
-          The tools for this workspace are temporarily unreachable. Reload the
-          page to try again.
-        </span>
-      )}
-      <span>
-        You can still edit and save this Agent; its existing tool selections are
-        left unchanged.
-      </span>
-    </AlertDescription>
-  </Alert>
-);
+      </AlertDescription>
+    </Alert>
+  );
+};

--- a/apps/frontend/components/tool-sets-unavailable-notice.tsx
+++ b/apps/frontend/components/tool-sets-unavailable-notice.tsx
@@ -1,0 +1,39 @@
+import { TriangleAlert } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { type ToolSetsFailureReason } from "@/lib/tool-sets-request";
+
+/**
+ * Shown in place of the Tools card when the tool sets couldn't be read.
+ *
+ * Deliberately distinct from the "this workspace has no tool sets" case, which
+ * renders nothing: substituting an empty list for a failed read hides the
+ * misconfiguration that caused it (issue #818).
+ */
+export const ToolSetsUnavailableNotice = ({
+  reason,
+}: {
+  reason: ToolSetsFailureReason;
+}) => (
+  <Alert variant="destructive">
+    <TriangleAlert />
+    <AlertTitle>Tools couldn&apos;t be loaded</AlertTitle>
+    <AlertDescription>
+      {reason === "unauthorized" ? (
+        <span>
+          The request for this workspace&apos;s tools wasn&apos;t authenticated.
+          Try signing in again — if it keeps happening, the deployment&apos;s
+          backend and frontend URLs are likely misconfigured.
+        </span>
+      ) : (
+        <span>
+          The tools for this workspace are temporarily unreachable. Reload the
+          page to try again.
+        </span>
+      )}
+      <span>
+        You can still edit and save this Agent; its existing tool selections are
+        left unchanged.
+      </span>
+    </AlertDescription>
+  </Alert>
+);

--- a/apps/frontend/lib/tool-sets-request.test.ts
+++ b/apps/frontend/lib/tool-sets-request.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchToolSets } from "./tool-sets-request";
+
+const cookie = "better-auth.session_token=abc";
+
+function stubFetch(impl: () => Promise<Response> | Response) {
+  const spy = vi.fn(impl);
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("fetchToolSets", () => {
+  beforeEach(() => {
+    process.env.INTERNAL_BACKEND_URL = "http://backend:4000";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.INTERNAL_BACKEND_URL;
+    delete process.env.BACKEND_URL;
+  });
+
+  it("returns the tool sets when the request succeeds", async () => {
+    stubFetch(() => jsonResponse({ results: [{ id: "ts1", name: "Web" }] }));
+
+    const result = await fetchToolSets("/organizations/o1/tools", cookie);
+
+    expect(result).toEqual({
+      ok: true,
+      toolSets: [{ id: "ts1", name: "Web" }],
+    });
+  });
+
+  it("returns an empty list, not a failure, when the workspace has no tool sets", async () => {
+    stubFetch(() => jsonResponse({ results: [] }));
+
+    const result = await fetchToolSets("/organizations/o1/tools", cookie);
+
+    expect(result).toEqual({ ok: true, toolSets: [] });
+  });
+
+  it("forwards the caller's cookie to the backend so SSR requests carry the session", async () => {
+    const spy = stubFetch(() => jsonResponse({ results: [] }));
+
+    await fetchToolSets("/organizations/o1/tools", cookie);
+
+    expect(spy).toHaveBeenCalledWith(
+      "http://backend:4000/organizations/o1/tools",
+      { headers: { cookie } },
+    );
+  });
+
+  it("reports an unauthorized failure on 401 rather than throwing", async () => {
+    stubFetch(() => jsonResponse({ error: "Unauthorized" }, 401));
+
+    const result = await fetchToolSets("/organizations/o1/tools", cookie);
+
+    expect(result).toEqual({ ok: false, reason: "unauthorized" });
+  });
+
+  it("reports an unauthorized failure on 403", async () => {
+    stubFetch(() => jsonResponse({ error: "Forbidden" }, 403));
+
+    const result = await fetchToolSets("/organizations/o1/tools", cookie);
+
+    expect(result).toEqual({ ok: false, reason: "unauthorized" });
+  });
+
+  it("reports an unavailable failure on a server error", async () => {
+    stubFetch(() => jsonResponse({ error: "Boom" }, 500));
+
+    const result = await fetchToolSets("/organizations/o1/tools", cookie);
+
+    expect(result).toEqual({ ok: false, reason: "unavailable" });
+  });
+
+  it("reports an unavailable failure when the body is not valid JSON", async () => {
+    stubFetch(() => new Response("<html>gateway</html>", { status: 200 }));
+
+    const result = await fetchToolSets("/organizations/o1/tools", cookie);
+
+    expect(result).toEqual({ ok: false, reason: "unavailable" });
+  });
+
+  it("reports an unavailable failure when a 200 body carries no results array", async () => {
+    stubFetch(() => jsonResponse({ unexpected: true }));
+
+    const result = await fetchToolSets("/organizations/o1/tools", cookie);
+
+    expect(result).toEqual({ ok: false, reason: "unavailable" });
+  });
+
+  it("reports an unavailable failure when the fetch itself rejects", async () => {
+    stubFetch(() => Promise.reject(new Error("ECONNREFUSED")));
+
+    const result = await fetchToolSets("/organizations/o1/tools", cookie);
+
+    expect(result).toEqual({ ok: false, reason: "unavailable" });
+  });
+
+  it("falls back to BACKEND_URL when no internal URL is configured", async () => {
+    delete process.env.INTERNAL_BACKEND_URL;
+    process.env.BACKEND_URL = "http://localhost:4000";
+    const spy = stubFetch(() => jsonResponse({ results: [] }));
+
+    await fetchToolSets("/organizations/o1/tools", cookie);
+
+    expect(spy).toHaveBeenCalledWith(
+      "http://localhost:4000/organizations/o1/tools",
+      { headers: { cookie } },
+    );
+  });
+});

--- a/apps/frontend/lib/tool-sets-request.ts
+++ b/apps/frontend/lib/tool-sets-request.ts
@@ -66,3 +66,16 @@ export async function fetchToolSets(
 
   return { ok: true, toolSets: results as ToolSet[] };
 }
+
+/**
+ * Decodes a result into the props the Agent form takes, so the three pages
+ * that render the form don't each repeat the unpacking.
+ */
+export function toolSetFormProps(result: ToolSetsResult): {
+  toolSets: ToolSet[];
+  toolSetsError?: ToolSetsFailureReason;
+} {
+  return result.ok
+    ? { toolSets: result.toolSets, toolSetsError: undefined }
+    : { toolSets: [], toolSetsError: result.reason };
+}

--- a/apps/frontend/lib/tool-sets-request.ts
+++ b/apps/frontend/lib/tool-sets-request.ts
@@ -1,0 +1,68 @@
+import { type ToolSet } from "@platypus/schemas";
+import { joinUrl } from "@/lib/utils";
+
+/**
+ * Why a server-side tool sets read failed.
+ *
+ * `unauthorized` is called out separately because it is the case operators
+ * actually hit: during SSR the frontend can only forward the cookies the
+ * browser sent to the *frontend* origin, so a deployment whose frontend and
+ * backend sit on different hosts forwards no session cookie and the backend
+ * answers 401 (issue #819). Naming authentication in that case is the
+ * difference between a dead end and a fixable one.
+ */
+export type ToolSetsFailureReason = "unauthorized" | "unavailable";
+
+export type ToolSetsResult =
+  | { ok: true; toolSets: ToolSet[] }
+  | { ok: false; reason: ToolSetsFailureReason };
+
+/**
+ * Reads a tool sets collection from the backend during server-side rendering,
+ * forwarding the caller's cookie header.
+ *
+ * Never throws and never returns `undefined`: a failed read is reported as a
+ * value so the page can render an honest error instead of dying mid-render.
+ * Callers get an empty `toolSets` array only when the backend really did
+ * return an empty collection — "none exist" stays distinguishable from
+ * "couldn't ask".
+ */
+export async function fetchToolSets(
+  path: string,
+  cookie: string,
+): Promise<ToolSetsResult> {
+  // Internal URL for SSR, falling back to BACKEND_URL for local dev.
+  const backendUrl =
+    process.env.INTERNAL_BACKEND_URL || process.env.BACKEND_URL || "";
+
+  let response: Response;
+  try {
+    response = await fetch(joinUrl(backendUrl, path), { headers: { cookie } });
+  } catch {
+    return { ok: false, reason: "unavailable" };
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      reason:
+        response.status === 401 || response.status === 403
+          ? "unauthorized"
+          : "unavailable",
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return { ok: false, reason: "unavailable" };
+  }
+
+  const results = (body as { results?: unknown } | null)?.results;
+  if (!Array.isArray(results)) {
+    return { ok: false, reason: "unavailable" };
+  }
+
+  return { ok: true, toolSets: results as ToolSet[] };
+}


### PR DESCRIPTION
Closes #818.

## The bug

The Agent create and edit pages read the Workspace's tool sets during SSR and passed the response body's `results` straight into the form without checking the request succeeded. On any non-2xx response there is no `results` key — the backend answers 401 with `{ error: "Unauthorized" }` — so `toolSets` became `undefined` and the form threw while deciding whether to render the Tools card:

```
TypeError: Cannot read properties of undefined (reading 'length')
```

The page then failed to render at all. The reporter got a digest-stamped stack trace and no hint that anything was wrong with authentication, which is why nothing useful showed up in their logs.

Reading their backend log by route rather than by time gives the whole story: the agents, boards and skills routes return 200, while the two routes fetched during SSR — the workspace route and the tool sets route — return 401 every time. Their browser was authenticated; the frontend's server-side calls were not.

## The change

Three call sites (Workspace Agent create, Workspace Agent edit, Shared Agent edit) now go through a shared `fetchToolSets` helper that reports failure as a value instead of throwing, and a `toolSetFormProps` decode so the pages don't each repeat the unpacking. The form renders a notice in place of the Tools card, naming authentication when the cause is a 401/403.

The important property: **a failed read stays distinguishable from a Workspace that genuinely has no tool sets.** Substituting an empty list for a failed read is exactly what hid the misconfiguration. A save while the read is failing leaves an existing Agent's tool selections untouched.

## Docs

`building-with-platypus/agents.mdx` previously said the Tools card is absent only when a Workspace has nothing to grant. This change makes that untrue, so the page now covers the third state and points a reader whose notice mentions authentication at the URL settings behind it.

## Not in scope

The reason SSR requests arrive unauthenticated on a split-origin deployment is **not** fixed here — that's #819. During SSR the frontend can only forward the cookies the browser sent to the *frontend* origin, so a deployment whose frontend and backend sit on different hosts forwards no session cookie. This PR makes that failure survivable and legible; whether the topology should be supported at all is the open question on #819.

That also means this does not on its own restore the reporter's ability to create Agents. It turns their crash into an actionable message; the URL wiring is still theirs to fix.

## Testing

`pnpm typecheck`, `pnpm lint` and `pnpm test` all pass (8/8 tasks, including the docs contract test). Frontend tests 789 → 805:

- `lib/tool-sets-request.test.ts` — success, empty catalogue, cookie forwarding, 401, 403, 500, invalid JSON, 200-without-`results`, thrown fetch, and the `BACKEND_URL` fallback.
- `app/agent-pages-tool-sets.test.tsx` — each of the three pages against 401, an unreachable backend, success and an empty catalogue, plus the org-vs-workspace route choice.
- `components/agent-form.test.tsx` — both notice variants, the Organization wording on a Shared Agent, no preservation promise when creating, no error state for a genuinely empty catalogue, existing category grouping, and that saving preserves stored `toolSetIds`.

The page tests mock the form to assert what the pages hand it; the form's own survival is covered separately. The split is deliberate, but no single test walks the entire original crash path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
