### PR TITLE
fix(frontend): only open a dropdown menu on a deliberate touch tap

### DIFF
--- a/apps/frontend/components/ui/dropdown-menu.test.tsx
+++ b/apps/frontend/components/ui/dropdown-menu.test.tsx
@@ -1,0 +1,298 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
+import { installRadixPointerPolyfills } from "@/lib/test-utils";
+
+beforeAll(() => {
+  installRadixPointerPolyfills();
+});
+
+function Menu({
+  onSelect,
+  ...props
+}: React.ComponentProps<typeof DropdownMenu> & { onSelect?: () => void }) {
+  return (
+    <DropdownMenu {...props}>
+      <DropdownMenuTrigger>Open</DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem onSelect={onSelect}>Delete</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+/**
+ * Radix marks everything outside the open menu `aria-hidden`, so the trigger
+ * disappears from the accessibility tree while it is open. Query the slot.
+ */
+const trigger = () => {
+  const el = document.querySelector<HTMLElement>(
+    '[data-slot="dropdown-menu-trigger"]',
+  );
+  if (!el) throw new Error("No dropdown menu trigger rendered");
+  return el;
+};
+const isOpen = () => trigger().getAttribute("data-state") === "open";
+
+// The pointer type is the whole point of these tests, so spell out each gesture
+// rather than leaning on fireEvent defaults (jsdom leaves `pointerType` empty).
+const press = (el: Element, pointerType: string) =>
+  fireEvent.pointerDown(el, { button: 0, pointerId: 1, pointerType });
+const release = (el: Element, pointerType: string) =>
+  fireEvent.pointerUp(el, { button: 0, pointerId: 1, pointerType });
+const click = (el: Element) => fireEvent.click(el, { button: 0 });
+
+/** A completed touch tap: down, up, then the click the browser synthesises. */
+const tap = (el: Element) => {
+  press(el, "touch");
+  release(el, "touch");
+  click(el);
+};
+
+describe("DropdownMenuTrigger pointer handling", () => {
+  it("does not open on a touch pointerdown", () => {
+    render(<Menu />);
+
+    press(trigger(), "touch");
+
+    expect(isOpen()).toBe(false);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("stays closed when a touch turns into a scroll", () => {
+    render(<Menu />);
+
+    // A scroll gesture: the browser suppresses the click, so none is fired.
+    press(trigger(), "touch");
+    fireEvent.pointerMove(trigger(), { pointerId: 1, pointerType: "touch" });
+    release(document.body, "touch");
+
+    expect(isOpen()).toBe(false);
+  });
+
+  it("opens on a completed touch tap", () => {
+    render(<Menu />);
+
+    tap(trigger());
+
+    expect(isOpen()).toBe(true);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("closes on a second touch tap", () => {
+    render(<Menu defaultOpen />);
+    expect(isOpen()).toBe(true);
+
+    tap(trigger());
+
+    expect(isOpen()).toBe(false);
+  });
+
+  it("opens immediately on a mouse pointerdown", () => {
+    render(<Menu />);
+
+    press(trigger(), "mouse");
+
+    expect(isOpen()).toBe(true);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("does not close again when a mouse press is followed by its click", () => {
+    render(<Menu />);
+
+    press(trigger(), "mouse");
+    release(trigger(), "mouse");
+    click(trigger());
+
+    expect(isOpen()).toBe(true);
+  });
+
+  it("ignores a right-click or ctrl-click pointerdown", () => {
+    render(<Menu />);
+
+    fireEvent.pointerDown(trigger(), {
+      button: 2,
+      pointerId: 1,
+      pointerType: "mouse",
+    });
+    expect(isOpen()).toBe(false);
+
+    fireEvent.pointerDown(trigger(), {
+      button: 0,
+      pointerId: 1,
+      pointerType: "mouse",
+      ctrlKey: true,
+    });
+    expect(isOpen()).toBe(false);
+  });
+
+  it("selects an item on a mouse press-drag-release gesture", () => {
+    const onSelect = vi.fn();
+    render(<Menu onSelect={onSelect} />);
+
+    press(trigger(), "mouse");
+    release(screen.getByRole("menuitem", { name: "Delete" }), "mouse");
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not open on a disabled trigger", () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger disabled>Open</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    press(trigger(), "mouse");
+    click(trigger());
+    expect(isOpen()).toBe(false);
+
+    tap(trigger());
+    expect(isOpen()).toBe(false);
+  });
+
+  it("still opens from the keyboard", () => {
+    render(<Menu />);
+
+    fireEvent.keyDown(trigger(), { key: "Enter" });
+    expect(isOpen()).toBe(true);
+
+    fireEvent.keyDown(trigger(), { key: "Enter" });
+    expect(isOpen()).toBe(false);
+
+    fireEvent.keyDown(trigger(), { key: "ArrowDown" });
+    expect(isOpen()).toBe(true);
+  });
+
+  it("composes the call site's own pointer handlers", () => {
+    const onPointerDown = vi.fn();
+    const onClick = vi.fn();
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger onPointerDown={onPointerDown} onClick={onClick}>
+          Open
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    tap(trigger());
+
+    expect(onPointerDown).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(isOpen()).toBe(true);
+  });
+
+  describe("a call site cancelling the gesture on pointerdown", () => {
+    const CancellingMenu = () => (
+      <DropdownMenu>
+        <DropdownMenuTrigger onPointerDown={(e) => e.preventDefault()}>
+          Open
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+
+    it("suppresses the mouse press and the click that follows", () => {
+      render(<CancellingMenu />);
+
+      press(trigger(), "mouse");
+      expect(isOpen()).toBe(false);
+
+      release(trigger(), "mouse");
+      click(trigger());
+      expect(isOpen()).toBe(false);
+    });
+
+    it("suppresses a completed touch tap too", () => {
+      render(<CancellingMenu />);
+
+      tap(trigger());
+
+      expect(isOpen()).toBe(false);
+    });
+  });
+
+  it("opens on a touch tap when the call site's click prevents default", () => {
+    // Triggers nested in a link do this to stop the link navigating.
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger onClick={(e) => e.preventDefault()}>
+          Open
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    tap(trigger());
+
+    expect(isOpen()).toBe(true);
+  });
+
+  it("works with asChild", () => {
+    render(
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button type="button">Open</button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Delete</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>,
+    );
+
+    press(trigger(), "touch");
+    expect(isOpen()).toBe(false);
+
+    click(trigger());
+    expect(isOpen()).toBe(true);
+  });
+});
+
+describe("DropdownMenu open state", () => {
+  it("honours defaultOpen", () => {
+    render(<Menu defaultOpen />);
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("reports uncontrolled changes through onOpenChange", () => {
+    const onOpenChange = vi.fn();
+    render(<Menu onOpenChange={onOpenChange} />);
+
+    press(trigger(), "mouse");
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+
+  it("stays closed when controlled open is false", () => {
+    const onOpenChange = vi.fn();
+    render(<Menu open={false} onOpenChange={onOpenChange} />);
+
+    press(trigger(), "mouse");
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(isOpen()).toBe(false);
+  });
+
+  it("renders open when controlled open is true", () => {
+    render(<Menu open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/ui/dropdown-menu.tsx
+++ b/apps/frontend/components/ui/dropdown-menu.tsx
@@ -2,14 +2,65 @@
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
+/*
+ * Deliberate divergence from the stock shadcn dropdown-menu.
+ *
+ * `@radix-ui/react-dropdown-menu`'s Trigger toggles the menu on `pointerdown`
+ * with no `pointerType` check, so on a touch device the menu opens the instant
+ * a finger lands on the trigger — before the gesture can be recognised as a
+ * scroll. Upstream: https://github.com/radix-ui/primitives/issues/1912
+ *
+ * The fix mirrors what Radix already does in `@radix-ui/react-select`: open on
+ * `pointerdown` for a mouse (which preserves the press-drag-release gesture)
+ * and on the subsequent `click` for touch and pen (which the browser suppresses
+ * when the gesture turns into a scroll). Radix does not expose the dropdown's
+ * internal context, so the root owns the open state and hands the trigger a
+ * toggle through the context below.
+ *
+ * Re-adding this component with the `shadcn` CLI will revert all of it.
+ */
+
+type DropdownMenuContextValue = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+};
+
+const DropdownMenuContext =
+  React.createContext<DropdownMenuContextValue | null>(null);
+
 function DropdownMenu({
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
-  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+  const [open, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: defaultOpen ?? false,
+    onChange: onOpenChange,
+    caller: "DropdownMenu",
+  });
+
+  const context = React.useMemo<DropdownMenuContextValue>(
+    () => ({ open, setOpen }),
+    [open, setOpen],
+  );
+
+  return (
+    <DropdownMenuContext.Provider value={context}>
+      <DropdownMenuPrimitive.Root
+        data-slot="dropdown-menu"
+        open={open}
+        onOpenChange={setOpen}
+        {...props}
+      />
+    </DropdownMenuContext.Provider>
+  );
 }
 
 function DropdownMenuPortal({
@@ -21,11 +72,76 @@ function DropdownMenuPortal({
 }
 
 function DropdownMenuTrigger({
+  disabled,
+  onPointerDown,
+  onClick,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  const context = React.useContext(DropdownMenuContext);
+  // What the last pointerdown said about the gesture now in progress. The
+  // click handler needs all three, so they travel together.
+  const gestureRef = React.useRef({
+    // As the Radix Select trigger does, assume touch until a pointer says otherwise.
+    pointerType: "touch",
+    openAtPointerDown: false,
+    cancelled: false,
+  });
+
+  if (!context) {
+    throw new Error("`DropdownMenuTrigger` must be used within `DropdownMenu`");
+  }
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
+    onPointerDown?.(event);
+
+    // Recorded before any bail-out below, because the click handler still runs
+    // for gestures this one declines to act on.
+    gestureRef.current = {
+      pointerType: event.pointerType,
+      openAtPointerDown: context.open,
+      // A call site that cancels pointerdown means to suppress the activation
+      // itself, so the click that follows must not open the menu either.
+      cancelled: event.defaultPrevented,
+    };
+
+    if (event.defaultPrevented || disabled) return;
+
+    // The primitive ignores anything but an unmodified primary press, so leave
+    // those to the browser.
+    if (event.button !== 0 || event.ctrlKey) return;
+
+    // Suppress the primitive's own pointerdown toggle. It composes our handler
+    // first and bails out on a default-prevented event, which is the only seam
+    // available for taking the gesture over.
+    event.preventDefault();
+
+    if (event.pointerType === "mouse") {
+      context.setOpen(!context.open);
+    }
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+
+    const { pointerType, openAtPointerDown, cancelled } = gestureRef.current;
+    if (disabled || cancelled || pointerType === "mouse") return;
+
+    // A touch or pen tap completed without turning into a scroll, so open.
+    //
+    // Deliberately not vetoed by this event's own `defaultPrevented`: triggers
+    // nested inside a link call `preventDefault()` on click to stop the link
+    // navigating, which says nothing about whether the menu should open, and
+    // treating it as a veto would leave those menus unopenable by touch.
+    event.currentTarget.focus();
+    context.setOpen(!openAtPointerDown);
+  };
+
   return (
     <DropdownMenuPrimitive.Trigger
       data-slot="dropdown-menu-trigger"
+      disabled={disabled}
+      onPointerDown={handlePointerDown}
+      onClick={handleClick}
       {...props}
     />
   );

--- a/apps/frontend/lib/test-utils.ts
+++ b/apps/frontend/lib/test-utils.ts
@@ -17,6 +17,9 @@ export function openDropdownMenu() {
   if (!trigger) {
     throw new Error("No dropdown menu trigger found in the document");
   }
+  // Our DropdownMenu trigger only opens on pointerdown for a mouse; jsdom
+  // leaves `pointerType` empty, so the tap has to be completed with a click.
   fireEvent.pointerDown(trigger, { button: 0, pointerId: 1 });
   fireEvent.pointerUp(trigger, { button: 0, pointerId: 1 });
+  fireEvent.click(trigger, { button: 0 });
 }


### PR DESCRIPTION
## What

Dropdown menus now open on a deliberate activation on every input type, fixed once in the shared `DropdownMenu` wrapper so all ~19 `DropdownMenuTrigger` call sites are covered by one change:

- **Touch / pen** — the menu no longer opens on `pointerdown`. It opens on the following `click`, which the browser suppresses when the gesture turns into a scroll.
- **Mouse** — unchanged. Opens on `pointerdown`, preserving press-drag-release (press the trigger, drag onto an item, release to select it).
- **Keyboard** — unchanged.

The wrapper's root now owns the open state (via `useControllableState`) and hands the trigger a toggle through a module-local context, because Radix does not export the dropdown's internal context. Controlled, `defaultOpen` and bare-uncontrolled usage all still work; call sites use all three.

Two things worth flagging for review:

- **`preventDefault()` fires for touch, not only for mouse.** The primitive composes our handler first and skips its own `onOpenToggle()` only when the event is already default-prevented, so that is the one seam available for taking the gesture over. Preventing only in the mouse branch would leave touch opening on `pointerdown` exactly as before.
- **The click handler is deliberately not vetoed by `defaultPrevented`.** Five call sites (`blueprints-list`, `boards-list`, `dashboards-list`, `skills-list`, `trigger-list`) pass `onClick={(e) => e.preventDefault()}` on the trigger to stop the wrapping `<Link>` navigating. That says nothing about whether the menu should open, and treating it as a veto would leave precisely those menus unopenable by touch. Cancelling the gesture on `pointerdown` still suppresses the activation on every input type.

The approach mirrors `@radix-ui/react-select`'s trigger — the shape the Radix maintainers said they would accept — so the wrapper converges rather than diverges if a fix ever lands upstream. A comment records the divergence from stock shadcn and warns that re-adding the component with the CLI reverts it.

## Why

Closes #808. On mobile, a scroll that began on an agent card's ⋮ opened the menu instead of scrolling the list, which made browsing the workspace home feel broken.

The cause is upstream: `@radix-ui/react-dropdown-menu`'s trigger toggles on `pointerdown` with no `pointerType` check, guarding only on `button === 0 && !ctrlKey`. It is radix-ui/primitives#1912, open since January 2023; the installed version is current `latest` and the unreleased `next` RC has a byte-identical trigger, so there is no upgrade that fixes it.

Verified against the running app with Pixel 5 touch emulation on the real agent cards, and in a desktop context for mouse and keyboard:

| gesture | before | after |
| --- | --- | --- |
| touch scroll from the ⋮ | menu opens, list does not move (`scrollTop` stuck at 30) | menu closed, `scrollTop` 30 → 330 |
| touch tap | — | opens |
| mouse press-drag-release onto an item | — | item selected in one gesture |
| keyboard `Enter` / `ArrowDown` | — | opens |

The "before" column is an A/B against this branch with the component stashed, so the harness is known to catch the regression.

## Checklist

- [x] The **PR title** is a Conventional Commit subject (`feat:`, `fix:` or `chore:`, optional scope). This is squash-merged as the commit on `main` and is what the changelog and version bump are built from — a title without one means the change ships with neither.
- [x] **The change is covered by tests.** 19 regression tests against the shared wrapper rather than any one consuming component; the touch cases fail without the fix. The shared `openDropdownMenu` test helper gained a `click` (jsdom leaves `pointerType` empty, which is not `"mouse"`); none of the ~20 existing dropdown assertions needed editing.
- [x] Docs in `apps/docs/content` are updated **in this PR** if it touched an `.env.example`, a user-facing limit or enum in `packages/schemas`, anything under `apps/backend/src/plugins`, or a visible label or field in the frontend. — none of these apply; no env var, schema limit, plugin surface or visible label changed.
- [x] `pnpm test`, `pnpm typecheck` and `pnpm format` pass locally. `pnpm lint` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
