### PR TITLE
feat: give Kanban cards a capped history

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -129,6 +129,10 @@ _Avoid_: lane, swimlane, list, stage.
 The unit of work on a **Board**: title, Markdown body, Labels, due date, priority (none/low/medium/high/urgent), a single Assignee, and threaded Comments. Every write records who made it — a User _or_ an Agent — and an Assignee may be either. An Agent is held to the same rules as a person: only Labels the Board actually has, only Assignees who can work in the Workspace.
 _Avoid_: ticket, issue, item, task.
 
+**Card history**:
+The record of how a **Card** reached its current state: an ordered, capped series of **history entries**, each naming what changed, when, and who did it — the User or Agent that made the write itself, at whatever delegation depth. Scoped to field writes addressed to one Card: a Board-level write that reshapes many Cards at once (deleting a Label) is in none of their histories, and a Comment is its own durable record rather than a history entry. Working context for whoever acts on the Card next, not an audit trail: entries roll off, and the history dies with the Card. Durable, exportable board activity is what the `card.*` **Webhook events** are for.
+_Avoid_: event log, audit log, audit trail, card timeline, activity feed.
+
 **Dashboard**:
 A Workspace-scoped grid of **Widgets** with separate desktop and mobile layouts, auto-refreshing in view mode. Deliberately split by ownership: Users own the layout and the widget set; an Agent updates Widget data only, and never an Embed's URL.
 _Avoid_: report, page, view.

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -9,6 +9,7 @@ import {
 // Import and re-export auth schema
 export * from "./auth-schema.ts";
 import { user } from "./auth-schema.ts";
+import type { KanbanCardHistoryChange } from "@platypus/schemas";
 
 // Custom vector type without fixed dimensions — allows variable-dimension vectors per workspace
 const unboundVector = customType<{
@@ -915,6 +916,48 @@ export const kanbanCardComment = pgTable(
     updatedAt: t.timestamp("updated_at").notNull().defaultNow(),
   }),
   (t) => [index("idx_kanban_card_comment_card_id").on(t.cardId)],
+);
+
+/**
+ * One write addressed to a Card, as its history remembers it (ADR-0024).
+ * Cascades with the Card by design: a Card history is working context, so it
+ * has no reason to outlive what it describes — which is also why `card.deleted`
+ * is unloggable here.
+ *
+ * The actor is the leaf writer, taken from the `KanbanActor` the service was
+ * called with and mirroring the Card's own `lastEditedBy*` columns, never the
+ * ambient causation chain (ADR-0022) — that models who is responsible for a
+ * run, which is a different question.
+ */
+export const kanbanCardHistory = pgTable(
+  "kanban_card_history",
+  (t) => ({
+    id: t.text("id").primaryKey(),
+    cardId: t
+      .text("card_id")
+      .notNull()
+      .references(() => kanbanCard.id, { onDelete: "cascade" }),
+    kind: t.text("kind").$type<"created" | "updated">().notNull(),
+    changes: t
+      .jsonb("changes")
+      .$type<KanbanCardHistoryChange[]>()
+      .notNull()
+      .default([]),
+    actorUserId: t
+      .text("actor_user_id")
+      .references(() => user.id, { onDelete: "set null" }),
+    actorAgentId: t
+      .text("actor_agent_id")
+      .references(() => agent.id, { onDelete: "set null" }),
+    createdAt: t.timestamp("created_at").notNull().defaultNow(),
+  }),
+  (t) => [
+    // Read newest-first for one card, and trimmed by the same key.
+    index("idx_kanban_card_history_card_id_created_at").on(
+      t.cardId,
+      t.createdAt,
+    ),
+  ],
 );
 
 // Dashboard

--- a/apps/backend/src/routes/kanban.test.ts
+++ b/apps/backend/src/routes/kanban.test.ts
@@ -615,6 +615,8 @@ describe("Kanban Routes", () => {
         { ownerId: "user-1", organizationId: "org-1" },
       ]); // requireWorkspaceAccess
       mockDb.limit.mockResolvedValueOnce([{ id: "col-1", boardId: "board-1" }]); // column guard
+      mockDb.limit.mockResolvedValueOnce([{ id: "col-1", name: "To do" }]); // the created entry snapshots its column name
+      mockDb.limit.mockResolvedValueOnce([]); // the history trim's subquery
 
       const mockCard = {
         id: "test-id-123",
@@ -673,8 +675,15 @@ describe("Kanban Routes", () => {
         { id: "card-1", columnId: "col-1", title: "Card" },
       ]); // prior row, for the changedFields value-diff
 
-      const mockCard = { id: "card-1", title: "Updated Card" };
+      // Carries its column: a row that omitted it would read as a column
+      // change to the value-diff behind the history entry.
+      const mockCard = {
+        id: "card-1",
+        columnId: "col-1",
+        title: "Updated Card",
+      };
       mockDb.returning.mockResolvedValueOnce([mockCard]);
+      mockDb.limit.mockResolvedValueOnce([]); // the history trim's subquery
 
       const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
         method: "PUT",
@@ -721,7 +730,20 @@ describe("Kanban Routes", () => {
           { id: "card-1", columnId: "col-1", labelIds: [] },
         ]); // prior row, for the changedFields value-diff
         mockBoardLabels([{ id: "lbl-a" }, { id: "lbl-b" }]);
-        mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
+        // Carries the column it stays in and the labels it persisted, so the
+        // value-diff behind the history entry sees only the label change.
+        mockDb.returning.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", labelIds: ["lbl-b", "lbl-a"] },
+        ]);
+        mockDb.limit.mockResolvedValueOnce([
+          {
+            labels: [
+              { id: "lbl-a", name: "A" },
+              { id: "lbl-b", name: "B" },
+            ],
+          },
+        ]); // board labels again, for the entry's name snapshot
+        mockDb.limit.mockResolvedValueOnce([]); // the history trim's subquery
 
         const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
           method: "PUT",
@@ -748,7 +770,15 @@ describe("Kanban Routes", () => {
           { id: "card-1", columnId: "col-1", labelIds: [] },
         ]); // prior row, for the changedFields value-diff
         mockBoardLabels([{ id: "lbl-new" }]);
-        mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
+        // Carries the column it stays in and the labels it persisted, so the
+        // value-diff behind the history entry sees only the label change.
+        mockDb.returning.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", labelIds: ["lbl-new"] },
+        ]);
+        mockDb.limit.mockResolvedValueOnce([
+          { labels: [{ id: "lbl-new", name: "New" }] },
+        ]); // board labels again, for the entry's name snapshot
+        mockDb.limit.mockResolvedValueOnce([]); // the history trim's subquery
 
         const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
           method: "PUT",
@@ -783,7 +813,12 @@ describe("Kanban Routes", () => {
           { id: "card-1", columnId: "col-1", labelIds: [] },
         ]); // prior row, for the changedFields value-diff
         mockBoardLabels([]);
-        mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
+        // Every submitted label was unknown, so the card ends where it started
+        // and the write changes nothing a history entry would record.
+        mockDb.returning.mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", labelIds: [] },
+        ]);
+        mockDb.limit.mockResolvedValueOnce([]); // the history trim's subquery
 
         const res = await app.request(`${baseUrl}/${boardId}/cards/card-1`, {
           method: "PUT",
@@ -858,6 +893,7 @@ describe("Kanban Routes", () => {
 
         const mockCard = {
           id: "card-1",
+          columnId: "col-1",
           title: "Test",
           assignees: [{ type: "user", id: "admin-user" }],
         };
@@ -912,6 +948,7 @@ describe("Kanban Routes", () => {
 
         const mockCard = {
           id: "card-1",
+          columnId: "col-1",
           title: "Test",
           assignees: [{ type: "agent", id: "shared-agent" }],
         };
@@ -989,6 +1026,7 @@ describe("Kanban Routes", () => {
 
         const mockCard = {
           id: "card-1",
+          columnId: "col-1",
           title: "Test",
           assignees: [{ type: "user", id: "user-1" }],
         };
@@ -1021,6 +1059,11 @@ describe("Kanban Routes", () => {
         { id: "card-1", columnId: "col-1", boardId: "board-1" },
       ]); // card guard
       mockDb.limit.mockResolvedValueOnce([{ id: "col-2", boardId: "board-1" }]); // target column guard
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "col-1", name: "To do" },
+        { id: "col-2", name: "Doing" },
+      ]); // the move's history entry snapshots both column names
+      mockDb.limit.mockResolvedValueOnce([]); // the history trim's subquery
 
       const existingCards = [
         { id: "card-2", columnId: "col-2", position: 1.0 },
@@ -1053,6 +1096,11 @@ describe("Kanban Routes", () => {
         { id: "card-1", columnId: "col-2", boardId: "board-1" },
       ]); // card guard — already moved on
       mockDb.limit.mockResolvedValueOnce([{ id: "col-2", boardId: "board-1" }]); // target column guard
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "col-1", name: "To do" },
+        { id: "col-2", name: "Doing" },
+      ]); // the move's history entry snapshots both column names
+      mockDb.limit.mockResolvedValueOnce([]); // the history trim's subquery
 
       mockDb.orderBy.mockResolvedValueOnce([]);
       mockDb.returning.mockResolvedValueOnce([]); // the predicate matched no row
@@ -1081,6 +1129,11 @@ describe("Kanban Routes", () => {
         { id: "card-1", columnId: "col-1", boardId: "board-1" },
       ]); // card guard
       mockDb.limit.mockResolvedValueOnce([{ id: "col-2", boardId: "board-1" }]); // target column guard
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "col-1", name: "To do" },
+        { id: "col-2", name: "Doing" },
+      ]); // the move's history entry snapshots both column names
+      mockDb.limit.mockResolvedValueOnce([]); // the history trim's subquery
 
       const existingCards = [
         { id: "card-2", columnId: "col-2", position: 1.0 },
@@ -1143,6 +1196,11 @@ describe("Kanban Routes", () => {
         { id: "card-1", columnId: "col-1", boardId: "board-1" },
       ]); // card guard
       mockDb.limit.mockResolvedValueOnce([{ id: "col-2", boardId: "board-1" }]); // target column guard
+      mockDb.limit.mockResolvedValueOnce([
+        { id: "col-1", name: "To do" },
+        { id: "col-2", name: "Doing" },
+      ]); // the move's history entry snapshots both column names
+      mockDb.limit.mockResolvedValueOnce([]); // the history trim's subquery
 
       const existingCards = [
         { id: "card-2", columnId: "col-2", position: 1.0 },

--- a/apps/backend/src/routes/kanban.ts
+++ b/apps/backend/src/routes/kanban.ts
@@ -39,6 +39,7 @@ import {
   createCard,
   createComment,
   deleteCard,
+  listCardHistory,
   listComments,
   moveCard,
   nextColumnPosition,
@@ -668,6 +669,23 @@ const requireCommentOnCard = async (
 /** Whether this user may edit or delete a comment somebody else wrote. */
 const canModerate = (c: Context<{ Variables: Variables }>) =>
   isSuperAdmin(c.get("user")) || c.get("orgMembership")?.role === "admin";
+
+/** A card's history, newest first */
+kanban.get(
+  "/:boardId/cards/:cardId/history",
+  requireAuth,
+  requireOrgAccess(),
+  requireWorkspaceAccess,
+  async (c) => {
+    const results = await listCardHistory(
+      db,
+      scopeOf(c),
+      c.req.param("cardId"),
+    );
+
+    return c.json({ results });
+  },
+);
 
 /** List comments for a card */
 kanban.get(

--- a/apps/backend/src/services/kanban.test.ts
+++ b/apps/backend/src/services/kanban.test.ts
@@ -12,10 +12,12 @@ import { eq } from "drizzle-orm";
 import { kanbanCard as kanbanCardTable } from "../db/schema.ts";
 import { ConflictError, NotFoundError, ValidationError } from "../errors.ts";
 import { dispatchEvent } from "./event-dispatch.ts";
+import { KANBAN_CARD_HISTORY_LIMIT } from "@platypus/schemas";
 import {
   applyBodyDiff,
   bulkUpdateCards,
   changedCardFields,
+  createCard,
   keepKnownLabelIds,
   moveCard,
   placeCardInColumn,
@@ -416,8 +418,13 @@ describe("kanban module", () => {
         .mockResolvedValueOnce([
           { id: "card-1", columnId: "col-old", boardId: "board-1" },
         ]) // requireCard
-        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]); // requireColumn
-      db.orderBy.mockResolvedValue([]); // placeCardInColumn
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]) // requireColumn
+        .mockResolvedValueOnce([
+          { id: "col-old", name: "Old" },
+          { id: "col-new", name: "New" },
+        ]); // history entry: the column names it snapshots
+      db.orderBy.mockResolvedValueOnce([]); // placeCardInColumn — once, so the
+      // history trim's own orderBy stays chainable
       db.returning.mockResolvedValue([
         { id: "card-1", columnId: "col-new", position: 1 },
       ]);
@@ -457,7 +464,8 @@ describe("kanban module", () => {
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]) // requireCard
         .mockResolvedValueOnce([{ id: "col-1", boardId: "board-1" }]); // requireColumn
-      db.orderBy.mockResolvedValue([]); // placeCardInColumn
+      db.orderBy.mockResolvedValueOnce([]); // placeCardInColumn — once, so the
+      // history trim's own orderBy stays chainable
       db.returning.mockResolvedValue([
         { id: "card-1", columnId: "col-1", position: 1 },
       ]);
@@ -491,8 +499,13 @@ describe("kanban module", () => {
         .mockResolvedValueOnce([
           { id: "card-1", columnId: "col-old", boardId: "board-1" },
         ]) // requireCard
-        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]); // requireColumn
-      db.orderBy.mockResolvedValue([]); // placeCardInColumn
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]) // requireColumn
+        .mockResolvedValueOnce([
+          { id: "col-old", name: "Old" },
+          { id: "col-new", name: "New" },
+        ]); // history entry: the column names it snapshots
+      db.orderBy.mockResolvedValueOnce([]); // placeCardInColumn — once, so the
+      // history trim's own orderBy stays chainable
       db.returning.mockResolvedValue([
         { id: "card-1", columnId: "col-new", position: 1 },
       ]);
@@ -523,8 +536,12 @@ describe("kanban module", () => {
         .mockResolvedValueOnce([
           { id: "card-1", columnId: "col-old", boardId: "board-1" },
         ])
-        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]);
-      db.orderBy.mockResolvedValue([]);
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }])
+        .mockResolvedValueOnce([
+          { id: "col-old", name: "Old" },
+          { id: "col-new", name: "New" },
+        ]); // history entry: the column names it snapshots
+      db.orderBy.mockResolvedValueOnce([]);
       db.returning.mockResolvedValue([
         { id: "card-1", columnId: "col-new", position: 1 },
       ]);
@@ -552,8 +569,12 @@ describe("kanban module", () => {
         .mockResolvedValueOnce([
           { id: "card-1", columnId: "col-old", boardId: "board-1" },
         ])
-        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]);
-      db.orderBy.mockResolvedValue([]);
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }])
+        .mockResolvedValueOnce([
+          { id: "col-old", name: "Old" },
+          { id: "col-new", name: "New" },
+        ]); // history entry: the column names it snapshots
+      db.orderBy.mockResolvedValueOnce([]);
       db.returning.mockResolvedValue([
         { id: "card-1", columnId: "col-new", position: 1 },
       ]);
@@ -578,8 +599,13 @@ describe("kanban module", () => {
         .mockResolvedValueOnce([
           { id: "card-1", columnId: "col-old", boardId: "board-1" },
         ]) // requireCard
-        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]); // requireColumn
-      db.orderBy.mockResolvedValue([]); // placeCardInColumn
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]) // requireColumn
+        .mockResolvedValueOnce([
+          { id: "col-old", name: "Old" },
+          { id: "col-new", name: "New" },
+        ]); // history entry: the column names it snapshots
+      db.orderBy.mockResolvedValueOnce([]); // placeCardInColumn — once, so the
+      // history trim's own orderBy stays chainable
       db.returning.mockResolvedValue([]); // the predicate matched no row
 
       await expect(
@@ -603,7 +629,7 @@ describe("kanban module", () => {
           { id: "card-1", columnId: "col-note-processing", boardId: "board-1" },
         ])
         .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]);
-      db.orderBy.mockResolvedValue([]);
+      db.orderBy.mockResolvedValueOnce([]);
       db.returning.mockResolvedValue([]);
 
       let message = "";
@@ -745,6 +771,245 @@ describe("kanban module", () => {
     });
   });
 
+  // A Card history is working context, not an audit trail (ADR-0024): capped,
+  // dropped rather than archived, and written from inside the Card's own
+  // transaction so it can never describe a write that rolled back.
+  describe("card history", () => {
+    /** The history entries a call wrote, in order. */
+    const entries = () =>
+      db.values.mock.calls
+        .map((call) => call[0] as Record<string, unknown>)
+        .filter((value) => value && "kind" in value);
+
+    it("records one entry naming every field that moved, not one per field", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // requireCard
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", title: "Old", priority: "low" },
+        ]) // currentCardRow
+        .mockResolvedValueOnce([]); // the history trim's subquery
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-1", title: "New", priority: "high" },
+      ]);
+
+      await updateCard(asDb(db), ctx, "card-1", {
+        title: "New",
+        priority: "high",
+      });
+
+      expect(entries()).toEqual([
+        expect.objectContaining({
+          cardId: "card-1",
+          kind: "updated",
+          changes: [
+            { field: "title", before: "Old", after: "New" },
+            { field: "priority", before: "low", after: "high" },
+          ],
+        }),
+      ]);
+    });
+
+    // Body is unbounded Markdown, so the entry says it moved and nothing more.
+    it("records a body edit without either version of the text", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", body: "the old body" },
+        ])
+        .mockResolvedValueOnce([]);
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-1", body: "the new body" },
+      ]);
+
+      await updateCard(asDb(db), ctx, "card-1", { body: "the new body" });
+
+      expect(entries()).toEqual([
+        expect.objectContaining({ changes: [{ field: "body" }] }),
+      ]);
+      expect(JSON.stringify(entries())).not.toContain("the old body");
+      expect(JSON.stringify(entries())).not.toContain("the new body");
+    });
+
+    // `position` is not a tracked field, so a reorder has an empty diff — which
+    // is what keeps a drag across a column from filling the history with noise.
+    it("writes nothing when the write moved no tracked field", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", title: "Same" },
+        ]);
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-1", title: "Same" },
+      ]);
+
+      await updateCard(asDb(db), ctx, "card-1", { title: "Same" });
+
+      expect(entries()).toEqual([]);
+    });
+
+    // The actor is the `KanbanActor` the module was called with — the same
+    // source as `lastEditedBy*`, never the ambient causation chain, so a
+    // Sub-Agent's write is attributed to the Sub-Agent.
+    it("attributes the entry to the acting agent", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", title: "A" },
+        ])
+        .mockResolvedValueOnce([]);
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-1", title: "B" },
+      ]);
+
+      await updateCard(asDb(db), ctx, "card-1", { title: "B" });
+
+      expect(entries()[0]).toMatchObject({ actorAgentId: "agent-1" });
+      expect(entries()[0]).not.toHaveProperty("actorUserId");
+    });
+
+    it("attributes the entry to the acting user", async () => {
+      const userCtx: KanbanContext = { ...scope, actor: { userId: "user-1" } };
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", title: "A" },
+        ])
+        .mockResolvedValueOnce([]);
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-1", title: "B" },
+      ]);
+
+      await updateCard(asDb(db), userCtx, "card-1", { title: "B" });
+
+      expect(entries()[0]).toMatchObject({ actorUserId: "user-1" });
+      expect(entries()[0]).not.toHaveProperty("actorAgentId");
+    });
+
+    // The name is snapshotted at write time, so the entry still reads after the
+    // Label is deleted from the board or the Column is renamed.
+    it("snapshots label names rather than storing bare ids", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // requireCard
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", labelIds: [] },
+        ]) // currentCardRow
+        .mockResolvedValueOnce([{ labels: [{ id: "lbl-a" }] }]) // keepKnownLabelIds
+        .mockResolvedValueOnce([{ labels: [{ id: "lbl-a", name: "Urgent" }] }]) // the entry's name snapshot
+        .mockResolvedValueOnce([]); // the history trim's subquery
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-1", labelIds: ["lbl-a"] },
+      ]);
+
+      await updateCard(asDb(db), ctx, "card-1", { labelIds: ["lbl-a"] });
+
+      expect(entries()[0]).toMatchObject({
+        changes: [
+          {
+            field: "labelIds",
+            before: [],
+            after: [{ id: "lbl-a", name: "Urgent" }],
+          },
+        ],
+      });
+    });
+
+    it("records a move as the columns it went between", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-old", boardId: "board-1" },
+        ]) // requireCard
+        .mockResolvedValueOnce([{ id: "col-new", boardId: "board-1" }]) // requireColumn
+        .mockResolvedValueOnce([
+          { id: "col-old", name: "Doing" },
+          { id: "col-new", name: "Done" },
+        ]) // the entry's column-name snapshot
+        .mockResolvedValueOnce([]); // the history trim's subquery
+      db.orderBy.mockResolvedValueOnce([]);
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-new", position: 1 },
+      ]);
+
+      await moveCard(asDb(db), ctx, {
+        cardId: "card-1",
+        columnId: "col-new",
+        afterCardId: null,
+      });
+
+      expect(entries()).toEqual([
+        expect.objectContaining({
+          kind: "updated",
+          changes: [
+            {
+              field: "columnId",
+              before: { id: "col-old", name: "Doing" },
+              after: { id: "col-new", name: "Done" },
+            },
+          ],
+        }),
+      ]);
+    });
+
+    it("records a creation as the column the card appeared in", async () => {
+      db.where
+        .mockReturnValueOnce(db) // requireColumn's chain
+        .mockResolvedValueOnce([{ maxPos: 1 }]); // nextCardPosition
+      db.limit
+        .mockResolvedValueOnce([{ id: "col-1", boardId: "board-1" }]) // requireColumn
+        .mockResolvedValueOnce([{ id: "col-1", name: "Backlog" }]) // the entry's column-name snapshot
+        .mockResolvedValueOnce([]); // the history trim's subquery
+      db.returning.mockResolvedValue([{ id: "card-1", columnId: "col-1" }]);
+
+      await createCard(asDb(db), ctx, { columnId: "col-1", title: "New" });
+
+      expect(entries()).toEqual([
+        expect.objectContaining({
+          cardId: "card-1",
+          kind: "created",
+          changes: [
+            {
+              field: "columnId",
+              before: null,
+              after: { id: "col-1", name: "Backlog" },
+            },
+          ],
+        }),
+      ]);
+    });
+
+    // The cap is enforced in the same transaction as the insert, so it is an
+    // invariant rather than something a sweep eventually restores.
+    it("trims past the cap on the same write that appended", async () => {
+      db.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ])
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", title: "A" },
+        ])
+        .mockResolvedValueOnce([]);
+      db.returning.mockResolvedValue([
+        { id: "card-1", columnId: "col-1", title: "B" },
+      ]);
+
+      await updateCard(asDb(db), ctx, "card-1", { title: "B" });
+
+      expect(db.delete).toHaveBeenCalled();
+      expect(db.limit).toHaveBeenCalledWith(KANBAN_CARD_HISTORY_LIMIT);
+    });
+  });
+
   describe("bulkUpdateCards", () => {
     it("reports the cards it could not reach and updates the rest", async () => {
       db.limit
@@ -796,6 +1061,11 @@ describe("kanban module", () => {
           { id: "card-2", columnId: "col-new", boardId: "board-1" },
         ]) // requireCard card-2, already in the target column
         .mockResolvedValueOnce([{ id: "card-1", columnId: "col-old" }]) // card-1's row before this write
+        .mockResolvedValueOnce([
+          { id: "col-old", name: "Old" },
+          { id: "col-new", name: "New" },
+        ]) // card-1 changed column, so its history entry snapshots both names
+        .mockResolvedValueOnce([]) // the history trim's subquery
         .mockResolvedValueOnce([{ id: "card-2", columnId: "col-new" }]); // card-2's row before this write
       db.returning
         .mockResolvedValueOnce([

--- a/apps/backend/src/services/kanban.ts
+++ b/apps/backend/src/services/kanban.ts
@@ -1,16 +1,20 @@
-import { and, asc, eq, inArray, max } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, max, notInArray } from "drizzle-orm";
 import { nanoid } from "nanoid";
 import type {
   KanbanCardAssignee,
+  KanbanCardHistoryChange,
+  KanbanCardHistoryRef,
   KanbanCardPriority,
   WebhookEvent,
 } from "@platypus/schemas";
+import { KANBAN_CARD_HISTORY_LIMIT } from "@platypus/schemas";
 import { db } from "../index.ts";
 import {
   kanbanBoard as kanbanBoardTable,
   kanbanColumn as kanbanColumnTable,
   kanbanCard as kanbanCardTable,
   kanbanCardComment as kanbanCardCommentTable,
+  kanbanCardHistory as kanbanCardHistoryTable,
   agent as agentTable,
   organizationMember as organizationMemberTable,
 } from "../db/schema.ts";
@@ -200,6 +204,257 @@ const dispatchCardWrite = (
     dispatch(ctx, "card.moved", { ...row, boardId, previousColumnId });
   }
   dispatch(ctx, "card.updated", { ...row, boardId, changedFields });
+};
+
+// --- Card history ---
+
+/**
+ * A Card history entry as stored. The actor mirrors the Card's own
+ * `lastEditedBy*` columns, so an entry and the Card can never disagree about
+ * who wrote it.
+ */
+export type CardHistoryRow = typeof kanbanCardHistoryTable.$inferSelect;
+
+/** A history entry with its actor's display name resolved. */
+export type CardHistoryEntry = CardHistoryRow & { actorName: string | null };
+
+/** The attribution columns for a history entry this actor is causing. */
+const historyActor = (actor: KanbanActor) =>
+  isAgent(actor)
+    ? { actorAgentId: actor.agentId }
+    : { actorUserId: actor.userId };
+
+/**
+ * The board's Labels by id, for snapshotting names into an entry. A Card can
+ * carry a Label id the board has since dropped, in which case the id stands in
+ * for the name — an unreadable entry is still better than a missing one.
+ */
+const boardLabelNames = async (
+  executor: Executor,
+  boardId: string,
+): Promise<Map<string, string>> => {
+  const rows = await executor
+    .select({ labels: kanbanBoardTable.labels })
+    .from(kanbanBoardTable)
+    .where(eq(kanbanBoardTable.id, boardId))
+    .limit(1);
+
+  return new Map(
+    (rows[0]?.labels ?? []).map((label) => [label.id, label.name]),
+  );
+};
+
+/** Column names by id, for the same reason. */
+const columnNames = async (
+  executor: Executor,
+  columnIds: string[],
+): Promise<Map<string, string>> => {
+  const ids = [...new Set(columnIds)];
+  if (ids.length === 0) return new Map();
+
+  const rows = await executor
+    .select({ id: kanbanColumnTable.id, name: kanbanColumnTable.name })
+    .from(kanbanColumnTable)
+    .where(inArray(kanbanColumnTable.id, ids))
+    .limit(ids.length);
+
+  return new Map(rows.map((row) => [row.id, row.name]));
+};
+
+const ref = (id: string, names: Map<string, string>): KanbanCardHistoryRef => ({
+  id,
+  name: names.get(id) ?? id,
+});
+
+const isoOrNull = (value: Date | null): string | null =>
+  value ? value.toISOString() : null;
+
+/**
+ * Turns a value-diff into the changes an entry records. Driven by the field
+ * names `changedCardFields` produced, so the history and the `card.updated`
+ * event can never disagree about what moved.
+ *
+ * `body` is the deliberate exception: recorded as having changed, never with
+ * its text (ADR-0024). Label and Column values carry the name as it stood
+ * here, which is what keeps an entry readable after a rename or a deletion.
+ */
+const historyChanges = async (
+  executor: Executor,
+  boardId: string,
+  changedFields: string[],
+  previous: CardRow,
+  next: CardRow,
+): Promise<KanbanCardHistoryChange[]> => {
+  const changes: KanbanCardHistoryChange[] = [];
+
+  const labels = changedFields.includes("labelIds")
+    ? await boardLabelNames(executor, boardId)
+    : new Map<string, string>();
+  const columns = changedFields.includes("columnId")
+    ? await columnNames(executor, [previous.columnId, next.columnId])
+    : new Map<string, string>();
+
+  for (const field of changedFields) {
+    switch (field) {
+      case "title":
+        changes.push({ field, before: previous.title, after: next.title });
+        break;
+      case "body":
+        changes.push({ field });
+        break;
+      case "priority":
+        changes.push({
+          field,
+          before: previous.priority,
+          after: next.priority,
+        });
+        break;
+      case "dueDate":
+        changes.push({
+          field,
+          before: isoOrNull(previous.dueDate),
+          after: isoOrNull(next.dueDate),
+        });
+        break;
+      case "assignees":
+        changes.push({
+          field,
+          before: previous.assignees,
+          after: next.assignees,
+        });
+        break;
+      case "labelIds":
+        changes.push({
+          field,
+          before: previous.labelIds.map((id) => ref(id, labels)),
+          after: next.labelIds.map((id) => ref(id, labels)),
+        });
+        break;
+      case "columnId":
+        changes.push({
+          field,
+          before: ref(previous.columnId, columns),
+          after: ref(next.columnId, columns),
+        });
+        break;
+    }
+  }
+
+  return changes;
+};
+
+/**
+ * Drops everything past the cap for one Card, in the caller's transaction.
+ * Trimming inline is what makes the bound an invariant rather than something
+ * a sweep job eventually restores.
+ */
+const trimCardHistory = async (
+  executor: Executor,
+  cardId: string,
+): Promise<void> => {
+  // One statement rather than a read then a write: the newest N are chosen by
+  // a subquery, so a write costs no extra round trip to stay within the cap.
+  const newest = executor
+    .select({ id: kanbanCardHistoryTable.id })
+    .from(kanbanCardHistoryTable)
+    .where(eq(kanbanCardHistoryTable.cardId, cardId))
+    .orderBy(
+      desc(kanbanCardHistoryTable.createdAt),
+      desc(kanbanCardHistoryTable.id),
+    )
+    .limit(KANBAN_CARD_HISTORY_LIMIT);
+
+  await executor
+    .delete(kanbanCardHistoryTable)
+    .where(
+      and(
+        eq(kanbanCardHistoryTable.cardId, cardId),
+        notInArray(kanbanCardHistoryTable.id, newest),
+      ),
+    );
+};
+
+/**
+ * Appends one entry for one write, and trims to the cap — both in the caller's
+ * transaction, never from `dispatch()`. `dispatchEvent` returns `void` and is
+ * unawaited, so an entry written from there would land outside the transaction
+ * and a rolled-back write would still be recorded (ADR-0024).
+ *
+ * An `updated` write whose diff is empty appends nothing, which is how a
+ * within-column reorder — `position` only, and `position` is not a tracked
+ * field — leaves no trace.
+ */
+const writeHistoryEntry = async (
+  executor: Executor,
+  ctx: KanbanContext,
+  cardId: string,
+  kind: "created" | "updated",
+  changes: KanbanCardHistoryChange[],
+): Promise<void> => {
+  await executor.insert(kanbanCardHistoryTable).values({
+    id: nanoid(),
+    cardId,
+    kind,
+    changes,
+    ...historyActor(ctx.actor),
+    createdAt: new Date(),
+  });
+
+  await trimCardHistory(executor, cardId);
+};
+
+/** The entry a Card's creation leaves: it came into existence in a Column. */
+const recordCardCreated = async (
+  executor: Executor,
+  ctx: KanbanContext,
+  card: CardRow,
+): Promise<void> => {
+  const names = await columnNames(executor, [card.columnId]);
+  await writeHistoryEntry(executor, ctx, card.id, "created", [
+    { field: "columnId", before: null, after: ref(card.columnId, names) },
+  ]);
+};
+
+/** The entry a Column change leaves, for a caller that knows only the move. */
+const recordCardMoved = async (
+  executor: Executor,
+  ctx: KanbanContext,
+  cardId: string,
+  previousColumnId: string,
+  nextColumnId: string,
+): Promise<void> => {
+  const names = await columnNames(executor, [previousColumnId, nextColumnId]);
+  await writeHistoryEntry(executor, ctx, cardId, "updated", [
+    {
+      field: "columnId",
+      before: ref(previousColumnId, names),
+      after: ref(nextColumnId, names),
+    },
+  ]);
+};
+
+const recordCardHistory = async (
+  executor: Executor,
+  ctx: KanbanContext,
+  input: {
+    boardId: string;
+    previous: CardRow;
+    next: CardRow;
+    /** What `changedCardFields` found. */
+    changedFields: string[];
+  },
+): Promise<void> => {
+  const changes = await historyChanges(
+    executor,
+    input.boardId,
+    input.changedFields,
+    input.previous,
+    input.next,
+  );
+
+  if (changes.length === 0) return;
+
+  await writeHistoryEntry(executor, ctx, input.next.id, "updated", changes);
 };
 
 // --- Scope guards ---
@@ -652,24 +907,31 @@ export const createCard = async (
   const position = await nextCardPosition(database, input.columnId);
   const now = new Date();
 
-  const rows = await database
-    .insert(kanbanCardTable)
-    .values({
-      id: nanoid(),
-      columnId: input.columnId,
-      title: input.title,
-      labelIds: input.labelIds ?? [],
-      assignees: input.assignees ?? [],
-      priority: input.priority ?? "none",
-      ...cardValues(input, input.body),
-      position,
-      ...createdBy(ctx.actor),
-      createdAt: now,
-      updatedAt: now,
-    })
-    .returning();
+  // The insert and its history entry share a transaction so the two can never
+  // disagree — the reason the entry is not written from `dispatch()`.
+  const card = await database.transaction(async (tx) => {
+    const rows = await tx
+      .insert(kanbanCardTable)
+      .values({
+        id: nanoid(),
+        columnId: input.columnId,
+        title: input.title,
+        labelIds: input.labelIds ?? [],
+        assignees: input.assignees ?? [],
+        priority: input.priority ?? "none",
+        ...cardValues(input, input.body),
+        position,
+        ...createdBy(ctx.actor),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
 
-  const card = rows[0];
+    const row = rows[0];
+    await recordCardCreated(tx, ctx, row);
+    return row;
+  });
+
   dispatch(ctx, "card.created", { ...card, boardId: column.boardId });
   return { card, boardId: column.boardId };
 };
@@ -699,19 +961,29 @@ export const updateCard = async (
       ? input.body
       : applyBodyDiff(previous.body ?? "", input.bodyDiff);
 
-  const rows = await database
-    .update(kanbanCardTable)
-    .set({
-      ...cardValues(input, body),
-      ...(labelIds !== undefined && { labelIds }),
-      ...lastEditedBy(ctx.actor),
-      updatedAt: new Date(),
-    })
-    .where(eq(kanbanCardTable.id, cardId))
-    .returning();
+  const record = await database.transaction(async (tx) => {
+    const rows = await tx
+      .update(kanbanCardTable)
+      .set({
+        ...cardValues(input, body),
+        ...(labelIds !== undefined && { labelIds }),
+        ...lastEditedBy(ctx.actor),
+        updatedAt: new Date(),
+      })
+      .where(eq(kanbanCardTable.id, cardId))
+      .returning();
 
-  const record = rows[0];
-  if (!record) throw new NotFoundError("Card not found");
+    const row = rows[0];
+    if (!row) throw new NotFoundError("Card not found");
+
+    await recordCardHistory(tx, ctx, {
+      boardId: card.boardId,
+      previous,
+      next: row,
+      changedFields: changedCardFields(previous, row),
+    });
+    return row;
+  });
 
   dispatch(ctx, "card.updated", {
     ...record,
@@ -786,6 +1058,14 @@ export const moveCard = async (
       throw new ConflictError(
         "Card is no longer in the expected column; re-read it before moving it",
       );
+    }
+
+    // A move only ever touches columnId and position, so the entry is built
+    // from the one comparison rather than a full-row diff — the same reason
+    // the dispatch below computes its `changedFields` by hand. A within-column
+    // reorder changes no tracked field and leaves no entry.
+    if (previous.columnId !== row.columnId) {
+      await recordCardMoved(tx, ctx, row.id, previous.columnId, row.columnId);
     }
     return row;
   });
@@ -878,6 +1158,10 @@ export const copyCard = async (
         });
       }
     }
+
+    // The copy's history starts at the copy: it is a new Card, and the
+    // source's past is not its own.
+    await recordCardCreated(tx, ctx, rows[0]);
 
     return rows[0];
   });
@@ -1033,7 +1317,12 @@ export const bulkUpdateCards = async (
     : 0;
 
   const updated = await database.transaction(async (tx) => {
-    const records: { card: CardRef; row: CardRow; previous: CardRow }[] = [];
+    const records: {
+      card: CardRef;
+      row: CardRow;
+      previous: CardRow;
+      changedFields: string[];
+    }[] = [];
 
     for (const [index, card] of cards.entries()) {
       // The value-diff each card's `card.updated` event carries is computed
@@ -1068,19 +1357,26 @@ export const bulkUpdateCards = async (
         .where(eq(kanbanCardTable.id, card.id))
         .returning();
 
-      records.push({ card, row: rows[0], previous });
+      const row = rows[0];
+      // Computed here rather than after the transaction: the history entry
+      // needs it inside, and one computation keeps the entry and the event
+      // reporting the same diff.
+      const fields = changedCardFields(previous, row);
+
+      await recordCardHistory(tx, ctx, {
+        boardId: card.boardId,
+        previous,
+        next: row,
+        changedFields: fields,
+      });
+
+      records.push({ card, row, previous, changedFields: fields });
     }
     return records;
   });
 
-  for (const { card, row, previous } of updated) {
-    dispatchCardWrite(
-      ctx,
-      row,
-      card.boardId,
-      card.columnId,
-      changedCardFields(previous, row),
-    );
+  for (const { card, row, changedFields } of updated) {
+    dispatchCardWrite(ctx, row, card.boardId, card.columnId, changedFields);
   }
 
   return input.cardIds.map((id) => outcomes.get(id)!);
@@ -1143,6 +1439,65 @@ export const resolveCommentNames = async (
       ? (userMap.get(comment.createdByUserId) ?? null)
       : comment.createdByAgentId
         ? (agentMap.get(comment.createdByAgentId) ?? null)
+        : null,
+  }));
+};
+
+/**
+ * A Card's history, newest first. Capped at the same limit the writes trim to,
+ * so a caller never has to page and the read is bounded by construction.
+ */
+export const listCardHistory = async (
+  database: Database,
+  scope: KanbanScope,
+  cardId: string,
+): Promise<CardHistoryEntry[]> => {
+  await requireCard(database, scope, cardId);
+
+  const rows = await database
+    .select()
+    .from(kanbanCardHistoryTable)
+    .where(eq(kanbanCardHistoryTable.cardId, cardId))
+    .orderBy(
+      desc(kanbanCardHistoryTable.createdAt),
+      desc(kanbanCardHistoryTable.id),
+    )
+    .limit(KANBAN_CARD_HISTORY_LIMIT);
+
+  const userIds = new Set<string>();
+  const agentIds = new Set<string>();
+  for (const row of rows) {
+    if (row.actorUserId) userIds.add(row.actorUserId);
+    if (row.actorAgentId) agentIds.add(row.actorAgentId);
+  }
+
+  const users =
+    userIds.size > 0
+      ? await database
+          .select({ id: user.id, name: user.name })
+          .from(user)
+          .where(inArray(user.id, Array.from(userIds)))
+      : [];
+  const userMap = new Map(users.map((u) => [u.id, u.name]));
+
+  const agents =
+    agentIds.size > 0
+      ? await database
+          .select({ id: agentTable.id, name: agentTable.name })
+          .from(agentTable)
+          .where(inArray(agentTable.id, Array.from(agentIds)))
+      : [];
+  const agentMap = new Map(agents.map((a) => [a.id, a.name]));
+
+  // A deleted User or Agent leaves the entry standing with no name — what
+  // changed is still the useful part, and the FK is `set null` for exactly
+  // this reason.
+  return rows.map((row) => ({
+    ...row,
+    actorName: row.actorUserId
+      ? (userMap.get(row.actorUserId) ?? null)
+      : row.actorAgentId
+        ? (agentMap.get(row.actorAgentId) ?? null)
         : null,
   }));
 };

--- a/apps/backend/src/tools/kanban.test.ts
+++ b/apps/backend/src/tools/kanban.test.ts
@@ -70,6 +70,59 @@ describe("createKanbanTools", () => {
         await tools.getCard.execute!({ cardId: "bad-id", label: "test" }, ctx),
       ).toEqual({ error: "Card not found" });
     });
+
+    // History is opt-in: most reads want what the card says now, and the flag
+    // is what keeps the common call from paying for a past it will not use.
+    it("omits the history unless it is asked for", async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard
+        .mockResolvedValueOnce([{ id: "card-1", title: "Card" }]); // the card row
+
+      const result = (await tools.getCard.execute!(
+        { cardId: "card-1", label: "test" },
+        ctx,
+      )) as Record<string, unknown>;
+
+      expect(result).not.toHaveProperty("history");
+    });
+
+    it("returns the card's history when includeHistory is set", async () => {
+      const entry = {
+        id: "hist-1",
+        cardId: "card-1",
+        kind: "updated",
+        changes: [{ field: "title", before: "Old", after: "New" }],
+        actorUserId: null,
+        actorAgentId: "agent-1",
+        createdAt: new Date(),
+      };
+      mockDb.limit
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard
+        .mockResolvedValueOnce([{ id: "card-1", title: "Card" }]) // the card row
+        .mockResolvedValueOnce([
+          { id: "card-1", columnId: "col-1", boardId: "board-1" },
+        ]) // card guard again, inside the history read
+        .mockResolvedValueOnce([entry]); // the entries
+      // Only the actor-name lookup terminates at where(); the chains before it
+      // have to stay chainable.
+      for (let i = 0; i < 4; i++) mockDb.where.mockReturnValueOnce(mockDb);
+      mockDb.where.mockResolvedValueOnce([
+        { id: "agent-1", name: "Triage bot" },
+      ]); // the actor's name
+
+      const result = (await tools.getCard.execute!(
+        { cardId: "card-1", label: "test", includeHistory: true },
+        ctx,
+      )) as { history?: { actorName: string | null }[] };
+
+      expect(result.history).toEqual([
+        expect.objectContaining({ id: "hist-1", actorName: "Triage bot" }),
+      ]);
+    });
   });
 
   describe("upsertCard (create)", () => {
@@ -292,8 +345,14 @@ describe("createKanbanTools", () => {
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]) // card guard
         .mockResolvedValueOnce([{ id: "card-1", columnId: "col-1" }]) // prior row, for the changedFields value-diff
-        .mockResolvedValueOnce([{ labels: [{ id: "lbl-a" }] }]); // board labels
-      mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
+        .mockResolvedValueOnce([{ labels: [{ id: "lbl-a" }] }]) // board labels
+        .mockResolvedValueOnce([{ labels: [{ id: "lbl-a", name: "A" }] }]) // board labels again, for the history entry's name snapshot
+        .mockResolvedValueOnce([]); // the history trim's subquery
+      // The written row carries the column it is already in: a `returning`
+      // stub that omitted it would read as a column change to the value-diff.
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "card-1", columnId: "col-1" },
+      ]);
 
       await tools.upsertCard.execute!(
         {
@@ -342,8 +401,12 @@ describe("createKanbanTools", () => {
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]) // card guard
         .mockResolvedValueOnce([{ id: "card-1", columnId: "col-1" }]) // prior row, for the changedFields value-diff
-        .mockResolvedValueOnce([{ labels: [{ id: "lbl-a" }] }]); // board labels
-      mockDb.returning.mockResolvedValueOnce([{ id: "card-1" }]);
+        .mockResolvedValueOnce([{ labels: [{ id: "lbl-a" }] }]) // board labels
+        .mockResolvedValueOnce([{ labels: [{ id: "lbl-a", name: "A" }] }]) // board labels again, for the history entry's name snapshot
+        .mockResolvedValueOnce([]); // the history trim's subquery
+      mockDb.returning.mockResolvedValueOnce([
+        { id: "card-1", columnId: "col-1" },
+      ]);
 
       await tools.bulkEditCards.execute!(
         {
@@ -447,7 +510,9 @@ describe("createKanbanTools", () => {
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]) // card guard
         .mockResolvedValueOnce([{ id: "col-2", boardId: "board-1" }]) // column guard
-        .mockResolvedValueOnce([sourceCard]); // source card select
+        .mockResolvedValueOnce([sourceCard]) // source card select
+        .mockResolvedValueOnce([{ id: "col-2", name: "Doing" }]) // the copy's created entry snapshots its column name
+        .mockResolvedValueOnce([]); // the history trim's subquery
       // Skip non-terminal where() calls, then resolve terminal where() for max position
       for (let i = 0; i < 3; i++) mockDb.where.mockReturnValueOnce(mockDb);
       mockDb.where.mockResolvedValueOnce([{ maxPos: 3 }]);
@@ -484,7 +549,9 @@ describe("createKanbanTools", () => {
           { id: "card-1", columnId: "col-1", boardId: "board-1" },
         ]) // card guard
         .mockResolvedValueOnce([{ id: "col-1", boardId: "board-1" }]) // column guard
-        .mockResolvedValueOnce([sourceCard]); // source card select
+        .mockResolvedValueOnce([sourceCard]) // source card select
+        .mockResolvedValueOnce([{ id: "col-2", name: "Doing" }]) // the copy's created entry snapshots its column name
+        .mockResolvedValueOnce([]); // the history trim's subquery
       // Skip non-terminal where() calls, then resolve terminal where() for max position
       for (let i = 0; i < 3; i++) mockDb.where.mockReturnValueOnce(mockDb);
       mockDb.where.mockResolvedValueOnce([{ maxPos: 1 }]);
@@ -503,8 +570,9 @@ describe("createKanbanTools", () => {
       )) as { error?: string };
 
       expect(result).not.toHaveProperty("error");
-      // insert called for the new card + once per comment
-      expect(mockDb.insert).toHaveBeenCalledTimes(2);
+      // insert called for the new card, once per comment, and once for the
+      // copy's own `created` history entry
+      expect(mockDb.insert).toHaveBeenCalledTimes(3);
     });
 
     it("returns error when source card not found", async () => {

--- a/apps/backend/src/tools/kanban.ts
+++ b/apps/backend/src/tools/kanban.ts
@@ -14,6 +14,7 @@ import {
   createCard,
   createComment,
   deleteCards,
+  listCardHistory,
   listComments,
   moveCard,
   requireBoard,
@@ -181,12 +182,19 @@ export function createKanbanTools(
   });
 
   const getCard = tool({
-    description: "Get full details of a specific kanban card.",
+    description:
+      "Get full details of a specific kanban card. Set includeHistory to also see how the card reached its current state — who changed which fields, and when — before acting on it.",
     inputSchema: z.object({
       cardId: z.string().describe("The ID of the card to get"),
       label: z.string().describe("The card title (for display purposes)"),
+      includeHistory: z
+        .boolean()
+        .optional()
+        .describe(
+          "Include the card's recent change history, newest first. Off by default.",
+        ),
     }),
-    execute: async ({ cardId }) =>
+    execute: async ({ cardId, includeHistory }) =>
       asToolResult(async () => {
         const ref = await requireCard(db, ctx, cardId);
 
@@ -196,7 +204,13 @@ export function createKanbanTools(
           .where(eq(kanbanCardTable.id, cardId))
           .limit(1);
 
-        return withCardUrl({ card: cards[0], boardId: ref.boardId });
+        const card = withCardUrl({ card: cards[0], boardId: ref.boardId });
+        if (!includeHistory) return card;
+
+        return {
+          ...card,
+          history: await listCardHistory(db, ctx, cardId),
+        };
       }),
   });
 

--- a/apps/docs/content/building-with-platypus/boards.mdx
+++ b/apps/docs/content/building-with-platypus/boards.mdx
@@ -60,6 +60,8 @@ Click a card to open its detail dialog, where you can edit:
   Agent_.
 - **Comments** — a threaded discussion on the card (also Markdown).
 
+Below the comments, **History** lists how the card got here — newest first.
+
 <Callout type="info">
   Cards record who created and last edited them — and that can be an **Agent**,
   not just a person. When an Agent works a board, its activity shows up in the
@@ -106,6 +108,40 @@ acting on a stale reading of the board is refused and told to look again.
   did not apply — nothing else was lost, and you can repeat it against the board
   as it now stands.
 </Callout>
+
+## Card history
+
+Every card keeps a short record of how it reached its current state: who moved
+it, who changed its labels, priority, due date, title or assignee, and when.
+Open a card and read **History** at the bottom of the dialog.
+
+One write is one entry, however many fields it touched — an Agent that retitles
+a card and bumps its priority in a single edit leaves one line, not two.
+Reordering a card inside its column changes nothing the history tracks and
+leaves no entry at all.
+
+Two things it deliberately does not record:
+
+- **The description's text.** An entry says the description was edited and who
+  edited it, never what it said before. Use a Comment if the previous wording
+  matters.
+- **Anything that happened to the board rather than the card.** Delete a Label
+  at board level and it disappears from every card carrying it, and no card's
+  history mentions it. Entries written earlier still show that Label by the
+  name it had at the time.
+
+<Callout type="warning">
+  A card keeps its **50 most recent** entries. Past that, the oldest are
+  dropped — permanently, and with no copy kept anywhere. Treating History as an
+  audit trail is the trap: it is there to tell whoever picks the card up next
+  how it got here, and a busy card outruns it. If you need a durable record of
+  board activity, send `card.*` events to a
+  [Webhook](/building-with-platypus/webhooks) and keep them your side. Deleting
+  a card deletes its history with it.
+</Callout>
+
+An Agent with the **Kanban** tool set reads the same history when it fetches a
+card, so you can tell it to check how a card has moved before acting on it.
 
 ## Where to next
 

--- a/apps/docs/content/building-with-platypus/tool-sets.mdx
+++ b/apps/docs/content/building-with-platypus/tool-sets.mdx
@@ -22,7 +22,7 @@ has loaded. If something below isn't there, your Operator hasn't enabled it — 
 | **Math Conversions**    | Math          | Convert temperature, distance, weight and volume between units.                                                     | Always                           |
 | **Time**                | Utilities     | Read the current time and convert between timezones.                                                                | Always                           |
 | **Identifiers**         | Utilities     | Generate unique ids — UUIDs, or short nanoids — for naming records and resources in external systems.               | Always                           |
-| **Kanban**              | Productivity  | Read a Board's full state, and create, move, copy, bulk-edit and delete cards and their comments.                   | Always                           |
+| **Kanban**              | Productivity  | Read a Board's full state and a card's history, and create, move, copy, bulk-edit and delete cards and their comments.                   | Always                           |
 | **Dashboards**          | Productivity  | List Dashboards and their widgets, and write new data into a widget.                                                | Always                           |
 | **Triggers**            | Automation    | List and read Triggers, and **create, edit and delete** them — including scheduling new unattended runs.             | Always                           |
 | **Agent Discovery**     | Productivity  | Read-only: list the Agents, Tool sets and Providers in the Workspace, and read one Agent's configuration.           | Always                           |

--- a/apps/frontend/components/kanban-card-dialog.tsx
+++ b/apps/frontend/components/kanban-card-dialog.tsx
@@ -69,6 +69,7 @@ import { useAuth } from "@/components/auth-provider";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { AgentAvatar } from "@/components/agent-avatar";
+import { KanbanCardHistory } from "@/components/kanban-card-history";
 import { Calendar } from "@/components/ui/calendar";
 import { toast } from "sonner";
 
@@ -471,6 +472,7 @@ export function KanbanCardDialog({
             <TabsList className="shrink-0">
               <TabsTrigger value="details">Details</TabsTrigger>
               <TabsTrigger value="comments">Comments</TabsTrigger>
+              <TabsTrigger value="history">History</TabsTrigger>
             </TabsList>
             <TabsContent
               value="details"
@@ -802,6 +804,17 @@ export function KanbanCardDialog({
                 </div>
               </div>
             </TabsContent>
+            <TabsContent
+              value="history"
+              className="flex-1 overflow-y-auto mt-0 pt-4 min-w-0"
+            >
+              <KanbanCardHistory
+                orgId={orgId}
+                workspaceId={workspaceId}
+                boardId={boardId}
+                cardId={card.id}
+              />
+            </TabsContent>
           </Tabs>
         ) : (
           <div className="flex flex-row gap-2 min-h-0 flex-1 overflow-hidden">
@@ -968,6 +981,14 @@ export function KanbanCardDialog({
                       Comment
                     </Button>
                   </div>
+                </div>
+                <div className="mt-6">
+                  <KanbanCardHistory
+                    orgId={orgId}
+                    workspaceId={workspaceId}
+                    boardId={boardId}
+                    cardId={card.id}
+                  />
                 </div>
               </div>
             </div>

--- a/apps/frontend/components/kanban-card-history.tsx
+++ b/apps/frontend/components/kanban-card-history.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import useSWR from "swr";
+import type {
+  KanbanCardHistoryChange,
+  KanbanCardHistoryRef,
+} from "@platypus/schemas";
+import { fetcher, joinUrl } from "@/lib/utils";
+import { useBackendUrl } from "@/app/client-context";
+
+/**
+ * A card's history as the API returns it — timestamps arrive as JSON strings
+ * rather than the `Date` the shared schema describes.
+ */
+type HistoryEntry = {
+  id: string;
+  kind: "created" | "updated";
+  changes: KanbanCardHistoryChange[];
+  actorName?: string | null;
+  createdAt: string;
+};
+
+const formatDate = (value: string | null): string =>
+  value ? new Date(value).toLocaleDateString() : "none";
+
+const formatTimestamp = (value: string): string =>
+  new Date(value).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+
+const labelNames = (labels: KanbanCardHistoryRef[]): string =>
+  labels.length > 0 ? labels.map((label) => label.name).join(", ") : "none";
+
+/**
+ * One change, in a sentence. Values are the snapshots the entry was written
+ * with, so a renamed Column still reads as the name it had at the time — and
+ * the body, which is recorded without its text, reads as an edit rather than a
+ * diff.
+ */
+function describeChange(change: KanbanCardHistoryChange): string {
+  switch (change.field) {
+    case "columnId":
+      return change.before === null
+        ? `created in ${change.after.name}`
+        : `moved from ${change.before.name} to ${change.after.name}`;
+    case "title":
+      return `renamed to "${change.after ?? ""}"`;
+    case "body":
+      return "edited the description";
+    case "priority":
+      return `priority ${change.before} → ${change.after}`;
+    case "dueDate":
+      return `due date ${formatDate(change.before)} → ${formatDate(change.after)}`;
+    case "labelIds":
+      return `labels ${labelNames(change.before)} → ${labelNames(change.after)}`;
+    case "assignees":
+      // Only ids are recorded for an assignee, so the change is described
+      // rather than named.
+      if (change.before.length === 0) return "assigned the card";
+      if (change.after.length === 0) return "removed the assignee";
+      return "changed the assignee";
+  }
+}
+
+/**
+ * A Card's history: how it reached its current state, newest first. Read-only
+ * and capped by the backend, so there is nothing here to page through.
+ */
+export function KanbanCardHistory({
+  orgId,
+  workspaceId,
+  boardId,
+  cardId,
+}: {
+  orgId: string;
+  workspaceId: string;
+  boardId: string;
+  cardId: string;
+}) {
+  const backendUrl = useBackendUrl();
+
+  const url =
+    backendUrl &&
+    joinUrl(
+      backendUrl,
+      `/organizations/${orgId}/workspaces/${workspaceId}/boards/${boardId}/cards/${cardId}/history`,
+    );
+
+  const { data } = useSWR<{ results: HistoryEntry[] }>(url, fetcher);
+  const entries = data?.results ?? [];
+
+  return (
+    <div>
+      <p className="text-sm font-medium mb-3">History</p>
+      {entries.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          No changes recorded yet.
+        </p>
+      ) : (
+        <ol className="space-y-3">
+          {entries.map((entry) => (
+            <li key={entry.id} className="space-y-1">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-medium">
+                  {entry.actorName ?? "Unknown"}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {formatTimestamp(entry.createdAt)}
+                </span>
+              </div>
+              <ul className="text-xs text-muted-foreground space-y-0.5">
+                {entry.changes.map((change, index) => (
+                  <li key={`${entry.id}-${index}`}>{describeChange(change)}</li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/docs/adr/0024-a-card-history-is-working-context-not-an-audit-trail.md
+++ b/docs/adr/0024-a-card-history-is-working-context-not-an-audit-trail.md
@@ -1,0 +1,71 @@
+---
+status: accepted
+---
+
+# A Card history is working context, not an audit trail
+
+A Card carries no record of its own past, so "why is this in Blocked?" has no
+answer, and an Agent picking a Card up sees a position with no path to it.
+#795 adds a **Card history**: an ordered, capped series of **history entries**
+naming what changed, when, and who changed it, readable by an Agent through
+`getCard` and by a person on the Card dialog.
+
+The decision is what that history is _for_, because the obvious next step from
+"record what changed" is to keep recording more of it until the feature is the
+compliance log nobody scoped. **A Card history answers how one Card reached
+its current state — and only that.** It is working context for whoever acts on
+the Card next. It is not an audit trail, not compliance evidence, not a Board
+activity feed, and not analytics. Where a question needs durable, complete,
+exportable board activity, the answer is the `card.*` Webhook stream, which
+already exists for exactly that and is the boundary here in the way OTEL is the
+boundary for a **Run timeline** (ADR-0023).
+
+That boundary is what licenses the three properties a reader would otherwise
+file as bugs. Entries are **capped at 50 per Card and the oldest are dropped**,
+not archived — a cap is indefensible in an audit trail and unremarkable in
+working context, and the constant is fixed rather than Operator-configurable
+precisely so the boundary is enforced by the code and not by a default someone
+can raise to ten thousand. The history **cascades with the Card**, which also
+means `card.deleted` is unloggable by construction: the row recording the
+deletion would be deleted by it. And the history is **scoped to field writes
+addressed to one Card**, so a Board-level Label deletion — which strips that
+Label from every Card carrying it — appears in no Card's history at all. The
+alternative, fanning an entry out to every affected Card, turns one click into
+unbounded write amplification for the rarest write on the Board.
+
+Two narrower decisions follow the same logic and are recorded here because a
+reader will otherwise assume the opposite.
+
+**The `body` field records only that it changed, never its before and after.**
+Every other tracked field — title, labels, assignees, due date, priority,
+column — stores both values. Body is unbounded Markdown, and storing it twice
+per edit is the case ADR-0023 already refused: the moment a capture needs a
+truncation policy, the capture is wrong. "Body edited by Ana on Tuesday" is the
+useful part at none of the cost. Body edits are therefore legible but not
+recoverable, which is the accepted limit.
+
+**A history entry is written inside the Card's own transaction, by the service
+function performing the write — not from the event dispatcher.** Hanging it off
+`dispatch()` would have caught every write path from one place, and that is
+the shape ADR-0022 argues for in general: it rejected making each write path
+volunteer its own causation, because one path forgot. The analogy does not hold
+here. `dispatchEvent` returns `void` and is unawaited, so a history write hung
+off it lands outside the transaction — a rolled-back `moveCard` would still
+record the move, and a failed insert would be an unobserved rejection. A
+history that can disagree with the Card it describes is worse than no history.
+And there is nothing here for a call site to get wrong: history attribution
+comes from the explicit `KanbanActor` parameter already threaded through every
+Kanban service function, deliberately _not_ from the ambient causation chain,
+so an entry and the Card's own `lastEditedBy*` columns can never disagree. That
+also means a Sub-Agent's write is attributed to the Sub-Agent, matching the
+Card rather than the loop guard, which reasons over the whole acting chain for
+its own separate purpose.
+
+The consequence worth naming is the one ADR-0022 predicted: the obligation now
+lives at each write path that changes a Card — creation, update, move, copy and
+bulk-edit, deletion needing none — and a further path added later can omit it
+silently and leave a Card whose history quietly stops being true. Every entry
+goes through one writer, which is what appends and trims, so the shape and the
+cap cannot drift between call sites; only the call itself can be forgotten, and
+it cannot be centralised without giving up the transaction that makes the entry
+trustworthy.

--- a/packages/schemas/index.ts
+++ b/packages/schemas/index.ts
@@ -2310,6 +2310,94 @@ export const kanbanCardCommentUpdateSchema = kanbanCardCommentSchema
 
 export type KanbanCardComment = z.infer<typeof kanbanCardCommentSchema>;
 
+// Kanban Card history
+
+/**
+ * The most recent entries a Card's history keeps. Older entries are dropped,
+ * never archived: a Card history is working context for whoever acts on the
+ * Card next, not an audit trail (ADR-0024). Deliberately a constant rather
+ * than an Operator setting — the cap is what keeps the concept honest.
+ */
+export const KANBAN_CARD_HISTORY_LIMIT = 50;
+
+/**
+ * A Label or Column as it stood when the entry was written. The id keeps the
+ * entry joinable while the referent exists; the name is what makes it readable
+ * after a rename or a deletion — and for a history the snapshot is the more
+ * correct of the two, since a Column renamed last month did not have its
+ * current name when the Card entered it.
+ */
+export const kanbanCardHistoryRefSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+
+export type KanbanCardHistoryRef = z.infer<typeof kanbanCardHistoryRefSchema>;
+
+/**
+ * One field's movement within a single write. `body` is the deliberate
+ * exception and carries no values at all: it is unbounded Markdown, and
+ * storing it twice per edit is the capture ADR-0024 refuses. A body edit is
+ * legible ("who touched it, when") but not recoverable.
+ */
+export const kanbanCardHistoryChangeSchema = z.discriminatedUnion("field", [
+  z.object({
+    field: z.literal("title"),
+    before: z.string().nullable(),
+    after: z.string().nullable(),
+  }),
+  z.object({ field: z.literal("body") }),
+  z.object({
+    field: z.literal("priority"),
+    before: kanbanCardPrioritySchema,
+    after: kanbanCardPrioritySchema,
+  }),
+  z.object({
+    field: z.literal("dueDate"),
+    before: z.string().nullable(),
+    after: z.string().nullable(),
+  }),
+  z.object({
+    field: z.literal("assignees"),
+    before: z.array(kanbanCardAssigneeSchema),
+    after: z.array(kanbanCardAssigneeSchema),
+  }),
+  z.object({
+    field: z.literal("labelIds"),
+    before: z.array(kanbanCardHistoryRefSchema),
+    after: z.array(kanbanCardHistoryRefSchema),
+  }),
+  z.object({
+    field: z.literal("columnId"),
+    before: kanbanCardHistoryRefSchema.nullable(),
+    after: kanbanCardHistoryRefSchema,
+  }),
+]);
+
+export type KanbanCardHistoryChange = z.infer<
+  typeof kanbanCardHistoryChangeSchema
+>;
+
+/**
+ * One write addressed to a Card, as its history remembers it. A `created`
+ * entry carries the single `columnId` change that brought the Card into
+ * existence; an `updated` entry carries every field that actually moved.
+ */
+export const kanbanCardHistoryEntrySchema = z.object({
+  id: z.string(),
+  cardId: z.string(),
+  kind: z.enum(["created", "updated"]),
+  changes: z.array(kanbanCardHistoryChangeSchema).default([]),
+  actorUserId: z.string().nullable().optional(),
+  actorAgentId: z.string().nullable().optional(),
+  actorName: z.string().nullable().optional(),
+  createdAt: z.date(),
+});
+
+export type KanbanCardHistoryEntry = z.infer<
+  typeof kanbanCardHistoryEntrySchema
+>;
+
 // Kanban Board State (nested response)
 
 export const kanbanBoardStateSchema = z.object({


### PR DESCRIPTION
Closes #795.

A Card recorded only its latest writer, so "why is this in Blocked?" had no
answer and an Agent picking a Card up saw a position with no path to it. The
value-diff was already computed on every write and then thrown away into a
fire-and-forget `card.updated` event.

This adds a **Card history**: an ordered series of entries naming what changed,
when, and who changed it. Readable by an Agent through a new `includeHistory`
flag on `getCard`, and by a person in a read-only section of the Card dialog.

Design was settled in a grilling session on the issue; the agent brief there is
the contract, and **ADR-0024** records the boundary.

## What it is, and what it deliberately is not

A Card history answers how one Card reached its current state — and only that.
It is working context for whoever acts on the Card next, not an audit trail, not
compliance evidence, not a Board activity feed. Durable, exportable board
activity stays the job of the `card.*` Webhook stream.

That boundary is what licenses three properties a reviewer would otherwise read
as bugs:

- **Capped at 50 entries per Card**, oldest dropped rather than archived. A
  fixed constant, not Operator-configurable — the cap is what keeps the concept
  honest, so it is enforced by the code rather than by a default someone can
  raise to ten thousand.
- **Cascades with the Card**, which makes `card.deleted` unloggable by
  construction: the row recording the deletion would be deleted by it.
- **Scoped to writes addressed to one Card.** A Board-level Label deletion
  strips that Label from every Card carrying it and appears in no Card's
  history — the alternative turns one click into unbounded write amplification.

Two narrower calls, both argued in the ADR:

- **`body` records only that it changed**, never its text. Unbounded Markdown
  stored twice per edit is the capture ADR-0023 already refused. Body edits are
  legible, not recoverable.
- **Entries are written inside each write's own transaction**, not from
  `dispatch()`. Hanging them there would have caught every path from one place,
  but `dispatchEvent` returns `void` and is unawaited — an entry written from it
  lands outside the transaction, so a rolled-back `moveCard` would still record
  the move. A history that can disagree with the Card it describes is worse than
  none.

Attribution comes from the existing `KanbanActor` parameter, mirroring the
Card's own `lastEditedBy*`, deliberately **not** from the ambient causation
chain — that models who is responsible for a run, which is a different question
(ADR-0022). A Sub-Agent's write is attributed to the Sub-Agent.

Label and Column values snapshot both the id and the name as it stood at write
time, so an entry still reads after a rename or a deletion — and for a history
the snapshot is the more correct of the two.

## Shape of the change

- New `kanban_card_history` table, indexed on `(card_id, created_at)`.
- One writer appends and trims; the trim is a single `DELETE … NOT IN
  (subquery)`, so a write costs no extra round trip to stay within the cap.
- Wired into the five paths that change a Card — create, update, move, copy,
  bulk-edit. Deletion writes none. `createCard` and `updateCard` gained
  transactions they did not have.
- `getCard` takes `includeHistory` (default false) rather than a twelfth Kanban
  tool — the set is already among the largest, and selection quality degrades
  with catalogue size.
- An empty diff writes nothing, so a within-column reorder leaves no entry.

## Notes for the reviewer

**34 existing tests changed.** Most were fixtures whose `returning` stub omitted
`columnId`, which the value-diff correctly read as a column change; those stubs
are now more faithful rather than merely appeased. The rest needed stubs for the
new reads. Nine new service tests and two new tool tests cover the behaviour.

**Not exercised against a real Postgres.** The table needs `pnpm
drizzle-kit-push`; the mock harness cannot catch a bad index or a subquery
Postgres rejects. Worth one manual card edit before merging.

`pnpm typecheck`, `pnpm lint` and `pnpm test` (3,607 tests, docs-contract
included) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
