### PR TITLE
fix(frontend): send the drag's origin column on cross-column card moves

### DIFF
--- a/apps/frontend/components/kanban-board.test.tsx
+++ b/apps/frontend/components/kanban-board.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
 import type {
   KanbanBoardState,
   KanbanCard,
@@ -52,6 +58,7 @@ vi.mock("swr", () => ({
 // board passes it, which is what lets a test drive a card drop.
 const dragHandlers: {
   onDragStart?: (event: unknown) => void;
+  onDragOver?: (event: unknown) => void;
   onDragEnd?: (event: unknown) => void;
 } = {};
 
@@ -63,6 +70,7 @@ vi.mock("@dnd-kit/core", async () => {
     ...actual,
     DndContext: (props: Record<string, unknown>) => {
       dragHandlers.onDragStart = props.onDragStart as (e: unknown) => void;
+      dragHandlers.onDragOver = props.onDragOver as (e: unknown) => void;
       dragHandlers.onDragEnd = props.onDragEnd as (e: unknown) => void;
       return React.createElement(actual.DndContext, props);
     },
@@ -498,6 +506,41 @@ describe("KanbanBoard transport", () => {
         over: { id: "col-2", rect: { top: 0, height: 10 } },
       });
     }
+
+    /**
+     * The full dnd-kit sequence: drag-over moves the card into the target
+     * column locally before drag-end fires.  The board must still report the
+     * column the drag *started* in, or the server refuses every cross-column
+     * move as a conflict.
+     */
+    it("sends the origin column after drag-over moved the card locally", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(jsonResponse(200, { id: "card-1" }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      renderBoard();
+      const active = {
+        id: "card-1",
+        data: { current: { type: "card" } },
+        rect: { current: { translated: null, initial: null } },
+      };
+      const over = { id: "col-2", rect: { top: 0, height: 10 } };
+      act(() => {
+        dragHandlers.onDragStart?.({ active });
+        dragHandlers.onDragOver?.({ active, over });
+      });
+      act(() => {
+        dragHandlers.onDragEnd?.({ active, over });
+      });
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(JSON.parse(init.body as string)).toMatchObject({
+        columnId: "col-2",
+        expectedColumnId: "col-1",
+      });
+    });
 
     it("sends the column the card was dragged from", async () => {
       const fetchMock = vi

--- a/apps/frontend/components/kanban-board.tsx
+++ b/apps/frontend/components/kanban-board.tsx
@@ -155,6 +155,12 @@ export function KanbanBoard({
   // (React #185).  Coalescing to one update per frame breaks the loop while
   // still letting the user see cards animate as they drag.
   const dragOverFrameRef = useRef<number | null>(null);
+  // The column a card drag started from, captured before drag-over rewrites
+  // localColumns. Cross-column moves are applied to the local copy while the
+  // card is still in flight, so by drag-end the card already sits in its
+  // target column locally — reading the source from there would send the
+  // target as `expectedColumnId` and refuse every cross-column move.
+  const dragOriginColumnRef = useRef<string | null>(null);
   const [selectedCard, setSelectedCard] = useState<KanbanCard | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -285,6 +291,11 @@ export function KanbanBoard({
       setActiveId(active.id as string);
       setActiveType(type);
       activeTypeRef.current = type;
+      dragOriginColumnRef.current =
+        type === "card"
+          ? (columns.find((col) => col.cards.some((c) => c.id === active.id))
+              ?.id ?? null)
+          : null;
       setLocalColumns([...columns.map((c) => ({ ...c, cards: [...c.cards] }))]);
     },
     [columns, setLocalColumns],
@@ -433,9 +444,10 @@ export function KanbanBoard({
         return;
       }
 
-      // Card drag end.  The active card stays in its source column during
-      // drag-over (cross-column moves are deferred to here), so we resolve
-      // the target column from the drop target rather than from the array.
+      // Card drag end.  Drag-over has already moved the card in the local
+      // copy, so `sourceColumn` here is where the card sits *now* — the drag's
+      // true origin lives in dragOriginColumnRef.  The target column is
+      // resolved from the drop target rather than from the array.
       const sourceColumn = cols.find((col) =>
         col.cards.some((c) => c.id === active.id),
       );
@@ -537,7 +549,7 @@ export function KanbanBoard({
             // The board polls, so the column this drag started from may already
             // be out of date. Sending it makes the move conditional: an agent's
             // move that landed mid-drag is reported rather than overwritten.
-            expectedColumnId: sourceColumn.id,
+            expectedColumnId: dragOriginColumnRef.current ?? sourceColumn.id,
           },
         },
       );


### PR DESCRIPTION
## Problem

Dragging a Kanban card between columns always failed with the toast "This card was moved by someone else. Your change was not applied." Reordering within a column worked.

Regression from #782, frontend side only.

## Cause

`handleDragOver` applies cross-column moves to the board's local copy while the drag is in flight, so by drag-end the card already sits in its target column locally. `handleDragEnd` derived `sourceColumn` by searching that same mutated state, so it sent `expectedColumnId: <target column>`. The card was still in its original column server-side, so the precondition never matched — every cross-column drop came back 409 and was reported as a concurrent move. Same-column reorders were unaffected because origin and target are the same column.

## Fix

Capture the origin column in a ref at drag start, from the server-backed `columns`, before drag-over rewrites anything, and send that as `expectedColumnId`. The backend precondition is unchanged — it was doing exactly what it should.

## Tests

The existing test drove `onDragStart` → `onDragEnd` and skipped `onDragOver`, which is why it never caught this. The `DndContext` mock now captures `onDragOver`, and a new test drives the real start/over/end sequence. Verified it fails on the old code (sends `col-2`) and passes with the fix. Full frontend suite green (806), typecheck clean.

## Docs

None needed — no env var, schema limit, plugin, or UI label changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)